### PR TITLE
Fix spelling error /confguration/configuration/

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1621,7 +1621,7 @@ function initialize(config) {
     logger.error(error)
 
     throw new Error([
-      `Unable to read confguration file "${filepath}".`,
+      `Unable to read configuration file "${filepath}".`,
       `A base configuration file can be copied from ${BASE_CONFIG_PATH}`,
       'and renamed to "newrelic.js" in the directory from which you will start',
       'your application.'


### PR DESCRIPTION
## CHANGE LOG

- Fix misspelling of configuration
