### PR TITLE
Add transaction name to span as intrinsic

### DIFF
--- a/lib/spans/span-context.js
+++ b/lib/spans/span-context.js
@@ -1,0 +1,13 @@
+'use strict'
+
+class SpanContext {
+  constructor(intrinsicAttributes) {
+    this.intrinsicAttributes = intrinsicAttributes || Object.create(null)
+  }
+
+  addIntrinsicAttribute(key, value) {
+    this.intrinsicAttributes[key] = value
+  }
+}
+
+module.exports = SpanContext

--- a/lib/spans/span-event.js
+++ b/lib/spans/span-event.js
@@ -91,6 +91,11 @@ class SpanEvent {
       span = new SpanEvent(attributes, customAttributes)
     }
 
+    const spanContext = segment.getSpanContext()
+    for (const [key, value] of Object.entries(spanContext.intrinsicAttributes)) {
+      span.intrinsics[key] = value
+    }
+
     const tx = segment.transaction
 
     span.intrinsics.traceId = tx.traceId

--- a/lib/spans/streaming-span-event.js
+++ b/lib/spans/streaming-span-event.js
@@ -112,6 +112,11 @@ class StreamingSpanEvent {
       span = new StreamingSpanEvent(traceId, agentAttributes, customAttributes)
     }
 
+    const spanContext = segment.getSpanContext()
+    for (const [key, value] of Object.entries(spanContext.intrinsicAttributes)) {
+      span.addIntrinsicAttribute(key, value)
+    }
+
     span.addIntrinsicAttribute('guid', segment.id)
     span.addIntrinsicAttribute('parentId', parentId)
     span.addIntrinsicAttribute('transactionId', transaction.id)

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -426,11 +426,24 @@ function finalizeNameFromUri(requestURL, statusCode) {
   }
 
   this.baseSegment && this._markAsWeb(requestURL)
+
+  this._copyNameToActiveSpan(this.name)
+
   logger.trace({
     transactionId: this.id,
     transactionName: this.name,
     ignore: this.ignore
   }, 'Finished setting transaction name from Uri')
