### PR TITLE
put off refreshing env until later

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -6,7 +6,7 @@ var os = require('os')
 var logger = require('../lib/logger').child({component: 'environment'})
 var stringifySync = require('./util/safe-json').stringifySync
 
-
+var loaded = false;
 var exists = fs.existsSync || path.existsSync
 
 /**
@@ -38,6 +38,10 @@ var remapping = {
 var settings = []
 
 function getSetting(name) {
+  if (!loaded) {
+    loaded = true
+    refresh()
+  }
   var items = settings.filter(function cb_filter(candidate) {
     return candidate[0] === name
   }).map(function cb_map(setting) {
@@ -63,6 +67,10 @@ function addSetting(name, value) {
  * @param {string} name
  */
 function clearSetting(name) {
+  if (!loaded) {
+    loaded = true
+    refresh()
+  }
   settings = settings.filter(function cb_filter(candidate) {
     return candidate[0] !== name
   })
@@ -76,6 +84,10 @@ function clearSetting(name) {
  * @return array List of packages.
  */
 function listPackages(root) {
+  if (!loaded) {
+    loaded = true
+    refresh()
+  }
   var packages = []
   if (existsDir(root)) {
     packages = fs.readdirSync(root)
@@ -381,8 +393,6 @@ function refresh() {
   remapConfigSettings()
   findPackages()
 }
-// initialize settings
-refresh()
 
 /**
  * Refreshes settings and returns the settings object.


### PR DESCRIPTION
because currently newrelic delays the server starting by 1.8 seconds, 1.6 of them are the refresh function, this just avoids environment being initialized until the first time it's used
