### PR TITLE
fix(stub): return actual transaction instance stub

### DIFF
--- a/lib/transaction/handle.js
+++ b/lib/transaction/handle.js
@@ -52,7 +52,7 @@ module.exports = class TransactionHandle {
   }
 }
 
-module.exports.stub = class TransactionHandleStub {
+module.exports.Stub = class TransactionHandleStub {
   end(callback) {
     if (callback instanceof Function) {
       setImmediate(callback)

--- a/stub_api.js
+++ b/stub_api.js
@@ -67,7 +67,7 @@ function getBrowserTimingHeader() {
 }
 
 function getTransaction() {
-  return TransactionHandle.stub
+  return new TransactionHandle.stub()
 }
 
 // Normally the following 3 calls return a wrapped callback, instead we

--- a/stub_api.js
+++ b/stub_api.js
@@ -67,7 +67,7 @@ function getBrowserTimingHeader() {
 }
 
 function getTransaction() {
-  return new TransactionHandle.stub()
+  return new TransactionHandle.Stub()
 }
 
 // Normally the following 3 calls return a wrapped callback, instead we


### PR DESCRIPTION
## CHANGE LOG
Return actual transaction instance stub.

## NOTES
`getTransaction` returns a class instead of an instance of that class, this PR should fix that. It has been happening since https://github.com/newrelic/node-newrelic/commit/81a9803bf1c3ae436188d8078a814ea3d2712876 (converted from object to class, but forgot to update the usage in the stub itself).

@lykkin please.
