### PR TITLE
add .npmignore to ignore examples and test folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+test
+examples


### PR DESCRIPTION
examples and tests are not useful in a npm package

ref https://docs.npmjs.com/files/package.json

To simplify the files array and make it more resilient to change, we could also move all source files into lib and use the main field of the package.json

Also, NEWS.md should probably be renamed CHANGELOG.md to even more strip down the files config.
