### PR TITLE
Immediately reconnects to infinite tracing endpoint on 200 OK status.

### DIFF
--- a/lib/grpc/connection.js
+++ b/lib/grpc/connection.js
@@ -19,10 +19,7 @@ const protoOptions = {keepCase: true,
 const pathProtoDefinition = __dirname +
   '../../../lib/grpc/endpoints/infinite-tracing/v1.proto'
 
-const defaultBackoffOpts = {
-  initialSeconds: 0,
-  seconds:15
-}
+const DEFAULT_RECONNECT_DELAY_MS = 15 * 1000
 
 /**
  * Class for managing the GRPC connection
@@ -41,25 +38,14 @@ class GrpcConnection extends EventEmitter {
    *
    * @param {Object} traceObserverConfig config item config.infinite_tracing.trace_observer
    * @param {MetricAggregator} metrics metric aggregator, for supportability metrics
-   * @param {Object} backoffOpts allows injecting specific backoff times
+   * @param {Number} [reconnectDelayMs=15000] number of milliseconds to wait before reconnecting
+   * for error states that require a reconnect delay.
    */
-  constructor(traceObserverConfig, metrics, backoffOpts = defaultBackoffOpts) {
+  constructor(traceObserverConfig, metrics, reconnectDelayMs) {
     super()
 
-    // only set opts if the object is valid
-    if ( (backoffOpts.initialSeconds || backoffOpts.initialSeconds === 0) &&
-         (backoffOpts.seconds || backoffOpts.seconds === 0)) {
-      this._backoffOpts = backoffOpts
-    } else {
-      this._backoffOpts = defaultBackoffOpts
-      logger.trace(
-        'invalid backoff information passed to constructor, using default values'
-      )
-    }
+    this._reconnectDelayMs = reconnectDelayMs || DEFAULT_RECONNECT_DELAY_MS
 
-    // initial "stream connection" has a 0 second backoff, unless
-    // different values are injected via _backoffOpts
-    this._streamBackoffSeconds = this._backoffOpts.initialSeconds
     this._metrics = metrics
     this._setState(connectionStates.disconnected)
 
@@ -118,35 +104,21 @@ class GrpcConnection extends EventEmitter {
     }
 
     this._setState(connectionStates.connecting)
-    logger.trace('connecting to grpc endpoint in [%s] seconds', this._getBackoffSeconds())
+    logger.trace('Connecting to gRPC endpoint.')
 
-    setTimeout(() => {
-      try {
-        this.stream = this._connectSpans(this._endpoint, this._licenseKey, this._runId)
+    try {
+      this.stream = this._connectSpans(this._endpoint, this._licenseKey, this._runId)
 
-        // May not actually be "connected" at this point but we can write to the stream
-        // immediately.
-        this._setState(connectionStates.connected, this.stream)
-
-        // any future stream connect/disconnect after initial connection
-        // should have a 15 second backoff
-        this._setStreamBackoffAfterInitialStreamSetup()
-      } catch (err) {
-        logger.trace(
-          err,
-          'Unexpected error establishing GRPC stream, will not attempt reconnect.'
-        )
-        this._disconnectWithoutReconnect()
-      }
-    }, this._getBackoffSeconds() * 1000)
-  }
-
-  _setStreamBackoffAfterInitialStreamSetup() {
-    this._streamBackoffSeconds = this._backoffOpts.seconds
-  }
-
-  _setStreamBackoffToInitialValue() {
-    this._streamBackoffSeconds = this._backoffOpts.initialSeconds
+      // May not actually be "connected" at this point but we can write to the stream
+      // immediately.
+      this._setState(connectionStates.connected, this.stream)
+    } catch (err) {
+      logger.trace(
+        err,
+        'Unexpected error establishing gRPC stream, will not attempt reconnect.'
+      )
+      this._disconnect()
+    }
   }
 
   /**
@@ -159,14 +131,7 @@ class GrpcConnection extends EventEmitter {
       return
     }
 
-    this._disconnectWithoutReconnect()
-  }
-
-  /**
-   * Calculates backoff seconds
-   */
-  _getBackoffSeconds() {
-    return this._streamBackoffSeconds
+    this._disconnect()
   }
 
   /**
@@ -197,18 +162,23 @@ class GrpcConnection extends EventEmitter {
   }
 
   /**
-   * Sets internal object state to disconnected initiates a new connection
-   *
-   * Called when we receive a stream status that indicates a potential
-   * problem with the stream.  We set the state (which will emit an event),
-   * increment tries to honor the backoff, and then reconnect.
+   * Disconnects from gRPC endpoint and schedules establishing a new connection.
+   * @param {number} reconnectDelayMs number of milliseconds to wait before reconnecting.
    */
-  _reconnect() {
+  _reconnect(reconnectDelayMs = 0) {
     this._disconnect()
-    this.connectSpans()
+
+    logger.trace('Reconnecting to gRPC endpoint in [%s] seconds', reconnectDelayMs)
+
+    setTimeout(
+      this.connectSpans.bind(this),
+      reconnectDelayMs
+    )
   }
 
   _disconnect() {
+    logger.trace('Disconnecting from gRPC endpoint.')
+
     if (this.stream) {
       this.stream.removeAllListeners()
 
@@ -219,17 +189,6 @@ class GrpcConnection extends EventEmitter {
     }
 
     this._setState(connectionStates.disconnected)
-  }
-
-  /**
-   * Disconnects Without Reconnect
-   *
-   * Certain GRPC statuses require us to disconnect and _not_
-   * attempt a stream reconnect.
-   */
-  _disconnectWithoutReconnect() {
-    this._disconnect()
-    this._setStreamBackoffToInitialValue()
   }
 
   /**
@@ -244,14 +203,14 @@ class GrpcConnection extends EventEmitter {
     // listen for responses from server and log
     if (logger.traceEnabled()) {
       stream.on('data', function data(response) {
-        logger.trace("grpc span response stream: %s", JSON.stringify(response))
+        logger.trace("gRPC span response stream: %s", JSON.stringify(response))
       })
     }
 
     // listen for status that indicate stream has ended,
     // and we need to disconnect
     stream.on('status', (grpcStatus) => {
-      logger.trace('GRPC Status Received [%s]: %s', grpcStatus.code, grpcStatus.details)
+      logger.trace('gRPC Status Received [%s]: %s', grpcStatus.code, grpcStatus.details)
       const grpcStatusName =
         grpc.status[grpcStatus.code] ? grpc.status[grpcStatus.code] : 'UNKNOWN'
 
@@ -263,19 +222,15 @@ class GrpcConnection extends EventEmitter {
         // per the spec, An UNIMPLEMENTED status code from gRPC indicates
         // that the versioned Trace Observer is no longer available. Agents
         // MUST NOT attempt to reconnect in this case
-        this._disconnectWithoutReconnect()
-      } else {
-        // all statuses are treated as "bad stuff" happened, and
-        // as a signal we need to reconnect (except UNIMPLEMENTED).
-        // Even an "OK status" indicates the call completed successfully,
-        // which indicates the stream is over.
-        if (grpc.status[grpc.status.OK] !== grpcStatusName) {
-          this._metrics.getOrCreateMetric(
-            util.format(NAMES.INFINITE_TRACING.SPAN_RESPONSE_GRPC_STATUS, grpcStatusName)
-          ).incrementCallCount()
-        }
-
+        this._disconnect()
+      } else if (grpc.status[grpc.status.OK] === grpcStatusName) {
         this._reconnect()
+      } else {
+        this._metrics.getOrCreateMetric(
+          util.format(NAMES.INFINITE_TRACING.SPAN_RESPONSE_GRPC_STATUS, grpcStatusName)
+        ).incrementCallCount()
+
+        this._reconnect(this._reconnectDelayMs)
       }
     })
 

--- a/lib/spans/streaming-span-event-aggregator.js
+++ b/lib/spans/streaming-span-event-aggregator.js
@@ -33,6 +33,8 @@ class StreamingSpanEventAggregator extends Aggregator {
     logger.trace('StreamingSpanEventAggregator starting up')
     this.stream.connect(this.runId)
     this.started = true
+
+    this.emit('started')
   }
 
   stop() {
@@ -43,6 +45,8 @@ class StreamingSpanEventAggregator extends Aggregator {
     logger.trace('StreamingSpanEventAggregator stopping')
     this.stream.disconnect()
     this.started = false
+
+    this.emit('stopped')
   }
 
   send() {

--- a/test/integration/grpc/reconnect.tap.js
+++ b/test/integration/grpc/reconnect.tap.js
@@ -79,7 +79,6 @@ tap.test(
 
       let countDisconnects = 0
 
-      connection.setConnectionDetails().connectSpans()
       connection.on('connected', (callStream) => {
         t.equals(
           callStream.constructor.name,
@@ -104,6 +103,8 @@ tap.test(
           resolve()
         }
       })
+
+      connection.setConnectionDetails().connectSpans()
     })
   }
 )


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Infinite tracing gRPC connection will now immediately reconnect on 200 OK status.

  A reconnect delay will only be used when receiving an error status that is not `UNIMPLEMENTED` (which is a permanent disconnect).

## Links

## Details

Since we only need to delay on error statuses, we didn't really need the state tracking for reconnect delay and multiple types of disconnect. Much of the red is ripping that out in favor of a simple delay configuration.

`connectSpans()` does not force an async boundary now, so there's a slightly different ordering of the `emit` that impacts tests. 
