### PR TITLE
fallback for empty cursor.collection

### DIFF
--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -123,7 +123,7 @@ function wrapCursorOperation(tracer, operationName) {
   return function cls_wrapCursorOperation(operation) {
     return tracer.segmentProxy(function mongoCursorOperationProxy() {
       var cursor = this
-      var collection = cursor.collection.collectionName
+      var collection = cursor.collection ? cursor.collection.collectionName : cursor.ns.split('.')[1];
       var terms = cursor.selector
 
       if (!tracer.getTransaction()) {


### PR DESCRIPTION
Since I upgraded to node's MongoDB connector v2 (specifically, my package.json says "mongodb": "^2.0.13") I started getting a fatal error

```sh
TypeError: Cannot read property 'collectionName' of undefined
    at mongoCursorOperationProxy (/var/www/apppath/node_modules/newrelic/lib/instrumentation/mongodb.js:125:41)
```

The errors line is

```js
var collection = cursor.collection.collectionName
```

and it seems that `cursor.collection` is empty now. BUT, I saw that cursor.ns has the form `databaseName.collectionName`, so I wrote a fallback to use that property instead if needed.




