### PR TITLE
Adds commonly skipped items to npmignore to avoid accidentally publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,10 @@ test
 examples
 out
 Makefile
+package-lock.json
+newrelic_agent.log
+**/node_modules/**
+.nyc_output
+.vscode
+.eslint*
+.github


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Added several items to `.npmignore` to prevent accidental publishing.

## Links

* https://github.com/newrelic/node-newrelic/issues/368

## Details

When publishing from a new location, I caught a few other things but missed that I had a rogue `newrelic_agent.log` hanging out. Our current `.npmignore` doesn't filter that out.

Long-term, using the "files" configuration which gives an allow-list will save us from such things including not needing to update for all possible cases in the future.

There's a backlog item and a community PR hanging-out around using the "files" list. That sort of change is higher-risk, though, as we could break something fundamental when we convert. As such, doing the quick fix now and leaving that for a more dedicated/careful approach.