### PR TITLE
Release v6.9.0.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,35 @@
+### 6.9.0 (2020-06-08):
+
+* Added AWS API Gateway V2 Support to lambda instrumentation.
+
+* Added 'transaction.name' intrinsic to active span at time transaction name is finalized.
+
+  This enables finding transaction name for traces that may not have a matching transaction event.
+
+* Added 'error.expected' attribute to span active at time expected error was noticed.
+
+* Dropped errors earlier during collection when error collection is disabled.
+
+  Error attributes will no longer show up on spans when error collection has been disabled. Other unnecessary work will also be avoided.
+
+* Removed allocation of logging-only objects used by transaction naming when those log levels are disabled.
+
+* Upgraded escodegen from 1.12.0 to 1.14.1.
+
+* Upgraded readable-stream from 3.4.0 to 3.6.0.
+
+* Upgraded @grpc/proto-loader from 0.5.3 to 0.5.4.
+
+* Converted facts unit test to use tap API.
+
+* Converted transaction 'finalizeName...' unit tests to use tap API.
+
+* Added several items to .npmignore to prevent accidental publishing.
+
+* Fixed Redis client w/o callback versioned test flicker.
+
+  Doesn't end transaction until error encountered. Increases wait time for first operation which has to complete for the second operation to be successful.
+
 ### 6.8.0 (2020-05-21):
 
 * Bumped @newrelic/native-metrics to ^5.1.0.


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Added AWS API Gateway V2 Support to lambda instrumentation.

* Added 'transaction.name' intrinsic to active span at time transaction name is finalized.

  This enables finding transaction name for traces that may not have a matching transaction event.

* Added 'error.expected' attribute to span active at time expected error was noticed.

* Dropped errors earlier during collection when error collection is disabled.

  Error attributes will no longer show up on spans when error collection has been disabled. Other unnecessary work will also be avoided.

* Removed allocation of logging-only objects used by transaction naming when those log levels are disabled.

* Upgraded escodegen from 1.12.0 to 1.14.1.

* Upgraded readable-stream from 3.4.0 to 3.6.0.

* Upgraded @grpc/proto-loader from 0.5.3 to 0.5.4.

* Converted facts unit test to use tap API.

* Converted transaction 'finalizeName...' unit tests to use tap API.

* Added several items to .npmignore to prevent accidental publishing.

* Fixed Redis client w/o callback versioned test flicker.

  Doesn't end transaction until error encountered. Increases wait time for first operation which has to complete for the second operation to be successful.

## Links

* https://github.com/newrelic/node-newrelic/pull/361
* https://github.com/newrelic/node-newrelic/pull/362
* https://github.com/newrelic/node-newrelic/pull/363
* https://github.com/newrelic/node-newrelic/pull/364
* https://github.com/newrelic/node-newrelic/pull/365
* https://github.com/newrelic/node-newrelic/pull/366
* https://github.com/newrelic/node-newrelic/pull/369
* https://github.com/newrelic/node-newrelic/pull/370
* https://github.com/newrelic/node-newrelic/pull/371
* https://github.com/newrelic/node-newrelic/pull/372
* https://github.com/newrelic/node-newrelic/pull/374
* https://github.com/newrelic/node-newrelic/pull/375

## Details
