### PR TITLE
Custom transaction atts to span

### DIFF
--- a/api.js
+++ b/api.js
@@ -272,7 +272,7 @@ API.prototype.setControllerName = function setControllerName(name, action) {
  * @param {string} value The value you want displayed. Must be serializable.
  */
 API.prototype.addCustomAttribute = function addCustomAttribute(key, value) {
-  var metric = this.agent.metrics.getOrCreateMetric(
+  const metric = this.agent.metrics.getOrCreateMetric(
     NAMES.SUPPORTABILITY.API + '/addCustomAttribute'
   )
   metric.incrementCallCount()
@@ -291,24 +291,35 @@ API.prototype.addCustomAttribute = function addCustomAttribute(key, value) {
     return false
   }
 
-  var transaction = this.agent.tracer.getTransaction()
+  const transaction = this.agent.tracer.getTransaction()
   if (!transaction) {
-    return logger.warn('No transaction found for custom attributes.')
+    logger.warn('No transaction found for custom attributes.')
+    return false
   }
 
-  var trace = transaction.trace
+  const trace = transaction.trace
   if (!trace.custom) {
-    return logger.warn(
+    logger.warn(
       'Could not add attribute %s to nonexistent custom attributes.',
       key
     )
+    return false
   }
 
   if (CUSTOM_DENYLIST.has(key)) {
-    return logger.warn('Not overwriting value of NR-only attribute %s.', key)
+    logger.warn('Not overwriting value of NR-only attribute %s.', key)
+    return false
   }
 
   trace.addCustomAttribute(key, value)
+
+  const spanContext = this.agent.tracer.getSpanContext()
+  if (!spanContext) {
+    logger.debug('No span found for custom attributes.')
+    return false
+  }
+
+  spanContext.addCustomAttribute(key, value, spanContext.ATTRIBUTE_PRIORITY.LOW)
 }
 
 /**
@@ -398,14 +409,16 @@ API.prototype.addCustomSpanAttribute = function addCustomSpanAttribute(key, valu
   const spanContext = this.agent.tracer.getSpanContext()
 
   if (!spanContext) {
-    return logger.debug(
+    logger.debug(
       'Could not add attribute %s. No available span.',
       key
     )
+    return false
   }
 
   if (CUSTOM_DENYLIST.has(key)) {
-    return logger.warn('Not overwriting value of NR-only attribute %s.', key)
+    logger.warn('Not overwriting value of NR-only attribute %s.', key)
+    return false
   }
 
   spanContext.addCustomAttribute(key, value)

--- a/api.js
+++ b/api.js
@@ -395,11 +395,11 @@ API.prototype.addCustomSpanAttribute = function addCustomSpanAttribute(key, valu
     return false
   }
 
-  const segment = this.agent.tracer.getSegment()
+  const spanContext = this.agent.tracer.getSpanContext()
 
-  if (!segment) {
+  if (!spanContext) {
     return logger.debug(
-      'Could not add attribute %s. No available span/segment.',
+      'Could not add attribute %s. No available span.',
       key
     )
   }
@@ -408,7 +408,7 @@ API.prototype.addCustomSpanAttribute = function addCustomSpanAttribute(key, valu
     return logger.warn('Not overwriting value of NR-only attribute %s.', key)
   }
 
-  segment.addCustomSpanAttribute(key, value)
+  spanContext.addCustomAttribute(key, value)
 }
 
 API.prototype.setIgnoreTransaction = util.deprecate(

--- a/api.js
+++ b/api.js
@@ -316,7 +316,8 @@ API.prototype.addCustomAttribute = function addCustomAttribute(key, value) {
   const spanContext = this.agent.tracer.getSpanContext()
   if (!spanContext) {
     logger.debug('No span found for custom attributes.')
-    return false
+    // success/failure is ambiguous here. since at least 1 attempt tried, not returning false
+    return
   }
 
   spanContext.addCustomAttribute(key, value, spanContext.ATTRIBUTE_PRIORITY.LOW)

--- a/lib/prioritized-attributes.js
+++ b/lib/prioritized-attributes.js
@@ -1,0 +1,157 @@
+'use strict'
+
+const Config = require('./config')
+const logger = require('./logger').child({component: 'attributes'})
+const isValidType = require('./util/attribute-types')
+const byteUtils = require('./util/byte-limit')
+const properties = require('./util/properties')
+
+const ATTRIBUTE_PRIORITY = {
+  HIGH: Infinity,
+  LOW: -Infinity
+}
+
+class PrioritizedAttributes {
+  constructor(scope, limit = Infinity) {
+    this.filter = makeFilter(scope)
+    this.limit = limit
+
+    this.attributes = new Map()
+  }
+
+
+  isValidLength(str) {
+    return typeof str === 'number' || byteUtils.isValidLength(str, 255)
+  }
+
+  _set(destinations, key, value, truncateExempt, priority) {
+    this.attributes.set(key, {value, destinations, truncateExempt, priority})
+  }
+
+  get(dest) {
+    const attrs = Object.create(null)
+
+    for (let [key, attr] of this.attributes) {
+      if (!(attr.destinations & dest)) {
+        continue
+      }
+
+      attrs[key] = typeof attr.value === 'string' && !attr.truncateExempt
+        ? byteUtils.truncate(attr.value, 255)
+        : attr.value
+    }
+
+    return attrs
+  }
+
+  has(key) {
+    this.attributes.has(key)
+  }
+
+  reset() {
+    this.attributes = new Map()
+  }
+
+  addAttribute(
+    destinations,
+    key,
+    value,
+    truncateExempt = false,
+    priority = ATTRIBUTE_PRIORITY.HIGH
+  ) {
+    const existingAttribute = this.attributes.get(key)
+    let droppableAttributeKey = null
+
+    const nextCount = this.attributes.size + 1
+    if (nextCount > this.limit && !existingAttribute) {
+      if (priority > ATTRIBUTE_PRIORITY.LOW) {
+        const keys = Array.from(this.attributes.keys())
+        for (let i = keys.length - 1; i >= 0; i--) {
+          const currentKey = keys[i]
+          const foundAttribute = this.attributes.get(currentKey)
+          if (foundAttribute.priority < priority) {
+            droppableAttributeKey = currentKey
+            break
+          }
+        }
+      }
+
+      if (!droppableAttributeKey) {
+        logger.debug(
+          `Maximum number of custom attributes have been added.
+          Dropping attribute ${key} with ${value} type.`
+        )
+
+        return
+      }
+    }
+
+    if (existingAttribute && priority < existingAttribute.priority) {
+      logger.debug('incoming priority for \'%s\' is lower than existing, not updating.', key)
+      logger.trace(
+        '%s attribute retained value: %s, ignored value: %s',
+        key,
+        existingAttribute.value,
+        value
+      )
+      return
+    }
+
+    if (!isValidType(value)) {
+      return logger.debug(
+        'Not adding attribute %s with %s value type. This is expected for undefined' +
+        'attributes and only an issue if an attribute is not expected to be undefined' +
+        'or not of the type expected.',
+        key,
+        typeof value
+      )
+    }
+
+    if (!this.isValidLength(key)) {
+      return logger.warn(
+        'Length limit exceeded for attribute name, not adding: %s',
+        key
+      )
+    }
+
+
+    // Only set the attribute if at least one destination passed
+    const validDestinations = this.filter(destinations, key)
+    if (validDestinations) {
+      if (droppableAttributeKey) {
+        logger.trace(
+          'dropping existing lower priority attribute %s ' +
+          'to add higher priority attribute %s',
+          droppableAttributeKey,
+          key
+        )
+
+        this.attributes.delete(droppableAttributeKey)
+      }
+
+      this._set(validDestinations, key, value, truncateExempt, priority)
+    }
+  }
+
+  addAttributes(destinations, attrs) {
+    for (let key in attrs) {
+      if (properties.hasOwn(attrs, key)) {
+        this.addAttribute(destinations, key, attrs[key])
+      }
+    }
+  }
+}
+
+function makeFilter(scope) {
+  const {attributeFilter} = Config.getInstance()
+  if (scope === 'transaction') {
+    return (d, k) => attributeFilter.filterTransaction(d, k)
+  } else if (scope === 'segment') {
+    return (d, k) => attributeFilter.filterSegment(d, k)
+  }
+}
+
+module.exports = {
+  PrioritizedAttributes: PrioritizedAttributes,
+  ATTRIBUTE_PRIORITY: ATTRIBUTE_PRIORITY
+}

--- a/lib/prioritized-attributes.js
+++ b/lib/prioritized-attributes.js
@@ -60,21 +60,10 @@ class PrioritizedAttributes {
     priority = ATTRIBUTE_PRIORITY.HIGH
   ) {
     const existingAttribute = this.attributes.get(key)
-    let droppableAttributeKey = null
 
-    const nextCount = this.attributes.size + 1
-    if (nextCount > this.limit && !existingAttribute) {
-      if (priority > ATTRIBUTE_PRIORITY.LOW) {
-        const keys = Array.from(this.attributes.keys())
-        for (let i = keys.length - 1; i >= 0; i--) {
-          const currentKey = keys[i]
-          const foundAttribute = this.attributes.get(currentKey)
-          if (foundAttribute.priority < priority) {
-            droppableAttributeKey = currentKey
-            break
-          }
-        }
-      }
+    let droppableAttributeKey = null
+    if (!existingAttribute && this.attributes.size === this.limit) {
+      droppableAttributeKey = this._getNewestDroppableAttribute(priority)
 
       if (!droppableAttributeKey) {
         logger.debug(
@@ -139,6 +128,23 @@ class PrioritizedAttributes {
     for (let key in attrs) {
       if (properties.hasOwn(attrs, key)) {
         this.addAttribute(destinations, key, attrs[key])
+      }
+    }
+  }
+
+  _getNewestDroppableAttribute(incomingPriority) {
+    // There will never be anything lower priority to drop
+    if (incomingPriority === ATTRIBUTE_PRIORITY.LOW) {
+      return
+    }
+
+    // Map maintains order keys were added.
+    const keys = Array.from(this.attributes.keys())
+    for (let i = keys.length - 1; i >= 0; i--) {
+      const currentKey = keys[i]
+      const foundAttribute = this.attributes.get(currentKey)
+      if (foundAttribute.priority < incomingPriority) {
+        return currentKey
       }
     }
   }

--- a/lib/prioritized-attributes.js
+++ b/lib/prioritized-attributes.js
@@ -61,11 +61,11 @@ class PrioritizedAttributes {
   ) {
     const existingAttribute = this.attributes.get(key)
 
-    let hasDroppableAttributeKey = null
+    let droppableAttributeKey = null
     if (!existingAttribute && this.attributes.size === this.limit) {
-      hasDroppableAttributeKey = this._hasDroppableAttribute(priority)
+      droppableAttributeKey = this._getDroppableAttributeKey(priority)
 
-      if (!hasDroppableAttributeKey) {
+      if (!droppableAttributeKey) {
         logger.debug(
           `Maximum number of custom attributes have been added.
           Dropping attribute ${key} with ${value} type.`
@@ -112,8 +112,7 @@ class PrioritizedAttributes {
       return
     }
 
-    if (hasDroppableAttributeKey) {
-      const droppableAttributeKey = this._lowPriorityAttributeNames.pop()
+    if (droppableAttributeKey) {
       logger.trace(
         'dropping existing lower priority attribute %s ' +
         'to add higher priority attribute %s',
@@ -135,24 +134,36 @@ class PrioritizedAttributes {
     }
   }
 
-  _hasDroppableAttribute(incomingPriority) {
+  _getDroppableAttributeKey(incomingPriority) {
     // There will never be anything lower priority to drop
     if (incomingPriority === ATTRIBUTE_PRIORITY.LOW) {
-      return
+      return null
     }
 
-    // Currently only support HIGH/LOW
-    if (!this._lowPriorityAttributeNames) {
-      this._lowPriorityAttributeNames = []
+    this.hasLowerCache = this.hasLowerCache || Object.create(null)
 
-      for (const [key, attribute] of this.attributes) {
-        if (attribute.priority === ATTRIBUTE_PRIORITY.LOW) {
-          this._lowPriorityAttributeNames.push(key)
-        }
+    // We've already dropped all items lower than incomingPriority
+    if (this.hasLowerCache[incomingPriority] === false) {
+      return null
+    }
+
+    // We can't reverse iterate w/o creating an array that will iterate,
+    // so we just do the one pass through to the end.
+    let lowerPriorityAttributeName = null
+    for (const [key, attribute] of this.attributes) {
+      if (attribute.priority < incomingPriority) {
+        lowerPriorityAttributeName = key
       }
     }
 
-    return this._lowPriorityAttributeNames.length > 0
+    // Item may not get dropped, so we wait til the next attempt to set to false
+    // for when the last lower-priority item has been grabbed.
+    // We can cache and honor the false because at the point by which we've dropped
+    // all lower priority items, due to being at max capacity, there will never be another
+    // lower-priority item added. Lower priority items are unable to drop higher priority items.
+    this.hasLowerCache[incomingPriority] = Boolean(lowerPriorityAttributeName)
+
+    return lowerPriorityAttributeName
   }
 }
 

--- a/lib/prioritized-attributes.js
+++ b/lib/prioritized-attributes.js
@@ -140,28 +140,42 @@ class PrioritizedAttributes {
       return null
     }
 
-    this.hasLowerCache = this.hasLowerCache || Object.create(null)
+    this.lastFoundIndexCache = this.lastFoundIndexCache || Object.create(null)
+    const lastFoundIndex = this.lastFoundIndexCache[incomingPriority]
 
-    // We've already dropped all items lower than incomingPriority
-    if (this.hasLowerCache[incomingPriority] === false) {
+    // We've already dropped all items lower than incomingPriority.
+    // We can honor the cache because at the point by which we've dropped
+    // all lower priority items, due to being at max capacity, there will never be another
+    // lower-priority item added. Lower priority items are unable to drop higher priority items.
+    if (lastFoundIndex === -1) {
       return null
     }
 
     // We can't reverse iterate w/o creating an array that will iterate,
-    // so we just do the one pass through to the end.
+    // so we just iterate forward stopping once we've checked the last cached index.
     let lowerPriorityAttributeName = null
+    let foundIndex = -1
+
+    let index = 0
     for (const [key, attribute] of this.attributes) {
+      // Don't search past last found lower priority item.
+      // At the point of dropping items for this priority,
+      // lower priority items will never be added.
+      if (lastFoundIndex && index > lastFoundIndex) {
+        break
+      }
+
       if (attribute.priority < incomingPriority) {
         lowerPriorityAttributeName = key
+        foundIndex = index
       }
+
+      index++
     }
 
-    // Item may not get dropped, so we wait til the next attempt to set to false
-    // for when the last lower-priority item has been grabbed.
-    // We can cache and honor the false because at the point by which we've dropped
-    // all lower priority items, due to being at max capacity, there will never be another
-    // lower-priority item added. Lower priority items are unable to drop higher priority items.
-    this.hasLowerCache[incomingPriority] = Boolean(lowerPriorityAttributeName)
+    // Item may not get dropped, so we simply store the index as
+    // an upper maximum and allow a future pass to clear out.
+    this.lastFoundIndexCache[incomingPriority] = foundIndex
 
     return lowerPriorityAttributeName
   }

--- a/lib/prioritized-attributes.js
+++ b/lib/prioritized-attributes.js
@@ -98,20 +98,22 @@ class PrioritizedAttributes {
     }
 
     if (!isValidType(value)) {
-      return logger.debug(
+      logger.debug(
         'Not adding attribute %s with %s value type. This is expected for undefined' +
         'attributes and only an issue if an attribute is not expected to be undefined' +
         'or not of the type expected.',
         key,
         typeof value
       )
+      return
     }
 
     if (!this.isValidLength(key)) {
-      return logger.warn(
+      logger.warn(
         'Length limit exceeded for attribute name, not adding: %s',
         key
       )
+      return
     }
 
 

--- a/lib/prioritized-attributes.js
+++ b/lib/prioritized-attributes.js
@@ -61,11 +61,11 @@ class PrioritizedAttributes {
   ) {
     const existingAttribute = this.attributes.get(key)
 
-    let droppableAttributeKey = null
+    let hasDroppableAttributeKey = null
     if (!existingAttribute && this.attributes.size === this.limit) {
-      droppableAttributeKey = this._getNewestDroppableAttribute(priority)
+      hasDroppableAttributeKey = this._hasDroppableAttribute(priority)
 
-      if (!droppableAttributeKey) {
+      if (!hasDroppableAttributeKey) {
         logger.debug(
           `Maximum number of custom attributes have been added.
           Dropping attribute ${key} with ${value} type.`
@@ -108,20 +108,23 @@ class PrioritizedAttributes {
 
     // Only set the attribute if at least one destination passed
     const validDestinations = this.filter(destinations, key)
-    if (validDestinations) {
-      if (droppableAttributeKey) {
-        logger.trace(
-          'dropping existing lower priority attribute %s ' +
-          'to add higher priority attribute %s',
-          droppableAttributeKey,
-          key
-        )
-
-        this.attributes.delete(droppableAttributeKey)
-      }
-
-      this._set(validDestinations, key, value, truncateExempt, priority)
+    if (!validDestinations) {
+      return
     }
+
+    if (hasDroppableAttributeKey) {
+      const droppableAttributeKey = this._lowPriorityAttributeNames.pop()
+      logger.trace(
+        'dropping existing lower priority attribute %s ' +
+        'to add higher priority attribute %s',
+        droppableAttributeKey,
+        key
+      )
+
+      this.attributes.delete(droppableAttributeKey)
+    }
+
+    this._set(validDestinations, key, value, truncateExempt, priority)
   }
 
   addAttributes(destinations, attrs) {
@@ -132,21 +135,24 @@ class PrioritizedAttributes {
     }
   }
 
-  _getNewestDroppableAttribute(incomingPriority) {
+  _hasDroppableAttribute(incomingPriority) {
     // There will never be anything lower priority to drop
     if (incomingPriority === ATTRIBUTE_PRIORITY.LOW) {
       return
     }
 
-    // Map maintains order keys were added.
-    const keys = Array.from(this.attributes.keys())
-    for (let i = keys.length - 1; i >= 0; i--) {
-      const currentKey = keys[i]
-      const foundAttribute = this.attributes.get(currentKey)
-      if (foundAttribute.priority < incomingPriority) {
-        return currentKey
+    // Currently only support HIGH/LOW
+    if (!this._lowPriorityAttributeNames) {
+      this._lowPriorityAttributeNames = []
+
+      for (const [key, attribute] of this.attributes) {
+        if (attribute.priority === ATTRIBUTE_PRIORITY.LOW) {
+          this._lowPriorityAttributeNames.push(key)
+        }
       }
     }
+
+    return this._lowPriorityAttributeNames.length > 0
   }
 }
 

--- a/lib/spans/span-context.js
+++ b/lib/spans/span-context.js
@@ -1,12 +1,31 @@
 'use strict'
 
+const {Attributes, MAXIMUM_CUSTOM_ATTRIBUTES} = require('../attributes')
+const {DESTINATIONS} = require('../config/attribute-filter')
+
+// Scoping impacts memoization. We could decide to add a scope instead of including
+// spans in segment scope in the future.
+const ATTRIBUTE_SCOPE = 'segment'
+
 class SpanContext {
-  constructor(intrinsicAttributes) {
+  constructor(intrinsicAttributes, customAttributes) {
     this.intrinsicAttributes = intrinsicAttributes || Object.create(null)
+
+    this.customAttributes =
+      customAttributes || new Attributes(ATTRIBUTE_SCOPE, MAXIMUM_CUSTOM_ATTRIBUTES)
   }
 
   addIntrinsicAttribute(key, value) {
     this.intrinsicAttributes[key] = value
+  }
+
+  addCustomAttribute(key, value, truncateExempt = false) {
+    this.customAttributes.addAttribute(
+      DESTINATIONS.SPAN_EVENT,
+      key,
+      value,
+      truncateExempt
+    )
   }
 }
 

--- a/lib/spans/span-context.js
+++ b/lib/spans/span-context.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const {Attributes, MAXIMUM_CUSTOM_ATTRIBUTES} = require('../attributes')
+const {MAXIMUM_CUSTOM_ATTRIBUTES} = require('../attributes')
+const {PrioritizedAttributes, ATTRIBUTE_PRIORITY} = require('../prioritized-attributes')
 const {DESTINATIONS} = require('../config/attribute-filter')
 
 // Scoping impacts memoization. We could decide to add a scope instead of including
@@ -12,19 +13,22 @@ class SpanContext {
     this.intrinsicAttributes = intrinsicAttributes || Object.create(null)
 
     this.customAttributes =
-      customAttributes || new Attributes(ATTRIBUTE_SCOPE, MAXIMUM_CUSTOM_ATTRIBUTES)
+      customAttributes || new PrioritizedAttributes(ATTRIBUTE_SCOPE, MAXIMUM_CUSTOM_ATTRIBUTES)
+
+    this.ATTRIBUTE_PRIORITY = ATTRIBUTE_PRIORITY
   }
 
   addIntrinsicAttribute(key, value) {
     this.intrinsicAttributes[key] = value
   }
 
-  addCustomAttribute(key, value, truncateExempt = false) {
+  addCustomAttribute(key, value, priority) {
     this.customAttributes.addAttribute(
       DESTINATIONS.SPAN_EVENT,
       key,
       value,
-      truncateExempt
+      false,
+      priority
     )
   }
 }

--- a/lib/spans/span-event.js
+++ b/lib/spans/span-event.js
@@ -80,7 +80,9 @@ class SpanEvent {
    */
   static fromSegment(segment, parentId = null, isRoot = false) {
     const attributes = segment.attributes.get(DESTINATIONS.SPAN_EVENT)
-    const customAttributes = segment.customAttributes.get(DESTINATIONS.SPAN_EVENT)
+
+    const spanContext = segment.getSpanContext()
+    const customAttributes = spanContext.customAttributes.get(DESTINATIONS.SPAN_EVENT)
 
     let span = null
     if (HttpSpanEvent.testSegment(segment)) {
@@ -91,7 +93,7 @@ class SpanEvent {
       span = new SpanEvent(attributes, customAttributes)
     }
 
-    const spanContext = segment.getSpanContext()
+
     for (const [key, value] of Object.entries(spanContext.intrinsicAttributes)) {
       span.intrinsics[key] = value
     }

--- a/lib/spans/streaming-span-event.js
+++ b/lib/spans/streaming-span-event.js
@@ -98,7 +98,9 @@ class StreamingSpanEvent {
 
   static fromSegment(segment, parentId = null, isRoot = false) {
     const agentAttributes = segment.attributes.get(DESTINATIONS.SPAN_EVENT)
-    const customAttributes = segment.customAttributes.get(DESTINATIONS.SPAN_EVENT)
+
+    const spanContext = segment.getSpanContext()
+    const customAttributes = spanContext.customAttributes.get(DESTINATIONS.SPAN_EVENT)
 
     const transaction = segment.transaction
     const traceId = transaction.traceId
@@ -112,7 +114,6 @@ class StreamingSpanEvent {
       span = new StreamingSpanEvent(traceId, agentAttributes, customAttributes)
     }
 
-    const spanContext = segment.getSpanContext()
     for (const [key, value] of Object.entries(spanContext.intrinsicAttributes)) {
       span.addIntrinsicAttribute(key, value)
     }

--- a/lib/transaction/trace/segment.js
+++ b/lib/transaction/trace/segment.js
@@ -6,7 +6,7 @@ const Timer = require('../../timer')
 const urltils = require('../../util/urltils')
 const hashes = require('../../util/hashes')
 
-const {Attributes, MAXIMUM_CUSTOM_ATTRIBUTES} = require('../../attributes')
+const {Attributes} = require('../../attributes')
 const ExclusiveCalculator = require('./exclusive-time-calculator')
 const SpanContext = require('../../spans/span-context')
 
@@ -53,7 +53,6 @@ function TraceSegment(transaction, name, recorder) {
   }
 
   this.attributes = new Attributes(ATTRIBUTE_SCOPE)
-  this.customAttributes = new Attributes(ATTRIBUTE_SCOPE, MAXIMUM_CUSTOM_ATTRIBUTES)
 
   this.children = []
 
@@ -101,16 +100,6 @@ function addAttribute(key, value, truncateExempt = false) {
 
 TraceSegment.prototype.getAttributes = function getAttributes() {
   return this.attributes.get(DESTINATIONS.TRANS_SEGMENT)
-}
-
-TraceSegment.prototype.addCustomSpanAttribute =
-function addCustomSpanAttribute(key, value, truncateExempt = false) {
-  this.customAttributes.addAttribute(
-    DESTINATIONS.SPAN_EVENT,
-    key,
-    value,
-    truncateExempt
-  )
 }
 
 TraceSegment.prototype.getSpanId = function getSpanId() {

--- a/test/benchmark/attributes/priority-add-max.js
+++ b/test/benchmark/attributes/priority-add-max.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const benchmark = require('../../lib/benchmark')
+
+const {PrioritizedAttributes, ATTRIBUTE_PRIORITY} = require('../../../lib/prioritized-attributes')
+const AttributeFilter = require('../../../lib/config/attribute-filter')
+
+const DESTINATIONS = AttributeFilter.DESTINATIONS
+const SEGMENT_SCOPE = 'segment'
+
+const testAttributes = new PrioritizedAttributes(SEGMENT_SCOPE, 64)
+batchAddAttributes(testAttributes, 64)
+
+const suite = benchmark.createBenchmark({name: 'priority attributes', runs: 100000})
+
+let iterationCount = 0
+suite.add({
+  name: 'add past maximum',
+  fn: function() {
+    iterationCount++
+    const name = iterationCount.toString()
+    testAttributes.addAttribute(
+      DESTINATIONS.SPAN_EVENT,
+      name,
+      iterationCount,
+      false,
+      ATTRIBUTE_PRIORITY.HIGH
+    )
+  }
+})
+
+suite.run()
+
+function batchAddAttributes(attributes, attributeCount) {
+  for (let i = 0; i < attributeCount; i++) {
+    const name = `attr: ${i}`
+    attributes.addAttribute(DESTINATIONS.SPAN_EVENT, name, i, false, ATTRIBUTE_PRIORITY.HIGH)
+  }
+}

--- a/test/benchmark/attributes/priority-add-max.js
+++ b/test/benchmark/attributes/priority-add-max.js
@@ -8,18 +8,55 @@ const AttributeFilter = require('../../../lib/config/attribute-filter')
 const DESTINATIONS = AttributeFilter.DESTINATIONS
 const SEGMENT_SCOPE = 'segment'
 
-const testAttributes = new PrioritizedAttributes(SEGMENT_SCOPE, 64)
-batchAddAttributes(testAttributes, 64)
+const highPriorityAttributes = new PrioritizedAttributes(SEGMENT_SCOPE, 64)
+batchAddAttributes(highPriorityAttributes, 64, ATTRIBUTE_PRIORITY.HIGH)
+
+const lowPriorityAttributes = new PrioritizedAttributes(SEGMENT_SCOPE, 64)
+batchAddAttributes(lowPriorityAttributes, 64, ATTRIBUTE_PRIORITY.LOW)
+
+const halfLowHalfHighPriorityAttributes = new PrioritizedAttributes(SEGMENT_SCOPE, 64)
+batchAddAttributes(halfLowHalfHighPriorityAttributes, 32, ATTRIBUTE_PRIORITY.LOW)
+batchAddAttributes(halfLowHalfHighPriorityAttributes, 32, ATTRIBUTE_PRIORITY.HIGH)
 
 const suite = benchmark.createBenchmark({name: 'priority attributes', runs: 100000})
 
 let iterationCount = 0
 suite.add({
-  name: 'add past maximum',
+  name: 'add past maximum, all high priority to start',
   fn: function() {
     iterationCount++
     const name = iterationCount.toString()
-    testAttributes.addAttribute(
+    highPriorityAttributes.addAttribute(
+      DESTINATIONS.SPAN_EVENT,
+      name,
+      iterationCount,
+      false,
+      ATTRIBUTE_PRIORITY.HIGH
+    )
+  }
+})
+
+suite.add({
+  name: 'add past maximum, all low priority to start',
+  fn: function() {
+    iterationCount++
+    const name = iterationCount.toString()
+    lowPriorityAttributes.addAttribute(
+      DESTINATIONS.SPAN_EVENT,
+      name,
+      iterationCount,
+      false,
+      ATTRIBUTE_PRIORITY.HIGH
+    )
+  }
+})
+
+suite.add({
+  name: 'add past maximum, first half low and last half high to start',
+  fn: function() {
+    iterationCount++
+    const name = iterationCount.toString()
+    lowPriorityAttributes.addAttribute(
       DESTINATIONS.SPAN_EVENT,
       name,
       iterationCount,
@@ -31,9 +68,9 @@ suite.add({
 
 suite.run()
 
-function batchAddAttributes(attributes, attributeCount) {
+function batchAddAttributes(attributes, attributeCount, priority) {
   for (let i = 0; i < attributeCount; i++) {
     const name = `attr: ${i}`
-    attributes.addAttribute(DESTINATIONS.SPAN_EVENT, name, i, false, ATTRIBUTE_PRIORITY.HIGH)
+    attributes.addAttribute(DESTINATIONS.SPAN_EVENT, name, i, false, priority)
   }
 }

--- a/test/integration/api/custom-attribute-span-propogation.tap.js
+++ b/test/integration/api/custom-attribute-span-propogation.tap.js
@@ -1,0 +1,225 @@
+'use strict'
+
+const tap = require('tap')
+
+const API = require('../../../api')
+const AttributeFilter = require('../../../lib/config/attribute-filter')
+const helper = require('../../lib/agent_helper')
+
+const DESTINATIONS = AttributeFilter.DESTINATIONS
+
+tap.test('#addAttribute', (t) => {
+  t.autoend()
+
+  let agent = null
+  let api = null
+
+  t.beforeEach((done) => {
+    agent = helper.loadMockedAgent({
+      distributed_tracing: {
+        enabled: true
+      }
+    })
+    api = new API(agent)
+    done()
+  })
+
+  t.afterEach((done) => {
+    helper.unloadAgent(agent)
+    done()
+  })
+
+  t.test('should add attribute to current span', (t) => {
+    helper.runInTransaction(agent, () => {
+      api.startSegment('segment1', true, () => {
+        api.addCustomAttribute('key1', 'value1')
+
+        const customSpanAttributes = getCustomSpanAttributes(agent)
+        t.equal(customSpanAttributes.key1, 'value1')
+
+        t.end()
+      })
+    })
+  })
+
+  t.test('should overwrite for same key added via addCustomAttribute', (t) => {
+    helper.runInTransaction(agent, () => {
+      api.startSegment('segment1', true, () => {
+        api.addCustomAttribute('key1', 'value1')
+        api.addCustomAttribute('key1', 'last-wins')
+
+        const customSpanAttributes = getCustomSpanAttributes(agent)
+        t.equal(customSpanAttributes.key1, 'last-wins')
+
+        t.end()
+      })
+    })
+  })
+
+  t.test('should not overwrite for same key added via addCustomSpanAttribute', (t) => {
+    helper.runInTransaction(agent, () => {
+      api.startSegment('segment1', true, () => {
+        api.addCustomSpanAttribute('key1', 'custom-span-wins')
+        api.addCustomAttribute('key1', 'does-not-overwrite')
+
+        const customSpanAttributes = getCustomSpanAttributes(agent)
+        t.equal(customSpanAttributes.key1, 'custom-span-wins')
+
+        t.end()
+      })
+    })
+  })
+
+  t.test('should not add attribute when over the limit', (t) => {
+    helper.runInTransaction(agent, () => {
+      api.startSegment('segment1', true, () => {
+        // the cap is 64
+        batchAddCustomAttributes(api, 32)
+        batchAddCustomSpanAttributes(api, 32)
+
+        const unexpectedAttributeName = 'should-not-exist'
+        api.addCustomAttribute(unexpectedAttributeName, 'does-not-exist')
+
+        const customSpanAttributes = getCustomSpanAttributes(agent)
+        const hasAttribute = Object.hasOwnProperty.bind(customSpanAttributes)
+
+        t.notOk(hasAttribute(unexpectedAttributeName))
+
+        t.end()
+      })
+    })
+  })
+})
+
+tap.test('#addCustomSpanAttribute', (t) => {
+  t.autoend()
+
+  let agent = null
+  let api = null
+
+  t.beforeEach((done) => {
+    agent = helper.loadMockedAgent({
+      distributed_tracing: {
+        enabled: true
+      }
+    })
+    api = new API(agent)
+    done()
+  })
+
+  t.afterEach((done) => {
+    helper.unloadAgent(agent)
+    done()
+  })
+
+  t.test('should not add attribute to transaction', (t) => {
+    helper.runInTransaction(agent, (transaction) => {
+      api.startSegment('segment1', true, () => {
+        const unexpectedAttributeName = 'should-not-exist'
+        api.addCustomSpanAttribute(unexpectedAttributeName, 'does-not-exist')
+
+        const customTransactionAttributes = getCustomTransactionAttributes(transaction)
+        const hasAttribute = Object.hasOwnProperty.bind(customTransactionAttributes)
+
+        t.notOk(hasAttribute(unexpectedAttributeName))
+
+        t.end()
+      })
+    })
+  })
+
+  t.test('should overwrite for same key added via addCustomAttribute', (t) => {
+    helper.runInTransaction(agent, () => {
+      api.startSegment('segment1', true, () => {
+        api.addCustomAttribute('key1', 'value1')
+        api.addCustomSpanAttribute('key1', 'custom-span-wins')
+
+        const customSpanAttributes = getCustomSpanAttributes(agent)
+
+        t.equal(customSpanAttributes.key1, 'custom-span-wins')
+
+        t.end()
+      })
+    })
+  })
+
+  t.test('should overwrite for same key added via addCustomSpanAttribute', (t) => {
+    helper.runInTransaction(agent, () => {
+      api.startSegment('segment1', true, () => {
+        api.addCustomSpanAttribute('key1', 'value1')
+        api.addCustomSpanAttribute('key1', 'last-wins')
+
+        const customSpanAttributes = getCustomSpanAttributes(agent)
+
+        t.equal(customSpanAttributes.key1, 'last-wins')
+
+        t.end()
+      })
+    })
+  })
+
+  t.test('should replace newest added via addCustomAttribute when over the limit', (t) => {
+    helper.runInTransaction(agent, () => {
+      api.startSegment('segment1', true, () => {
+        // the cap is 64
+        const lastAddedName = batchAddCustomAttributes(api, 32)
+        batchAddCustomSpanAttributes(api, 32)
+
+        api.addCustomSpanAttribute('should-replace-add-custom', 'replaced')
+
+        const customSpanAttributes = getCustomSpanAttributes(agent)
+        const hasAttribute = Object.hasOwnProperty.bind(customSpanAttributes)
+
+        t.notOk(hasAttribute(lastAddedName), 'should drop last added via addCustomAttribute')
+
+        t.equal(customSpanAttributes['should-replace-add-custom'], 'replaced')
+
+        t.end()
+      })
+    })
+  })
+
+  t.test('should not replace any added via addCustomSpanAttribute when over the limit', (t) => {
+    helper.runInTransaction(agent, () => {
+      api.startSegment('segment1', true, () => {
+        // the cap is 64
+        batchAddCustomSpanAttributes(api, 64)
+
+        const unexpectedAttributeName = 'should-not-replace-add-custom-span'
+        api.addCustomSpanAttribute(unexpectedAttributeName, 'does-not-exist')
+
+        const customSpanAttributes = getCustomSpanAttributes(agent)
+        const hasAttribute = Object.hasOwnProperty.bind(customSpanAttributes)
+
+        t.notOk(hasAttribute(unexpectedAttributeName))
+
+        t.end()
+      })
+    })
+  })
+})
+
+function getCustomSpanAttributes(agent) {
+  const spanContext = agent.tracer.getSpanContext()
+  return spanContext && spanContext.customAttributes.get(DESTINATIONS.SPAN_EVENT)
+}
+
+function getCustomTransactionAttributes(transaction) {
+  return transaction.trace.custom.get(DESTINATIONS.TRANS_SCOPE)
+}
+
+function batchAddCustomAttributes(api, attributeCount) {
+  let addedName = null
+  for (let i = 0; i < attributeCount; i++) {
+    addedName = `custom-${i}`
+    api.addCustomAttribute(addedName, i)
+  }
+
+  return addedName
+}
+
+function batchAddCustomSpanAttributes(api, attributeCount) {
+  for (let i = 0; i < attributeCount; i++) {
+    api.addCustomSpanAttribute(`custom-span-${i}`, i)
+  }
+}

--- a/test/unit/high-security.test.js
+++ b/test/unit/high-security.test.js
@@ -243,9 +243,11 @@ describe('high security mode', function() {
     })
 
     it('should not affect addCustomAttribute if high_security is off', function() {
-      agent.config.high_security = false
-      var success = api.addCustomAttribute('key', 'value')
-      should.not.exist(success)
+      helper.runInTransaction(agent, () => {
+        agent.config.high_security = false
+        const success = api.addCustomAttribute('key', 'value')
+        should.not.exist(success)
+      })
     })
   })
 })

--- a/test/unit/prioritized-attributes.test.js
+++ b/test/unit/prioritized-attributes.test.js
@@ -1,0 +1,436 @@
+'use strict'
+
+const tap = require('tap')
+
+const helper = require('../lib/agent_helper')
+const {PrioritizedAttributes, ATTRIBUTE_PRIORITY} = require('../../lib/prioritized-attributes')
+const AttributeFilter = require('../../lib/config/attribute-filter')
+
+const DESTINATIONS = AttributeFilter.DESTINATIONS
+const TRANSACTION_SCOPE = 'transaction'
+
+tap.test('#addAttribute', (t) => {
+  t.autoend()
+
+  let agent = null
+
+  t.beforeEach((done) => {
+    agent = helper.loadMockedAgent()
+    done()
+  })
+
+  t.afterEach((done) => {
+    helper.unloadAgent(agent)
+    done()
+  })
+
+  t.test('adds an attribute to instance', (t) => {
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE)
+    inst.addAttribute(DESTINATIONS.TRANS_SCOPE, 'test', 'success')
+    const attributes = inst.get(DESTINATIONS.TRANS_SCOPE)
+
+    t.equal(attributes.test, 'success')
+
+    t.end()
+  })
+
+  t.test('does not add attribute if key length limit is exceeded', (t) => {
+    const tooLong = [
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      'Cras id lacinia erat. Suspendisse mi nisl, sodales vel est eu,',
+      'rhoncus lacinia ante. Nulla tincidunt efficitur diam, eget vulputate',
+      'lectus facilisis sit amet. Morbi hendrerit commodo quam, in nullam.'
+    ].join(' ')
+
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE)
+    inst.addAttribute(DESTINATIONS.TRANS_SCOPE, tooLong, 'will fail')
+
+    t.notOk(inst.has(tooLong))
+
+    t.end()
+  })
+})
+
+tap.test('#addAttribute - high priority', (t) => {
+  t.autoend()
+
+  let agent = null
+
+  t.beforeEach((done) => {
+    agent = helper.loadMockedAgent()
+    done()
+  })
+
+  t.afterEach((done) => {
+    helper.unloadAgent(agent)
+    done()
+  })
+
+  t.test('should overwrite existing high priority attribute', (t) => {
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE, 2)
+    inst.addAttribute(0x01, 'Roboto', 1, false, ATTRIBUTE_PRIORITY.HIGH)
+
+    inst.addAttribute(0x01, 'Roboto', 99, false, ATTRIBUTE_PRIORITY.HIGH)
+
+    const res = inst.get(0x01)
+
+    t.equal(Object.keys(res).length, 1)
+    t.equal(res.Roboto, 99)
+
+    t.end()
+  })
+
+  t.test('should overwrite existing low priority attribute', (t) => {
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE, 2)
+    inst.addAttribute(0x01, 'Roboto', 1, false, ATTRIBUTE_PRIORITY.LOW)
+
+    inst.addAttribute(0x01, 'Roboto', 99, false, ATTRIBUTE_PRIORITY.HIGH)
+
+    const res = inst.get(0x01)
+
+    t.equal(Object.keys(res).length, 1)
+    t.equal(res.Roboto, 99)
+
+    t.end()
+  })
+
+  t.test('should overwrite existing attribute even when at maximum', (t) => {
+    const maxAttributeCount = 1
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE, maxAttributeCount)
+    inst.addAttribute(0x01, 'Roboto', 1, false, ATTRIBUTE_PRIORITY.LOW)
+
+    inst.addAttribute(0x01, 'Roboto', 99, false, ATTRIBUTE_PRIORITY.HIGH)
+
+    const res = inst.get(0x01)
+
+    t.equal(Object.keys(res).length, 1)
+    t.equal(res.Roboto, 99)
+
+    t.end()
+  })
+
+  t.test('should not add new attribute past maximum when no lower priority attributes', (t) => {
+    const maxAttributeCount = 1
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE, maxAttributeCount)
+    inst.addAttribute(0x01, 'old', 1, false, ATTRIBUTE_PRIORITY.HIGH)
+
+    inst.addAttribute(0x01, 'new', 99, false, ATTRIBUTE_PRIORITY.HIGH)
+
+    const res = inst.get(0x01)
+    const hasAttribute = Object.hasOwnProperty.bind(res)
+
+    t.equal(Object.keys(res).length, maxAttributeCount)
+    t.equal(res.old, 1)
+    t.notOk(hasAttribute('new'))
+
+    t.end()
+  })
+
+  t.test('should add new attribute, drop newest low priority attribute, when at maximum', (t) => {
+    const maxAttributeCount = 4
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE, maxAttributeCount)
+    inst.addAttribute(0x01, 'old-low', 1, false, ATTRIBUTE_PRIORITY.LOW)
+    inst.addAttribute(0x01, 'old-high', 1, false, ATTRIBUTE_PRIORITY.HIGH)
+    inst.addAttribute(0x01, 'new-low', 99, false, ATTRIBUTE_PRIORITY.LOW)
+    inst.addAttribute(0x01, 'newish-high', 50, false, ATTRIBUTE_PRIORITY.HIGH)
+
+    inst.addAttribute(0x01, 'new-high', 99, false, ATTRIBUTE_PRIORITY.HIGH)
+
+    const res = inst.get(0x01)
+    const hasAttribute = Object.hasOwnProperty.bind(res)
+
+    t.equal(Object.keys(res).length, maxAttributeCount)
+    t.equal(res['old-low'], 1)
+    t.equal(res['old-high'], 1)
+    t.equal(res['newish-high'], 50)
+    t.equal(res['new-high'], 99)
+    t.notOk(hasAttribute('new-low'))
+
+    t.end()
+  })
+
+  t.test('should stop adding attributes after all low priority dropped, when at maximum', (t) => {
+    const maxAttributeCount = 3
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE, maxAttributeCount)
+    inst.addAttribute(0x01, 'old-low', 1, false, ATTRIBUTE_PRIORITY.LOW)
+    inst.addAttribute(0x01, 'oldest-high', 1, false, ATTRIBUTE_PRIORITY.HIGH)
+    inst.addAttribute(0x01, 'new-low', 99, false, ATTRIBUTE_PRIORITY.LOW)
+    inst.addAttribute(0x01, 'older-high', 50, false, ATTRIBUTE_PRIORITY.HIGH)
+    inst.addAttribute(0x01, 'newish-high', 99, false, ATTRIBUTE_PRIORITY.HIGH)
+
+    inst.addAttribute(0x01, 'failed-new-high', 999, false, ATTRIBUTE_PRIORITY.HIGH)
+
+    const res = inst.get(0x01)
+    const hasAttribute = Object.hasOwnProperty.bind(res)
+
+    t.equal(Object.keys(res).length, maxAttributeCount)
+    t.equal(res['oldest-high'], 1)
+    t.equal(res['older-high'], 50)
+    t.equal(res['newish-high'], 99)
+
+    t.notOk(hasAttribute('old-low'))
+    t.notOk(hasAttribute('new-low'))
+    t.notOk(hasAttribute('failed-new-high'))
+
+    t.end()
+  })
+})
+
+tap.test('#addAttribute - low priority', (t) => {
+  t.autoend()
+
+  let agent = null
+
+  t.beforeEach((done) => {
+    agent = helper.loadMockedAgent()
+    done()
+  })
+
+  t.afterEach((done) => {
+    helper.unloadAgent(agent)
+    done()
+  })
+
+  t.test('should overwrite existing low priority attribute', (t) => {
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE, 2)
+    inst.addAttribute(0x01, 'Roboto', 1, false, ATTRIBUTE_PRIORITY.LOW)
+
+    inst.addAttribute(0x01, 'Roboto', 99, false, ATTRIBUTE_PRIORITY.LOW)
+
+    const res = inst.get(0x01)
+
+    t.equal(Object.keys(res).length, 1)
+    t.equal(res.Roboto, 99)
+
+    t.end()
+  })
+
+  t.test('should overwrite existing low priority attribute even when at maximum', (t) => {
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE, 1)
+    inst.addAttribute(0x01, 'Roboto', 1, false, ATTRIBUTE_PRIORITY.LOW)
+
+    inst.addAttribute(0x01, 'Roboto', 99, false, ATTRIBUTE_PRIORITY.LOW)
+
+    const res = inst.get(0x01)
+
+    t.equal(Object.keys(res).length, 1)
+    t.equal(res.Roboto, 99)
+
+    t.end()
+  })
+
+  t.test('should not overwrite existing high priority attribute', (t) => {
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE, 1)
+    inst.addAttribute(0x01, 'Roboto', 1, false, ATTRIBUTE_PRIORITY.HIGH)
+
+    inst.addAttribute(0x01, 'Roboto', 99, false, ATTRIBUTE_PRIORITY.LOW)
+
+    const res = inst.get(0x01)
+
+    t.equal(Object.keys(res).length, 1)
+    t.equal(res.Roboto, 1)
+
+    t.end()
+  })
+
+  t.test('should not add new attribute past maximum', (t) => {
+    const maxAttributeCount = 2
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE, maxAttributeCount)
+    inst.addAttribute(0x01, 'old-high', 1, false, ATTRIBUTE_PRIORITY.HIGH)
+    inst.addAttribute(0x01, 'old-low', 99, false, ATTRIBUTE_PRIORITY.LOW)
+
+    inst.addAttribute(0x01, 'failed-new-low', 999, false, ATTRIBUTE_PRIORITY.LOW)
+
+    const res = inst.get(0x01)
+    const hasAttribute = Object.hasOwnProperty.bind(res)
+
+    t.equal(Object.keys(res).length, maxAttributeCount)
+    t.equal(res['old-high'], 1)
+    t.equal(res['old-low'], 99)
+    t.notOk(hasAttribute('failed-new-low'))
+
+    t.end()
+  })
+})
+
+tap.test('#addAttributes', (t) => {
+  t.autoend()
+
+  let agent = null
+
+  t.beforeEach((done) => {
+    agent = helper.loadMockedAgent()
+    done()
+  })
+
+  t.afterEach((done) => {
+    helper.unloadAgent(agent)
+    done()
+  })
+
+  t.test('adds multiple attributes to instance', (t) => {
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE)
+    inst.addAttributes(
+      DESTINATIONS.TRANS_SCOPE,
+      {one: '1', two: '2'}
+    )
+    const attributes = inst.get(DESTINATIONS.TRANS_SCOPE)
+
+    t.equal(attributes.one, '1')
+    t.equal(attributes.two, '2')
+
+    t.end()
+  })
+
+  t.test('only allows non-null-type primitive attribute values', (t) => {
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE, 10)
+    const attributes = {
+      first: 'first',
+      second: [ 'second' ],
+      third: { key: 'third' },
+      fourth: 4,
+      fifth: true,
+      sixth: undefined,
+      seventh: null,
+      eighth: Symbol('test'),
+      ninth: function() {}
+    }
+
+    inst.addAttributes(
+      DESTINATIONS.TRANS_SCOPE,
+      attributes
+    )
+
+    const res = inst.get(DESTINATIONS.TRANS_SCOPE)
+    t.equal(Object.keys(res).length, 3)
+
+    const hasAttribute = Object.hasOwnProperty.bind(res)
+    t.notOk(hasAttribute('second'))
+    t.notOk(hasAttribute('third'))
+    t.notOk(hasAttribute('sixth'))
+    t.notOk(hasAttribute('seventh'))
+    t.notOk(hasAttribute('eighth'))
+    t.notOk(hasAttribute('ninth'))
+
+    t.end()
+  })
+
+  t.test('disallows adding more than maximum allowed attributes', (t) => {
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE, 3)
+    const attributes = {
+      first: 1,
+      second: 2,
+      portishead: 3,
+      so: 4
+    }
+
+    inst.addAttributes(
+      DESTINATIONS.TRANS_SCOPE,
+      attributes
+    )
+    const res = inst.get(DESTINATIONS.TRANS_SCOPE)
+
+    t.equal(Object.keys(res).length, 3)
+
+    t.end()
+  })
+
+  t.test('Overwrites value of added attribute with same key', (t) => {
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE, 2)
+    inst.addAttribute(0x01, 'Roboto', 1)
+    inst.addAttribute(0x01, 'Roboto', 99)
+
+    const res = inst.get(0x01)
+
+    t.equal(Object.keys(res).length, 1)
+    t.equal(res.Roboto, 99)
+
+    t.end()
+  })
+})
+
+tap.test('#get', (t) => {
+  t.autoend()
+
+  let agent = null
+
+  t.beforeEach((done) => {
+    agent = helper.loadMockedAgent()
+    done()
+  })
+
+  t.afterEach((done) => {
+    helper.unloadAgent(agent)
+    done()
+  })
+
+  t.test('gets attributes by destination, truncating values if necessary', (t) => {
+    const longVal = [
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      'Cras id lacinia erat. Suspendisse mi nisl, sodales vel est eu,',
+      'rhoncus lacinia ante. Nulla tincidunt efficitur diam, eget vulputate',
+      'lectus facilisis sit amet. Morbi hendrerit commodo quam, in nullam.',
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+    ].join(' ')
+
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE)
+    inst.addAttribute(0x01, 'valid', 50)
+    inst.addAttribute(0x01, 'tooLong', longVal)
+    inst.addAttribute(0x08, 'wrongDest', 'hello')
+
+    t.ok(Buffer.byteLength(longVal) > 255)
+
+    const res = inst.get(0x01)
+    t.equal(res.valid, 50)
+
+    t.equal(Buffer.byteLength(res.tooLong), 255)
+
+    t.end()
+  })
+
+  t.test('only returns attributes up to specified limit', (t) => {
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE, 2)
+    inst.addAttribute(0x01, 'first', 'first')
+    inst.addAttribute(0x01, 'second', 'second')
+    inst.addAttribute(0x01, 'third', 'third')
+
+    const res = inst.get(0x01)
+    const hasAttribute = Object.hasOwnProperty.bind(res)
+
+    t.equal(Object.keys(res).length, 2)
+    t.notOk(hasAttribute('third'))
+
+    t.end()
+  })
+})
+
+tap.test('#reset', (t) => {
+  t.autoend()
+
+  let agent = null
+
+  t.beforeEach((done) => {
+    agent = helper.loadMockedAgent()
+    done()
+  })
+
+  t.afterEach((done) => {
+    helper.unloadAgent(agent)
+    done()
+  })
+
+  t.test('resets instance attributes', (t) => {
+    const inst = new PrioritizedAttributes(TRANSACTION_SCOPE)
+    inst.addAttribute(0x01, 'first', 'first')
+    inst.addAttribute(0x01, 'second', 'second')
+    inst.addAttribute(0x01, 'third', 'third')
+
+    inst.reset()
+
+    t.notOk(inst.has('first'))
+    t.notOk(inst.has('second'))
+    t.notOk(inst.has('third'))
+
+    t.end()
+  })
+})

