### PR TITLE
handle ignore_status_codes defined as strings

### DIFF
--- a/lib/util/urltils.js
+++ b/lib/util/urltils.js
@@ -22,7 +22,9 @@ module.exports = {
     if (config &&
         config.error_collector &&
         config.error_collector.ignore_status_codes) {
-      codes = config.error_collector.ignore_status_codes;
+      codes = config.error_collector.ignore_status_codes.map(function(code) {
+        return parseInt(code, 10);
+      });
     }
     return code >= 400 && codes.indexOf(code) === -1;
   },

--- a/test/urltils.test.js
+++ b/test/urltils.test.js
@@ -123,6 +123,16 @@ describe("NR URL utilities", function () {
     it("should mark a request for enhanced calm (brah) as an error", function () {
       return expect(urltils.isError(config, 420)).true;
     });
+
+    it("should handle ignore_status_codes defined as strings", function () {
+      var config = {error_collector : {ignore_status_codes : ['404', '401']}};
+      return expect(urltils.isError(config, 401)).false;
+    });
+
+    it("should handle ignore_status_codes defined as integers", function () {
+      var config = {error_collector : {ignore_status_codes : [404, 401]}};
+      return expect(urltils.isError(config, 401)).false;
+    });
   });
 
   describe("copying parameters from a query hash", function () {


### PR DESCRIPTION
This should solve the problem with `NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES` not working as expected.

For example, if you want to ignore in your 401 errors, and 404 errors, you can set:

```
NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES=404,401
```

and it should work with that change.
