### PR TITLE
Extracts smoke tests to separate workflow.

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -21,23 +21,6 @@ jobs:
     - name: Run Linting
       run: npm run lint
 
-  smoke:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [8.x, 10.x, 12.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    # Smoke tests do own install
-    - name: Run Smoke Tests
-      run: npm run smoke
-
   unit:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/smoke-test-workflow.yml
+++ b/.github/workflows/smoke-test-workflow.yml
@@ -1,0 +1,30 @@
+name: Server Smoke Tests
+
+on:
+    # Run on pushes to any branch. Not triggered for forked repo PRs.
+  push:
+  schedule:
+    # Run once a day at 9AM PDT (16 UTC) on week days (1-5).
+    # Last commit on default branch.
+    # https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule
+    - cron:  '0 16 * * 1-5'
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    # Smoke tests do own install
+    - name: Run Smoke Tests
+      run: npm run smoke
+      env:
+        TEST_LICENSE: ${{ secrets.TEST_LICENSE }}

--- a/test/smoke/newrelic.js
+++ b/test/smoke/newrelic.js
@@ -14,7 +14,7 @@ exports.config = {
   /**
    * Your New Relic license key.
    */
-  license_key: process.env.BENDER_LICENSE,
+  license_key: process.env.TEST_LICENSE,
   logging: {
     /**
      * Level at which to log. 'trace' is most useful to New Relic when diagnosing


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details

Isolates this grouping's need for full-setup smoke testing to non-forked repo runs. Executes on repo branch pushes and a once-a-day scheduled run. Scheduled run accounts for catching server changes (eventually) during periods of time without branch pushes.

These tests actually pass if not validly setup cause then the agent just doesn't do anything. Eventually, some more robust smoke testing would be good. 

Given the dependency on a key, it made for a good first-pass at what this sort of smoke test job will look like. Long-term vision being we isolate a collection of smoke tests that need secrets and exercise a proper server to catch issues from our standard functionality tests intended for all PR's, including from forked repos.

I verified that a purely forked PR, w/o branch existing in the main repo, only runs the PR jobs which is why the smoke test runs on any branch and not just `master`. This was any special branch activity on the main repo can get those.
