### PR TITLE
[shim] Fix TypeError: segment.transaction.isActive is not a function

### DIFF
--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -1326,7 +1326,9 @@ function getSegment(obj) {
  */
 function getActiveSegment(obj) {
   var segment = this.getSegment(obj)
-  if (segment && segment.transaction && segment.transaction.isActive()) {
+  if (segment && segment.transaction &&
+    typeof segment.transaction.isActive === 'function' &&
+    segment.transaction.isActive()) {
     return segment
   }
   return null
@@ -2024,7 +2026,7 @@ function _wrap(shim, original, name, spec, args) {
       wrapped = arity.fixArity(original, wrapped)
     }
 
-    // TODO: Once all wrapping is converted to proxies, we won't need to 
+    // TODO: Once all wrapping is converted to proxies, we won't need to
     // set this property as the trap on 'get' will return the original for
     // __NR_original. For now, we have to prevent setting this on original.
     if (!wrapped.__NR_original) {


### PR DESCRIPTION
## CHANGE LOG
- [shim] Fix TypeError: segment.transaction.isActive is not a function
## INTERNAL LINKS

## NOTES
- Although this might be a hack, it's required to not crash the process
fixes #281 