### PR TITLE
node-cassandra-cql: support for prepared statements

### DIFF
--- a/lib/instrumentation/node-cassandra-cql.js
+++ b/lib/instrumentation/node-cassandra-cql.js
@@ -22,7 +22,7 @@ module.exports = function initialize(agent, cassandracql) {
       'node-cassandra-cql.Client.prototype',
       operation,
       function wrapper(cmd) {
-        return tracer.segmentProxy(function wrapped() {
+        return tracer.segmentProxy(function wrapped(cql) {
           if (!tracer.getTransaction() || arguments.length < 1) {
             logger.trace("Not tracing cassandra-cql command due to no transaction state.");
             return cmd.apply(this, arguments);
@@ -30,7 +30,9 @@ module.exports = function initialize(agent, cassandracql) {
 
           var transaction = tracer.getTransaction()
             , args = tracer.slice(arguments)
-            , name = CASSANDRA.OPERATION + operation
+            , name = operation === "executeAsPrepared" && typeof cql === "string"
+              ? CASSANDRA.STATEMENT + cql
+              : CASSANDRA.OPERATION + operation
             , segment = tracer.addSegment(name, record)
             , position = args.length - 1
             , last = args[position]

--- a/lib/metrics/names.js
+++ b/lib/metrics/names.js
@@ -64,6 +64,7 @@ var REDIS = {
 var CASSANDRA = {
   PREFIX    : 'Cassandra',
   OPERATION : DB.OPERATION + '/Cassandra/',
+  STATEMENT : DB.STATEMENT + '/Cassandra/',
   INSTANCE  : DB.INSTANCE  + '/Cassandra/'
 };
 


### PR DESCRIPTION
This gets us as close to stored proc monitoring as we're going to get for Cassandra.
