### PR TITLE
Add instrumentation for Q

### DIFF
--- a/lib/instrumentation/q.js
+++ b/lib/instrumentation/q.js
@@ -6,8 +6,19 @@ module.exports = initialize
 
 function initialize(agent, Q) {
   if (Q.nextTick) {
-    wrap(Q, 'Q.nextTick', 'nextTick', function wrapUninstrumented(original, method) {
+    // The wrap() call for nextTick wipes the sub-function.  Save a reference
+    // now so it can be restored later
+    var savedRunAfter = Q.nextTick.runAfter
+
+    wrap(Q, 'Q', 'nextTick', function wrapUninstrumented(original, method) {
       return agent.tracer.wrapFunctionFirstNoSegment(original, method)
     })
+
+    if (savedRunAfter) {
+      Q.nextTick.runAfter = savedRunAfter;
+      wrap(Q.nextTick, 'Q.nextTick', 'runAfter', function wrapUninstrumented(original, method) {
+        return agent.tracer.wrapFunctionFirstNoSegment(original, method)
+      })
+    }
   }
 }

--- a/lib/instrumentation/q.js
+++ b/lib/instrumentation/q.js
@@ -1,0 +1,13 @@
+'use strict'
+
+var wrap = require('../shimmer').wrapMethod
+
+module.exports = initialize
+
+function initialize(agent, Q) {
+  if (Q.nextTick) {
+    wrap(Q, 'Q.nextTick', 'nextTick', function wrapUninstrumented(original, method) {
+      return agent.tracer.wrapFunctionFirstNoSegment(original, method)
+    })
+  }
+}

--- a/lib/instrumentations.js
+++ b/lib/instrumentations.js
@@ -13,6 +13,7 @@ module.exports = function instrumentations() {
     'node-cassandra-cql',
     'cassandra-driver',
     'pg',
+    'q',
     'redis',
     'restify',
     'oracle'

--- a/test/integration/instrumentation/q.tap.js
+++ b/test/integration/instrumentation/q.tap.js
@@ -1,0 +1,79 @@
+'use strict'
+
+var test = require('tap').test
+var helper = require('../../lib/agent_helper')
+
+function QContext(test, agent) {
+    this.agent = agent;
+    this.test = test;
+}
+
+QContext.prototype.assertTransaction = function assertTransaction(transaction) {
+    this.test.equal(this.agent.getTransaction(), transaction)
+    this.test.equal(this.agent.getTransaction().trace.root.children.length, 0)
+}
+
+test('Q.ninvoke', function testQNInvoke(t) {
+  var agent = setupAgent(t)
+  var Q = require('q')
+  var qContext = new QContext(t, agent)
+
+  var firstTest = Q.defer()
+  var secondTest = Q.defer()
+    
+  helper.runInTransaction(agent, function transactionWrapper(transaction) {
+    Q.ninvoke(function anonymous() {
+      qContext.assertTransaction(transaction)
+      firstTest.resolve()
+    })
+  })
+
+  helper.runInTransaction(agent, function transactionWrapper(transaction) {
+    Q.ninvoke(function anonymous() {
+      qContext.assertTransaction(transaction)
+      secondTest.resolve()
+    })
+  })
+
+  Q.all([firstTest, secondTest])
+    .then(function done() {
+      t.end()
+    })
+})
+
+test('Q.then', function testQNInvoke(t) {
+  var agent = setupAgent(t)
+  var Q = require('q')
+  var qContext = new QContext(t, agent)
+
+  var firstTest = Q.defer()
+  var secondTest = Q.defer()
+    
+  helper.runInTransaction(agent, function transactionWrapper(transaction) {
+    Q(true).then(function anonymous() {
+      qContext.assertTransaction(transaction)
+      firstTest.resolve()
+    })
+  })
+
+  helper.runInTransaction(agent, function transactionWrapper(transaction) {
+    Q(true).then(function anonymous() {
+      qContext.assertTransaction(transaction)
+      secondTest.resolve()
+    })
+  })
+
+  Q.all([firstTest, secondTest])
+    .then(function done() {
+      t.end()
+    })
+})
+
+function setupAgent(t) {
+  var agent = helper.instrumentMockedAgent()
+  t.tearDown(function tearDown() {
+    helper.unloadAgent(agent)
+  })
+
+  return agent
+}


### PR DESCRIPTION
My project uses Q for promises and I've noticed that when Q and newrelic are used together, the recorded segments are sometimes lost or placed on the wrong transaction.  

It turns out that Q has it's own internal queue and depending on the ordering of calls to Q APIs, the transactions can get lost or the wrong one picked up.