### PR TITLE
Stub for "shutdown" API method

### DIFF
--- a/stub_api.js
+++ b/stub_api.js
@@ -30,6 +30,7 @@ Stub.prototype.createTracer = createTracer
 Stub.prototype.createWebTransaction = createWebTransaction
 Stub.prototype.createBackgroundTransaction = createBackgroundTransaction
 Stub.prototype.getBrowserTimingHeader = getBrowserTimingHeader
+Stub.prototype.shutdown = shutdown
 
 // This code gets injected into HTML templates
 // and we don't want it to return undefined/null.
@@ -53,6 +54,12 @@ function createWebTransaction(url, callback) {
 function createBackgroundTransaction(name, group, callback) {
   logger.debug('Not calling createBackgroundTransaction because New Relic is disabled.')
   return (callback === undefined) ? group : callback
+}
+
+// Normally the following call executes callback asynchronously
+function shutdown(options, callback) {
+  logger.debug('Not calling shutdown because New Relic is disabled.')
+  process.nextTick(callback);
 }
 
 module.exports = Stub

--- a/stub_api.js
+++ b/stub_api.js
@@ -57,8 +57,18 @@ function createBackgroundTransaction(name, group, callback) {
 }
 
 // Normally the following call executes callback asynchronously
-function shutdown(options, callback) {
+function shutdown(options, cb) {
   logger.debug('Not calling shutdown because New Relic is disabled.')
+  
+  var callback = cb
+  if (!callback) {
+    if (typeof options === 'function') {
+      callback = options
+    } else {
+      callback = new Function()
+    }
+  }
+  
   process.nextTick(callback);
 }
 


### PR DESCRIPTION
This PR fixes work of [`shutdown()`](https://docs.newrelic.com/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#other-api) API method with disabled NewRelic module via `newrelic.js`.

Right now callback that was passed to `shutdown()` won't be called.