### PR TITLE
Don't skip tests if secrets should be available

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -63,6 +63,7 @@ jobs:
         COLLECTOR_LICENSE: ${{ secrets.COLLECTOR_LICENSE }}
         LASP_LICENSE: ${{ secrets.LASP_LICENSE }}
         LASP_SECURE_LICENSE: ${{ secrets.LASP_SECURE_LICENSE }}
+        FORCE_RUN_TESTS_WITH_SECRETS: ${{ github.repository_owner == 'newrelic' && github.head_ref == 'master' }}
 
   versioned:
     runs-on: ubuntu-latest

--- a/test/helpers/secrets.js
+++ b/test/helpers/secrets.js
@@ -1,0 +1,29 @@
+'use strict'
+
+/**
+ * A helper function to get secrets needed by tests
+ */
+function getTestSecret(secretName) {
+  const envVar = process.env[secretName] || ''
+  return envVar.trim()
+}
+
+/**
+ * Checks whether any of the secrets needed by the test are missing or if the
+ * FORCE_RUN_TESTS_WITH_SECRETS env var is set. This is set by the github
+ * actions workflow when tests are being run on the newrelic repository where
+ * secrets should be available. In this case, even if the license key that a
+ * test is looking for is not present, run the test anyway and let it fail,
+ * because it should be present on the newrelic repo.
+ */
+function shouldSkipTest(...secrets) {
+  const missing = secrets.some(s => !s)  // !s catches empty strings
+  const forceTestRun = process.env.FORCE_RUN_TESTS_WITH_SECRETS === 'true'
+  const shouldRun = forceTestRun || !missing
+  return !shouldRun
+}
+
+module.exports = {
+  getTestSecret,
+  shouldSkipTest
+}

--- a/test/integration/agent/agent-restart-listener.tap.js
+++ b/test/integration/agent/agent-restart-listener.tap.js
@@ -3,13 +3,15 @@
 const tap = require('tap')
 const configurator = require('../../../lib/config')
 const Agent = require('../../../lib/agent')
