### PR TITLE
Fix for url tracking.

### DIFF
--- a/lib/instrumentation/core/http.js
+++ b/lib/instrumentation/core/http.js
@@ -18,7 +18,9 @@ module.exports = function initialize(agent, http) {
       /* FIXME: favicon often causes performance problems, should NR
        * special-case it?
        */
+      
       if (state && request.url !== '/favicon.ico') {
+    	 var url = request.url;
         var segment     = state.getSegment().addWeb(request.url);
 
         response.once('finish', function instrumentedFinish() {
@@ -26,7 +28,7 @@ module.exports = function initialize(agent, http) {
           /* Node's http library only offers a status code, not a textual
            * message.
            */
-          transaction.measureWeb(request.url,
+          transaction.measureWeb(url,
                                  response.statusCode,
                                  segment.getDurationInMillis());
           transaction.end();


### PR DESCRIPTION
Using server.use('/prefix', function(req,res,next){}) will show up as a root (/*) level object in next relic. This is because connect overwrites the request.url. You need to save it off at the beginning of the request.
