### PR TITLE
Bumps @newrelic/native-metrics to ^5.1.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -344,13 +344,21 @@
       }
     },
     "@newrelic/native-metrics": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-5.0.0.tgz",
-      "integrity": "sha512-6Smx/9MlsZTcbLe+Co39O9kJ3sYo/3xunNTOhTP+nPlLxQmQBPDT0/ULmEogTkhaEX5MuCx6L4cN+1QU4uZdDw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-5.1.0.tgz",
+      "integrity": "sha512-AD0C+QuPcmOH0n6hNfLacweJ/Kb35Hp9PChTmMqZ/7+Fflk2GbwrT/L/wVIZRXYrejByRV3Yh6Z1pyzl2g42Zg==",
       "optional": true,
       "requires": {
-        "nan": "^2.14.0",
+        "nan": "^2.14.1",
         "semver": "^5.5.1"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+          "optional": true
+        }
       }
     },
     "@newrelic/proxy": {
@@ -3483,6 +3491,7 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "dev": true,
       "optional": true
     },
     "natural-compare": {

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "semver": "^5.3.0"
   },
   "optionalDependencies": {
-    "@newrelic/native-metrics": "^5.0.0"
+    "@newrelic/native-metrics": "^5.1.0"
   },
   "devDependencies": {
     "@newrelic/proxy": "^2.0.0",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Bumps @newrelic/native-metrics to ^5.1.0.

  Upgraded nan to ^2.14.1 to resolve 'GetContents' deprecation warning with Node 14. This version of the native metrics module is tested against Node 14 and includes a pre-built binary download backup for Node 14.

## Links

* https://github.com/newrelic/node-native-metrics/pull/73

## Details
