### PR TITLE
Updates release notes for 6.8.0.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+### 6.8.0 (2020-05-21):
+
+* Bumped @newrelic/native-metrics to ^5.1.0.
+
+  Upgraded nan to ^2.14.1 to resolve 'GetContents' deprecation warning with Node 14. This version of the native metrics module is tested against Node 14 and includes a pre-built binary download backup for Node 14.
+
+* Added whitespace trimming of license key configuration values.
+
+  Previously, when a license key was entered with leading or trailing whitespace, it would be used as-is and result in a validation failure. This most commonly occurred with environment variable based configuration.
+
+* Moved to GitHub actions for CI.
+
+* Updated PR template and added initial issue templates.
+
+* Converted most of the collector API unit tests to use the tap API. Split larger test groupings into their own test files.
+
 ### 6.7.1 (2020-05-14):
 
 * Added synthetics headers to transaction event intrinsics for DT


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Bumped @newrelic/native-metrics to ^5.1.0.

  Upgraded nan to ^2.14.1 to resolve 'GetContents' deprecation warning with Node 14. This version of the native metrics module is tested against Node 14 and includes a pre-built binary download backup for Node 14.

* Added whitespace trimming of license key configuration values.

  Previously, when a license key was entered with leading or trailing whitespace, it would be used as-is and result in a validation failure. This most commonly occurred with environment variable based configuration.

* Moved to GitHub actions for CI.

* Updated PR template and added initial issue templates.

* Converted most of the collector API unit tests to use the tap API. Split larger test groupings into their own test files.

## Links

* https://github.com/newrelic/node-newrelic/pull/346
* https://github.com/newrelic/node-newrelic/pull/347
* https://github.com/newrelic/node-newrelic/pull/348
* https://github.com/newrelic/node-newrelic/pull/350
* https://github.com/newrelic/node-newrelic/pull/351
* https://github.com/newrelic/node-newrelic/pull/353
* https://github.com/newrelic/node-newrelic/pull/355
* https://github.com/newrelic/node-newrelic/pull/356
* https://github.com/newrelic/node-newrelic/pull/358

## Details

Release deemed "medium" risk due to touching license keys but change itself was very straightforward.
