### PR TITLE
Adding test for __NR_instrumented

### DIFF
--- a/test/integration/shimmer/module-load-fixture.js
+++ b/test/integration/shimmer/module-load-fixture.js
@@ -1,0 +1,4 @@
+'use strict'
+module.exports = () => {
+  return 'hello world'
+}

--- a/test/integration/shimmer/module-load.test.js
+++ b/test/integration/shimmer/module-load.test.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const helper = require('../../lib/agent_helper')
+const shimmer = require('../../../lib/shimmer')
+
+tap.test('Test Module Instrumentation Loading', (t) => {
+  t.autoend()
+  let agent = null
+
+  t.beforeEach((done) => {
+    agent = helper.loadMockedAgent()
+    done()
+  })
+
+  t.afterEach((done) => {
+    helper.unloadAgent(agent)
+    agent = null
+    done()
+  })
+
+  t.test("__NR_instrumented set correctly", (t) => {
+    // path to our module fixture from this file
+    const modulePathLocal = './module-load-fixture'
+
+    // path to our module fixture from the shimmer --
+    // needed since `reinstrument` results in a call
+    // to require _from_ from the shimmer
+    const modulePathFromShimmer = '../test/integration/shimmer/module-load-fixture'
+
+    // register our instrumentation == onRequire will be
+    // the code that's normally in the "instrument" function
+    // that a instrumentation module exports
+    shimmer.registerInstrumentation({
+      moduleName: modulePathFromShimmer,
+      type: null,
+      onRequire: () => {
+        // throw new Error('our instrumentation errors')
+      }
+    })
+
+    // use reinstrument helper method to
+    // manually instrument our module
+    shimmer.reinstrument(agent, modulePathFromShimmer)
+
+    const module = require(modulePathLocal)
+
+    t.ok(module, 'loaded module')
+    t.equals(module(), 'hello world', 'module behaves as expected')
+    t.ok(module.__NR_instrumented, '__NR_instrumented set and true')
+    t.end()
+  })
+})


### PR DESCRIPTION
## Proposed Release Notes

- Test added to check for pretense of `__NR_instrumented` in loaded modules

## Links

## Details

This came out of some work [over in a different PR](https://github.com/newrelic/node-newrelic/pull/450/) -- I had asked our potential contributor to add a test for their new property before I realized we had no good example of testing these properties.

This integration tests exercises the instrumentation loading code to ensure it sets the `__NR_instrumented` property.  Once this lands we should be able to add a test for the new property in #450.