### PR TITLE
fix TypeError: Object.keys called on non-object

### DIFF
--- a/lib/util/urltils.js
+++ b/lib/util/urltils.js
@@ -73,7 +73,7 @@ module.exports = {
       , parameters = {}
 
 
-    if (parsed.search) {
+    if (parsed.search !== '' && typeof parsed.query === 'object' && parsed.query !== null) {
       Object.keys(parsed.query).forEach(function cb_forEach(key) {
         if (parsed.query[key] === '' && parsed.path.indexOf(key + '=') < 0) {
           parameters[key] = true
@@ -104,7 +104,7 @@ module.exports = {
   copyParameters : function copyParameters(config, source, destination) {
     if (!(config && config.capture_params && source && destination)) return
 
-    var keys = Object.keys(source)
+    var keys = (typeof source === 'object' && source !== null) ? Object.keys(source) : []
     for (var i = 0; i < keys.length; i++) {
       var key = keys[i]
       if (config.ignored_params.indexOf(key) === -1 && !(key in destination)) {


### PR DESCRIPTION
Bug fixed under Restify (almost the same with express.js)

## Error 1:

```
TypeError: Object.keys called on non-object
    at Function.keys (native)
    at Object.parseParameters (/home/open-api/node_modules/newrelic/lib/util/urltils.js:77:14)
    at TraceSegment.markAsWeb (/home/open-api/node_modules/newrelic/lib/transaction/trace/segment.js:91:32)
    at ServerResponse.instrumentedFinish (/home/open-api/node_modules/newrelic/lib/instrumentation/core/http.js:126:15)
    at ServerResponse.g (events.js:199:16)
    at ServerResponse.<anonymous> (/home/open-api/node_modules/newrelic/node_modules/continuation-local-storage/context.js:74:17)
    at ServerResponse.emit (events.js:104:17)
    at ServerResponse.emitted [as emit] (/home/open-api/node_modules/newrelic/node_modules/continuation-local-storage/node_modules/emitter-listener/listener.js:122:21)
    at finish (_http_outgoing.js:517:10)
    at /home/open-api/node_modules/newrelic/node_modules/continuation-local-storage/node_modules/async-listener/glue.js:188:31js-bson: Failed to load c++ bson extension, using pure JS version
```

## Error 2:

```
Error: Can't set headers after they are sent.
    at ServerResponse.OutgoingMessage.setHeader (_http_outgoing.js:331:11)
    at ServerResponse.format (/home/open-api/node_modules/restify/lib/response.js:95:10)
    at ServerResponse.send (/home/open-api/node_modules/restify/lib/response.js:205:24)
    at Server.<anonymous> (/home/open-api/app.js:99:8)
    at Server.emit (events.js:129:20)
    at Domain.onError (/home/open-api/node_modules/restify/lib/server.js:775:18)
    at Domain.emit (events.js:107:17)
    at Domain.errorHandler [as _errorHandler] (domain.js:102:19)
    at process._fatalException (node.js:234:33)
    at process._asyncFatalException [as _fatalException] (/home/open-api/node_modules/newrelic/node_modules/continuation-local-storage/node_modules/async-listener/glue.js:211:34).write(string, encoding, offset, length) is deprecated. Use write(string[, offset[, length]][, encoding]) instead.
```