### PR TITLE
Stop pools double counting mysql calls

### DIFF
--- a/lib/instrumentation/mysql.js
+++ b/lib/instrumentation/mysql.js
@@ -252,9 +252,6 @@ module.exports = function initialize(agent, mysql) {
           return getConnectionHandler(pool, getConnection)
         })
 
-        // patch the pools .query method
-        wrapQueriable(pool, 'pool')
-
         return pool
       }
     })


### PR DESCRIPTION
I noticed that all my database calls were being reported twice, and it had something to do with using a pooled connection. 

I worked out it was due to the pool's query method being wrapped, as well as each of the pooled connection's query method being wrapped too.

Before:
![screenshot from 2016-11-08 08-19-51](https://cloud.githubusercontent.com/assets/551150/20092475/4e4bf9e4-a590-11e6-8e4f-a768416e5d69.png)

After:
![screenshot from 2016-11-08 08-49-10](https://cloud.githubusercontent.com/assets/551150/20092476/50cb01b0-a590-11e6-8aad-199b867673d8.png)
