### PR TITLE
CAT Documentation

### DIFF
--- a/lib/config.default.js
+++ b/lib/config.default.js
@@ -494,5 +494,13 @@ exports.config = {
    slow_sql: {
     enabled: false,
     max_samples: 10
-  }
+  },
+  
+  /**
+   * These options control features of New Relic not found elsewhere.
+   * cat enables and disables cross application tracing.  The default is enabled. (https://docs.newrelic.com/docs/apm/transactions/cross-application-traces/cross-application-tracing)
+   */
+   feature_flag: {
+     cat: true
+   }
 }


### PR DESCRIPTION
This documents the ability to enable or disable cross application tracing from the config file.