### PR TITLE
Add semi-colon to fix webpack usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ if (require.cache.__NR_cache) {
     'Attempting to load a second copy of newrelic from %s, using cache instead',
     __dirname
   )
-  module.exports = require.cache.__NR_cache;
-  return
+  module.exports = require.cache.__NR_cache
+  ; return
 }
 
 logger.debug(

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ if (require.cache.__NR_cache) {
     'Attempting to load a second copy of newrelic from %s, using cache instead',
     __dirname
   )
-  module.exports = require.cache.__NR_cache
+  module.exports = require.cache.__NR_cache;
   return
 }
 


### PR DESCRIPTION
Fix for [this issue](https://discuss.newrelic.com/t/node-agent-fails-with-webpack/24874).

Webpack currently throws the following error when trying to parse this module:

```
ERROR in ./~/newrelic/index.js
Module parse failed: newrelic/index.js Line 18: Illegal return statement 
You may need an appropriate loader to handle this file type. 
| ) 
| module.exports = require.cache.__NR_cache 
| return 
| } 
```