### PR TITLE
Use of `hasOwnProperty` in node v8

### DIFF
--- a/lib/uninstrumented.js
+++ b/lib/uninstrumented.js
@@ -70,8 +70,13 @@ function moduleNameFromFilename(filename) {
 // cache. But, users probably are missing instrumentation for other modules if
 // they are missing instrumentation for core modules.
 function check() {
+  var hasFilename = (
+    require.cache.hasOwnProperty ||
+    function(filename) { return require.cache[filename] }
+  )
+
   for (var filename in require.cache) {
-    if (!require.cache.hasOwnProperty(filename)) {
+    if (!hasFilename(filename)) {
       continue
     }
     var name = moduleNameFromFilename(filename)


### PR DESCRIPTION
similar problem to https://github.com/aseemk/requireDir/pull/46
this is because of using clean objects in https://github.com/mscdex/io.js/commit/3d8528d5060d9cc27d1b335925d51622c5e87ec6

don't know if this conforms to code style https://github.com/vnguyen94/node-newrelic/blob/19519d6270a5007d5e12d229618ffc7c4b880f4b/lib/uninstrumented.js#L73-L76, feel free to review that