### PR TITLE
Don't attempt to instrument Ramda.js "when"

### DIFF
--- a/lib/instrumentation/when.js
+++ b/lib/instrumentation/when.js
@@ -42,5 +42,6 @@ var WHEN_SPEC = {
 }
 
 module.exports = function initialize(agent, library) {
+  if (!library || !library.Promise) return
   promInit(agent, library, WHEN_SPEC)
 }


### PR DESCRIPTION
The Ramda library (http://ramdajs.com/) contains a file named "when.js", which is completely unrelated to the When.js library (and is not even about promises).

This causes a warning `Failed to instrument module when...` when New Relic attempts to instrument it (tested with newrelic 1.38.2, ramda 0.23.0, Node 6.9.4), with stack trace
```
TypeError: Cannot read property 'prototype' of undefined
    at initialize (<DIR>/node_modules/newrelic/lib/instrumentation/promise.js:87:24)
    at initialize (<DIR>/node_modules/newrelic/lib/instrumentation/when.js:45:3)
    at instrument (<DIR>/node_modules/newrelic/lib/shimmer.js:51:22)
    at _postLoad (<DIR>/node_modules/newrelic/lib/shimmer.js:89:5)
    at Function.cls_wrapMethod [as _load] (<DIR>/node_modules/newrelic/lib/shimmer.js:263:16)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (<DIR>/node_modules/ramda/index.js:232:9)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Function.cls_wrapMethod [as _load] (<DIR>/node_modules/newrelic/lib/shimmer.js:263:38)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
```

The pull requests just tests whether the loaded "when" looks reasonable.