### PR TITLE
Allow changing the transaction name in a custom web transaction

### DIFF
--- a/api.js
+++ b/api.js
@@ -477,7 +477,7 @@ API.prototype.createWebTransaction = function createWebTransaction(url, callback
       tx.id
     )
     tx.partialName = NAMES.CUSTOM + NAMES.ACTION_DELIMITER + url
-    tx.setName(url, 0)
+    tx.url = url
     tx.webSegment = tracer.addSegment(url, recordWeb)
 
     return callback.apply(this, arguments)
@@ -553,6 +553,7 @@ API.prototype.endTransaction = function endTransaction() {
     if (tx.webSegment) {
       tx.webSegment.markAsWeb(tx.url)
       tx.webSegment.end()
+      tx.setName(tx.url, 0)
     }
     tx.end()
   } else {

--- a/test/unit/api/custom-instrumentation.test.js
+++ b/test/unit/api/custom-instrumentation.test.js
@@ -299,6 +299,20 @@ describe('The custom instrumentation API', function () {
       var value = txHandler()
       expect(value).to.be.equal('a thing')
     })
+
+    it('should allow changing the transaction name', function (done) {
+      var txHandler = api.createWebTransaction('/custom/transaction', function (outerTx) {
+        var tx = agent.tracer.getTransaction()
+
+        api.setTransactionName('new_name')
+        api.endTransaction()
+
+        expect(tx.name).to.be.equal('WebTransaction/Custom/new_name')
+        done()
+      })
+
+      txHandler()
+    })
   })
 
   describe('when creating an background transaction', function () {


### PR DESCRIPTION
While using the custom transaction API call, I noticed that I wasn't allowed to rename a transaction after creating it, like I was for transactions that are created by the agent itself.  In my usecase I have a bunch of incoming work that I know needs to be processed.  I want to start work the transaction immediately so I can track the time it takes to prepare for the work and the time it takes to decide what needs to be done.  In my situation, I want to give the transaction a better name after some preparation has been done and I know more information.  

When I dug into the code for custom transactions, I saw that it was calling transaction.setName() as soon as the transaction was created.  The documentation for setName() says:

```
/**
 * Sets the name of this transaction, figuring out along the way whether the
 * transaction should be ignored. Should run as late in the transaction's
 * lifetime as possible.
 *
```

To respect the documentation of setName(), and to enable changing the name in the middle of a custom transaction, my changes move the setName() call to the endTransaction() code instead.  I've added a testcase that fails without my changes.