--- a/test/unit/spans/span-event.test.js
+++ b/test/unit/spans/span-event.test.js
@@ -63,7 +63,10 @@ tap.test('fromSegment()', (t) => {
 
       setTimeout(() => {
         const segment = agent.tracer.getTransaction().trace.root.children[0]
-        segment.addCustomSpanAttribute('Span Lee', 'no prize')
+
+        const spanContext = segment.getSpanContext()
+        spanContext.addCustomAttribute('Span Lee', 'no prize')
+
         const span = SpanEvent.fromSegment(segment, 'parent')
 
         // Should have all the normal properties.

--- a/test/unit/spans/streaming-span-event.test.js
+++ b/test/unit/spans/streaming-span-event.test.js
@@ -58,7 +58,9 @@ tap.test('fromSegment()', (t) => {
 
       setTimeout(() => {
         const segment = agent.tracer.getTransaction().trace.root.children[0]
-        segment.addCustomSpanAttribute('Span Lee', 'no prize')
+        const spanContext = segment.getSpanContext()
+        spanContext.addCustomAttribute('Span Lee', 'no prize')
+
         const span = StreamingSpanEvent.fromSegment(segment, 'parent')
 
         // Should have all the normal properties.
@@ -271,8 +273,10 @@ tap.test('fromSegment()', (t) => {
 
       setTimeout(() => {
         const segment = agent.tracer.getSegment()
-        segment.addCustomSpanAttribute('customKey', 'customValue')
         segment.addAttribute('anAgentAttribute', true)
+
+        const spanContext = agent.tracer.getSpanContext()
+        spanContext.addCustomAttribute('customKey', 'customValue')
 
         const span = StreamingSpanEvent.fromSegment(segment, 'parent')
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Custom transaction attributes added via `API.addCustomAttribute` or `API.addCustomAttributes` will now be propagated to the currently active span, if available.

  **Security Recommendation:** Review your Transaction Event attributes configuration. Any attribute include or exclude setting specific to Transaction Events should be applied to your Span Attributes configuration or global attributes configuration. Please see [Node.js agent attributes](https://docs.newrelic.com/docs/agents/nodejs-agent/attributes/nodejs-agent-attributes#configure-attributes) for more on how to configure.

## Links

## Details

* Added a priority attribute system. Much of the built-in attribute stuff isn't *really* required for where this is used but leaves open in case we want this to apply to other or prior usages of attributes. Kept intentionally separate for now to limit risk of introducing the new system. See prioritized attributes unit tests for business logic here. 

* Moved custom span attributes off of segments onto SpanContext.

Prioritized attributes allow for prioritization of custom span attributes over transaction attributes. The rough business logic looks like: 
  * attribute w/ same key from transaction should override from transaction
  * attribute w/ same key from span should override from transaction
  * attribute w/ same key from span should override from span
  * attribute w/ same key from transaction should not override from span
  * new attribute from span should replace from transaction when over the limit
  * new attribute from transaction should not replace from transaction or from span, when over the limit

Did some benchmarking of a worst-case scenario around span adding/dropping and optimized a little bit. This made me lose a little confidence in our benchmarking, based on what I was seeing for certain scenarios, but current solution against optimized was verified both with the include benchmark in this PR as well as using `benchmarks` for an iteration based benchmarking approach. 

Due to awkward business logic situation, had to change the optimization a bit. There's ways this could be faster but trying not to make the code too complicated for a "please don't do this" scenario and also avoid introducing a new data structure behind the scenes. That being said, the little bit of added complication here helps keeps too much damage from happening in the case where attribute maximums are hit and we are determining if we can or cannot drop. It will perform the worst when all attributes start out as a lower priority. Either way is much faster than converting to an array and iterating backwards. Def open if others know of a better way of resolving the reverse iteration problem. It also shortens the scan length which is nice even if the reverse iteration wasn't an issue.
