### PR TITLE
Prevent Memcached undefined error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,7 @@ and not ready for general-purpose use.
 
 ### Setup
 
-To run the tests you need a GNU-compatible make, the openssl command-line
-binary, and some services:
+To run the tests you need an openssl command-line binary, and some services:
 
 * Cassandra
 * Memcached
@@ -50,7 +49,7 @@ binary, and some services:
 If you have these all running locally on the standard ports, then you are good
 to go. However, the suggested path is to use [Docker](http://www.docker.com).
 If you use OS X or Windows, use Docker Machine, which can be installed as a part of
-[Docker Toolbox](https://www.docker.com/docker-toolbox).  Then, run `make services`
+[Docker Toolbox](https://www.docker.com/docker-toolbox).  Then, run `npm run services`
 to start docker containers for each of the above services.
 
 If you have these services available on non-standard ports or elsewhere on your
@@ -75,7 +74,7 @@ tests if all of the unit tests pass.
 If you don't feel like dealing with the hassle of setting up the servers, just
 the unit tests can be run with:
 
-    make unit
+    npm run unit
 
 ### Writing tests
 

--- a/lib/instrumentation/memcached.js
+++ b/lib/instrumentation/memcached.js
@@ -46,11 +46,12 @@ module.exports = function initialize(agent, memcached, moduleName, shim) {
       // Capture connection info for datastore instance metric.
       var location = null
       if (typeof server === 'string') {
-        location = server.split(':')
+        location = server
       } else if (this.HashRing && this.HashRing.get && metacall.key) {
-        location = this.HashRing.get(metacall.key).split(':')
+        location = this.HashRing.get(metacall.key)
       }
       if (location) {
+        location = location.split(':')
         parameters.host = location[0]
         parameters.port_path_or_id = location[1]
       }


### PR DESCRIPTION

I am getting these errors:
> TypeError: Cannot read property 'split' of undefined\n    at Client.commandWrapper (/usr/app/node_modules/newrelic/lib/instrumentation/memcached.js:51:51)

on this line of code: `mycache.del(key)`

The del() call was after a key (probably) timed out or potentially removed by another pod.  I cannot replicate this in dev/staging though! >:O

I attempted to write integration tests, but could not get it to fail in this process:
1. Deleting a key after a delete
2. Deleting a key after previous key timed out
3. Deleting a key after end() entire cache.
