### PR TITLE
Make agent.transactionNameNormalizer load config data.

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -76,6 +76,7 @@ function Agent(config, options) {
     'transaction_name_rules',
     this.transactionNameNormalizer.load.bind(this.transactionNameNormalizer)
   );
+  this.transactionNameNormalizer.loadFromConfig();
   this.urlNormalizer = new MetricNormalizer(this.config, 'URL');
   this.config.on('url_rules', this.urlNormalizer.load.bind(this.urlNormalizer));
   this.urlNormalizer.loadFromConfig();


### PR DESCRIPTION
Howdy, thanks for a great service and module.

I tried to add some config rules to ignore a path in my app, but ended up doubting my regexp skills, since they were not taken into account. So I started debugging, and found that the agent.transactionNameNormalizer does not load from config, thus not loading my ignore rules. This patch fixes that.

I must note that this was just a quick debugging from my side, but surely you guys can quickly see if this was indeed something you overlooked, or if there is something else wrong.

Should probably have a quick test too?

Anyways. Thanks again. Hope this helps.
