### PR TITLE
Env variable to customize metric hostname

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -702,6 +702,12 @@ exports.config = () => ({
      */
     display_name: '',
     /**
+     * Configurable metric name for hosts
+     *
+     * @env NEW_RELIC_METRIC_HOST_NAME
+     */
+    metric_hostname: '',
+    /**
      * ip address preference when creating hostnames
      *
      * @env NEW_RELIC_IPV_PREFERENCE

--- a/lib/config/env.js
+++ b/lib/config/env.js
@@ -94,6 +94,7 @@ const ENV_MAPPING = {
   },
   process_host: {
     display_name: 'NEW_RELIC_PROCESS_HOST_DISPLAY_NAME',
+    metric_hostname: 'NEW_RELIC_METRIC_HOST_NAME',
     ipv_preference: 'NEW_RELIC_IPV_PREFERENCE'
   },
   api: {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -736,6 +736,10 @@ function getHostnameSafe() {
   this.getHostnameSafe = function getCachedHostname() {
     return _hostname
   }
+  if (process.env.NEW_RELIC_METRIC_HOST_NAME) {
+    _hostname = process.env.NEW_RELIC_METRIC_HOST_NAME
+    return _hostname
+  }
   try {
     _hostname = os.hostname()
     return _hostname


### PR DESCRIPTION
## CHANGE LOG

Add an environment variable which can be used to customize the metric hostname.

## INTERNAL LINKS

## NOTES

This is to workaround hostname explosion if you are using dynamic hostnames in k8s for example:

https://discuss.newrelic.com/t/relic-solution-hostname-explosions/58911

> A Hostname Explosion is when an agent installed on an application generates a large number of unique Real Agent IDs, that when queried, causes issues in the APM UI. Real Agent IDs are used for tying an instance of a New Relic Agent to an application on a given host to the New Relic Collector. Unique Real Agent IDs are a symptom of spinning up an agent on a host with a dynamic name.


We are using k8s, and at times of peak traffic can have more than 1000 pods reporting to Newrelic. We would like to keep the original hostname in our log aggregation, and only customize it for reporting to Newrelic. 

We found the NEW_RELIC_PROCESS_HOST_DISPLAY_NAME environment variable, but that only customizes the display name, not the hostname in the metric. One solution we thought of would be to add an environment variable so that consumers can override the `os.hostname()`. For now, I've named it NEW_RELIC_METRIC_HOST_NAME, but I'm open to suggestions!

### How this was tested

```
total ........................................... 3916/5203


  3916 passing (6m)
  23 pending
  1264 failing


real	6m11.288s
user	0m46.105s
sys	0m9.363s
```