### PR TITLE
Error in Strict Mode

### DIFF
--- a/lib/instrumentation/connect.js
+++ b/lib/instrumentation/connect.js
@@ -69,7 +69,7 @@ module.exports = function initialize(agent, connect) {
     }
     // I am a bad person and this makes me feel bad.
     var wrapped = eval(
-      '(function(){return function ' + (handle.name || '') + arglist +
+      '(function(){return function' + arglist +
       '{return agent.tracer.callbackProxy(handle).apply(this,arguments);};}())'
     );
     wrapped[ORIGINAL] = handle;


### PR DESCRIPTION
When executing in strict mode (coffeescript default), I got this error:

```
undefined:1
(function(){return function static(req, res, next){return agent.tracer.callbac
                   ^^^^^^^^^^^^^^^
SyntaxError: Use of future reserved word in strict mode
    at wrapHandle (/Users/wintonwelsh/Sites/gitcycle_api/node_modules/newrelic/lib/instrumentation/connect.js:72:70)
    at HTTPServer.<anonymous> (/Users/wintonwelsh/Sites/gitcycle_api/node_modules/newrelic/lib/instrumentation/connect.js:94:26)
    at HTTPServer.app.use (/Users/wintonwelsh/Sites/gitcycle_api/node_modules/express/lib/http.js:231:36)
    at HTTPServer.<anonymous> (/Users/wintonwelsh/Sites/gitcycle_api/lib/app.js:163:7)
    at HTTPServer.app.configure (/Users/wintonwelsh/Sites/gitcycle_api/node_modules/express/lib/http.js:543:61)
    at Object.<anonymous> (/Users/wintonwelsh/Sites/gitcycle_api/lib/app.js:162:5)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
```
