### PR TITLE
add option to wrap Promises to recorderSpec

### DIFF
--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -228,6 +228,9 @@ DatastoreShim.prototype.captureInstanceAttributes = captureInstanceAttributes
  * @property {bool} [stream=false]
  *  If `true`, the return value will be wrapped as a stream.
  *
+ * @property {bool} [promise=false]
+ *  If `true`, the return value will be wrapped as a Promise.
+ *
  * @property {number|string|QueryFunction} query
  *  If a number, it is the offset in the arguments array for the query string
  *  argument. If a string, it is the query being executed. If a function, it
@@ -750,6 +753,7 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
         callback:     'callback'    in queryDesc ? queryDesc.callback : null,
         rowCallback:  'rowCallback' in queryDesc ? queryDesc.rowCallback : null,
         stream:       'stream'      in queryDesc ? queryDesc.stream : null,
+        promise:       'promise'      in queryDesc ? queryDesc.promise : null,
         internal:     'internal'    in queryDesc ? queryDesc.internal : false
       }
     }
@@ -772,6 +776,7 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
       callback:     'callback'    in queryDesc ? queryDesc.callback : null,
       rowCallback:  'rowCallback' in queryDesc ? queryDesc.rowCallback : null,
       stream:       'stream'      in queryDesc ? queryDesc.stream : null,
+      promise:       'promise'      in queryDesc ? queryDesc.promise : null,
       internal:     'internal'    in queryDesc ? queryDesc.internal : true,
       recorder: function queryRecorder(segment, scope) {
         if (segment) {

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -455,6 +455,11 @@ Shim.prototype.__NR_unwrap = unwrapAll
  *  stream. If the value is a string it is assumed to be the name of an event to
  *  measure. A segment will be created to record emissions of the event.
  *
+ * @property {bool} [promise]
+ *  Indicates if the return value from the wrapped function is a Promise. If the
+ *  value is truthy then the recording will extend to the completion of the
+ *  Promise. A segment will be created to record completion of the Promise.
+ *
  * @property {number|CallbackBindFunction} [callback]
  *  If this is a number, it identifies which argument is the callback and the
  *  segment will also be bound to the callback. Otherwise, the passed function
@@ -886,12 +891,17 @@ function record(nodule, properties, recordNamer) {
 
       // Apply the function, and (if it returned a stream) bind that too.
       var ret = shim.applySegment(fn, segment, true, this, args)
-      if (segment && segDesc.stream && ret) {
-        shim.logger.trace('Binding return value as stream.')
-        _bindStream(shim, ret, segment, {
-          event: shim.isString(segDesc.stream) ? segDesc.stream : null,
-          shouldCreateSegment: shouldCreateSegment
-        })
+      if (segment && ret) {
+        if (segDesc.stream ) {
+          shim.logger.trace('Binding return value as stream.')
+          _bindStream(shim, ret, segment, {
+            event: shim.isString(segDesc.stream) ? segDesc.stream : null,
+            shouldCreateSegment: shouldCreateSegment
+          })
+        } else if (segDesc.promise) {
+          shim.logger.trace('Binding return value as Promise.')
+          _bindPromise(shim, ret, segment)
+        }
       }
       return ret
     }
@@ -1899,4 +1909,25 @@ function _bindStream(shim, stream, segment, spec) {
       })
     }
   }
+}
+
+/**
+ * Binds the given segment to the completion of the Promise.
+ *
+ * @private
+ *
+ * @param {Shim} shim
+ *  The shim performing the wrapping/binding.
+ *
+ * @param {Promise} promise
+ *  The Promise to bind.
+ *
+ * @param {?TraceSegment} segment
+ *  The segment to bind to the Promise.
+ */
+function _bindPromise(shim, promise, segment) {
+  shim.bindSegment(promise, 'then', segment)
+  shim.bindSegment(promise, 'catch', segment)
+  promise.then(function () { segment && segment.touch() })
+  promise.catch(function () { segment && segment.touch() })
 }


### PR DESCRIPTION
Is this something you would consider adding?

I was trying to use DatastoreShim to create an isntrumentation for [neo4j/neo4j-javascript-driver](https://github.com/neo4j/neo4j-javascript-driver) which returns a Promise when you want to run a query. Seems to me like an easy way to handle this with the shim api would be very handy.