### PR TITLE
Adding support to Node 11 and Node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   ],
   "homepage": "http://github.com/newrelic/node-newrelic",
   "engines": {
-    "node": ">=6.0.0 <11.0.0",
+    "node": ">=6.0.0 <13.0.0",
     "npm": ">=3.0.0"
   },
   "directories": {


### PR DESCRIPTION
## CHANGE LOG
Changed the support version on `package.json` to support Node 11 and Node 12. 

New Relic code is completely compatible with Node 12.
