### PR TITLE
Upgrade https-proxy-agent to address vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": "New Relic Node.js agent team <nodejs@newrelic.com>",
   "licenses": [
     {
@@ -114,7 +114,7 @@
     "@newrelic/koa": "^1.0.0",
     "async": "^2.1.4",
     "concat-stream": "^1.5.0",
-    "https-proxy-agent": "^0.3.6",
+    "https-proxy-agent": "^2.2.0",
     "json-stringify-safe": "^5.0.0",
     "readable-stream": "^2.1.4",
     "semver": "^5.3.0"


### PR DESCRIPTION
Testing newrelic@3.3.0...
✗ High severity vulnerability found on https-proxy-agent@0.3.6
- desc: Uninitialized Memory Exposure
- info: https://snyk.io/vuln/npm:https-proxy-agent:20180402
- from: newrelic@3.3.0 > https-proxy-agent@0.3.6
Upgrade direct dependency https-proxy-agent@0.3.6 to https-proxy-agent@2.2.0

## CHANGE LOG

## INTERNAL LINKS

## NOTES
