### PR TITLE
Make sure cursor.collection exists

### DIFF
--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -50,7 +50,7 @@ function wrapNextObject(tracer) {
 
       if (typeof callback === 'function' && cursor.collection) {
         args[last] = tracer.callbackProxy(function (err, object) {
-          var collection = cursor.collection.collectionName || 'unknown'
+          var collection = cursor.collection && cursor.collection.collectionName || 'unknown'
             , remaining  = cursor.items.length
             , total      = cursor.totalNumberOfRecords
             , limit      = cursor.limitValue === -1 ? 1 : cursor.limitValue


### PR DESCRIPTION
If you use `nextObject` method of a `cursor` object on a non-existent collection it crashes your application. Found and fixed with @humanchimp
