### PR TITLE
Avoid logging NaN when Express version is not detected

### DIFF
--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -622,7 +622,7 @@ module.exports = function initialize(agent, express) {
       }
       break
     default:
-      logger.warn("Unrecognized version %d of Express detected; not instrumenting",
+      logger.warn("Unrecognized version %s of Express detected; not instrumenting",
                   version)
   }
 }


### PR DESCRIPTION
We are debugging the Express instrumentation inside our app, and we are seeing this logged message: 
> Unrecognized version NaN of Express detected; not instrumenting

This PR avoids writing NaN in the message, by outputting the detected version as a String.

In the instrumentation code, the Express version is handled as a String.