### PR TITLE
node version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   ],
   "homepage": "http://github.com/newrelic/node-newrelic",
   "engines": {
-    "node": ">=6.0.0 <11.0.0",
+    "node": ">=6.0.0",
     "npm": ">=3.0.0"
   },
   "directories": {


### PR DESCRIPTION
## CHANGE LOG
This PR determines the version of NODE, to use `> 11.0.0` versions

Error for use `node = 12.4.0`

```
$ error newrelic@5.9.1: The engine "node" is incompatible with this module. Expected version "> = 6.0.0 <11.0.0".
```

- [x] installation
- [x] run tests

## NOTES
Analyze the possibility of using the latest version of Node