### PR TITLE
Fix loading logger configuration from environment variables

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -30,8 +30,16 @@ try {
   if (config && config.logging && config.logging.level) level = config.logging.level;
 }
 catch (e) {
-  console.error("Unable to load New Relic agent configuration to start logger:",
-                e.stack);
+  if (process.env.NEW_RELIC_NO_CONFIG_FILE) {
+    config = {};
+    config.logging = {
+      level : process.env.NEW_RELIC_LOG_LEVEL || 'info',
+      filepath : process.env.NEW_RELIC_LOG || ''
+    };
+  } else {
+    console.error("Unable to load New Relic agent configuration to start logger:",
+                  e.stack);
+  }
 }
 
 var filepath;


### PR DESCRIPTION
Fixes #6.

This is a pretty hacky fix. Testing it will be difficult, since you need to change the environment variables for that one specific test. Maybe add a separate mocha invocation in the Makefile?

Or refactoring config.js so it doesn't have a dependency on logger.js. I think I'll see if I can do that...
