### PR TITLE
Support Node >= 1.0 and io.js.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,9 @@ try {
   logger.debug("Process was running %s seconds before agent was loaded.",
                process.uptime())
 
-  if (process.version && process.version.split('.')[1] < 6) {
+  var major =  parseInt(process.version.split('.')[0]);
+  var minor =  process.version.split('.')[1];
+  if (process.version && (major === 0) && (minor < 6)) {
     message = "New Relic for Node.js requires a version of Node equal to or\n" +
               "greater than 0.6.0. Not starting!"
 

--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ try {
 
   var major =  parseInt(process.version.split('.')[0]);
   var minor =  process.version.split('.')[1];
-  if (process.version && (major === 0) && (minor < 6)) {
+  if (process.version && (major === 0) && (minor < 8)) {
     message = "New Relic for Node.js requires a version of Node equal to or\n" +
-              "greater than 0.6.0. Not starting!"
+              "greater than 0.8.0. Not starting!"
 
     logger.error(message)
     throw new Error(message)


### PR DESCRIPTION
io.js is out now and although it is version 1.0.1, trying to require
'newrelic' with it was crashing:

     message = "New Relic for Node.js requires a version of Node equal to or\n" +
               "greater than 0.6.0. Not starting!"

There was a bug in a version checking that was only checking that
the minor version was less than 6, but was ignoring the major version,
so it failed to notice that that 1.0.1 > = 0.6.0.

Before and after checking was done by loading the iojs REPL and trying
this:

   var nr = require('./index.js');

This crashes before the change and works after it.

Ref: https://iojs.org/