### PR TITLE
Update to continuation-local-storage@2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "bunyan": "0.14.6",
-    "continuation-local-storage": "2.4.3"
+    "continuation-local-storage": "2.5.1"
   },
   "bundledDependencies": [
     "bunyan",


### PR DESCRIPTION
Resolves issue #71 ("AssertionError: context not currently entered; can't exit" on all http requests). 

2.5.1 is the latest release.

I am seeing a couple failing tests (e.g. test/integration/instrumentation-redis.tap.js) but I also see the same failures when I run `npm test` in master so I do not believe this update is an issue.
