### PR TITLE
Return Hapi server object from wrappedConnection

### DIFF
--- a/lib/instrumentation/hapi.js
+++ b/lib/instrumentation/hapi.js
@@ -286,6 +286,8 @@ module.exports = function initialize(agent, hapi) {
           'connection'
         )
       }
+
+      return plugin
     }
   }
 


### PR DESCRIPTION
This was causing an issue when creating connections with Hapi.

Code to reproduce:

```
require('newrelic');

const Hapi = require('hapi');

const server = new Hapi.Server();
const connection = server.connection();

connection.route({/*...*/}); // Throws NPE
```

I didn't write any tests due to the size of the change. If you'd still like tests let me know and I'll add one.