### PR TITLE
Fix Cannot read property transaction of null

### DIFF
--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -216,7 +216,12 @@ module.exports = function initialize(agent, express) {
 
       function wrapLayerHandleError(handleError) {
         return function wrappedLayerHandleError(error, req, res, next) {
-          var parent = tracer.segment
+          var parent = tracer.segment;
+
+          if (!parent) {
+            return handleError.apply(this, arguments);
+          }
+
           var transaction = parent.transaction
 
           if (!transaction.isActive()) {


### PR DESCRIPTION
When you want to log data after rendering the view to the user, in multiple cases it is logging the error: "Cannot read property transaction of null".

With this fix we check if there is any tracer segment before the transaction, if not we do the same as the transaction is not active.