### PR TITLE
Adds trimming of license key string to help avoid copy-paste issues.

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1323,6 +1323,10 @@ Config.prototype._canonicalize = function _canonicalize() {
 
   this.serverless_mode.enabled = this.serverless_mode.enabled
     && this.feature_flag.serverless_mode
+
+  if (this.license_key) {
+    this.license_key = this.license_key.trim()
+  }
 }
 
 function _parseCodes(codes) {

--- a/test/unit/config/config.test.js
+++ b/test/unit/config/config.test.js
@@ -83,6 +83,14 @@ describe('the agent configuration', function() {
       })
     })
 
+    it('should trim spaces from license key', function() {
+      idempotentEnv({'NEW_RELIC_LICENSE_KEY': ' license '}, function(tc) {
+        should.exist(tc.license_key)
+        expect(tc.license_key).to.equal('license')
+        expect(tc.host).to.equal('collector.newrelic.com')
+      })
+    })
+
     it('should pick up the apdex_t', function() {
       idempotentEnv({'NEW_RELIC_APDEX_T': '111'}, function(tc) {
         should.exist(tc.apdex_t)
@@ -1306,6 +1314,11 @@ describe('the agent configuration', function() {
         error_collector: options
       })
       expect(config.error_collector.ignore_messages).eql(options.ignore_messages)
+    })
+
+    it('should trim should trim spaces from license key', () => {
+      const config = new Config({ license_key: ' license '})
+      expect(config.license_key).equals('license')
     })
   })
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Adds whitespace trimming of license key configuration values.

  Previously, when a license key was entered with leading or trailing whitespace, it would be used as-is and result in a validation failure. This most commonly occurred with environment variable based configuration.

## Links

## Details

Flagging as "medium" risk just cause touches license keys but actual change is straightforward.
