### PR TITLE
Fixed typo in shimmer

### DIFF
--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -44,7 +44,7 @@ var CORE_INSTRUMENTATION = {
   },
   https: {
     type: MODULE_TYPE.TRANSACTION,
-    file: 'http.js'
+    file: 'https.js'
   },
   inspector: {
     type: MODULE_TYPE.GENERIC,


### PR DESCRIPTION
## CHANGE LOG

~Fixed a typo that was causing `https` to not be instrumented.~

Never mind, I now understand what's going on.

