### PR TITLE
Update https-proxy-agent baseline version

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   "dependencies": {
     "async": "^2.1.4",
     "concat-stream": "^1.5.0",
-    "https-proxy-agent": "^0.3.5",
+    "https-proxy-agent": "^0.3.6",
     "json-stringify-safe": "^5.0.0",
     "readable-stream": "^2.1.4",
     "semver": "^5.3.0"


### PR DESCRIPTION
One of our depenencies, `https-proxy-agent` version `0.3.5`, calls for a vulnerable version of the `debug` package. This is being detected by customers running [nsp](https://github.com/nodesecurity/nsp), even though it will install `0.3.6` by default. This is a failure of the tools checking this dependency, but updating `package.json` will avoid this issue.