### PR TITLE
workaround for json files without a .json file extension not working

### DIFF
--- a/lib/serverless/aws-lambda.js
+++ b/lib/serverless/aws-lambda.js
@@ -17,7 +17,7 @@ const EVENT_SOURCE_ARN_KEY = `${EVENT_SOURCE_PREFIX}.arn`
 const EVENT_SOURCE_TYPE_KEY = `${EVENT_SOURCE_PREFIX}.eventType`
 const NAMES = require('../metrics/names')
 
-const EVENT_SOURCE_INFO = require('./event-sources')
+const EVENT_SOURCE_INFO = require('./event-sources.json')
 
 // A function with no references used to stub out closures
 function cleanClosure() {}


### PR DESCRIPTION
workaround for JSON files without a .json file extension not working
<img width="1176" alt="Screenshot 2020-05-12 at 11 11 04 AM" src="https://user-images.githubusercontent.com/11535686/81642624-70887e80-9441-11ea-8ec2-18fd6cadc236.png">

Here is the open issue: https://github.com/microsoft/TypeScript/issues/24357

## CHANGE LOG

## INTERNAL LINKS

## NOTES
