### PR TITLE
Add AWS API Gateway V2 Support

### DIFF
--- a/lib/serverless/event-sources.json
+++ b/lib/serverless/event-sources.json
@@ -21,7 +21,7 @@
             "httpMethod",
             "path",
             "requestContext",
-            "resource"
+            "requestContext.stage"
         ]
     },
     "cloudFront": {


### PR DESCRIPTION
AWS released a new version of their API Gateway service. This adds support for V2.

v1: https://github.com/awsdocs/aws-lambda-developer-guide/blob/master/sample-apps/nodejs-apig/event.json
V2: https://github.com/awsdocs/aws-lambda-developer-guide/blob/master/sample-apps/nodejs-apig/event-v2.json

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
