### PR TITLE
use host header as hostname if exists in http outbound

### DIFF
--- a/lib/instrumentation/core/http-outbound.js
+++ b/lib/instrumentation/core/http-outbound.js
@@ -55,7 +55,7 @@ module.exports = function instrumentOutbound(agent, opts, makeRequest) {
   // but due to legacy issues we can't do that without moving customer's cheese.
   //
   // TODO: Move customers cheese by not appending the default port for https.
-  if (port && port !== DEFAULT_PORT) {
+  if (port && port !== DEFAULT_PORT && !hostname.includes(':')) {
     hostname += ':' + port
   }
 

--- a/lib/instrumentation/core/http-outbound.js
+++ b/lib/instrumentation/core/http-outbound.js
@@ -37,7 +37,7 @@ module.exports = function instrumentOutbound(agent, opts, makeRequest) {
     opts = copy.shallow(opts)
   }
 
-  let hostname = opts.hostname || opts.host || DEFAULT_HOST
+  let hostname = opts.getHeader && opts.getHeader('Host') || opts.headers && opts.headers['Host'] ||  opts.hostname || opts.host || DEFAULT_HOST
   let port = opts.port || opts.defaultPort
   if (!port) {
     port = (!opts.protocol || opts.protocol === 'http:') ? DEFAULT_PORT : DEFAULT_SSL_PORT

--- a/lib/instrumentation/core/http-outbound.js
+++ b/lib/instrumentation/core/http-outbound.js
@@ -37,7 +37,12 @@ module.exports = function instrumentOutbound(agent, opts, makeRequest) {
     opts = copy.shallow(opts)
   }
 
-  let hostname = opts.getHeader && opts.getHeader('Host') || opts.headers && opts.headers['Host'] ||  opts.hostname || opts.host || DEFAULT_HOST
+  let hostname =
+    (opts.getHeader && opts.getHeader("Host")) ||
+    (opts.headers && opts.headers.Host) ||
+    opts.hostname ||
+    opts.host ||
+    DEFAULT_HOST    
   let port = opts.port || opts.defaultPort
   if (!port) {
     port = (!opts.protocol || opts.protocol === 'http:') ? DEFAULT_PORT : DEFAULT_SSL_PORT


### PR DESCRIPTION
## CHANGE LOG
If there's a `Host` header, use it as hostname prior to `url.host`
## INTERNAL LINKS
https://support.newrelic.com/tickets/343043/edit
## NOTES
