### PR TITLE
Update dependency https-proxy-agent to 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "@tyriar/fibonacci-heap": "^2.0.7",
     "async": "^2.1.4",
     "concat-stream": "^2.0.0",
-    "https-proxy-agent": "^2.2.1",
+    "https-proxy-agent": "^3.0.0",
     "json-stringify-safe": "^5.0.0",
     "readable-stream": "^3.1.1",
     "semver": "^5.3.0"


### PR DESCRIPTION
https://github.com/TooTallNate/node-https-proxy-agent/releases

This fix a vulnerability issue

## CHANGE LOG

Update a dependency to version 3 from version 2.

## INTERNAL LINKS

## NOTES
