### PR TITLE
Support mysql2

### DIFF
--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -66,6 +66,8 @@ function _postLoad(agent, nodule, name) {
   if (name === 'pg.js') {
     instrumentation = 'pg'
   } if (name === 'mysql2') {
+    // mysql2 (https://github.com/sidorares/node-mysql2) is a drop in replacement for mysql
+    // which conforms to the existing mysql API. If we see mysql2, treat it as mysql
     instrumentation = 'mysql'
   } else {
     instrumentation = base

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -65,6 +65,8 @@ function _postLoad(agent, nodule, name) {
   // to allow for instrumenting both 'pg' and 'pg.js'.
   if (name === 'pg.js') {
     instrumentation = 'pg'
+  } if (name === 'mysql2') {
+    instrumentation = 'mysql'
   } else {
     instrumentation = base
   }


### PR DESCRIPTION
We're using [node-mysql2](https://github.com/sidorares/node-mysql2) which is a drop in replacement for [node-mysql](https://github.com/felixge/node-mysql). From testing we've found the existing mysql instrumentation works perfectly for mysql2. This PR just replaces `mysql2` for `mysql` if its loaded.