### PR TITLE
Fix TypeError: Object.keys called on non-object

### DIFF
--- a/lib/util/urltils.js
+++ b/lib/util/urltils.js
@@ -71,9 +71,9 @@ module.exports = {
   parseParameters : function parseParameters(requestURL) {
     var parsed     = url.parse(requestURL, true)
       , parameters = {}
-      
 
-    if (parsed.search !== '') {
+
+    if (parsed.search) {
       Object.keys(parsed.query).forEach(function cb_forEach(key) {
         if (parsed.query[key] === '' && parsed.path.indexOf(key + '=') < 0) {
           parameters[key] = true

--- a/test/unit/urltils.test.js
+++ b/test/unit/urltils.test.js
@@ -4,12 +4,26 @@ var path    = require('path')
   , chai    = require('chai')
   , expect  = chai.expect
   , urltils = require('../../lib/util/urltils.js')
-  
+
 
 describe("NR URL utilities", function () {
   describe("scrubbing URLs", function () {
     it("should return '/' if there's no leading slash on the path", function () {
       expect(urltils.scrub('?t_u=http://some.com/o/p')).equal('/')
+    })
+  })
+
+  describe("parsing parameters", function () {
+    it("should find empty object of params in url lacking query", function () {
+      expect(urltils.parseParameters('/favicon.ico')).deep.equal({});
+    })
+
+    it("should find v param in url containing ?v with no value", function () {
+      expect(urltils.parseParameters('/status?v')).deep.equal({v:true});
+    })
+
+    it("should find v param with value in url containing ?v=1", function () {
+      expect(urltils.parseParameters('/status?v=1')).deep.equal({v:'1'});
     })
   })
 
@@ -129,7 +143,7 @@ describe("NR URL utilities", function () {
     var config
       , source
       , dest
-      
+
 
     beforeEach(function () {
       config = {


### PR DESCRIPTION
```
TypeError: Object.keys called on non-object
    at Function.keys (native)
    at Object.parseParameters (/home/cloud-user/did_groups_api/node_modules/newrelic/lib/util/urltils.js:78:14)
    at TraceSegment.markAsWeb (/home/cloud-user/did_groups_api/node_modules/newrelic/lib/transaction/trace/segment.js:91:32)
    at ServerResponse.instrumentedFinish (/home/cloud-user/did_groups_api/node_modules/newrelic/lib/instrumentation/core/http.js:127:15)
    at ServerResponse.g (events.js:199:16)
    at ServerResponse.<anonymous> (/home/cloud-user/did_groups_api/node_modules/newrelic/node_modules/continuation-local-storage/context.js:74:17)
    at ServerResponse.emit (events.js:129:20)
    at ServerResponse.emitted [as emit] (/home/cloud-user/did_groups_api/node_modules/newrelic/node_modules/continuation-local-storage/node_modules/emitter-listener/listener.js:122:21)
    at finish (_http_outgoing.js:517:10)
    at /home/cloud-user/did_groups_api/node_modules/newrelic/node_modules/continuation-local-storage/node_modules/async-listener/glue.js:188:31
```

At least in node 0.11.14, parsed.search is null, not an empty string when query is null:

```
parsed { protocol: null,
  hostname: null,
  slashes: null,
  hash: null,
  auth: null,
  search: null,
  host: null,
  query: null,
  port: null,
  pathname: '/favicon.ico',
  hostname: null,
  path: '/favicon.ico',
  hash: null,
  href: '/favicon.ico' }
  search: null,
  query: null,
  pathname: '/favicon.ico',
  path: '/favicon.ico',
  href: '/favicon.ico' }
```
