### PR TITLE
Fix TypeError during instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log
 ca-index*
 ca-serial*
 .DS_Store
+.idea

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -315,6 +315,10 @@ module.exports = function initialize(agent, express) {
         return function wrappedLayerHandleRequest(req, res, next) {
           var segment
           var parent = tracer.getSegment()
+          if (!parent) {
+            return handleRequest.apply(this, arguments)
+          }
+
           var transaction = parent.transaction
           var transactionInfo = getTransactionInfo(transaction)
 


### PR DESCRIPTION
We've been receiving errors like the following, which are crashing our processes:

```
TypeError: Cannot read property 'transaction' of null
    at Layer.wrappedLayerHandleRequest [as handle_request] (/src/node_modules/newrelic/lib/instrumentation/express.js:305:35)
    at /src/node_modules/express/lib/router/index.js:277:22
    ...
```

It appears that, for whatever reason, `tracer.getSegment()` is returning null, and execution of the following line of code when this happens causes an unhandled error. This adds a simple null/undefined check to avoid that and continue with the request the same way as with an inactive transaction.