### PR TITLE
Add comment explaining what _fatalException is for

### DIFF
--- a/lib/instrumentation/core/globals.js
+++ b/lib/instrumentation/core/globals.js
@@ -9,6 +9,8 @@ module.exports = initialize
 function initialize(agent) {
   // Add handler for uncaught/fatal exceptions to record them.
   var tracer = agent.tracer
+  // _fatalException is an undocumented feature of domains, introduced in Node.js v0.8
+  // We use _fatalException when possible because wrapping it will not potentially change the behavior of the server. 
   if (process._fatalException) {
     wrap(process, 'process', '_fatalException', function wrapper(original) {
       return function wrappedFatalException(error) {


### PR DESCRIPTION
  * Clarify in what cases it's used (since Node.js 0.8.x) and why it's preferred over the 'unCaughtException' event.