### PR TITLE
support groups in createBackgroundTransaction stub

### DIFF
--- a/stub_api.js
+++ b/stub_api.js
@@ -45,9 +45,9 @@ Stub.prototype.createWebTransaction = function(url, callback) {
   return callback;
 };
 
-Stub.prototype.createBackgroundTransaction = function(name, callback) {
+Stub.prototype.createBackgroundTransaction = function(name, group, callback) {
   logger.debug('Not calling createBackgroundTransaction because New Relic is disabled.');
-  return callback;
+  return (callback === undefined) ? group : callback;
 };
 
 module.exports = Stub;

--- a/test/api-stub.test.js
+++ b/test/api-stub.test.js
@@ -120,6 +120,18 @@ describe("the stubbed New Relic agent API", function () {
     var retVal = api.createBackgroundTransaction('name', myNop);
     expect(retVal).to.be.equal(myNop);
   });
+  
+    it("shouldn't throw when a custom background transaction with a group is added", function () {
+    expect(function () {
+      api.createBackgroundTransaction('name', 'group', function nop(){});
+    }).not.throws();
+  });
+
+  it("should return a function when calling createBackgroundTransaction", function () {
+    function myNop () {}
+    var retVal = api.createBackgroundTransaction('name', 'group', myNop);
+    expect(retVal).to.be.equal(myNop);
+  });
 
   it("shouldn't throw when a transaction is ended", function () {
     expect(function () {


### PR DESCRIPTION
The full api for [createBackgroundTransaction](https://github.com/newrelic/node-newrelic/blob/master/api.js#L433) supports three arguments with the second argument being optional. The fallback stub only supported the _name_ and _callback_ arguments. I've update the stub and the tests to support the optional _group_ argument as the full version of the api does.

Thanks! 
