### PR TITLE
Import NormalizerRule as NormalizerRule instead of Rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,3 +742,5 @@ license and the licenses of its dependencies.
 [6]: https://github.com/newrelic/node-newrelic/blob/master/lib/config/default.js
 [7]: https://docs.newrelic.com/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration
 
+
+

--- a/lib/metrics/normalizer.js
+++ b/lib/metrics/normalizer.js
@@ -4,7 +4,7 @@ var EventEmitter = require('events').EventEmitter
 var util = require('util')
 var logger = require('../logger').child({component: 'metric_normalizer'})
 var deepEqual = require('../util/deep-equal')
-var Rule = require('./normalizer/rule')
+var NormalizerRule = require('./normalizer/rule')
 var NAMES = require('../metrics/names.js')
 
 
@@ -82,7 +82,7 @@ MetricNormalizer.prototype.load = function load(json) {
 
     json.forEach(function cb_forEach(ruleJSON) {
       // no need to add the same rule twice
-      var rule = new Rule(ruleJSON)
+      var rule = new NormalizerRule(ruleJSON)
       if (!this.rules.find(deepEqual.bind(null, rule))) {
         this.rules.push(rule)
         logger.trace("Loaded %s normalization rule: %s", this.type, rule)
@@ -142,9 +142,9 @@ MetricNormalizer.prototype.loadFromConfig = function loadFromConfig() {
           : r.precedence > json.eval_order
       })
       if (insert === -1) {
-        this.rules.push(new Rule(json))
+        this.rules.push(new NormalizerRule(json))
       } else {
-        this.rules.splice(insert, 0, new Rule(json))
+        this.rules.splice(insert, 0, new NormalizerRule(json))
       }
     }, this)
   }
@@ -186,7 +186,7 @@ MetricNormalizer.prototype.addSimple = function addSimple(pattern, name) {
     json.ignore = true
   }
 
-  this.rules.unshift(new Rule(json))
+  this.rules.unshift(new NormalizerRule(json))
 }
 
 /**


### PR DESCRIPTION
## Proposed Release Notes

## Links

## Details

- Some internal cleanup to make navigating our code base a little more straight forward. `./normalizer/rule` exports a `NormalizerRule` constructor function, so lets import it with the same name -- came from some real world head scratching where we couldn't find where `NormalizerRule` was used.