### PR TITLE
Log the actual error for config not being read

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -855,6 +855,8 @@ function initialize(config) {
     return config
   }
   catch (error) {
+    logger.error(error)
+    
     throw new Error(
       "Unable to read configuration file " + filepath + ". A default\n" +
       "configuration file can be copied from " + DEFAULT_CONFIG_PATH + "\n" +


### PR DESCRIPTION
Basically it's impossible to debug, especially if the error only happens in a Docker container (which it is, for me).