### PR TITLE
This fixes a test failure when NODE_ENV was set in the environment when ...

### DIFF
--- a/test/unit/environment.test.js
+++ b/test/unit/environment.test.js
@@ -1,5 +1,8 @@
 'use strict'
 
+// For consistent results, unset this in case the user had it set in their environment when testing.
+delete process.env.NODE_ENV;
+
 var path        = require('path')
   , fs          = require('fs')
   , spawn       = require('child_process').spawn


### PR DESCRIPTION
...running the tests.

For example:

   NODE_ENV=foo npm test

To get consistent results when quering the state of the environment, the
environment needs to start out in a consistent state.