### PR TITLE
Further redis test flicker reduction

### DIFF
--- a/test/versioned/redis/redis.tap.js
+++ b/test/versioned/redis/redis.tap.js
@@ -21,23 +21,28 @@ test('Redis instrumentation', {timeout : 10000}, function(t) {
 
   t.beforeEach(function(done) {
     helper.bootstrapRedis(DB_INDEX, function cb_bootstrapRedis(error) {
-      if (error) return t.fail(error)
+      if (error) {
+        return t.fail(error)
+      }
+
       agent = helper.instrumentMockedAgent()
-      var redis = require('redis')
+
+      const redis = require('redis')
       client = redis.createClient(params.redis_port, params.redis_host)
+      client.once('ready', () => {
+        client.select(DB_INDEX, function(err) {
+          METRIC_HOST_NAME = urltils.isLocalhost(params.redis_host)
+            ? agent.config.getHostnameSafe()
+            : params.redis_host
+          HOST_ID = METRIC_HOST_NAME + '/' + params.redis_port
 
-      client.select(DB_INDEX, function(err) {
-        METRIC_HOST_NAME = urltils.isLocalhost(params.redis_host)
-          ? agent.config.getHostnameSafe()
-          : params.redis_host
-        HOST_ID = METRIC_HOST_NAME + '/' + params.redis_port
+          // need to capture attributes
+          agent.config.attributes.enabled = true
 
-        // need to capture attributes
-        agent.config.attributes.enabled = true
-
-        // Start testing!
-        t.notOk(agent.getTransaction(), "no transaction should be in play")
-        done(err)
+          // Start testing!
+          t.notOk(agent.getTransaction(), "no transaction should be in play")
+          done(err)
+        })
       })
     })
   })
@@ -123,13 +128,26 @@ test('Redis instrumentation', {timeout : 10000}, function(t) {
     let transaction = null
 
     helper.runInTransaction(agent, function(tx) {
+      transaction = tx
+
       client.set('testKey', 'testvalue')
-      setTimeout(function() {
-        transaction = tx
+
+      triggerError()
+
+      function triggerError() {
+        // When the redis service responds, the command is dequeued and then
+        // the command callback is executed, if exists. Since we don't have a callback,
+        // we wait for the command to be removed from the queue.
+        if (client.commandQueueLength > 0) {
+          t.comment('set command still in command queue. scheduling retry')
+
+          setTimeout(triggerError, 100)
+          return
+        }
 
         // This will generate an error because `testKey` is not a hash.
         client.hset('testKey', 'hashKey', 'foobar')
-      }, 200) // Wait for client.set('testKey', 'testvalue') to complete
+      }
     })
 
     client.on('error', function(err) {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Modified redis callback-less versioned test to use `commandQueueLength` as indicator redis command has completed and test can continue. This is in effort to further reduce these test flickers. Additionally, added wait for client 'ready' before moving on to tests.

## Links

## Details
