### PR TITLE
Have default export as a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,111 +3,113 @@
 var logger = require('./lib/logger.js')
 var semver = require('semver')
 
-var message
-var agent
+module.exports = function init(_config) {
+  var message
+  var agent
 
-var agentVersion = require('./package.json').version
-logger.info(
-  "Using New Relic for Node.js. Agent version: %s; Node version: %s.",
-  agentVersion, process.version
-)
-
-if (require.cache.__NR_cache) {
-  logger.warn(
-    'Attempting to load a second copy of newrelic from %s, using cache instead',
-    __dirname
-  )
-  module.exports = require.cache.__NR_cache
-} else {
-  initialize()
-}
-
-function initialize() {
-  logger.debug(
-    'Loading agent from %s',
-    __dirname
+  var agentVersion = require('./package.json').version
+  logger.info(
+    "Using New Relic for Node.js. Agent version: %s; Node version: %s.",
+    agentVersion, process.version
   )
 
-  try {
-    logger.debug("Process was running %s seconds before agent was loaded.",
-                 process.uptime())
-    // Technically we run on 0.6, until we verify there are 0 users on 0.6, we
-    // should leave this code doing a check against 0.6, but then advise that
-    // people upgrade to one of our officially supported version (0.8 and higher)
-    if (semver.satisfies(process.version, '<0.6.0')) {
-      message = "New Relic for Node.js requires a version of Node equal to or\n" +
-                "greater than 0.8.0. Not starting!"
+  if (require.cache.__NR_cache) {
+    logger.warn(
+      'Attempting to load a second copy of newrelic from %s, using cache instead',
+      __dirname
+    )
+    module.exports = require.cache.__NR_cache
+  } else {
+    initialize(_config)
+  }
 
-      logger.error(message)
-      throw new Error(message)
-    }
+  function initialize(appConfig) {
+    logger.debug(
+      'Loading agent from %s',
+      __dirname
+    )
 
-    logger.debug("Current working directory at module load is %s.", process.cwd())
-    logger.debug("Process title is %s.", process.title)
-    logger.debug("Application was invoked as %s.", process.argv.join(' '))
+    try {
+      logger.debug("Process was running %s seconds before agent was loaded.",
+                   process.uptime())
+      // Technically we run on 0.6, until we verify there are 0 users on 0.6, we
+      // should leave this code doing a check against 0.6, but then advise that
+      // people upgrade to one of our officially supported version (0.8 and higher)
+      if (semver.satisfies(process.version, '<0.6.0')) {
+        message = "New Relic for Node.js requires a version of Node equal to or\n" +
+                  "greater than 0.8.0. Not starting!"
 
-    /* Loading the configuration can throw if a configuration file isn't found and
-     * the environment variable NEW_RELIC_NO_CONFIG_FILE isn't set.
-     */
-    var config = require('./lib/config.js').initialize()
-    if (!config.agent_enabled) {
-      logger.info("Module not enabled in configuration; not starting.")
-    } else {
-      /* Only load the rest of the module if configuration is available and the
-       * configurator didn't throw.
-       *
-       * The agent must be a singleton, or else module loading will be patched
-       * multiple times, with undefined results. New Relic's instrumentation
-       * can't be enabled or disabled without an application restart.
-       */
-      var Agent = require('./lib/agent.js')
-      agent = new Agent(config)
-      var appNames = agent.config.applications()
-
-      if (config.logging.diagnostics) {
-        logger.warn(
-          'Diagnostics logging is enabled, this may cause significant overhead.'
-        )
-      }
-
-      if (appNames.length < 1) {
-        message = "New Relic requires that you name this application!\n" +
-                  "Set app_name in your newrelic.js file or set environment variable\n" +
-                  "NEW_RELIC_APP_NAME. Not starting!"
         logger.error(message)
         throw new Error(message)
       }
 
-      var shimmer = require('./lib/shimmer.js')
-      shimmer.patchModule(agent)
-      shimmer.bootstrapInstrumentation(agent)
+      logger.debug("Current working directory at module load is %s.", process.cwd())
+      logger.debug("Process title is %s.", process.title)
+      logger.debug("Application was invoked as %s.", process.argv.join(' '))
 
-      agent.start(function cb_start(error) {
-        if (!error) {
-          return logger.debug("New Relic for Node.js is connected to New Relic.")
+      /* Loading the configuration can throw if a configuration file isn't found and
+       * the environment variable NEW_RELIC_NO_CONFIG_FILE isn't set.
+       */
+      var config = require('./lib/config.js').initialize(appConfig)
+      if (!config.agent_enabled) {
+        logger.info("Module not enabled in configuration; not starting.")
+      } else {
+        /* Only load the rest of the module if configuration is available and the
+         * configurator didn't throw.
+         *
+         * The agent must be a singleton, or else module loading will be patched
+         * multiple times, with undefined results. New Relic's instrumentation
+         * can't be enabled or disabled without an application restart.
+         */
+        var Agent = require('./lib/agent.js')
+        agent = new Agent(config)
+        var appNames = agent.config.applications()
+
+        if (config.logging.diagnostics) {
+          logger.warn(
+            'Diagnostics logging is enabled, this may cause significant overhead.'
+          )
         }
 
-        var errorMessage = "New Relic for Node.js halted startup due to an error:"
-        logger.error(error, errorMessage)
+        if (appNames.length < 1) {
+          message = "New Relic requires that you name this application!\n" +
+                    "Set app_name in your newrelic.js file or set environment variable\n" +
+                    "NEW_RELIC_APP_NAME. Not starting!"
+          logger.error(message)
+          throw new Error(message)
+        }
 
-        console.error(errorMessage)
-        console.error(error.stack)
-      })
+        var shimmer = require('./lib/shimmer.js')
+        shimmer.patchModule(agent)
+        shimmer.bootstrapInstrumentation(agent)
+
+        agent.start(function cb_start(error) {
+          if (!error) {
+            return logger.debug("New Relic for Node.js is connected to New Relic.")
+          }
+
+          var errorMessage = "New Relic for Node.js halted startup due to an error:"
+          logger.error(error, errorMessage)
+
+          console.error(errorMessage)
+          console.error(error.stack)
+        })
+      }
+    } catch (error) {
+      message = "New Relic for Node.js was unable to bootstrap itself due to an error:"
+      logger.error(error, message)
+
+      console.error(message)
+      console.error(error.stack)
     }
-  } catch (error) {
-    message = "New Relic for Node.js was unable to bootstrap itself due to an error:"
-    logger.error(error, message)
 
-    console.error(message)
-    console.error(error.stack)
+    var API
+    if (agent) {
+      API = require('./api.js')
+    } else {
+      API = require('./stub_api.js')
+    }
+
+    require.cache.__NR_cache = module.exports = new API(agent)
   }
-
-  var API
-  if (agent) {
-    API = require('./api.js')
-  } else {
-    API = require('./stub_api.js')
-  }
-
-  require.cache.__NR_cache = module.exports = new API(agent)
 }

--- a/test/integration/agent/multiple.tap.js
+++ b/test/integration/agent/multiple.tap.js
@@ -5,7 +5,7 @@ var test = require('tap').test
 test('Multiple require("newrelic")', function(t) {
   process.env.NEW_RELIC_ENABLED = false
 
-  var path = require.resolve('../../../index.js')()
+  var path = require.resolve('../../../index.js')
   var first = require(path)
 
   delete require.cache[path]

--- a/test/integration/agent/multiple.tap.js
+++ b/test/integration/agent/multiple.tap.js
@@ -5,7 +5,7 @@ var test = require('tap').test
 test('Multiple require("newrelic")', function(t) {
   process.env.NEW_RELIC_ENABLED = false
 
-  var path = require.resolve('../../../index.js')
+  var path = require.resolve('../../../index.js')()
   var first = require(path)
 
   delete require.cache[path]

--- a/test/integration/index-disabled.tap.js
+++ b/test/integration/index-disabled.tap.js
@@ -8,7 +8,7 @@ test("loading the application via index.js with agent disabled", function (t) {
   t.plan(2)
 
   process.env.NEW_RELIC_ENABLED = 'false'
-  var api = require('../../index.js')
+  var api = require('../../index.js')()
 
   t.ok(api, "have an API")
   t.notOk(api.agent, "no associated agent")

--- a/test/integration/index.tap.js
+++ b/test/integration/index.tap.js
@@ -12,7 +12,7 @@ test('loading the application via index.js', {timeout: 5000}, function(t) {
   process.env.NEW_RELIC_LICENSE_KEY = 'd67afc830dab717fd163bfcb0b8b88423e9a1a3b'
 
   t.doesNotThrow(function cb_doesNotThrow() {
-    var api = require('../../index.js')
+    var api = require('../../index.js')()
     agent = api.agent
     t.equal(agent._state, 'starting', "agent is booting")
   }, "just loading the agent doesn't throw")
@@ -33,7 +33,7 @@ test('loading the application via index.js', {timeout: 5000}, function(t) {
       }
     }
 
-    var api = require('../../index.js')
+    var api = require('../../index.js')()
     agent = api.agent
     t.ok(agent)
 

--- a/test/smoke/express-server.js
+++ b/test/smoke/express-server.js
@@ -1,4 +1,4 @@
-require('../../index.js') // same as require('newrelic')
+require('../../index.js')() // same as require('newrelic')
 var express = require('express')
 
 var app = express()


### PR DESCRIPTION
I was looking at the code and found it odd that the `Config.initialize()` does take a config parameter but it's not used in `./index.js`. 

Therefor I'd like propose this change. I do realise that this is a breaking change for the package. Now instead of doing `require('newrelic)`, it would need to be `require('newrelic')()`.

This additionally allows for use of sending a config into the constructor of the package instead of having to rely on a file in the root of the project so projects could do something like `require('newrelic')(config)` which could then be located else where than in the root. I generally don't like having files located in the root due to the folder structure in projects I work on. I don't like having hard dependencies on where files are located as configurations to packages

If there's a specific reason for the other API feel free to close this. Since the config initialiser accepts the argument already this makes I think this could make sense.