### PR TITLE
TypeError: this._resetInterval.unref is not a function

### DIFF
--- a/lib/adaptive-sampler.js
+++ b/lib/adaptive-sampler.js
@@ -1,7 +1,7 @@
 'use strict'
 
 class AdaptiveSampler {
-  constructor(opts) {
+  constructor (opts) {
     this._serverless = opts.serverless
     this._seen = 0
     this._sampled = 0
@@ -20,38 +20,38 @@ class AdaptiveSampler {
     }
   }
 
-  get sampled() {
+  get sampled () {
     return this._sampled
   }
 
-  get samplingThreshold() {
+  get samplingThreshold () {
     return this._samplingThreshold
   }
 
-  get samplingTarget() {
+  get samplingTarget () {
     return this._samplingTarget
   }
 
-  set samplingTarget(target) {
+  set samplingTarget (target) {
     this._samplingTarget = target
     this._maxSamples = 2 * target
     this._adjustStats(this._samplingTarget)
   }
 
-  get samplingPeriod() {
+  get samplingPeriod () {
     return this._samplingPeriod
   }
 
-  set samplingPeriod(period) {
+  set samplingPeriod (period) {
     this._samplingPeriod = period
     if (!this._serverless) {
       clearInterval(this._resetInterval)
 
       if (period) {
-        try{
+        try {
           this._resetInterval = setInterval(() => this._reset(), period)
           this._resetInterval.unref()
-        }catch(e){
+        } catch (e) {
           logger.debug('Could not reset interval', e)
         }
       }
@@ -65,7 +65,7 @@ class AdaptiveSampler {
    *  @param {object} transaction - The transaction to compare against the current
    *                                window.
    */
-  maybeUpdateWindow(transaction) {
+  maybeUpdateWindow (transaction) {
     const timestamp = transaction.timer.start
     if (!this._windowStart || timestamp - this._windowStart >= this._samplingPeriod) {
       this._windowStart = timestamp
@@ -81,7 +81,7 @@ class AdaptiveSampler {
    *
    * @return {bool} True if the object should be sampled.
    */
-  shouldSample(roll) {
+  shouldSample (roll) {
     ++this._seen
     if (roll >= this._samplingThreshold) {
       this._incrementSampled()
@@ -94,7 +94,7 @@ class AdaptiveSampler {
   /**
    * Starts a new sample period after adjusting the sampling statistics.
    */
-  _reset() {
+  _reset () {
     ++this._resetCount
     this._adjustStats(this._samplingTarget)
 
@@ -106,7 +106,7 @@ class AdaptiveSampler {
    * Increments the sampled counter and adjusted the sampling threshold to maintain
    * a steady sample rate.
    */
-  _incrementSampled() {
+  _incrementSampled () {
     if (++this._sampled >= this._samplingTarget) {
       // For the first sample window we take the first 10 transactions and only
       // the first 10.
@@ -126,7 +126,7 @@ class AdaptiveSampler {
    *
    * @param {number} target - The target number of objects to sample.
    */
-  _adjustStats(target) {
+  _adjustStats (target) {
     if (this._seen) {
       const ratio = Math.min(target / this._seen, 1)
       this._samplingThreshold = 1 - ratio

--- a/lib/adaptive-sampler.js
+++ b/lib/adaptive-sampler.js
@@ -52,7 +52,7 @@ class AdaptiveSampler {
           this._resetInterval = setInterval(() => this._reset(), period)
           this._resetInterval.unref()
         } catch (e) {
-          console.log('Could not reset interval')
+          // skip on conflict
         }
       }
     }

--- a/lib/adaptive-sampler.js
+++ b/lib/adaptive-sampler.js
@@ -51,8 +51,8 @@ class AdaptiveSampler {
         try {
           this._resetInterval = setInterval(() => this._reset(), period)
           this._resetInterval.unref()
-        } catch(e){
-          logger.debug('Could not reset interval', e)
+        } catch (e) {
+          console.log('Could not reset interval')
         }
       }
     }

--- a/lib/adaptive-sampler.js
+++ b/lib/adaptive-sampler.js
@@ -1,7 +1,7 @@
 'use strict'
 
 class AdaptiveSampler {
-  constructor (opts) {
+  constructor(opts) {
     this._serverless = opts.serverless
     this._seen = 0
     this._sampled = 0
@@ -20,29 +20,29 @@ class AdaptiveSampler {
     }
   }
 
-  get sampled () {
+  get sampled() {
     return this._sampled
   }
 
-  get samplingThreshold () {
+  get samplingThreshold() {
     return this._samplingThreshold
   }
 
-  get samplingTarget () {
+  get samplingTarget() {
     return this._samplingTarget
   }
 
-  set samplingTarget (target) {
+  set samplingTarget(target) {
     this._samplingTarget = target
     this._maxSamples = 2 * target
     this._adjustStats(this._samplingTarget)
   }
 
-  get samplingPeriod () {
+  get samplingPeriod() {
     return this._samplingPeriod
   }
 
-  set samplingPeriod (period) {
+  set samplingPeriod(period) {
     this._samplingPeriod = period
     if (!this._serverless) {
       clearInterval(this._resetInterval)
@@ -51,7 +51,7 @@ class AdaptiveSampler {
         try {
           this._resetInterval = setInterval(() => this._reset(), period)
           this._resetInterval.unref()
-        } catch (e) {
+        } catch(e){
           logger.debug('Could not reset interval', e)
         }
       }
@@ -65,7 +65,7 @@ class AdaptiveSampler {
    *  @param {object} transaction - The transaction to compare against the current
    *                                window.
    */
-  maybeUpdateWindow (transaction) {
+  maybeUpdateWindow(transaction) {
     const timestamp = transaction.timer.start
     if (!this._windowStart || timestamp - this._windowStart >= this._samplingPeriod) {
       this._windowStart = timestamp
@@ -81,7 +81,7 @@ class AdaptiveSampler {
    *
    * @return {bool} True if the object should be sampled.
    */
-  shouldSample (roll) {
+  shouldSample(roll) {
     ++this._seen
     if (roll >= this._samplingThreshold) {
       this._incrementSampled()
@@ -94,7 +94,7 @@ class AdaptiveSampler {
   /**
    * Starts a new sample period after adjusting the sampling statistics.
    */
-  _reset () {
+  _reset() {
     ++this._resetCount
     this._adjustStats(this._samplingTarget)
 
@@ -106,7 +106,7 @@ class AdaptiveSampler {
    * Increments the sampled counter and adjusted the sampling threshold to maintain
    * a steady sample rate.
    */
-  _incrementSampled () {
+  _incrementSampled() {
     if (++this._sampled >= this._samplingTarget) {
       // For the first sample window we take the first 10 transactions and only
       // the first 10.
@@ -126,7 +126,7 @@ class AdaptiveSampler {
    *
    * @param {number} target - The target number of objects to sample.
    */
-  _adjustStats (target) {
+  _adjustStats(target) {
     if (this._seen) {
       const ratio = Math.min(target / this._seen, 1)
       this._samplingThreshold = 1 - ratio

--- a/lib/adaptive-sampler.js
+++ b/lib/adaptive-sampler.js
@@ -48,8 +48,12 @@ class AdaptiveSampler {
       clearInterval(this._resetInterval)
 
       if (period) {
-        this._resetInterval = setInterval(() => this._reset(), period)
-        this._resetInterval.unref()
+        try{
+          this._resetInterval = setInterval(() => this._reset(), period)
+          this._resetInterval.unref()
+        }catch(e){
+          logger.debug('Could not reset interval', e)
+        }
       }
     }
   }

--- a/lib/sampler.js
+++ b/lib/sampler.js
@@ -18,8 +18,12 @@ var SAMPLE_INTERVAL = 15 * MILLIS
 var samplers = []
 
 function Sampler(sampler, interval) {
-  this.id = setInterval(sampler, interval)
-  this.id.unref()
+  try{
+    this.id = setInterval(sampler, interval)
+    this.id.unref()
+  }catch(e){
+    logger.debug('Could not reset interval', e)
+  }
 }
 
 Sampler.prototype.stop = function stop() {

--- a/lib/sampler.js
+++ b/lib/sampler.js
@@ -21,7 +21,7 @@ function Sampler(sampler, interval) {
   try {
     this.id = setInterval(sampler, interval)
     this.id.unref()
-  } catch(e){
+  } catch (e) {
     logger.debug('Could not reset interval', e)
   }
 }

--- a/lib/sampler.js
+++ b/lib/sampler.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var NAMES = require('./metrics/names')
-var logger = require('./logger').child({component: 'sampler'})
+var logger = require('./logger').child({ component: 'sampler' })
 var Timer = require('./timer')
 var os = require('os')
 
@@ -17,26 +17,26 @@ var SAMPLE_INTERVAL = 15 * MILLIS
 
 var samplers = []
 
-function Sampler(sampler, interval) {
-  try{
+function Sampler (sampler, interval) {
+  try {
     this.id = setInterval(sampler, interval)
     this.id.unref()
-  }catch(e){
+  } catch (e) {
     logger.debug('Could not reset interval', e)
   }
 }
 
-Sampler.prototype.stop = function stop() {
+Sampler.prototype.stop = function stop () {
   clearInterval(this.id)
 }
 
-function recordQueueTime(agent, timer) {
+function recordQueueTime (agent, timer) {
   timer.end()
   agent.metrics.measureMilliseconds(NAMES.EVENTS.WAIT, null, timer.getDurationInMillis())
 }
 
-function sampleMemory(agent) {
-  return function memorySampler() {
+function sampleMemory (agent) {
+  return function memorySampler () {
     try {
       var mem = process.memoryUsage()
       agent.metrics.measureBytes(NAMES.MEMORY.PHYSICAL, mem.rss)
@@ -51,15 +51,15 @@ function sampleMemory(agent) {
   }
 }
 
-function checkEvents(agent) {
-  return function eventSampler() {
+function checkEvents (agent) {
+  return function eventSampler () {
     var timer = new Timer()
     timer.begin()
     setTimeout(recordQueueTime.bind(null, agent, timer), 0)
   }
 }
 
-function getCpuSample(lastSample) {
+function getCpuSample (lastSample) {
   try {
     return process.cpuUsage(lastSample)
   } catch (e) {
@@ -68,10 +68,10 @@ function getCpuSample(lastSample) {
   }
 }
 
-function generateCPUMetricRecorder(agent) {
+function generateCPUMetricRecorder (agent) {
   var lastSampleTime
   // userTime and sysTime are in seconds
-  return function recordCPUMetrics(userTime, sysTime) {
+  return function recordCPUMetrics (userTime, sysTime) {
     var elapsedUptime
     if (!lastSampleTime) {
       elapsedUptime = process.uptime()
@@ -84,7 +84,7 @@ function generateCPUMetricRecorder(agent) {
     lastSampleTime = Date.now()
 
     var userUtil = userTime / totalCpuTime
-    var sysUtil  = sysTime / totalCpuTime
+    var sysUtil = sysTime / totalCpuTime
 
     recordValue(agent, NAMES.CPU.USER_TIME, userTime)
     recordValue(agent, NAMES.CPU.SYSTEM_TIME, sysTime)
@@ -93,10 +93,10 @@ function generateCPUMetricRecorder(agent) {
   }
 }
 
-function sampleCpu(agent) {
+function sampleCpu (agent) {
   var lastSample
   var recordCPU = generateCPUMetricRecorder(agent)
-  return function cpuSampler() {
+  return function cpuSampler () {
     var cpuSample = getCpuSample(lastSample)
     lastSample = getCpuSample()
 
@@ -108,19 +108,19 @@ function sampleCpu(agent) {
   }
 }
 
-function sampleCpuNative(agent, nativeMetrics) {
+function sampleCpuNative (agent, nativeMetrics) {
   var recordCPU = generateCPUMetricRecorder(agent)
-  nativeMetrics.on('usage', function collectResourceUsage(usage) {
+  nativeMetrics.on('usage', function collectResourceUsage (usage) {
     recordCPU(usage.diff.ru_utime / MILLIS, usage.diff.ru_stime / MILLIS)
   })
 
-  return function cpuSampler() {
+  return function cpuSampler () {
     // NOOP?
   }
 }
 
-function sampleLoop(agent, nativeMetrics) {
-  return function loopSampler() {
+function sampleLoop (agent, nativeMetrics) {
+  return function loopSampler () {
     // Convert from microseconds to seconds
     const loopMetrics = nativeMetrics.getLoopMetrics()
     divideMetric(loopMetrics.usage, MICROS)
@@ -129,11 +129,11 @@ function sampleLoop(agent, nativeMetrics) {
   }
 }
 
-function sampleGc(agent, nativeMetrics) {
-  return function gcSampler() {
+function sampleGc (agent, nativeMetrics) {
+  return function gcSampler () {
     const gcMetrics = nativeMetrics.getGCMetrics()
 
-    Object.keys(gcMetrics).forEach(function forEachGCType(gcType) {
+    Object.keys(gcMetrics).forEach(function forEachGCType (gcType) {
       // Convert from milliseconds to seconds.
       const gc = gcMetrics[gcType]
       divideMetric(gc.metrics, MILLIS)
@@ -157,7 +157,7 @@ var sampler = module.exports = {
   sampleLoop: sampleLoop,
   nativeMetrics: null,
 
-  start: function start(agent) {
+  start: function start (agent) {
     samplers.push(new Sampler(sampleMemory(agent), 5 * MILLIS))
     samplers.push(new Sampler(checkEvents(agent), SAMPLE_INTERVAL))
 
@@ -169,7 +169,7 @@ var sampler = module.exports = {
         })
       } catch (err) {
         logger.info(
-          {error: {message: err.message, stack: err.stack}},
+          { error: { message: err.message, stack: err.stack } },
           'Not adding native metric sampler.'
         )
         agent.metrics.getOrCreateMetric(
@@ -209,8 +209,8 @@ var sampler = module.exports = {
     sampler.state = 'running'
   },
 
-  stop: function stop() {
-    samplers.forEach(function forEachSampler(s) {
+  stop: function stop () {
+    samplers.forEach(function forEachSampler (s) {
       s.stop()
     })
     samplers = []
@@ -226,19 +226,19 @@ var sampler = module.exports = {
   }
 }
 
-function recordValue(agent, metric, value) {
+function recordValue (agent, metric, value) {
   var stats = agent.metrics.getOrCreateMetric(metric)
   stats.recordValue(value)
   logger.trace('Recorded metric %s: %j', metric, value)
 }
 
-function recordCompleteMetric(agent, metricName, metric) {
+function recordCompleteMetric (agent, metricName, metric) {
   var stats = agent.metrics.getOrCreateMetric(metricName)
   stats.merge(metric)
   logger.trace('Recorded metric %s: %j', metricName, metric)
 }
 
-function divideMetric(metric, divisor) {
+function divideMetric (metric, divisor) {
   metric.min /= divisor
   metric.max /= divisor
   metric.total /= divisor

--- a/lib/sampler.js
+++ b/lib/sampler.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var NAMES = require('./metrics/names')
-var logger = require('./logger').child({ component: 'sampler' })
+var logger = require('./logger').child({component: 'sampler'})
 var Timer = require('./timer')
 var os = require('os')
 
@@ -21,7 +21,7 @@ function Sampler(sampler, interval) {
   try {
     this.id = setInterval(sampler, interval)
     this.id.unref()
-  } catch(e) {
+  } catch(e){
     logger.debug('Could not reset interval', e)
   }
 }
@@ -45,7 +45,7 @@ function sampleMemory(agent) {
       agent.metrics.measureBytes(NAMES.MEMORY.FREE_HEAP, mem.heapTotal - mem.heapUsed)
       agent.metrics.measureBytes(NAMES.MEMORY.USED_NONHEAP, mem.rss - mem.heapTotal)
       logger.trace(mem, 'Recorded memory')
-    } catch(e) {
+    } catch (e) {
       logger.debug('Could not record memory usage', e)
     }
   }
@@ -62,7 +62,7 @@ function checkEvents(agent) {
 function getCpuSample(lastSample) {
   try {
     return process.cpuUsage(lastSample)
-  } catch(e) {
+  } catch (e) {
     logger.debug('Could not record cpu usage', e)
     return null
   }
@@ -73,10 +73,10 @@ function generateCPUMetricRecorder(agent) {
   // userTime and sysTime are in seconds
   return function recordCPUMetrics(userTime, sysTime) {
     var elapsedUptime
-    if(!lastSampleTime) {
+    if (!lastSampleTime) {
       elapsedUptime = process.uptime()
     } else {
-      elapsedUptime =(Date.now() - lastSampleTime) / MILLIS
+      elapsedUptime = (Date.now() - lastSampleTime) / MILLIS
     }
 
     var totalCpuTime = CPUS * elapsedUptime
@@ -84,7 +84,7 @@ function generateCPUMetricRecorder(agent) {
     lastSampleTime = Date.now()
 
     var userUtil = userTime / totalCpuTime
-    var sysUtil = sysTime / totalCpuTime
+    var sysUtil  = sysTime / totalCpuTime
 
     recordValue(agent, NAMES.CPU.USER_TIME, userTime)
     recordValue(agent, NAMES.CPU.SYSTEM_TIME, sysTime)
@@ -100,7 +100,7 @@ function sampleCpu(agent) {
     var cpuSample = getCpuSample(lastSample)
     lastSample = getCpuSample()
 
-    if(lastSample == null) {
+    if (lastSample == null) {
       return
     }
 
@@ -139,7 +139,7 @@ function sampleGc(agent, nativeMetrics) {
       divideMetric(gc.metrics, MILLIS)
 
       recordCompleteMetric(agent, NAMES.GC.PAUSE_TIME, gc.metrics)
-      if(gc.type) {
+      if (gc.type) {
         recordCompleteMetric(agent, NAMES.GC.PREFIX + gc.type, gc.metrics)
       } else {
         logger.debug(gc, 'Unknown GC type %j', gc.typeId)
@@ -162,14 +162,14 @@ var sampler = module.exports = {
     samplers.push(new Sampler(checkEvents(agent), SAMPLE_INTERVAL))
 
     // This requires a native module which may have failed to build.
-    if(agent.config.plugins.native_metrics.enabled && !this.nativeMetrics) {
+    if (agent.config.plugins.native_metrics.enabled && !this.nativeMetrics) {
       try {
         this.nativeMetrics = require('@newrelic/native-metrics')({
           timeout: SAMPLE_INTERVAL
         })
-      } catch(err) {
+      } catch (err) {
         logger.info(
-          { error: { message: err.message, stack: err.stack } },
+          {error: {message: err.message, stack: err.stack}},
           'Not adding native metric sampler.'
         )
         agent.metrics.getOrCreateMetric(
@@ -178,27 +178,27 @@ var sampler = module.exports = {
       }
     }
 
-    if(this.nativeMetrics) {
-      if(!this.nativeMetrics.bound) {
+    if (this.nativeMetrics) {
+      if (!this.nativeMetrics.bound) {
         this.nativeMetrics.bind(SAMPLE_INTERVAL)
       }
 
       // Add GC events if available.
-      if(this.nativeMetrics.gcEnabled) {
+      if (this.nativeMetrics.gcEnabled) {
         samplers.push(new Sampler(sampleGc(agent, this.nativeMetrics), SAMPLE_INTERVAL))
       }
 
       // Add loop metrics if available.
-      if(this.nativeMetrics.loopEnabled) {
+      if (this.nativeMetrics.loopEnabled) {
         samplers.push(new Sampler(sampleLoop(agent, this.nativeMetrics), SAMPLE_INTERVAL))
       }
     }
 
     // Add CPU sampling using the built-in data if available, otherwise pulling
     // from the native module.
-    if(process.cpuUsage) { // introduced in 6.1.0
+    if (process.cpuUsage) { // introduced in 6.1.0
       samplers.push(new Sampler(sampleCpu(agent), SAMPLE_INTERVAL))
-    } else if(this.nativeMetrics && this.nativeMetrics.usageEnabled) {
+    } else if (this.nativeMetrics && this.nativeMetrics.usageEnabled) {
       samplers.push(
         new Sampler(sampleCpuNative(agent, this.nativeMetrics), SAMPLE_INTERVAL)
       )
@@ -215,7 +215,7 @@ var sampler = module.exports = {
     })
     samplers = []
     sampler.state = 'stopped'
-    if(this.nativeMetrics) {
+    if (this.nativeMetrics) {
       this.nativeMetrics.unbind()
       this.nativeMetrics.removeAllListeners()
 
@@ -242,5 +242,5 @@ function divideMetric(metric, divisor) {
   metric.min /= divisor
   metric.max /= divisor
   metric.total /= divisor
-  metric.sumOfSquares /=(divisor * divisor)
+  metric.sumOfSquares /= (divisor * divisor)
 }

--- a/lib/sampler.js
+++ b/lib/sampler.js
@@ -17,26 +17,26 @@ var SAMPLE_INTERVAL = 15 * MILLIS
 
 var samplers = []
 
-function Sampler (sampler, interval) {
+function Sampler(sampler, interval) {
   try {
     this.id = setInterval(sampler, interval)
     this.id.unref()
-  } catch (e) {
+  } catch(e) {
     logger.debug('Could not reset interval', e)
   }
 }
 
-Sampler.prototype.stop = function stop () {
+Sampler.prototype.stop = function stop() {
   clearInterval(this.id)
 }
 
-function recordQueueTime (agent, timer) {
+function recordQueueTime(agent, timer) {
   timer.end()
   agent.metrics.measureMilliseconds(NAMES.EVENTS.WAIT, null, timer.getDurationInMillis())
 }
 
-function sampleMemory (agent) {
-  return function memorySampler () {
+function sampleMemory(agent) {
+  return function memorySampler() {
     try {
       var mem = process.memoryUsage()
       agent.metrics.measureBytes(NAMES.MEMORY.PHYSICAL, mem.rss)
@@ -45,38 +45,38 @@ function sampleMemory (agent) {
       agent.metrics.measureBytes(NAMES.MEMORY.FREE_HEAP, mem.heapTotal - mem.heapUsed)
       agent.metrics.measureBytes(NAMES.MEMORY.USED_NONHEAP, mem.rss - mem.heapTotal)
       logger.trace(mem, 'Recorded memory')
-    } catch (e) {
+    } catch(e) {
       logger.debug('Could not record memory usage', e)
     }
   }
 }
 
-function checkEvents (agent) {
-  return function eventSampler () {
+function checkEvents(agent) {
+  return function eventSampler() {
     var timer = new Timer()
     timer.begin()
     setTimeout(recordQueueTime.bind(null, agent, timer), 0)
   }
 }
 
-function getCpuSample (lastSample) {
+function getCpuSample(lastSample) {
   try {
     return process.cpuUsage(lastSample)
-  } catch (e) {
+  } catch(e) {
     logger.debug('Could not record cpu usage', e)
     return null
   }
 }
 
-function generateCPUMetricRecorder (agent) {
+function generateCPUMetricRecorder(agent) {
   var lastSampleTime
   // userTime and sysTime are in seconds
-  return function recordCPUMetrics (userTime, sysTime) {
+  return function recordCPUMetrics(userTime, sysTime) {
     var elapsedUptime
-    if (!lastSampleTime) {
+    if(!lastSampleTime) {
       elapsedUptime = process.uptime()
     } else {
-      elapsedUptime = (Date.now() - lastSampleTime) / MILLIS
+      elapsedUptime =(Date.now() - lastSampleTime) / MILLIS
     }
 
     var totalCpuTime = CPUS * elapsedUptime
@@ -93,14 +93,14 @@ function generateCPUMetricRecorder (agent) {
   }
 }
 
-function sampleCpu (agent) {
+function sampleCpu(agent) {
   var lastSample
   var recordCPU = generateCPUMetricRecorder(agent)
-  return function cpuSampler () {
+  return function cpuSampler() {
     var cpuSample = getCpuSample(lastSample)
     lastSample = getCpuSample()
 
-    if (lastSample == null) {
+    if(lastSample == null) {
       return
     }
 
@@ -108,19 +108,19 @@ function sampleCpu (agent) {
   }
 }
 
-function sampleCpuNative (agent, nativeMetrics) {
+function sampleCpuNative(agent, nativeMetrics) {
   var recordCPU = generateCPUMetricRecorder(agent)
-  nativeMetrics.on('usage', function collectResourceUsage (usage) {
+  nativeMetrics.on('usage', function collectResourceUsage(usage) {
     recordCPU(usage.diff.ru_utime / MILLIS, usage.diff.ru_stime / MILLIS)
   })
 
-  return function cpuSampler () {
+  return function cpuSampler() {
     // NOOP?
   }
 }
 
-function sampleLoop (agent, nativeMetrics) {
-  return function loopSampler () {
+function sampleLoop(agent, nativeMetrics) {
+  return function loopSampler() {
     // Convert from microseconds to seconds
     const loopMetrics = nativeMetrics.getLoopMetrics()
     divideMetric(loopMetrics.usage, MICROS)
@@ -129,17 +129,17 @@ function sampleLoop (agent, nativeMetrics) {
   }
 }
 
-function sampleGc (agent, nativeMetrics) {
-  return function gcSampler () {
+function sampleGc(agent, nativeMetrics) {
+  return function gcSampler() {
     const gcMetrics = nativeMetrics.getGCMetrics()
 
-    Object.keys(gcMetrics).forEach(function forEachGCType (gcType) {
+    Object.keys(gcMetrics).forEach(function forEachGCType(gcType) {
       // Convert from milliseconds to seconds.
       const gc = gcMetrics[gcType]
       divideMetric(gc.metrics, MILLIS)
 
       recordCompleteMetric(agent, NAMES.GC.PAUSE_TIME, gc.metrics)
-      if (gc.type) {
+      if(gc.type) {
         recordCompleteMetric(agent, NAMES.GC.PREFIX + gc.type, gc.metrics)
       } else {
         logger.debug(gc, 'Unknown GC type %j', gc.typeId)
@@ -157,17 +157,17 @@ var sampler = module.exports = {
   sampleLoop: sampleLoop,
   nativeMetrics: null,
 
-  start: function start (agent) {
+  start: function start(agent) {
     samplers.push(new Sampler(sampleMemory(agent), 5 * MILLIS))
     samplers.push(new Sampler(checkEvents(agent), SAMPLE_INTERVAL))
 
     // This requires a native module which may have failed to build.
-    if (agent.config.plugins.native_metrics.enabled && !this.nativeMetrics) {
+    if(agent.config.plugins.native_metrics.enabled && !this.nativeMetrics) {
       try {
         this.nativeMetrics = require('@newrelic/native-metrics')({
           timeout: SAMPLE_INTERVAL
         })
-      } catch (err) {
+      } catch(err) {
         logger.info(
           { error: { message: err.message, stack: err.stack } },
           'Not adding native metric sampler.'
@@ -178,27 +178,27 @@ var sampler = module.exports = {
       }
     }
 
-    if (this.nativeMetrics) {
-      if (!this.nativeMetrics.bound) {
+    if(this.nativeMetrics) {
+      if(!this.nativeMetrics.bound) {
         this.nativeMetrics.bind(SAMPLE_INTERVAL)
       }
 
       // Add GC events if available.
-      if (this.nativeMetrics.gcEnabled) {
+      if(this.nativeMetrics.gcEnabled) {
         samplers.push(new Sampler(sampleGc(agent, this.nativeMetrics), SAMPLE_INTERVAL))
       }
 
       // Add loop metrics if available.
-      if (this.nativeMetrics.loopEnabled) {
+      if(this.nativeMetrics.loopEnabled) {
         samplers.push(new Sampler(sampleLoop(agent, this.nativeMetrics), SAMPLE_INTERVAL))
       }
     }
 
     // Add CPU sampling using the built-in data if available, otherwise pulling
     // from the native module.
-    if (process.cpuUsage) { // introduced in 6.1.0
+    if(process.cpuUsage) { // introduced in 6.1.0
       samplers.push(new Sampler(sampleCpu(agent), SAMPLE_INTERVAL))
-    } else if (this.nativeMetrics && this.nativeMetrics.usageEnabled) {
+    } else if(this.nativeMetrics && this.nativeMetrics.usageEnabled) {
       samplers.push(
         new Sampler(sampleCpuNative(agent, this.nativeMetrics), SAMPLE_INTERVAL)
       )
@@ -209,13 +209,13 @@ var sampler = module.exports = {
     sampler.state = 'running'
   },
 
-  stop: function stop () {
-    samplers.forEach(function forEachSampler (s) {
+  stop: function stop() {
+    samplers.forEach(function forEachSampler(s) {
       s.stop()
     })
     samplers = []
     sampler.state = 'stopped'
-    if (this.nativeMetrics) {
+    if(this.nativeMetrics) {
       this.nativeMetrics.unbind()
       this.nativeMetrics.removeAllListeners()
 
@@ -226,21 +226,21 @@ var sampler = module.exports = {
   }
 }
 
-function recordValue (agent, metric, value) {
+function recordValue(agent, metric, value) {
   var stats = agent.metrics.getOrCreateMetric(metric)
   stats.recordValue(value)
   logger.trace('Recorded metric %s: %j', metric, value)
 }
 
-function recordCompleteMetric (agent, metricName, metric) {
+function recordCompleteMetric(agent, metricName, metric) {
   var stats = agent.metrics.getOrCreateMetric(metricName)
   stats.merge(metric)
   logger.trace('Recorded metric %s: %j', metricName, metric)
 }
 
-function divideMetric (metric, divisor) {
+function divideMetric(metric, divisor) {
   metric.min /= divisor
   metric.max /= divisor
   metric.total /= divisor
-  metric.sumOfSquares /= (divisor * divisor)
+  metric.sumOfSquares /=(divisor * divisor)
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
Electron application workaround for to overcome interval setting conflicts

## Links
- Initial Question: https://discuss.newrelic.com/t/typeerror-this-resetinterval-unref-is-not-a-function/104242
- Reviewed Question: https://github.com/electron/electron/issues/21162

## Details
As can be seen in the above, Electron application users commonly run into the above situation fairly often. It appears as though there is simple a timer conflict with New Relic and Electron applications. The above change allows the opportunity to pick and choose which timer is relevant based on what is available at the time.