+}
+
+Transaction.prototype._copyNameToActiveSpan = function _copyNameToActiveSpan(name) {
+  const spanContext = this.agent.tracer.getSpanContext()
+  if (!spanContext) {
+    logger.trace('Span context not available, not adding transaction.name attribute for %s', name)
+    return
+  }
+
+  spanContext.addIntrinsicAttribute('transaction.name', name)
 }
 
 /**
@@ -489,6 +502,8 @@ Transaction.prototype.finalizeName = function finalizeName(name) {
   }
 
   this.baseSegment && this.baseSegment.setNameFromTransaction()
+
+  this._copyNameToActiveSpan(this.name)
 
   logger.trace({
     transactionId: this.id,

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -381,8 +381,10 @@ Transaction.prototype.isIgnored = function getIgnore() {
  */
 Transaction.prototype.finalizeNameFromUri = finalizeNameFromUri
 function finalizeNameFromUri(requestURL, statusCode) {
-  logger.trace({requestURL: requestURL, statusCode: statusCode, transactionId: this.id,
-    transactionName: this.name}, 'Setting transaction name')
+  if (logger.traceEnabled()) {
+    logger.trace({requestURL: requestURL, statusCode: statusCode, transactionId: this.id,
+      transactionName: this.name}, 'Setting transaction name')
+  }
 
   this.url = urltils.scrub(requestURL)
   this.statusCode = statusCode
@@ -429,11 +431,13 @@ function finalizeNameFromUri(requestURL, statusCode) {
 
   this._copyNameToActiveSpan(this.name)
 
-  logger.trace({
-    transactionId: this.id,
-    transactionName: this.name,
-    ignore: this.ignore
-  }, 'Finished setting transaction name from Uri')
+  if (logger.traceEnabled()) {
+    logger.trace({
+      transactionId: this.id,
+      transactionName: this.name,
+      ignore: this.ignore
+    }, 'Finished setting transaction name from Uri')
+  }
 }
 
 Transaction.prototype._copyNameToActiveSpan = function _copyNameToActiveSpan(name) {
@@ -505,11 +509,13 @@ Transaction.prototype.finalizeName = function finalizeName(name) {
 
   this._copyNameToActiveSpan(this.name)
 
-  logger.trace({
-    transactionId: this.id,
-    transactionName: this.name,
-    ignore: this.ignore
-  }, 'Finished setting transaction name from string')
+  if (logger.traceEnabled()) {
+    logger.trace({
+      transactionId: this.id,
+      transactionName: this.name,
+      ignore: this.ignore
+    }, 'Finished setting transaction name from string')
+  }
 }
 
 /**

--- a/lib/transaction/trace/segment.js
+++ b/lib/transaction/trace/segment.js
@@ -8,6 +8,7 @@ const hashes = require('../../util/hashes')
 
 const {Attributes, MAXIMUM_CUSTOM_ATTRIBUTES} = require('../../attributes')
 const ExclusiveCalculator = require('./exclusive-time-calculator')
+const SpanContext = require('../../spans/span-context')
 
 const NAMES = require('../../metrics/names')
 const INSTANCE_UNKNOWN = 'unknown'
@@ -77,6 +78,17 @@ function TraceSegment(transaction, name, recorder) {
   this.probe('new TraceSegment')
 }
 
+TraceSegment.prototype.getSpanContext = function getSpanContext() {
+  const config = this.transaction.agent.config
+  const spansEnabled = config.distributed_tracing.enabled && config.span_events.enabled
+
+  if (!this._spanContext && spansEnabled) {
+    this._spanContext = new SpanContext()
+  }
+
+  return this._spanContext
+}
+
 TraceSegment.prototype.addAttribute =
 function addAttribute(key, value, truncateExempt = false) {
   this.attributes.addAttribute(
@@ -91,7 +103,7 @@ TraceSegment.prototype.getAttributes = function getAttributes() {
   return this.attributes.get(DESTINATIONS.TRANS_SEGMENT)
 }
 
-TraceSegment.prototype.addCustomSpanAttribute = 
+TraceSegment.prototype.addCustomSpanAttribute =
 function addCustomSpanAttribute(key, value, truncateExempt = false) {
   this.customAttributes.addAttribute(
     DESTINATIONS.SPAN_EVENT,

--- a/lib/transaction/tracer/index.js
+++ b/lib/transaction/tracer/index.js
@@ -21,6 +21,7 @@ function Tracer(agent) {
 
 Tracer.prototype.getTransaction = getTransaction
 Tracer.prototype.getSegment = getSegment
+Tracer.prototype.getSpanContext = getSpanContext
 Tracer.prototype.createSegment = createSegment
 Tracer.prototype.addSegment = addSegment
 Tracer.prototype.transactionProxy = transactionProxy
@@ -59,6 +60,10 @@ function getTransaction() {
 
 function getSegment() {
   return this.segment
+}
+
+function getSpanContext() {
+  return this.segment && this.segment.getSpanContext()
 }
 
 function createSegment(name, recorder, _parent) {

--- a/test/integration/distributed-tracing/transaction-span-attributes.tap.js
+++ b/test/integration/distributed-tracing/transaction-span-attributes.tap.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const tap = require('tap')
+
+const helper = require('../../lib/agent_helper')
+
+tap.test('should apply transaction name as active span intrinsic on transaction end', (t) => {
+  let agent = helper.instrumentMockedAgent({
+    distributed_tracing: {
+      enabled: true
+    }
+  })
+
+  t.tearDown(() => {
+    helper.unloadAgent(agent)
+  })
+
+  helper.runInTransaction(agent, (transaction) => {
+    // forces a web transaction
+    transaction.type = 'web'
+    transaction.url = '/some/test/url'
+    transaction.statusCode = 200
+
+    // forces creation of spans
+    transaction.priority = 42
+    transaction.sampled = true
+
+    setTimeout(() => {
+      const segment = agent.tracer.getSegment()
+
+      transaction.end()
+
+      const span = findSpanByName(agent, segment.name)
+      const serialized = span.toJSON()
+
+      const [intrinsics] = serialized
+
+      t.equal(intrinsics['transaction.name'], transaction.name)
+
+      t.end()
+    }, 10)
+  })
+})
+
+function findSpanByName(agent, name) {
+  const spans = agent.spanEventAggregator.getEvents()
+
+  for (const [, span] of spans.entries()) {
+    if (span.intrinsics.name === name) {
+      return span
+    }
+  }
+}

--- a/test/unit/api/api-custom-attributes.test.js
+++ b/test/unit/api/api-custom-attributes.test.js
@@ -16,6 +16,7 @@ tap.test('Agent API - custom attributes', (t) => {
   t.beforeEach((done) => {
     agent = helper.loadMockedAgent()
     agent.config.attributes.enabled = true
+    agent.config.distributed_tracing.enabled = true
 
     api = new API(agent)
 

--- a/test/unit/spans/span-event-aggregator.test.js
+++ b/test/unit/spans/span-event-aggregator.test.js
@@ -23,7 +23,11 @@ describe('SpanAggregator', () => {
       runId: RUN_ID,
       limit: LIMIT
     }, {}, new Metrics(5, {}, {}))
-    agent = helper.instrumentMockedAgent()
+    agent = helper.instrumentMockedAgent({
+      distributed_tracing: {
+        enabled: true
+      }
+    })
   })
 
   afterEach(() => {

--- a/test/unit/spans/streaming-span-event.test.js
+++ b/test/unit/spans/streaming-span-event.test.js
@@ -38,7 +38,11 @@ tap.test('fromSegment()', (t) => {
   let agent = null
 
   t.beforeEach((done) => {
-    agent = helper.instrumentMockedAgent()
+    agent = helper.instrumentMockedAgent({
+      distributed_tracing: {
+        enabled: true
+      }
+    })
     done()
   })
 
@@ -166,7 +170,6 @@ tap.test('fromSegment()', (t) => {
   })
 
   t.test('should create an datastore span with an datastore segment', (t) => {
-    agent.config.distributed_tracing.enabled = true
     agent.config.transaction_tracer.record_sql = 'raw'
 
     const shim = new DatastoreShim(agent, 'test-data-store', '', 'TestStore')
@@ -264,7 +267,7 @@ tap.test('fromSegment()', (t) => {
   t.test('should serialize to proper format with toStreamingFormat()', (t) => {
     helper.runInTransaction(agent, (transaction) => {
       transaction.priority = 42
-      transaction.sample = true
+      transaction.sampled = true
 
       setTimeout(() => {
         const segment = agent.tracer.getSegment()
@@ -290,6 +293,30 @@ tap.test('fromSegment()', (t) => {
         t.deepEqual(userAttributes.customKey, {[STRING_TYPE]: 'customValue'})
 
         t.deepEqual(agentAttributes.anAgentAttribute, {[BOOL_TYPE]: true})
+
+        t.end()
+      }, 10)
+    })
+  })
+
+  t.test('should populate intrinsics from span context', (t) => {
+    helper.runInTransaction(agent, (transaction) => {
+      transaction.priority = 42
+      transaction.sampled = true
+
+      setTimeout(() => {
+        const segment = agent.tracer.getSegment()
+        const spanContext = segment.getSpanContext()
+        spanContext.addIntrinsicAttribute('intrinsic.1', 1)
+        spanContext.addIntrinsicAttribute('intrinsic.2', 2)
+
+        const span = StreamingSpanEvent.fromSegment(segment, 'parent')
+
+        const serializedSpan = span.toStreamingFormat()
+        const {intrinsics} = serializedSpan
+
+        t.deepEqual(intrinsics['intrinsic.1'], {[INT_TYPE]: 1})
+        t.deepEqual(intrinsics['intrinsic.2'], {[INT_TYPE]: 2})
 
         t.end()
       }, 10)

--- a/test/unit/trace-segment.test.js
+++ b/test/unit/trace-segment.test.js
@@ -568,3 +568,76 @@ test('when serialized', (t) => {
     t.end()
   })
 })
+
+test('getSpanContext', (t) => {
+  t.autoend()
+
+  let agent = null
+  let transaction = null
+  let segment = null
+
+  t.beforeEach((done) => {
+    agent = helper.loadMockedAgent({
+      distributed_tracing: {
+        enabled: true
+      }
+    })
+
+    transaction = new Transaction(agent)
+    segment = new TraceSegment(transaction, 'UnitTest')
+
+    done()
+  })
+
+  t.afterEach((done) => {
+    helper.unloadAgent(agent)
+    agent = null
+    transaction = null
+    segment = null
+
+    done()
+  })
+
+  t.test('should not initialize with a span context', (t) => {
+    t.notOk(segment._spanContext)
+
+    t.end()
+  })
+
+  t.test('should create a new context when empty', (t) => {
+    const spanContext = segment.getSpanContext()
+
+    t.ok(spanContext)
+
+    t.end()
+  })
+
+  t.test('should not create a new context when empty and DT disabled', (t) => {
+    agent.config.distributed_tracing.enabled = false
+
+    const spanContext = segment.getSpanContext()
+
+    t.notOk(spanContext)
+
+    t.end()
+  })
+
+  t.test('should not create a new context when empty and Spans disabled', (t) => {
+    agent.config.span_events.enabled = false
+
+    const spanContext = segment.getSpanContext()
+
+    t.notOk(spanContext)
+
+    t.end()
+  })
+
+  t.test('should return existing span context', (t) => {
+    const originalContext = segment.getSpanContext()
+    const secondContext = segment.getSpanContext()
+
+    t.equal(originalContext, secondContext)
+
+    t.end()
+  })
+})


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Added `transaction.name` intrinsic to active span at time transaction name is finalized.

  This enables finding transaction name for traces that may not have a matching transaction event.

* Removed allocation of logging-only objects used by transaction naming when those log levels are disabled.

## Links

## Details

This softly introduces the concept of a "span context" as a baby step towards decoupling spans from segments as a concept.

This PR is built on top of https://github.com/newrelic/node-newrelic/pull/366, which shoudl be merged first.