### PR TITLE
Fix bug in hapi.js instrumentation when using vhosts

### DIFF
--- a/lib/instrumentation/hapi.js
+++ b/lib/instrumentation/hapi.js
@@ -153,7 +153,7 @@ module.exports = function initialize(agent, hapi) {
       if (!router) return logger.warn("no router found on hapi server")
 
       var vhosts = router.vhosts
-      var beforeHosts
+      var beforeHosts = {}
       if (vhosts) {
         logger.debug("capturing vhosts on hapi router")
 


### PR DESCRIPTION
hapi.js instrumentation is broken when using vhosts and crashes the application.

You can reproduce the issue by running this:

``` js
require('newrelic');

var Hapi = require('hapi');
var server = new Hapi.Server(3000);

server.route({
    method: 'GET',
    path: '/',
    handler: function (request, reply) {
        reply('Hello, world!');
    },
    vhost: 'static.site.com'
});

server.route({
    method: 'GET',
    path: '/{name}',
    handler: function (request, reply) {
        reply('Hello, ' + encodeURIComponent(request.params.name) + '!');
    }
});

server.start(function () {
    console.log('Server running at:', server.info.uri);
});
```

The new relic node agent will throw the following exception:

```
/Users/brian/outhouse/newrelic-hapi-crash/node_modules/newrelic/lib/instrumentation/hapi.js:190
          tableVisitor(beforeHosts[host], vhosts[host], host, wrapHandler)
                                  ^
TypeError: Cannot read property 'static.site.com' of undefined
    at cb_forEach (/Users/brian/outhouse/newrelic-hapi-crash/node_modules/newrelic/lib/instrumentation/hapi.js:190:35)
    at Array.forEach (native)
    at wrappedRoute [as _route] (/Users/brian/outhouse/newrelic-hapi-crash/node_modules/newrelic/lib/instrumentation/hapi.js:189:29)
    at internals.Connection.route (/Users/brian/outhouse/newrelic-hapi-crash/node_modules/hapi/lib/connection.js:277:10)
    at Object.<anonymous> (/Users/brian/outhouse/newrelic-hapi-crash/index.js:6:8)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain [as _onTimeout] (module.js:497:10)
```

This fix below addresses this issue.
