### PR TITLE
Fix for incomplete transaction names on new-relic dashboard

### DIFF
--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -446,11 +446,8 @@ module.exports = function initialize(agent, express) {
             arguments[2] = cleanup
           }
 
-          var original
           if (this.handle.__NR_path || this.route) {
             var path = this.handle.__NR_path
-
-            original = transaction.partialName
 
             // If route is defined on the Layer, then it is the middleware
             // responsible for routing, and we call nameFromRoute as it worked before.
@@ -495,10 +492,6 @@ module.exports = function initialize(agent, express) {
               transactionInfo.error = err
               return next.apply(this, arguments)
             }
-
-            // if (!transactionInfo.responded && original) {
-            //   transaction.partialName = original
-            // }
 
             next.apply(this, arguments)
           }

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -456,17 +456,21 @@ module.exports = function initialize(agent, express) {
             // responsible for routing, and we call nameFromRoute as it worked before.
             // Otherwise if path is defined, then it is a Router or subApp middleware,
             // which originally went through wrappedHandle().
-            if (this.route) {
+            if (this.route && (!transaction.partialName || 
+              transaction.partialName.indexOf(this.route.path) == -1)) {
               nameFromRoute(tracer.getSegment(), this.route, this.params, true)
             } else {
-              ensurePartialName(transaction)
+              if(!transaction.partialName || 
+                  transaction.partialName.indexOf(path) == -1){
+                ensurePartialName(transaction)
 
-              if (path && path !== '/') {
-                transaction.partialName += path[0] === '/' ? path.slice(1) : path
-              }
+                if (path && path !== '/') {
+                  transaction.partialName += path[0] === '/' ? path.slice(1) : path
+                }
 
-              if (transaction.partialName[transaction.partialName.length - 1] !== '/') {
-                transaction.partialName += '/'
+                if (transaction.partialName[transaction.partialName.length - 1] !== '/') {
+                  transaction.partialName += '/'
+                }
               }
             }
           }
@@ -492,9 +496,9 @@ module.exports = function initialize(agent, express) {
               return next.apply(this, arguments)
             }
 
-            if (!transactionInfo.responded && original) {
-              transaction.partialName = original
-            }
+            // if (!transactionInfo.responded && original) {
+            //   transaction.partialName = original
+            // }
 
             next.apply(this, arguments)
           }

--- a/test/versioned/express4-ejs/express4-transaction-naming.tap.js
+++ b/test/versioned/express4-ejs/express4-transaction-naming.tap.js
@@ -231,6 +231,25 @@ function runTests(flags) {
     runTest(t, '/router1/router2/path1', '/:router1/:router2/path1')
   })
 
+  test('using two routers and final callback handler for success', function(t){
+        setup(t)
+
+    var router1 = express.Router()
+    var router2 = express.Router()
+
+    app.use('/:router1', router1)
+    router1.use('/:router2', router2)
+
+    router2.get('/path1', function(req, res, next) {
+      next();
+    })
+
+    app.use(function(req, res, next){
+      res.end();
+    })
+    runTest(t, '/router1/router2/path1', '/:router1/:router2/path1')
+  })
+
   function setup(t) {
     agent = helper.instrumentMockedAgent(flags)
     express = require('express')


### PR DESCRIPTION
- Avoid polluting the partial name, which eventaully is the transaction name
- Hence do not worry it at cleanup