+const {getTestSecret, shouldSkipTest} = require('../../helpers/secrets')
 
 
-const skip = !Boolean(process.env.TEST_LICENSE)
+const license = getTestSecret('TEST_LICENSE')
+const skip = shouldSkipTest(license)
 tap.test('Collector API should connect to staging-collector.newrelic.com', {skip}, (t) => {
   const config = configurator.initialize({
     app_name: 'node.js Tests',
-    license_key: process.env.TEST_LICENSE,
+    license_key: license,
     host: 'staging-collector.newrelic.com',
     port: 443,
     ssl: true,

--- a/test/integration/agent/lasp-send-trace.tap.js
+++ b/test/integration/agent/lasp-send-trace.tap.js
@@ -1,21 +1,23 @@
 'use strict'
 
-var tap = require('tap')
-var configurator = require('../../../lib/config')
-var Agent = require('../../../lib/agent')
-var API = require('../../../api')
+const tap = require('tap')
+const configurator = require('../../../lib/config')
+const Agent = require('../../../lib/agent')
+const API = require('../../../api')
+const {getTestSecret, shouldSkipTest} = require('../../helpers/secrets')
 
 
-const skip = !Boolean(process.env.LASP_LICENSE)
-tap.test('LASP-enabled agent', {skip}, function(t) {
-  var agent = null
-  var api = null
-  var config = null
+const license = getTestSecret('LASP_LICENSE')
+const skip = shouldSkipTest(license)
+tap.test('LASP-enabled agent', {skip}, (t) => {
+  let agent = null
+  let api = null
+  let config = null
 
   t.beforeEach(function(done) {
     config = configurator.initialize({
       app_name: 'node.js Tests',
-      license_key: process.env.LASP_LICENSE,
+      license_key: license,
       security_policies_token: 'ffff-ffff-ffff-ffff',
       host: 'staging-collector.newrelic.com',
       port: 443,

--- a/test/integration/agent/serverless-harvest.tap.js
+++ b/test/integration/agent/serverless-harvest.tap.js
@@ -5,6 +5,7 @@ const helper = require('../../lib/agent_helper')
 const tap = require('tap')
 const sinon = require('sinon')
 const API = require('../../../api')
+const {getTestSecret, shouldSkipTest} = require('../../helpers/secrets')
 
 const DESTS = require('../../../lib/config/attribute-filter').DESTINATIONS
 const TEST_ARN = 'test:arn'
@@ -12,8 +13,8 @@ const TEST_FUNC_VERSION = '$LATEST'
 const TEST_EX_ENV = 'test-AWS_Lambda_nodejs8.10'
 const PROTOCOL_VERSION = 16
 
-
-const skip = !Boolean(process.env.TEST_LICENSE)
+const license = getTestSecret('TEST_LICENSE')
+const skip = shouldSkipTest(license)
 tap.test('Serverless mode harvest', {skip}, (t) => {
   t.autoend()
 
@@ -29,7 +30,7 @@ tap.test('Serverless mode harvest', {skip}, (t) => {
         enabled: true
       },
       app_name: 'serverless mode tests',
-      license_key: process.env.TEST_LICENSE
+      license_key: license
     })
     agent.setLambdaArn(TEST_ARN)
     agent.setLambdaFunctionVersion(TEST_FUNC_VERSION)

--- a/test/integration/agent/start-stop.tap.js
+++ b/test/integration/agent/start-stop.tap.js
@@ -3,13 +3,15 @@
 const tap = require('tap')
 const configurator = require('../../../lib/config')
 const Agent = require('../../../lib/agent')
+const {getTestSecret, shouldSkipTest} = require('../../helpers/secrets')
 
 
-const skip = !Boolean(process.env.TEST_LICENSE)
+const license = getTestSecret('TEST_LICENSE')
+const skip = shouldSkipTest(license)
 tap.test('Collector API should connect to staging-collector.newrelic.com', {skip}, (t) => {
   const config = configurator.initialize({
     app_name: 'node.js Tests',
-    license_key: process.env.TEST_LICENSE,
+    license_key: license,
     host: 'staging-collector.newrelic.com',
     port: 443,
     ssl: true,

--- a/test/integration/api/connection.tap.js
+++ b/test/integration/api/connection.tap.js
@@ -1,15 +1,16 @@
 'use strict'
 
-var tap = require('tap')
-var configurator = require('../../../lib/config')
-var Agent = require('../../../lib/agent')
+const tap = require('tap')
+const configurator = require('../../../lib/config')
+const Agent = require('../../../lib/agent')
+const {getTestSecret, shouldSkipTest} = require('../../helpers/secrets')
 
-
-const skip = !Boolean(process.env.TEST_LICENSE)
-tap.test('Collector API should connect to staging-collector.newrelic.com', {skip}, function(t) {
-  var config = configurator.initialize({
+const license = getTestSecret('TEST_LICENSE')
+const skip = shouldSkipTest(license)
+tap.test('Collector API should connect to staging-collector.newrelic.com', {skip}, (t) => {
+  const config = configurator.initialize({
     app_name: 'node.js Tests',
-    license_key: process.env.TEST_LICENSE,
+    license_key: license,
     host: 'staging-collector.newrelic.com',
     port: 443,
     ssl: true,

--- a/test/integration/api/error-data.tap.js
+++ b/test/integration/api/error-data.tap.js
@@ -1,15 +1,17 @@
 'use strict'
 
-var test = require('tap').test
-var configurator = require('../../../lib/config')
-var Agent = require('../../../lib/agent')
+const test = require('tap').test
+const configurator = require('../../../lib/config')
+const Agent = require('../../../lib/agent')
+const {getTestSecret, shouldSkipTest} = require('../../helpers/secrets')
 
 
-const skip = !Boolean(process.env.TEST_LICENSE)
-test('Collector API should send errors to staging-collector.newrelic.com', {skip}, function(t) {
-  var config = configurator.initialize({
+const license = getTestSecret('TEST_LICENSE')
+const skip = shouldSkipTest(license)
+test('Collector API should send errors to staging-collector.newrelic.com', {skip}, (t) => {
+  const config = configurator.initialize({
     app_name: 'node.js Tests',
-    license_key: process.env.TEST_LICENSE,
+    license_key: license,
     host: 'staging-collector.newrelic.com',
     port: 443,
     ssl: true,

--- a/test/integration/api/metric-data.tap.js
+++ b/test/integration/api/metric-data.tap.js
@@ -1,16 +1,18 @@
 'use strict'
 
-var test = require('tap').test
-var configurator = require('../../../lib/config')
-var Agent = require('../../../lib/agent')
-var CollectorAPI = require('../../../lib/collector/api')
+const test = require('tap').test
+const configurator = require('../../../lib/config')
+const Agent = require('../../../lib/agent')
+const CollectorAPI = require('../../../lib/collector/api')
+const {getTestSecret, shouldSkipTest} = require('../../helpers/secrets')
 
 
-const skip = !Boolean(process.env.TEST_LICENSE)
-test('Collector API should send metrics to staging-collector.newrelic.com', {skip}, function(t) {
-  var config = configurator.initialize({
+const license = getTestSecret('TEST_LICENSE')
+const skip = shouldSkipTest(license)
+test('Collector API should send metrics to staging-collector.newrelic.com', {skip}, (t) => {
+  const config = configurator.initialize({
     app_name: 'node.js Tests',
-    license_key: process.env.TEST_LICENSE,
+    license_key: license,
     host: 'staging-collector.newrelic.com',
     port: 443,
     ssl: true,

--- a/test/integration/api/transaction-sample-data.tap.js
+++ b/test/integration/api/transaction-sample-data.tap.js
@@ -1,15 +1,17 @@
 'use strict'
 
-var tap = require('tap')
-var configurator = require('../../../lib/config')
-var Agent = require('../../../lib/agent')
+const tap = require('tap')
+const configurator = require('../../../lib/config')
+const Agent = require('../../../lib/agent')
+const {getTestSecret, shouldSkipTest} = require('../../helpers/secrets')
 
 
-const skip = !Boolean(process.env.COLLECTOR_LICENSE)
-tap.test('Collector API should send errors to newrelic.com', {skip}, function(t) {
-  var config = configurator.initialize({
+const license = getTestSecret('COLLECTOR_LICENSE')
+const skip = shouldSkipTest(license)
+tap.test('Collector API should send errors to newrelic.com', {skip}, (t) => {
+  const config = configurator.initialize({
     app_name: 'node.js Tests',
-    license_key: process.env.COLLECTOR_LICENSE,
+    license_key: license,
     port: 443,
     ssl: true,
     utilization: {

--- a/test/integration/index/index-bad-config.tap.js
+++ b/test/integration/index/index-bad-config.tap.js
@@ -1,14 +1,17 @@
 'use strict'
 
 const tap = require('tap')
+const {getTestSecret, shouldSkipTest} = require('../../helpers/secrets')
 
-const skip = !Boolean(process.env.TEST_LICENSE)
+
+const license = getTestSecret('TEST_LICENSE')
+const skip = shouldSkipTest(license)
 tap.test('loading the app with invalid config', {skip}, (t) => {
   t.plan(3)
 
   process.env.AWS_LAMBDA_FUNCTION_NAME = 'lambdaName'
   process.env.NEW_RELIC_DISTRIBUTED_TRACING_ENABLED = true
-  process.env.NEW_RELIC_LICENSE_KEY = process.env.TEST_LICENSE
+  process.env.NEW_RELIC_LICENSE_KEY = license
   process.env.NEW_RELIC_NO_CONFIG_FILE = true
 
   let api = null

--- a/test/integration/index/index-bad-version.tap.js
+++ b/test/integration/index/index-bad-version.tap.js
@@ -1,15 +1,17 @@
 'use strict'
 
-var tap = require('tap')
+const tap = require('tap')
+const {getTestSecret, shouldSkipTest} = require('../../helpers/secrets')
 
 
-const skip = !Boolean(process.env.TEST_LICENSE)
-tap.test('loading the agent with a bad version', {timeout: 20000, skip}, function(t) {
-  var agent = null
+const license = getTestSecret('TEST_LICENSE')
+const skip = shouldSkipTest(license)
+tap.test('loading the agent with a bad version', {timeout: 20000, skip}, (t) => {
+  let agent = null
 
   process.env.NEW_RELIC_HOME = __dirname + '/..'
   process.env.NEW_RELIC_HOST = 'staging-collector.newrelic.com'
-  process.env.NEW_RELIC_LICENSE_KEY = process.env.TEST_LICENSE
+  process.env.NEW_RELIC_LICENSE_KEY = license
 
   t.doesNotThrow(function() {
     var _version = process.version

--- a/test/integration/index/index.tap.js
+++ b/test/integration/index/index.tap.js
@@ -1,15 +1,16 @@
 'use strict'
 
-var test = require('tap').test
+const test = require('tap').test
+const {getTestSecret, shouldSkipTest} = require('../../helpers/secrets')
 
-
-const skip = !Boolean(process.env.TEST_LICENSE)
-test('loading the application via index.js', {timeout: 15000, skip}, function(t) {
-  var agent = null
+const license = getTestSecret('TEST_LICENSE')
+const skip = shouldSkipTest(license)
+test('loading the application via index.js', {timeout: 15000, skip}, (t) => {
+  let agent = null
 
   process.env.NEW_RELIC_HOME = __dirname + '/..'
   process.env.NEW_RELIC_HOST = 'staging-collector.newrelic.com'
-  process.env.NEW_RELIC_LICENSE_KEY = process.env.TEST_LICENSE
+  process.env.NEW_RELIC_LICENSE_KEY = license
 
   t.doesNotThrow(function() {
     var api = require('../../../index.js')

--- a/test/integration/lasp_connect.tap.js
+++ b/test/integration/lasp_connect.tap.js
@@ -4,13 +4,15 @@ const tap = require('tap')
 const configurator = require('../../lib/config')
 const Agent = require('../../lib/agent')
 const CollectorAPI = require('../../lib/collector/api')
+const { getTestSecret, shouldSkipTest } = require('../helpers/secrets')
 
 
-let skip = !Boolean(process.env.LASP_LICENSE)
-tap.test('connecting with a LASP token should not error', {skip}, function(t) {
+let lasp_license = getTestSecret('LASP_LICENSE')
+let skip = shouldSkipTest(lasp_license)
+tap.test('connecting with a LASP token should not error', {skip}, (t) => {
   const config = configurator.initialize({
     app_name: 'node.js Tests',
-    license_key: process.env.LASP_LICENSE,
+    license_key: lasp_license,
     security_policies_token: 'ffff-ffff-ffff-ffff',
     host: 'staging-collector.newrelic.com',
     utilization: {
@@ -43,11 +45,12 @@ tap.test('connecting with a LASP token should not error', {skip}, function(t) {
   })
 })
 
-skip = !Boolean(process.env.LASP_SECURE_LICENSE)
-tap.test('missing required policies should result in shutdown', {skip}, function(t) {
+let lasp_secure_license = getTestSecret('LASP_SECURE_LICENSE')
+skip = shouldSkipTest(lasp_secure_license)
+tap.test('missing required policies should result in shutdown', {skip}, (t) => {
   const config = configurator.initialize({
     app_name: 'node.js Tests',
-    license_key: process.env.LASP_SECURE_LICENSE,
+    license_key: lasp_secure_license,
     security_policies_token: 'ffff-ffff-ffff-ffff',
     host: 'staging-collector.newrelic.com',
     utilization: {

--- a/test/integration/proxy-api-connection-noproxy.tap.js
+++ b/test/integration/proxy-api-connection-noproxy.tap.js
@@ -4,13 +4,15 @@ const tap = require('tap')
 const configurator = require('../../lib/config')
 const Agent = require('../../lib/agent')
 const CollectorAPI = require('../../lib/collector/api')
+const {getTestSecret, shouldSkipTest} = require('../helpers/secrets')
 
 
-const skip = !Boolean(process.env.LASP_LICENSE)
+const license = getTestSecret('TEST_LICENSE')
+const skip = shouldSkipTest(license)
 tap.test('no proxy set should not use proxy agent', {skip}, (t) => {
   const config = configurator.initialize({
     app_name: 'node.js Tests',
-    license_key: process.env.TEST_LICENSE,
+    license_key: license,
     host: 'staging-collector.newrelic.com',
     port: 443,
     ssl: true,

--- a/test/integration/proxy-api-connection-port.tap.js
+++ b/test/integration/proxy-api-connection-port.tap.js
@@ -8,14 +8,16 @@ const read = require('fs').readFileSync
 const configurator = require('../../lib/config')
 const Agent = require('../../lib/agent')
 const CollectorAPI = require('../../lib/collector/api')
+const {getTestSecret, shouldSkipTest} = require('../helpers/secrets')
 
 let port = 0
 const SSL_CONFIG = {
   key: read(join(__dirname, '../lib/test-key.key')),
   cert: read(join(__dirname, '../lib/self-signed-test-certificate.crt')),
 }
+const license = getTestSecret('TEST_LICENSE')
+const skip = shouldSkipTest(license)
 
-const skip = !Boolean(process.env.TEST_LICENSE)
 tap.test('setting proxy_port should use the proxy agent', {skip}, (t) => {
   const server = proxySetup(https.createServer(SSL_CONFIG))
 
@@ -23,7 +25,7 @@ tap.test('setting proxy_port should use the proxy agent', {skip}, (t) => {
     port = server.address().port
     const config = configurator.initialize({
       app_name: 'node.js Tests',
-      license_key: process.env.TEST_LICENSE,
+      license_key: license,
       host: 'staging-collector.newrelic.com',
       port: 443,
       proxy_host: 'ssl.lvh.me',

--- a/test/integration/proxy-api-connection-ssl.tap.js
+++ b/test/integration/proxy-api-connection-ssl.tap.js
@@ -8,14 +8,15 @@ const read = require('fs').readFileSync
 const configurator = require('../../lib/config')
 const Agent = require('../../lib/agent')
 const CollectorAPI = require('../../lib/collector/api')
+const {getTestSecret, shouldSkipTest} = require('../helpers/secrets')
 
 let port = 0
 const SSL_CONFIG = {
   key: read(join(__dirname, '../lib/test-key.key')),
   cert: read(join(__dirname, '../lib/self-signed-test-certificate.crt')),
 }
-
-const skip = !Boolean(process.env.TEST_LICENSE)
+const license = getTestSecret('TEST_LICENSE')
+const skip = shouldSkipTest(license)
 
 tap.test('support ssl to the proxy', {skip}, (t) => {
   const server = proxySetup(https.createServer(SSL_CONFIG))
@@ -24,7 +25,7 @@ tap.test('support ssl to the proxy', {skip}, (t) => {
     port = server.address().port
     const config = configurator.initialize({
       app_name: 'node.js Tests',
-      license_key: process.env.TEST_LICENSE,
+      license_key: license,
       host: 'staging-collector.newrelic.com',
       proxy: `https://ssl.lvh.me:${port}`,
       ssl: true,


### PR DESCRIPTION
## Proposed Release Notes

## Links

## Details
* Another follow up to the CI stuff, adding a failsafe. It forces tests that need secrets to run when the branch being run is master even if the secret they need is not available. This will force tests to fail, we'll be notified, and we can see why our secrets aren't working.