### PR TITLE
Fix domain circular reference

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -125,7 +125,7 @@ var HIGH_SECURITY_SETTINGS = {
 var HIGH_SECURITY_KEYS = Object.keys(HIGH_SECURITY_SETTINGS)
 
 // blank out these config values before sending to the collector
-var REDACT_BEFORE_SEND = ['proxy_pass', 'proxy_user', 'proxy']
+var REDACT_BEFORE_SEND = ['proxy_pass', 'proxy_user', 'proxy', 'domain']
 
 function isTruthular(setting) {
   if (setting === undefined || setting === null) return false


### PR DESCRIPTION
Prevent newrelic agent from trying to serialize process.domain to JSON.