### PR TITLE
Exclude node_modules from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 test
 examples
+node_modules


### PR DESCRIPTION
newrelic@1.30.2 caused me a problem.

I found 1.30.2 does not include ```/node_modules/readable-stream/node_modules/core-util-is``` while 1.30.1 includes it.

I think 1.30.2 made with npm@3 that installs packages flat. But I'm using npm@2, so it fails to find core-util-is.

npm package should not include node_modules.