### PR TITLE
WIP: Couchbase bucket operation instrumentation

### DIFF
--- a/lib/instrumentation/couchbase.js
+++ b/lib/instrumentation/couchbase.js
@@ -1,0 +1,85 @@
+'use strict'
+var shimmer = require('../shimmer')
+var ParsedStatement = require('../db/parsed-statement')
+var COUCHBASE = require('../metrics/names').COUCHBASE
+
+var BUCKET_OPERATIONS = [
+  'get',
+  'query',
+  'getMulti',
+  'getAndTouch',
+  'getAndLock',
+  'getReplica',
+  'touch',
+  'unlock',
+  'remove',
+  'upsert',
+  'insert',
+  'replace',
+  'append',
+  'prepend',
+  'counter'
+]
+
+module.exports = function initialize(agent, couchbase) {
+  var tracer = agent.tracer
+  var bucketInstrumented = false
+
+  if (couchbase.Cluster && couchbase.Cluster.name === 'MockCluster') {
+    return
+  }
+
+  // Couchbase don't export Bucket, can only instrument this once a 
+  // a call to Cluster.openBucket is called for the first time.
+  shimmer.wrapMethod(
+    couchbase && couchbase.Cluster && couchbase.Cluster.prototype,
+    'couchbase.Cluster.prototype',
+    'openBucket',
+    function wrapOpenBucket(original) {
+      return function wrappedOpenBucket() {
+        var bucket = original.apply(this, arguments)
+        instrumentBucket(bucket)
+        return bucket
+      }
+    }
+  )
+
+  function instrumentBucket(bucket) {
+    if (bucketInstrumented) {
+      return
+    }
+    bucketInstrumented = true
+    
+    var bucketProto = Object.getPrototypeOf(bucket)
+    BUCKET_OPERATIONS.forEach(function forEachOperations(operationName) {
+      shimmer.wrapMethod(
+        bucketProto,
+        'couchbase.Bucket.prototype',
+        operationName,
+        function wrapBucketOperation(original) {
+          return tracer.wrapFunction(
+            COUCHBASE.OPERATION + 'Unknown/' + operationName,
+            null,
+            original,
+            bucketOperationWrapper(operationName)
+          )
+        }
+      )
+    }, this)
+  }
+
+  function bucketOperationWrapper(operationName) {
+    return function operationWrap(segment, args, bind) {
+      var bucketName = this._name
+      var statement = new ParsedStatement(COUCHBASE.PREFIX, operationName, bucketName)
+      
+      segment.name = COUCHBASE.STATEMENT + bucketName + '/' + operationName
+      segment.transaction.addRecorder(statement.recordMetrics.bind(statement, segment))
+
+      var callback = args[args.length - 1]
+      args[args.length - 1] = bind(callback)
+      
+      return args
+    }
+  }
+}

--- a/lib/instrumentations.js
+++ b/lib/instrumentations.js
@@ -19,6 +19,7 @@ module.exports = function instrumentations() {
     'redis',
     'ioredis',
     'restify',
-    'oracle'
+    'oracle',
+    'couchbase'
   ]
 }

--- a/lib/metrics/names.js
+++ b/lib/metrics/names.js
@@ -164,6 +164,14 @@ var TRUNCATED = {
   PREFIX: 'Truncated/'
 }
 
+var COUCHBASE = {
+  PREFIX: 'Couchbase',
+  OPERATION: DB.OPERATION + '/Couchbase/',
+  STATEMENT: DB.STATEMENT + '/Couchbase/',
+  INSTANCE: DB.INSTANCE + '/Couchbase/',
+  ALL: DB.PREFIX + 'Couchbase/' + ALL
+}
+
 module.exports = {
   ACTION_DELIMITER: '/',
   ALL: ALL,
@@ -200,5 +208,6 @@ module.exports = {
   URI: 'Uri',
   UTILIZATION: UTILIZATION,
   VIEW: VIEW,
-  WEB: WEB
+  WEB: WEB,
+  COUCHBASE: COUCHBASE
 }


### PR DESCRIPTION
Instrumenting couchbase (couchnode). WIP as i have not yet finished the tests, wanted to get early feedback.

couchbase module doesn't export the `Bucket` object, so having to wrap `cluster.openBucket` which returns a Bucket and from that i get the prototype and wrap. This is only done once. 

I opted to wrap the individual methods of Bucket object and not the private `Bucket._invoke` method as i think it gives a more granular metrics. However i'm happy to update if you deem it better to wrap fewer methods.
