### PR TITLE
support sql-template-strings generated params

### DIFF
--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -13,7 +13,7 @@ function initializeSegment(tracer, segment, config) {
   var statement
   if (config && (typeof config === 'string' || config instanceof String)) {
     statement = config
-  } else if (config && config.hasOwnProperty('text')) {
+  } else if (config && config.text) {
     statement = config.text
   } else {
     // Won't be matched by parser, but should be handled properly


### PR DESCRIPTION
I'm using `sql-template-strings` to build parameterized query.
the object doesn't have text property but object.text returns sql statement. I guess it implemented it though a getter function.