### PR TITLE
Keep correct transaction when calling Bluebird promise.nodeify nodeback

### DIFF
--- a/lib/instrumentation/bluebird.js
+++ b/lib/instrumentation/bluebird.js
@@ -6,7 +6,7 @@ var BLUEBIRD_SPEC = {
   name: 'bluebird',
   constructor: 'Promise',
   $proto: {
-    then: ['then', 'done', 'spread', 'all', 'asCallback', 'finally', 'lastly'],
+    then: ['then', 'done', 'spread', 'all', 'asCallback', 'nodeify', 'finally', 'lastly'],
     catch: ['catch', 'caught', 'error'],
 
     // _resolveFromResolver is in bluebird 2.x


### PR DESCRIPTION
When using Bluebird's `promise.nodeify` the current transaction is lost. The same support for `asCallback` should also be provied to `nodeify` since they are aliases of each other.