### PR TITLE
Release v6.10.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,32 @@
+### 6.10.0 (2020-06-22):
+
+* Additional Transaction Information applied to Span Events
+  * When Distributed Tracing and/or Infinite Tracing are enabled, the Agent will now incorporate additional information from the Transaction Event on to the currently available Span Event of the transaction.
+* The following items are affected:
+  * `aws-lambda` related attributes
+  * `error.message`
+  * `error.class`
+  * `error.expected`
+  * `http.statusCode`
+  * `http.statusText`
+  * `message.*`
+  * `parent.type`
+  * `parent.app`
+  * `parent.account`
+  * `parent.transportType`
+  * `parent.transportDuration`
+  * Request Parameters `request.parameters.*`
+  * `request.header.*`
+  * `request.method`
+  * `request.uri`
+* Custom Attributes
+  * Custom transaction attributes added via `API.addCustomAttribute` or `API.addCustomAttributes` will now be propagated to the currently active span, if available.
+* Security Recommendation:
+  * Review your Transaction Event attributes configuration. Any attribute include or exclude setting specific to Transaction Events should be applied to your Span Attributes configuration or global attributes configuration. Please see Node.js agent attributes for more on how to configure.
+* Upgraded @grpc/grpc-js from 1.0.3 to 1.0.4
+* Modified redis callback-less versioned test to use `commandQueueLength` as indicator redis command has completed and test can continue. This is in effort to further reduce these test flickers. Additionally, added wait for client 'ready' before moving on to tests.
+* Updated force secret test runs to run on branch pushes to the main repository.
+
 ### 6.9.0 (2020-06-08):
 
 * Added AWS API Gateway V2 Support to lambda instrumentation.

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,7 @@
       * `request.uri`
   * Custom Attributes
     * Custom transaction attributes added via `API.addCustomAttribute` or `API.addCustomAttributes` will now be propagated to the currently active span, if available.
-  * Security Recommendation:
+  * **Security Recommendation:**
     * Review your Transaction Event attributes configuration. Any attribute include or exclude setting specific to Transaction Events should be applied to your Span Attributes configuration or global attributes configuration. Please see [Node.js agent attributes](https://docs.newrelic.com/docs/agents/nodejs-agent/attributes/nodejs-agent-attributes#configure-attributes) for more on how to configure.
 * Upgraded @grpc/grpc-js from 1.0.3 to 1.0.4
 * Modified redis callback-less versioned test to use `commandQueueLength` as indicator redis command has completed and test can continue. This is in effort to further reduce these test flickers. Additionally, added wait for client 'ready' before moving on to tests.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,27 +2,27 @@
 
 * Additional Transaction Information applied to Span Events
   * When Distributed Tracing and/or Infinite Tracing are enabled, the Agent will now incorporate additional information from the Transaction Event on to the currently available Span Event of the transaction.
-* The following items are affected:
-  * `aws-lambda` related attributes
-  * `error.message`
-  * `error.class`
-  * `error.expected`
-  * `http.statusCode`
-  * `http.statusText`
-  * `message.*`
-  * `parent.type`
-  * `parent.app`
-  * `parent.account`
-  * `parent.transportType`
-  * `parent.transportDuration`
-  * Request Parameters `request.parameters.*`
-  * `request.header.*`
-  * `request.method`
-  * `request.uri`
-* Custom Attributes
-  * Custom transaction attributes added via `API.addCustomAttribute` or `API.addCustomAttributes` will now be propagated to the currently active span, if available.
-* Security Recommendation:
-  * Review your Transaction Event attributes configuration. Any attribute include or exclude setting specific to Transaction Events should be applied to your Span Attributes configuration or global attributes configuration. Please see Node.js agent attributes for more on how to configure.
+    * The following items are affected:
+      * `aws-lambda` related attributes
+      * `error.message`
+      * `error.class`
+      * `error.expected`
+      * `http.statusCode`
+      * `http.statusText`
+      * `message.*`
+      * `parent.type`
+      * `parent.app`
+      * `parent.account`
+      * `parent.transportType`
+      * `parent.transportDuration`
+      * Request Parameters `request.parameters.*`
+      * `request.header.*`
+      * `request.method`
+      * `request.uri`
+  * Custom Attributes
+    * Custom transaction attributes added via `API.addCustomAttribute` or `API.addCustomAttributes` will now be propagated to the currently active span, if available.
+  * Security Recommendation:
+    * Review your Transaction Event attributes configuration. Any attribute include or exclude setting specific to Transaction Events should be applied to your Span Attributes configuration or global attributes configuration. Please see [Node.js agent attributes](https://docs.newrelic.com/docs/agents/nodejs-agent/attributes/nodejs-agent-attributes#configure-attributes) for more on how to configure.
 * Upgraded @grpc/grpc-js from 1.0.3 to 1.0.4
 * Modified redis callback-less versioned test to use `commandQueueLength` as indicator redis command has completed and test can continue. This is in effort to further reduce these test flickers. Additionally, added wait for client 'ready' before moving on to tests.
 * Updated force secret test runs to run on branch pushes to the main repository.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -18,6 +18,8 @@ can be found at https://github.com/newrelic/node-newrelic.
 * [json-stringify-safe](#json-stringify-safe)
 * [readable-stream](#readable-stream)
 * [semver](#semver)
+* [@grpc/grpc-js](#@grpc/grpc-js)
+* [@grpc/proto-loader](#@grpc/proto-loader)
 
 ## async
 


### PR DESCRIPTION
## Proposed Release Notes

* Additional Transaction Information applied to Span Events
  * When Distributed Tracing and/or Infinite Tracing are enabled, the Agent will now incorporate additional information from the Transaction Event on to the currently available Span Event of the transaction.
    * The following items are affected:
      * `aws-lambda` related attributes
      * `error.message`
      * `error.class`
      * `error.expected`
      * `http.statusCode`
      * `http.statusText`
      * `message.*`
      * `parent.type`
      * `parent.app`
      * `parent.account`
      * `parent.transportType`
      * `parent.transportDuration`
      * Request Parameters `request.parameters.*`
      * `request.header.*`
      * `request.method`
      * `request.uri`
  * Custom Attributes
    * Custom transaction attributes added via `API.addCustomAttribute` or `API.addCustomAttributes` will now be propagated to the currently active span, if available.
  * **Security Recommendation:**
    * Review your Transaction Event attributes configuration. Any attribute include or exclude setting specific to Transaction Events should be applied to your Span Attributes configuration or global attributes configuration. Please see [Node.js agent attributes](https://docs.newrelic.com/docs/agents/nodejs-agent/attributes/nodejs-agent-attributes#configure-attributes) for more on how to configure.
* Upgraded @grpc/grpc-js from 1.0.3 to 1.0.4
* Modified redis callback-less versioned test to use `commandQueueLength` as indicator redis command has completed and test can continue. This is in effort to further reduce these test flickers. Additionally, added wait for client 'ready' before moving on to tests.
* Updated force secret test runs to run on branch pushes to the main repository.

## Links
https://github.com/newrelic/node-newrelic/pull/381
https://github.com/newrelic/node-newrelic/pull/382
https://github.com/newrelic/node-newrelic/pull/383
https://github.com/newrelic/node-newrelic/pull/384
https://github.com/newrelic/node-newrelic/pull/386
https://github.com/newrelic/node-newrelic/pull/387
https://github.com/newrelic/node-newrelic/pull/388
https://github.com/newrelic/node-newrelic/pull/389
## Details
