### PR TITLE
Fix large JSON inserts obfuscation

### DIFF
--- a/lib/util/sql/obfuscate.js
+++ b/lib/util/sql/obfuscate.js
@@ -7,7 +7,7 @@
 
 module.exports = obfuscate
 
-var singleQuote = /'(?:[^']|'')*?(?:\\'.*|'(?!'))/
+var singleQuote = /'(?:''|[^'])*?(?:\\'.*|'(?!'))/
 var doubleQuote = /"(?:[^"]|"")*?(?:\\".*|"(?!"))/
 var dollarQuote = /(\$(?!\d)[^$]*?\$).*?(?:\1|$)/
 var oracleQuote = /q'\[.*?(?:\]'|$)|q'\{.*?(?:\}'|$)|q'\<.*?(?:\>'|$)|q'\(.*?(?:\)'|$)/

--- a/test/unit/util/obfuscate-sql.test.js
+++ b/test/unit/util/obfuscate-sql.test.js
@@ -37,5 +37,13 @@ tap.test('sql obfuscation', (t) => {
     t.end()
   })
 
+  t.test('should handle large JSON inserts', (t) => {
+    const JSONData = '{"data": "' + new Array(8400000).fill('a').join('') + '"}'
+    const result = obfuscate(
+      'INSERT INTO "Documents" ("data") VALUES (\'' + JSONData + '\')', 'postgres')
+    t.equal(result, 'INSERT INTO "Documents" ("data") VALUES (?)')
+    t.end()
+  })
+
   t.end()
 })


### PR DESCRIPTION
Based on discussion from https://github.com/newrelic/node-newrelic/issues/446
creating a PR to fix `RangeError: Maximum call stack size exceeded error on big queries` caused by obfuscation RegEx

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

Fixes obfuscation of SQL queries with large data inserts

## Links

https://github.com/newrelic/node-newrelic/issues/446

## Details

Fixes `Obfuscation causes RangeError: Maximum call stack size exceeded error on big queries`
