### PR TITLE
Make shallowCopy work with "clean" objects

### DIFF
--- a/lib/util/copy.js
+++ b/lib/util/copy.js
@@ -13,7 +13,7 @@ exports.shallow = shallowCopy
 function shallowCopy(source, dest) {
   dest = dest || {}
   for (var k in source) {
-    if (source.hasOwnProperty(k)) {
+    if (Object.prototype.hasOwnProperty.call(source ,k)) {
       dest[k] = source[k]
     }
   }


### PR DESCRIPTION
It seems in node 8 it's possible to have objects that don't have Object.prototype methods included. This was causing our application to break. I think by calling Object.prototype explicitly this should solve it.