### PR TITLE
Fix incorrect github handle in NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@
 
 * The agent will no longer lose transaction state across Bluebird's `promise.nodify`.
 
-  Thanks to Matt Lavin (@mlavin) for this contribution!
+  Thanks to Matt Lavin (@mdlavin) for this contribution!
 
 ### v1.34.0 (2016-11-10):
 


### PR DESCRIPTION
I noticed that my github handle was incorrect in the NEWS.md entry associated with a PR of mine.  The incorrect one actually gives credit to my brother!  