### PR TITLE
`next` is null prop `__NR_segment` doesn't exist

### DIFF
--- a/lib/instrumentation/promise.js
+++ b/lib/instrumentation/promise.js
@@ -261,6 +261,8 @@ module.exports = function initialize(agent, library, spec) {
   function linkTransaction(ctx, fn, next, args) {
     // next needs to have a wrapper function even if the callback throws.
     try {
+      if (!next) throw new Error('Next is null :(')
+      
       if (!next.__NR_segment) {
         var segmentName = 'Promise#then ' + (fn.name || '<anonymous>')
         next.__NR_segment = _createSegment(segmentName)


### PR DESCRIPTION
I've upgraded newrelic to `1.27.x` and starting up the application now throws a TypeError since it's trying to access property `__NR_segment` of null. It seems to be this [commit](https://github.com/newrelic/node-newrelic/commit/ce90a33ef30a9a30d536ef8d0c9afb826def60b4).

`newrelic@1.26.x` works fine.