### PR TITLE
Fix New Relic instrumentation of Hapi 7.2 - 7.5.3

### DIFF
--- a/lib/instrumentation/hapi.js
+++ b/lib/instrumentation/hapi.js
@@ -236,20 +236,6 @@ module.exports = function initialize(agent, hapi) {
     }
   }
 
-  function wrapCreateServer(createServer) {
-    return function createServerWrapper() {
-      var server = createServer.apply(this, arguments)
-      shimServerPrototype(
-        server.constructor.prototype,
-        'hapi.Server.constructor.prototype'
-      )
-      // Now that we have instrumented the server prototype, un-instrument
-      // createServer as it serves no purpose.
-      shimmer.unwrapMethod(hapi, 'hapi', 'createServer')
-      return server
-    }
-  }
-
   function shimServerPrototype(proto, name) {
     shimmer.wrapMethod(proto, name, 'start', wrapStart)
     shimmer.wrapMethod(proto, name, 'views', wrapViews)
@@ -291,6 +277,53 @@ module.exports = function initialize(agent, hapi) {
     }
   }
 
+  function wrapPackConnection(connection) {
+    return function wrappedConnection() {
+      setDispatcher(agent)
+      // `this` will reference an instance of `hapi.Pack`
+      var plugin = connection.apply(this, arguments)
+
+      // Defensive against the possiblity that there isn't a connection for some
+      // reason.
+      if (this && this.connections && this.connections.length > 0) {
+        shimmer.wrapMethod(
+          this.connections[0].constructor.prototype,
+          'this.connections[0].constructor.prototype',
+          '_route',
+          wrapRoute
+        )
+
+        shimmer.wrapMethod(
+          this.connections[0].constructor.prototype,
+          'this.connections[0].constructor.prototype',
+          'start',
+          wrapStart
+        )
+
+        shimmer.wrapMethod(
+          this.connections[0].constructor.prototype,
+          'this.connections[0].constructor.prototype',
+          'views',
+          wrapViews
+        )
+
+        // Unwrap connection & server now that we've managed to patch the prototype
+        shimmer.unwrapMethod(
+          hapi.Pack.prototype,
+          'hapi.Pack.prototype',
+          'connection'
+        )
+        shimmer.unwrapMethod(
+          hapi.Pack.prototype,
+          'hapi.Pack.prototype',
+          'server'
+        )
+      }
+
+      return plugin;
+    }
+  }
+
   function wrapInterface(replier) {
     return function wrappedInterface() {
       var reply = replier.apply(this, arguments)
@@ -312,15 +345,17 @@ module.exports = function initialize(agent, hapi) {
     }
   }
 
-  var proto = hapi && hapi.Server && hapi.Server.prototype
-  if (proto && proto.start && proto.views && proto._route) { // Hapi 1 - 7.1.1
-    shimServerPrototype(proto, 'hapi.Server.prototype')
-  } else if (proto && Object.keys(proto).length === 0) { // Hapi 7.2 - 7.5.2
+  var serverProto = hapi && hapi.Server && hapi.Server.prototype
+  var packProto = hapi && hapi.Pack && hapi.Pack.prototype
+
+  if (serverProto && serverProto.start && serverProto.views && serverProto._route) { // Hapi 1 - 7.1.1
+    shimServerPrototype(serverProto, 'hapi.Server.prototype')
+  } else if (serverProto && Object.keys(serverProto).length === 0 && packProto && packProto.connection && packProto.server) { // Hapi 7.2 - 7.5.2
     // This gets removed on first invocation as it is just used to patch a
     // deeper prototype.
-    shimmer.wrapMethod(hapi, 'hapi', 'createServer', wrapCreateServer)
-  } else if (proto && proto.start && proto.route && proto.connection) { // Hapi 8+
-    shimmer.wrapMethod(proto, 'hapi.Server.prototype', 'connection', wrapConnection)
+    shimmer.wrapMethod(packProto, 'hapi.Pack.prototype', ['connection', 'server'], wrapPackConnection)
+  } else if (serverProto && serverProto.start && serverProto.route && serverProto.connection) { // Hapi 8+
+    shimmer.wrapMethod(serverProto, 'hapi.Server.prototype', 'connection', wrapConnection)
   } else { // Some unknown future or hacked up version
     logger.warn('hapi Server constructor not found; can\'t instrument')
   }


### PR DESCRIPTION
## Overview

The way New Relic was patching the `hapi` module meant that instrumentation would be incomplete if you did not start your server using the primary creation method, `Hapi.createServer`, in Hapi versions 7.2 - 7.5.2. This aims to enable instrumentation on all Hapi versions in this range regardless of how you choose to start the Hapi server (as long as you are still using a "public" method).
## Problem

We build our Hapi servers with [rejoice](https://github.com/hapijs/rejoice/tree/v1.0.0) & a static configuration file. Internally rejoice uses the [compose](http://hapijs.com/api/7.5.2#packcomposemanifest-options-callback) interface (a proxy for [glue](https://github.com/hapijs/glue/tree/v1.0.0)), which will start the server using [pack.server](https://github.com/hapijs/glue/blob/v1.0.0/lib/index.js#L129).

Currently the New Relic module instruments Hapi versions 7.2 - 7.5.2 by [patching the `Hapi.createServer` method](https://github.com/newrelic/node-newrelic/blob/master/lib/instrumentation/hapi.js#L321). Since this method is not called when using the compose interface New Relic instrumentation is incomplete. Our application would still report to New Relic with memory usage and high level request information (number, time, etc), but all requests appear as `/*` or, for example, `/*.txt`, with no route level granularity. Setting logging to `trace` it was clear the new relic code for wrapping hapi routes was not even being called.
## Solution

The `Hapi.createServer` method is really only a [thin wrapper](https://github.com/hapijs/hapi/blob/v7.5.2/lib/index.js#L39) around the `Hapi.Pack.prototype.connection`, which is [an alias](https://github.com/hapijs/hapi/blob/v7.5.2/lib/pack.js#L118) of `Hapi.Pack.prototype.server`. This means we can patch these 2 methods to gain access to the `Connection` prototype through the [array of created connections](https://github.com/hapijs/hapi/blob/v7.5.2/lib/pack.js#L126), [similar to the way New Relic does for Hapi >= 8](https://github.com/newrelic/node-newrelic/blob/master/lib/instrumentation/hapi.js#L267), but wrapping different properties ([1](https://github.com/hapijs/hapi/blob/v7.5.2/lib/connection.js#L129) [2](https://github.com/hapijs/hapi/blob/v7.5.2/lib/connection.js#L281) [3](https://github.com/hapijs/hapi/blob/v7.5.2/lib/connection.js#L312) - the same properties we wrap in Hapi < 7.2).

After changing the hapi instrumentation to pack the connection prototype route level information began appearing in our New Relic transactions as expected.
## Discussion

I have not yet had time to add new tests for this fix or to setup my local machine to run the full integration test suite - however all unit tests passed on my local machine as did the Hapi integration tests.
