### PR TITLE
Waits for error to trigger on test before ending transaction.

### DIFF
--- a/test/versioned/redis/redis.tap.js
+++ b/test/versioned/redis/redis.tap.js
@@ -120,12 +120,15 @@ test('Redis instrumentation', {timeout : 10000}, function(t) {
   t.test('when called without a callback', function(t) {
     t.plan(4)
 
+    let transaction = null
+
     helper.runInTransaction(agent, function(tx) {
       client.set('testKey', 'testvalue')
       setTimeout(function() {
         // This will generate an error because `testKey` is not a hash.
         client.hset('testKey', 'hashKey', 'foobar')
-        setTimeout(tx.end.bind(tx), 100)
+
+        transaction = tx
       }, 100) // Redis calls should never take 100 ms
     })
 
@@ -136,6 +139,10 @@ test('Redis instrumentation', {timeout : 10000}, function(t) {
           'WRONGTYPE Operation against a key holding the wrong kind of value',
           'errors should have the expected error message'
         )
+
+        // Ensure error triggering operation has completed before
+        // continuing test assertions.
+        transaction.end()
       }
     })
 

--- a/test/versioned/redis/redis.tap.js
+++ b/test/versioned/redis/redis.tap.js
@@ -125,11 +125,11 @@ test('Redis instrumentation', {timeout : 10000}, function(t) {
     helper.runInTransaction(agent, function(tx) {
       client.set('testKey', 'testvalue')
       setTimeout(function() {
+        transaction = tx
+
         // This will generate an error because `testKey` is not a hash.
         client.hset('testKey', 'hashKey', 'foobar')
-
-        transaction = tx
-      }, 100) // Redis calls should never take 100 ms
+      }, 200) // Wait for client.set('testKey', 'testvalue') to complete
     })
 
     client.on('error', function(err) {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Fixed Redis client w/o callback versioned test flicker.

  Doesn't end transaction until error encountered. Increases wait time for first operation which has to complete for the second operation to be successful.

## Links

## Details

Should reduce test flickers by not having a hard-set 100ms sleep for the operation. Relies on test framework timeout to end if call hangs. Worst case, will be easier to debug.

Did find second issue. The first key has to exist for the second call to fail. Increasing the timeout will still be somewhat fragile but trying not to have to do major surgery here.
