### PR TITLE
dont assume error middleware is being passed an error

### DIFF
--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -83,7 +83,7 @@ module.exports = function initialize(agent, express) {
   var interceptor
   // This is the error handler we inject for express4. Yanked from connect support.
   function sentinel(error, req, res, next) {
-    if (error) {
+    if (error && error instanceof Error) {
       var transaction = agent.tracer.getTransaction()
       agent.errors.add(transaction, error)
     }


### PR DESCRIPTION
We use "error-handling" middlewares to do more than just error handling.

Our app uses 2 error handling middlewares - one to handle errors, and another to just handle versioning and response formatting for normal requests.

For example. We just call `next` with a model (or an array of models, or some json including models) and our middleware looks at the requested version and converts the model to a specific formatted output for that model at that specific version.

Anyway, you just need to check if the first arg being passed to the middleware is actually an error!