### PR TITLE
remove readable-stream from bundled deps?

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "concat-stream",
     "https-proxy-agent",
     "json-stringify-safe",
-    "readable-stream",
     "semver"
   ],
   "devDependencies": {


### PR DESCRIPTION
Hi there - i'm wondering if i might be doing something wrong on my end here (please let me know if i am!) but i wasn't able to shrinkwrap without removing the 'readable-stream' from the package.json.  it would always pull in the latest 2.2.3 version rather than the expected ^1.1.13 range:

```
vagrant@***:/vagrant/codebases/***$ npm shrinkwrap
npm ERR! Linux 3.16.0-4-amd64
npm ERR! argv "/usr/bin/nodejs" "/usr/bin/npm" "shrinkwrap"
npm ERR! node v4.8.2
npm ERR! npm  v2.15.11

npm ERR! Problems were encountered
npm ERR! Please correct and try again.
npm ERR! invalid: readable-stream@2.2.3 /vagrant/codebases/***/node_modules/newrelic/node_modules/readable-stream
npm ERR!
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /vagrant/codebases/***/npm-debug.log
vagrant@bcapp:/vagrant/codebases/***
```

```
$ npm ls readable-stream | grep newrelic -A 3
├─┬ newrelic@1.38.2
│ ├─┬ concat-stream@1.6.0
│ │ └── readable-stream@2.2.3
│ └── readable-stream@2.2.3  invalid
npm ERR! invalid: readable-stream@2.2.3 /vagrant/codebases/***/node_modules/newrelic/node_modules/readable-stream
```

note the `invalid` message