### PR TITLE
remove 'bound' from function name to avoid error in node >=4.x

### DIFF
--- a/lib/instrumentation/connect.js
+++ b/lib/instrumentation/connect.js
@@ -121,7 +121,7 @@ module.exports = function initialize(agent, connect) {
     // allow for lookup.
     /*eslint-disable no-eval*/
     var wrapped = eval(
-      '(function(){return function ' + name + arglist +
+      '(function(){return function ' + name.replace(/\s|bound(?!$)/g,'') + arglist +
       template.toString().substring(11) + '}())'
     )
     /*eslint-enable no-eval*/

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -276,7 +276,7 @@ module.exports = function initialize(agent, express) {
     // name to allow for lookup.
     var wrapped = new Function(
       'tracer', '__NR_handle', 'wrappedHandle', 'path', 'template',
-      'return function ' + name + arglist + handlerTemplate.toString().substring(11)
+      'return function ' + name.replace(/\s|bound(?!$)/g,'') + arglist + handlerTemplate.toString().substring(11)
     )(tracer, __NR_handle, wrappedHandle, path, template)
 
     wrapped[ORIGINAL] = __NR_handle


### PR DESCRIPTION
Newer versions of V8 that support ES2015 automatically prepend the word "bound" to the name of a function that was created with `bind`. Node 4.0.0 uses V8 v4.5 which has this behavior. This breaks express and connect instrumentation in the newest version of node because the following code uses the name value from bound functions:

```javascript
var wrapped = new Function(
      'tracer', '__NR_handle', 'wrappedHandle', 'path', 'template',
      'return function ' + name + arglist + handlerTemplate.toString().substring(11)
    )(tracer, __NR_handle, wrappedHandle, path, template)
```
>https://github.com/newrelic/node-newrelic/blob/6ef82e8dcc0eee2fc3f847b11cd5e8bb41080923/lib/instrumentation/express.js#L279

>Ex of binding: https://github.com/newrelic/node-newrelic/blob/6ef82e8dcc0eee2fc3f847b11cd5e8bb41080923/lib/instrumentation/express.js#L573

When the string is eval'ed it tries to create a function that has two names `function bound foo(){}`.

This fix removes all occurrences of "bound" in the function name unless the name of the function is "bound" in which case it keeps the last occurrence.