### PR TITLE
Add core files to NPM file allowlist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-test
-examples
-out
-Makefile

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
   "files": [
     "lib/",
     "api.js",
+    "LICENSE",
     "index.js",
     "stub_api.js",
     "newrelic.js",

--- a/package.json
+++ b/package.json
@@ -182,5 +182,13 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/newrelic/node-newrelic.git"
-  }
+  },
+  "files": [
+    "lib/",
+    "api.js",
+    "index.js",
+    "stub_api.js",
+    "newrelic.js",
+    "bin/tracetractor"
+  ]
 }


### PR DESCRIPTION
## CHANGE LOG

## INTERNAL LINKS

## NOTES
This PR aims to utilise NPM's file allowlisting feature to reduce the size of the package and follow best security practices. The core (used-in-production) files and directories from the repo . are referenced in a list against the `files` property of `package.json` to achieve this.

This should directly replace the `.npmignore` file, which is advised against because:
- It is a blacklist, so additional directories and files will have to be manually added to prevent bloat / minimise the risk of leaking sensitive data
- It has caused issues when swapping from `.gitignore` (see [this article](https://medium.com/@jdxcode/for-the-love-of-god-dont-use-npmignore-f93c08909d8d)), although as this repo already contains this it is not a problem, more another reason against the choice to use an `.npmignore` file.

There are no functional changes, so it is possible that a pre-release version with this allowlist should be published on npm and tested to ensure all core functionality remains, then to evaluate the improvement in the package size once the docker/travis/git files are no longer bundled.