### PR TITLE
Don't add interceptor (error middleware) to Express Route's stack

### DIFF
--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -292,9 +292,6 @@ module.exports = function initialize(agent, express) {
 
   function wrapMiddlewareStack(route, use) {
     return function cls_wrapMiddlewareStack() {
-      // Remove our custom error handler.
-      removeInterceptor(this)
-
       /* We allow `use` to go through the arguments so it can reject bad things
        * for us so we don't have to also do argument type checking.
        */
@@ -306,6 +303,9 @@ module.exports = function initialize(agent, express) {
        * added, not the Router.
        */
       if (!route) {
+        // Remove our custom error handler.
+        removeInterceptor(this)
+        
         // wrap most recently added unwrapped handler
         var i = this.stack.length
         var top
@@ -318,9 +318,8 @@ module.exports = function initialize(agent, express) {
           top.handle = wrapHandle(top.handle, path)
         }
         /*eslint-enable no-cond-assign*/
+        addInterceptor(this)
       }
-
-      addInterceptor(this)
 
       return app
     }


### PR DESCRIPTION
The current problem is that the error middleware that new relic adds to the main stack is also being added to every Router method's stack.
This means that the error middleware is actually being run twice, once from the Router method's stack and once from the general stack.
Besides this being wrong the other problem is that the cleanup function (line 398) that runs after the first error middleware finished removes the partialName thus causing the errors in new relic to appear without the specific url. it will only show '/' in the Errors view because of the cleanup.
The solution is to not add the error middleware for Router stacks. Add it only for the main stack.