### PR TITLE
Use more secure sha256 hashing

### DIFF
--- a/lib/util/hashes.js
+++ b/lib/util/hashes.js
@@ -54,9 +54,9 @@ function calculatePathHash(appName, pathName, referingPathHash) {
 }
 
 function getHash(appName, txName) {
-  var md5sum = crypto.createHash('md5')
-  md5sum.update(appName + ';' + txName, 'utf8')
-  var buf = md5sum.digest()
+  var hash = crypto.createHash('sha256')
+  hash.update(appName + ';' + txName, 'utf8')
+  var buf = hash.digest()
   // pull the low 4 bytes in network byte order
   return buf.slice(buf.length - 4, buf.length).readUInt32BE(0)
 }


### PR DESCRIPTION
I ran a security audit against my web application which includes the newrelic agent, and it flagged the use of the md5 hashing algorithm as insecure. Would it be better to use sha256 as the hashing algorithm, because it is much more secure than md5?