### PR TITLE
Undefined check on segment transaction trace

### DIFF
--- a/lib/transaction/trace/segment.js
+++ b/lib/transaction/trace/segment.js
@@ -386,7 +386,12 @@ TraceSegment.prototype.toJSON = function toJSON() {
         segment.getExclusiveDurationInMillis()
     }
 
-    var start = segment.timer.startedRelativeTo(segment.transaction.trace.root.timer)
+    var trace = segment.transaction.trace
+    if (!trace) {
+      continue
+    }
+
+    var start = segment.timer.startedRelativeTo(trace.root.timer)
     var duration = segment.getDurationInMillis()
 
     var segmentChildren = segment.getCollectedChildren()


### PR DESCRIPTION
We're getting some errors when doing a `JSON.stringify`:

```
TypeError: Cannot read property 'root' of undefined
    at TraceSegment.toJSON
(/src/node_modules/newrelic/lib/transaction/trace/segment.js:389:75)
    at JSON.stringify (<anonymous>)
    at <our code...>
```

It appears that `segment.transaction.trace` is `undefined`. Note that this occurs during a connection timeout, in case you want to fix the underlying bug where that is not populated. I'm not sure where the trace segment is getting attached to the object tree we're serializing, but I thought you'd probably want this `TypeError` fixed in any case.

It's unclear to me where a test for this should reside, but I can add one if someone has a pointer to how this condition can be reproduced/tested.