### PR TITLE
Don't crash when using mongodb driver 2.0.16

### DIFF
--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -123,7 +123,9 @@ function wrapCursorOperation(tracer, operationName) {
   return function cls_wrapCursorOperation(operation) {
     return tracer.segmentProxy(function mongoCursorOperationProxy() {
       var cursor = this
-      var collection = cursor.collection.collectionName
+      var collection = cursor.collection ?
+        cursor.collection.collectionName :
+        cursor.namespace.collection
       var terms = cursor.selector
 
       if (!tracer.getTransaction()) {


### PR DESCRIPTION
One of the companies that's been helping QA the new version of the mongodb driver uses New Relic in their test environment, and turns out the New Relic agent crashes ungracefully with the new version of the driver. See LearnBoost/mongoose#2652 and mongodb/node-mongodb-native#1253. We added the ability to get the collection name from the cursor back into the driver for v2.0.16. I'm not sure if this is the correct way to handle this on your end, but this tweak seems to be enough to at least make the agent stop crashing.