### PR TITLE
Update normalizeConnectArgs to latest master

### DIFF
--- a/lib/instrumentation/core/net.js
+++ b/lib/instrumentation/core/net.js
@@ -61,27 +61,36 @@ function initialize(agent, net) {
   }
 }
 
-// taken from node master on 2013/10/30
-function normalizeConnectArgs(args) {
-  var options = {}
+// taken from node master on 2017/03/13
+function toNumber(x) {
+  return (x = Number(x)) >= 0 ? x : false
+}
 
-  function toNumber(x) {
-    return (x = Number(x)) >= 0 ? x : false
+function isPipeName(s) {
+  return typeof s === 'string' && toNumber(s) === false
+}
+
+function normalizeConnectArgs(args) {
+  if (args.length === 0) {
+    return [{}, null]
   }
-  if (typeof args[0] === 'object' && args[0] !== null) {
-    // connect(options, [cb])
-    options = args[0]
-  } else if (typeof args[0] === 'string' && toNumber(args[0]) === false) {
-    // connect(path, [cb]);
-    options.path = args[0]
+
+  var arg0 = args[0]
+  var options = {}
+  if (typeof arg0 === 'object' && arg0 !== null) {
+    // (options[...][, cb])
+    options = arg0
+  } else if (isPipeName(arg0)) {
+    // (path[...][, cb])
+    options.path = arg0
   } else {
-    // connect(port, [host], [cb])
-    options.port = args[0]
-    if (typeof args[1] === 'string') {
+    // ([port][, host][...][, cb])
+    options.port = arg0
+    if (args.length > 1 && typeof args[1] === 'string') {
       options.host = args[1]
     }
   }
 
   var cb = args[args.length - 1]
-  return typeof cb === 'function' ? [options, cb] : [options]
+  return (typeof cb === 'function') ? [options, cb] : [options, null]
 }


### PR DESCRIPTION
Fixes the following error with `pg`:

```text
TypeError: "listener" argument must be a function
    at Socket.once (events.js:307:11)
    at Socket.connect (net.js:943:10)
    at wrappedConnect (/node_modules/newrelic/lib/instrumentation/core/net.js:53:31)
    at wrapped (/node_modules/newrelic/lib/transaction/tracer/index.js:183:28)
    at Tracer.addSegment (/node_modules/newrelic/lib/transaction/tracer/index.js:83:48)
    at Socket.connectWrapper [as connect] (/node_modules/newrelic/lib/instrumentation/core/net.js:43:27)
    at Connection.connect (/node_modules/pg/lib/connection.js:66:17)
    at Client.connect (/node_modules/pg/lib/client.js:56:9)
    at BoundPool.Pool._create (/node_modules/pg-pool/index.js:68:10)
    at Pool._createResource (/node_modules/generic-pool/lib/generic-pool.js:325:17)
    at Pool.dispense [as _dispense] (/node_modules/generic-pool/lib/generic-pool.js:313:12)
    at Pool.acquire (/node_modules/generic-pool/lib/generic-pool.js:388:8)
    at BoundPool.<anonymous> (/node_modules/pg-pool/index.js:83:15)
    at BoundPool.Pool._promiseNoCallback (/node_modules/pg-pool/index.js:47:7)
    at BoundPool.Pool.connect (/node_modules/pg-pool/index.js:81:15)
    at PG.connect (/node_modules/pg/lib/index.js:77:15)
    [...]
```