### PR TITLE
Fix bug of var m equals null（Hot fix for v1.7.2）

### DIFF
--- a/lib/instrumentation/shared/connect-express.js
+++ b/lib/instrumentation/shared/connect-express.js
@@ -126,6 +126,9 @@ function wrapMiddlewareStack(route, interceptor, sentinel, tracer, use) {
     var myInterceptor = interceptor || null;
     if (this.stack && this.stack.length) {
       this.stack = this.stack.filter(function cb_filter(m) {
+        if (!m) {
+          return true;
+        }
         if (interceptor !== null) {
           return m !== interceptor;
         }


### PR DESCRIPTION
newrelic/lib/instrumentation/shared/connect-express.js:141
          if (m.handle !== sentinel) {
               ^
TypeError: Cannot read property 'handle' of null
