### PR TITLE
tracer: update to newest version of CLS

### DIFF
--- a/lib/transaction/tracer.js
+++ b/lib/transaction/tracer.js
@@ -29,7 +29,7 @@ if (!namespace) namespace = cls.createNamespace(TRACER);
  * @param {Namespace} namespace CLS instance.
  */
 function _patchErrorTracerOntoCLS(agent, namespace) {
-  var callbacks = namespace && namespace.id && namespace.id.callbacks;
+  var callbacks = namespace && namespace.id;
   if (callbacks && callbacks.error) {
     callbacks.error = function cb_error(domain, error) {
       var context     = namespace.fromException(error)

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "bunyan": "0.14.6",
-    "continuation-local-storage": "^3.0.0",
+    "continuation-local-storage": "^3.1.0",
     "yakaa": "^1.0.0"
   },
   "bundledDependencies": [


### PR DESCRIPTION
In retrospect, I probably should have bumped CLS to 4.0.0, but the bits that changed in `node-newrelic` were using undocumented internals that I originally piggybacked upon to avoid needing 2 async listeners to handle CLS _and_ error tracing. As a workaround, I updated the dependency in `package.json` so that you won't somehow end up with a version of CLS with the old internal API.

`continuation-local-storage@3.1.0` includes @groundwater's fix for othiym23/async-listener#19 / othiym23/async-listener#20, which is the main motivator for the upgrade. All tests are passing (although you should probably upgrade `CONTRIBUTING.md` to reflect the fact that `boot2docker` is also a dependency for running the integration tests).
