### PR TITLE
Add instrumentation for mongodb aggregate call

### DIFF
--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -9,6 +9,7 @@ var path            = require('path')
 
 
 var COLLECTION_OPERATIONS = [
+  'aggregate',
   'findOne',
   'insert',
   'remove',


### PR DESCRIPTION
One of the most potentially problematic calls in mongodb is the aggregate call, and it lacked instrumentation.  Fortunately, it's a very simple call in the mongodb node driver, it's just a collection operation, and that's _really_ easy to add instrumentation for the way you have things written.
