### PR TITLE
Include `find` in instrumented MongoDB operations

### DIFF
--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -48,6 +48,7 @@ var COLLECTION_OPS = [
   'dropAllIndexes',
   'dropIndex',
   'ensureIndex',
+  'find',
   'findAndModify',
   'findAndRemove',
   'findOne',


### PR DESCRIPTION
I noticed that `find` operations were not showing up in transaction traces and performance breakdowns. Looking at mongodb.js revealed that it was missing. Adding `find` here caused find to show up in the transactions in New Relic. Am I missing something? It seems odd that such a ubiquitous operation as "find" would have been omitted. Perhaps we are doing something else wrong/unusual in our app or how we are integrating with New Relic or MongoDB? Note that we are using Mongoose v4.3.7 at the moment.
![image](https://cloud.githubusercontent.com/assets/565213/21032246/39a8fffc-bd76-11e6-80c8-7f57a17fe83a.png)
