### PR TITLE
Update https-proxy-agent to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   "dependencies": {
     "async": "^2.1.4",
     "concat-stream": "^1.5.0",
-    "https-proxy-agent": "^0.3.5",
+    "https-proxy-agent": "^2.1.0",
     "json-stringify-safe": "^5.0.0",
     "readable-stream": "^2.1.4",
     "semver": "^5.3.0"


### PR DESCRIPTION
## CHANGE LOG
your version of https-proxy-agent is using an old version of debugger that has a know vulnerability:

https://nodesecurity.io/advisories/534

## INTERNAL LINKS

## NOTES
