### PR TITLE
Allow to pass nonce option to getBrowserTimingHeader.

### DIFF
--- a/api.js
+++ b/api.js
@@ -21,7 +21,7 @@ const MODULE_TYPE = require('./lib/shim/constants').MODULE_TYPE
  * CONSTANTS
  *
  */
-const RUM_STUB = "<script type='text/javascript'>window.NREUM||(NREUM={});" +
+const RUM_STUB = "<script type='text/javascript' %s>window.NREUM||(NREUM={});" +
                 "NREUM.info = %s; %s</script>"
 
 // these messages are used in the _gracefail() method below in getBrowserTimingHeader
@@ -499,15 +499,18 @@ API.prototype.addIgnoringRule = function addIgnoringRule(pattern) {
  *
  * Do *not* reuse the headers between users, or even between requests.
  *
+ * @param {{nonce: string}} options Options used to generate `<script>` header.
  * @returns {string} The `<script>` header to be injected.
  */
-API.prototype.getBrowserTimingHeader = function getBrowserTimingHeader() {
+API.prototype.getBrowserTimingHeader = function getBrowserTimingHeader(options) {
   var metric = this.agent.metrics.getOrCreateMetric(
     NAMES.SUPPORTABILITY.API + '/getBrowserTimingHeader'
   )
   metric.incrementCallCount()
 
   var config = this.agent.config
+
+  options = options || {}
 
   /**
    * Gracefully fail.
@@ -616,10 +619,13 @@ API.prototype.getBrowserTimingHeader = function getBrowserTimingHeader() {
   var tabs = config.browser_monitoring.debug ? 2 : 0
   var json = JSON.stringify(rum_hash, null, tabs)
 
+  // set nonce attribute if passed in options
+  var nonce = options.nonce ? 'nonce="' + options.nonce + '"' : ''
 
   // the complete header to be written to the browser
   var out = util.format(
     RUM_STUB,
+    nonce,
     json,
     js_agent_loader
   )

--- a/test/unit/rum.test.js
+++ b/test/unit/rum.test.js
@@ -118,7 +118,7 @@ describe("the RUM API", function() {
     var nonce = "12345";
     helper.runInTransaction(agent, function (t) {
       t.finalizeNameFromUri('hello')
-      api.getBrowserTimingHeader({ nonce })
+      api.getBrowserTimingHeader({ nonce: nonce })
         .indexOf('nonce="' + nonce + '">').should.not.equal(-1)
     })
   })

--- a/test/unit/rum.test.js
+++ b/test/unit/rum.test.js
@@ -114,4 +114,13 @@ describe("the RUM API", function() {
     })
   })
 
+  it('should add nonce attribute to script if passed in options', function () {
+    var nonce = "12345";
+    helper.runInTransaction(agent, function (t) {
+      t.finalizeNameFromUri('hello')
+      api.getBrowserTimingHeader({ nonce })
+        .indexOf('nonce="' + nonce + '">').should.not.equal(-1)
+    })
+  })
+
 })


### PR DESCRIPTION
## CHANGE LOG
* Allow to pass `nonce` to getBrowserTimingHeader()

## INTERNAL LINKS

https://discuss.newrelic.com/t/content-security-policy-and-browser-injection/2629/42

## NOTES

`getBrowserTimingHeader` generates an inline script tag. This is generally a bad practice if you want to protect your page with HTTP Content-Security-Policy (CSP) header. In the situations you do require it you should generate and pass a `nonce` UUID which tells the browser those scripts are allowed to be executed.

This PR adds an option to add a `nonce` attribute to the generated `<script>` tag.

Currently we're injecting the nonce in the middle of the returned string header with `String.substr()` - which is not ideal.