### PR TITLE
Don't reset partialName to original on Express wrappedHandle

### DIFF
--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -397,7 +397,6 @@ module.exports = function initialize(agent, express) {
     handle.apply(this, args)
 
     function cleanup() {
-      transaction.partialName = original
       next.apply(this, arguments)
     }
   }


### PR DESCRIPTION
The problem:
In Errors page in new relic site, you see an empty url (for example: 'post /').
This happens because 'cleanup' function (line 400) resets the transaction partialName from the full url to the original which is always empty ('/').
The clean up function is being called in case there is an error middleware for a specific handler. so what happens is that the transaction name is being reset and then you don't see the url in the main errors page.

The solution:
remove the line because there is not need to reset the partialName and this fixes the bug.