### PR TITLE
Fixed error if process.config.variables.node_prefix missing

### DIFF
--- a/lib/collector/facts.js
+++ b/lib/collector/facts.js
@@ -12,6 +12,9 @@ function facts(agent, callback) {
     systemInfo: a.apply(fetchSystemInfo, agent),
     environment: agent.environment.getJSON
   }, function factMapCb(err, data) {
+    if (err) {
+      return callback(err)
+    }
     var systemInfo = data.systemInfo
     var environment = data.environment
 

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -273,7 +273,7 @@ function getGlobalPackages(cb) {
     }
   }
 
-  setImmediate(cb, {packages: [], dependencies: []})
+  setImmediate(cb, null, {packages: [], dependencies: []})
 }
 
 /**


### PR DESCRIPTION
## CHANGE LOG
- If process.config.variables.node_prefix is falsey (which can happen if using electron, leading to this issue https://discuss.newrelic.com/t/new-relic-on-electron-nodejs/53601)  the getGlobalPackages function in lib/environment.js will give an err when it shouldn't
- Added a missing error check

## INTERNAL LINKS

## NOTES
