### PR TITLE
On failed instrumentation, prevent multiple requires from re-wrapping shims

### DIFF
--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -83,6 +83,7 @@ function applyDebugState(shimmer, shim, nodule) {
     shim.enableDebug()
     instrumented.push(shim)
     instrumented.push({__NR_unwrap: function unwrapNodule() {
+      delete nodule.__NR_instrumented_errored
       delete nodule.__NR_instrumented
       delete nodule.__NR_shim
     }})
@@ -97,7 +98,7 @@ function applyDebugState(shimmer, shim, nodule) {
  */
 function instrument(agent, nodule, moduleName, resolvedName) {
   var instrumentation = shimmer.registeredInstrumentations[moduleName]
-  if (properties.hasOwn(nodule, '__NR_instrumented')) {
+  if (properties.hasOwn(nodule, '__NR_instrumented') || properties.hasOwn(nodule, '__NR_instrumented_errored')) {
     logger.trace(
       'Already instrumented %s, skipping redundant instrumentation',
       moduleName
@@ -121,6 +122,7 @@ function instrument(agent, nodule, moduleName, resolvedName) {
       nodule.__NR_instrumented = true
     }
   } catch (instrumentationError) {
+    nodule.__NR_instrumented_errored = true
     if (instrumentation.onError) {
       try {
         instrumentation.onError(instrumentationError)

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -98,7 +98,8 @@ function applyDebugState(shimmer, shim, nodule) {
  */
 function instrument(agent, nodule, moduleName, resolvedName) {
   var instrumentation = shimmer.registeredInstrumentations[moduleName]
-  if (properties.hasOwn(nodule, '__NR_instrumented') || properties.hasOwn(nodule, '__NR_instrumented_errored')) {
+  if (properties.hasOwn(nodule, '__NR_instrumented')
+      || properties.hasOwn(nodule, '__NR_instrumented_errored')) {
     logger.trace(
       'Already instrumented %s, skipping redundant instrumentation',
       moduleName

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -101,7 +101,7 @@ function instrument(agent, nodule, moduleName, resolvedName) {
   if (properties.hasOwn(nodule, '__NR_instrumented')
       || properties.hasOwn(nodule, '__NR_instrumented_errored')) {
     logger.trace(
-      'Already instrumented %s, skipping redundant instrumentation',
+      'Already instrumented or failed to instrument %s, skipping redundant instrumentation',
       moduleName
     )
     return nodule

--- a/test/integration/shimmer/module-load-fixture-errored.js
+++ b/test/integration/shimmer/module-load-fixture-errored.js
@@ -1,0 +1,4 @@
+'use strict'
+module.exports = () => {
+  return 'hello world'
+}

--- a/test/integration/shimmer/module-load.test.js
+++ b/test/integration/shimmer/module-load.test.js
@@ -70,7 +70,6 @@ tap.test('Test Module Instrumentation Loading', (t) => {
       moduleName: modulePathFromShimmer,
       type: null,
       onRequire: () => {
-        console.log('errored?')
         throw new Error('our instrumentation errors')
       }
     })
@@ -81,7 +80,6 @@ tap.test('Test Module Instrumentation Loading', (t) => {
 
     const module = require(modulePathLocal)
 
-console.log('module', module);
     t.ok(module, 'loaded module')
     t.equals(module(), 'hello world', 'module behaves as expected')
     t.ok(module.__NR_instrumented_errored, '__NR_instrumented_errored set and true')

--- a/test/integration/shimmer/module-load.test.js
+++ b/test/integration/shimmer/module-load.test.js
@@ -39,9 +39,7 @@ tap.test('Test Module Instrumentation Loading', (t) => {
     shimmer.registerInstrumentation({
       moduleName: modulePathFromShimmer,
       type: null,
-      onRequire: () => {
-        // throw new Error('our instrumentation errors')
-      }
+      onRequire: () => {}
     })
 
     // use reinstrument helper method to
@@ -53,6 +51,40 @@ tap.test('Test Module Instrumentation Loading', (t) => {
     t.ok(module, 'loaded module')
     t.equals(module(), 'hello world', 'module behaves as expected')
     t.ok(module.__NR_instrumented, '__NR_instrumented set and true')
+    t.end()
+  })
+
+  t.test("__NR_instrumented_errored set correctly", (t) => {
+    // path to our module fixture from this file
+    const modulePathLocal = './module-load-fixture-errored'
+
+    // path to our module fixture from the shimmer --
+    // needed since `reinstrument` results in a call
+    // to require _from_ from the shimmer
+    const modulePathFromShimmer = '../test/integration/shimmer/module-load-fixture-errored'
+
+    // register our instrumentation == onRequire will be
+    // the code that's normally in the "instrument" function
+    // that a instrumentation module exports
+    shimmer.registerInstrumentation({
+      moduleName: modulePathFromShimmer,
+      type: null,
+      onRequire: () => {
+        console.log('errored?')
+        throw new Error('our instrumentation errors')
+      }
+    })
+
+    // use reinstrument helper method to
+    // manually instrument our module
+    shimmer.reinstrument(agent, modulePathFromShimmer)
+
+    const module = require(modulePathLocal)
+
+console.log('module', module);
+    t.ok(module, 'loaded module')
+    t.equals(module(), 'hello world', 'module behaves as expected')
+    t.ok(module.__NR_instrumented_errored, '__NR_instrumented_errored set and true')
     t.end()
   })
 })

--- a/test/unit/shimmer.test.js
+++ b/test/unit/shimmer.test.js
@@ -32,10 +32,11 @@ describe('shimmer', function() {
   describe('custom instrumentation', function() {
     describe('of relative modules', makeModuleTests('../helpers/module'))
     describe('of modules', makeModuleTests('chai'))
+    describe('of modules, where instrumentation fails', makeModuleTests('chai', true))
     describe('of deep modules', makeModuleTests('chai/lib/chai'))
   })
 
-  function makeModuleTests(moduleName) {
+  function makeModuleTests(moduleName, throwsError) {
     return function moduleTests() {
       var agent = null
       var onRequireArgs = null
@@ -51,6 +52,9 @@ describe('shimmer', function() {
             instrumentedModule = module
             ++counter
             onRequireArgs = arguments
+            if (throwsError) {
+                throw new Error('This threw an error! Oh no!')
+            }
           },
           onError: function() {}
         }
@@ -92,7 +96,6 @@ describe('shimmer', function() {
         require(moduleName)
         expect(counter).to.equal(1)
       })
-
 
       it('should clean up NR added properties', () => {
         const nrKeys =

--- a/test/unit/shimmer.test.js
+++ b/test/unit/shimmer.test.js
@@ -53,7 +53,7 @@ describe('shimmer', function() {
             ++counter
             onRequireArgs = arguments
             if (throwsError) {
-                throw new Error('This threw an error! Oh no!')
+              throw new Error('This threw an error! Oh no!')
             }
           },
           onError: function() {}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->


## Proposed Release Notes

* Adjusted instrumentation error handling to only make one attempt

## Links

https://support.newrelic.com/tickets/416443 - There is a 10 minute video in this ticket that shows the problem in our codebase. I highly suggest watching it.

## Details

While debugging a very confusing memory leak, I uncovered the problem was with our newrelic instrumentation. I made a change elsewhere in our codebase, which caused the instrumentation to fail halfway through, after already recording several shims. When the onRequire function fails, it never sets the flag to tell itself that the code has already been (or at least has already attempted to) wrapped. If you require that same module with failed instrumentation several times, you end up re-shimming the code over and over. This causes excessively high CPU% and memory usage, which quickly spiked our app past what we allocate. By marking the nodule as instrumented, this prevents the constant re-recording of shims-on-shims.  

Unfortunately, this bug bit me when I didn't realize it was related to anything New Relic, and my organization has the logging turned off. This led to a really confusing path to even discovering the root cause, as I was not aware I should be debugging New Relic instrumentation, as the docs mention. Perhaps fatal errors should log, regardless of level? 

Without this change: ~1.9 GB and a pegged CPU. With the change: ~400MB and much less CPU usage. Perhaps a better approach could be to ensure there is a console log if this occurs. 

In my head, it makes sense for it to only want to instrument once, and only once, even if it fails. In the current master branch, it will continue to attempt to instrument on proceeding requires, because it only marks it as instrumented if it was successful.

I'm not entirely sure this is the correct way to tackle this problem, so I'm hoping for this to be a starting point to explain this problem. There is probably many other cases for how error handling should be considered, which I do not have the domain knowledge for. If this is agreed upon to be a bug, I can most certainly help bring this pull request up to spec with a test, or make other adjustments as necessary.

As a New Relic customer (Gannett Inc.), I would be more than happy to hop on a screen share to show the problem in our local code base and how it impacts our application. 

Thanks,
Ryan