### PR TITLE
Explicitly reference package.json as a .json file in require()

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var logger = require('./lib/logger')
 var psemver = require('./lib/util/process-version')
 
 
-var agentVersion = require('./package').version
+var agentVersion = require('./package.json').version
 logger.info(
   "Using New Relic for Node.js. Agent version: %s; Node version: %s.",
   agentVersion, process.version

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -161,7 +161,7 @@ function Config(config) {
   this._canonicalize()
 
   // 6. put the version in the config
-  this.version = require('../../package').version
+  this.version = require('../../package.json').version
 
   // 7. apply high security overrides
   if (this.high_security === true) {

--- a/test/unit/licenses.test.js
+++ b/test/unit/licenses.test.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect
 var fs = require('fs')
 var licenses = require('./licenses')
 var path = require('path')
-var pkg = require('../../package')
+var pkg = require('../../package.json')
 
 
 var MODULE_DIR = path.resolve(__dirname, '../../node_modules')


### PR DESCRIPTION
## CHANGE LOG

- Make `require()` statements explicitly reference `package.json` as a `.json` file.

## INTERNAL LINKS

## NOTES

- This solves a problem when requiring/importing newrelic from a Typescript file.
