### PR TITLE
Config filepath bug

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -519,7 +519,7 @@ function initialize(bootstrapLogger, c) {
         filepath = path.join(NEW_RELIC_HOME, DEFAULT_FILENAME);
       }
       else {
-        filepath = path.join(process.cwd(), DEFAULT_FILENAME);
+        filepath = path.join(path.dirname(process.mainModule.filename), DEFAULT_FILENAME);
       }
 
       try {


### PR DESCRIPTION
If the app is started from another directory, it didn't work: 'node app/index.js'
