### PR TITLE
Segment attributes intended for Spans should be explicitly added to Spans

### DIFF
--- a/lib/instrumentation/core/http-outbound.js
+++ b/lib/instrumentation/core/http-outbound.js
@@ -133,7 +133,7 @@ module.exports = function instrumentOutbound(agent, opts, makeRequest) {
     if (parsed.parameters) {
       // Scrub and parse returns on object with a null prototype.
       for (let key in parsed.parameters) { // eslint-disable-line guard-for-in
-        segment.addAttribute(`request.parameters.${key}`, parsed.parameters[key])
+        segment.addSpanAttribute(`request.parameters.${key}`, parsed.parameters[key])
       }
     }
     segment.addAttribute('url', `${proto}//${hostname}${parsed.path}`)
@@ -196,8 +196,8 @@ function handleError(segment, req, error) {
  */
 function handleResponse(segment, hostname, req, res) {
   // Add response attributes for spans
-  segment.addAttribute('http.statusCode', res.statusCode)
-  segment.addAttribute('http.statusText', res.statusMessage)
+  segment.addSpanAttribute('http.statusCode', res.statusCode)
+  segment.addSpanAttribute('http.statusText', res.statusMessage)
   
   // If CAT is enabled, grab those headers!
   const agent = segment.transaction.agent

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -746,15 +746,15 @@ function _linkExceptionToSegment(exception) {
 
   // Add error attributes to the span
   const details = exception.getErrorDetails(config)
-  segment.addAttribute('error.message', details.message)
-  segment.addAttribute('error.class', details.type)
+  segment.addSpanAttribute('error.message', details.message)
+  segment.addSpanAttribute('error.class', details.type)
 
   const isExpected =
     errorHelper.isExpectedErrorClass(config, details.type) ||
     errorHelper.isExpectedErrorMessage(config, details.type, details.message)
 
   if (isExpected) {
-    segment.addAttribute('error.expected', isExpected)
+    segment.addSpanAttribute('error.expected', isExpected)
   }
 
   // Add the span/segment ID to the exception as agent attributes

--- a/test/unit/error_events.test.js
+++ b/test/unit/error_events.test.js
@@ -69,8 +69,8 @@ test('Error events', (t) => {
 
         const spanAttributes = segment.attributes.get(DESTINATIONS.SPAN_EVENT)
 
-        expect(spanAttributes['error.class']).to.equal('Error')
-        expect(spanAttributes['error.message']).to.equal('some error')
+        t.equal(spanAttributes['error.class'], 'Error')
+        t.equal(spanAttributes['error.message'], 'some error')
 
         tx.end()
         const attributes = agent.errors.eventAggregator.getEvents()[0][0]

--- a/test/unit/instrumentation/http/outbound.test.js
+++ b/test/unit/instrumentation/http/outbound.test.js
@@ -12,6 +12,7 @@ var instrumentOutbound = require('../../../../lib/instrumentation/core/http-outb
 var hashes = require('../../../../lib/util/hashes')
 var nock = require('nock')
 var Segment = require('../../../../lib/transaction/trace/segment')
+const { DESTINATIONS } = require('../../../../lib/config/attribute-filter')
 
 
 tap.test('instrumentOutbound', (t) => {
@@ -93,14 +94,14 @@ tap.test('instrumentOutbound', (t) => {
     helper.runInTransaction(agent, function(transaction) {
       agent.config.attributes.enabled = true
       instrumentOutbound(agent, {host: HOSTNAME, port: PORT}, makeFakeRequest)
-      t.same(transaction.trace.root.children[0].getAttributes(), {
+      t.same(transaction.trace.root.children[0].attributes.get(DESTINATIONS.SPAN_EVENT), {
         'url': `http://${HOSTNAME}:${PORT}/asdf`,
         'procedure': 'GET',
         'request.parameters.a': 'b',
         'request.parameters.another': 'yourself',
         'request.parameters.thing': true,
         'request.parameters.grownup': 'true'
-      })
+      }, 'adds attributes to spans')
 
       function makeFakeRequest() {
         req.path = '/asdf?a=b&another=yourself&thing&grownup=true'


### PR DESCRIPTION
## Proposed Release Notes
Migrated the following attributes to Spans only
http.statusCode
http.statusText
error.message
error.class
error.expected

## Links

## Details
We should not be sending attributes intended for spans, and not segments, on segments.  This work is to make sure no attributes added to a segment intended for spans were properly scoped to the attribute filter SPAN_EVENT scope.
