### PR TITLE
Fix issue with chainable on calls in pg.

### DIFF
--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -116,7 +116,7 @@ module.exports = function initialize(agent, pgsql) {
               shimmer.wrapMethod(res, 'query.on', 'on', function queryOnWrapper(on) {
                 return tracer.callbackProxy(function queryOnWrapped() {
                   if (arguments[1]) arguments[1] = tracer.callbackProxy(arguments[1])
-                  on.apply(this, arguments)
+                  return on.apply(this, arguments)
                 })
               })
 
@@ -197,7 +197,7 @@ module.exports = function initialize(agent, pgsql) {
       shimmer.wrapMethod(query, 'query.on', 'on', function queryOnWrapper(on) {
         return tracer.callbackProxy(function queryOnWrapped() {
           if (arguments[1]) arguments[1] = tracer.callbackProxy(arguments[1])
-          on.apply(this, arguments)
+          return on.apply(this, arguments)
         })
       })
 


### PR DESCRIPTION
EventEmitters `on` method is chainable as documented here: http://nodejs.org/api/events.html#events_emitter_on_event_listener

By not returning the handler you introduce a breaking behavior that other libraries (like SequelizeJS) might rely on.
