### PR TITLE
feat: Adding ability to write to named pipe instead of stdout.

### DIFF
--- a/lib/collector/serverless.js
+++ b/lib/collector/serverless.js
@@ -35,6 +35,10 @@ class ServerlessCollector {
       agent_version: agent.version
     }
     this.payload = {}
+    this.pipePath = (agent.pipePath || process.env.pipePath) ?
+      (agent.pipePath || process.env.pipePath) :
+      '/tmp/newrelic-telemetry'
+    this.pipeError = false
   }
 
   /**
@@ -244,6 +248,29 @@ class ServerlessCollector {
   }
 
   /**
+   * Tests for writing to named pipe
+   */
+  shouldUsePipe() {
+    if (this.pipeError) {
+      return false
+    }
+    return fs.existsSync(this.pipePath)
+  }
+
+  /**
+   * Writes payload to pipe
+   */
+  flushToPipe(payload) {
+    try {
+      fs.writeFileSync(this.pipePath, payload)
+    } catch (e) {
+      // cache error and try again.
+      this.pipeError = e
+      this._doFlush(payload, true)
+    }
+  }
+
+  /**
    * Internal method to handle flushing to stdout.
    *
    * @private
@@ -257,6 +284,10 @@ class ServerlessCollector {
       PAYLOAD_MARKER,
       payload
     ]) + '\n'
+
+    if (this.shouldUsePipe()) {
+      return this.flushToPipe(serializedPayload)
+    }
 
     if (sync) {
       // Long log lines have been truncated at 65538

--- a/test/unit/collector/serverless.test.js
+++ b/test/unit/collector/serverless.test.js
@@ -14,9 +14,13 @@ const nock = require('nock')
 const chai = require('chai')
 const expect = chai.expect
 const sinon = require('sinon')
+const fs = require('fs')
 const helper = require('../../lib/agent_helper')
 const API = require('../../../lib/collector/serverless')
 const serverfulAPI = require('../../../lib/collector/api')
+
+const pipePath = '/tmp/newrelic-telemetry'
+const shouldUsePipe = fs.existsSync(pipePath)
 
 describe('ServerlessCollector API', () => {
   let api = null
@@ -164,8 +168,13 @@ describe('ServerlessCollector API', () => {
     let logStub = null
 
     beforeEach(() => {
-      logStub = sinon.stub(process.stdout, 'write').callsFake(() => {
-      })
+      if (shouldUsePipe) {
+        logStub = sinon.stub(fs, 'writeFileSync').callsFake(() => {
+        })
+      } else {
+        logStub = sinon.stub(process.stdout, 'write').callsFake(() => {
+        })
+      }
     })
 
     afterEach(() => {
@@ -175,11 +184,19 @@ describe('ServerlessCollector API', () => {
     it('compresses full payload and writes formatted to stdout', (done) => {
       api.payload = {type: 'test payload'}
       api.flushPayload(() => {
-        const logPayload = JSON.parse(logStub.args[0][0])
+        let logPayload = null
+
+        if (shouldUsePipe) {
+          logPayload = JSON.parse(logStub.args[0][1])
+        } else {
+          logPayload = JSON.parse(logStub.args[0][0])
+        }
         expect(logPayload).to.be.an('array')
         expect(logPayload[0]).to.be.a('number')
+
         expect(logPayload[1]).to.equal('NR_LAMBDA_MONITORING')
         expect(logPayload[2]).to.be.a('string')
+
         done()
       })
     })
@@ -190,8 +207,105 @@ describe('ServerlessCollector API', () => {
       }
 
       api.flushPayload(() => {
-        const logPayload = JSON.parse(logStub.getCall(0).args[0])
+        let logPayload = null
+
+        if (shouldUsePipe) {
+          logPayload = JSON.parse(logStub.getCall(0).args[1])
+        } else {
+          logPayload = JSON.parse(logStub.getCall(0).args[0])
+        }
+
         const buf = Buffer.from(logPayload[2], 'base64')
+
+        zlib.gunzip(buf, (err, unpack) => {
+          expect(err).to.be.null
+          const payload = JSON.parse(unpack)
+          expect(payload.data).to.be.ok
+          expect(Object.keys(payload.data)).to.have.lengthOf.above(4000)
+          done()
+        })
+      })
+    })
+  })
+})
+
+
+describe('ServerlessCollector with constructor-injected pipe', () => {
+  let api = null
+  let agent = null
+  const customPath = '/tmp/custom-output'
+
+  before(async function() {
+    // create a placeholder file so we can test custom paths
+    process.env.pipePath = customPath
+    await fs.open(customPath, 'w', (err, fd) => {
+      expect(err).to.be.null
+      expect(fd).to.be.ok
+      return fd
+    })
+  })
+
+  after(async function() {
+    // remove the placeholder file
+    await fs.unlink(customPath, (err ) => {
+      expect(err).to.be.null
+      return
+    })
+  })
+
+  beforeEach(() => {
+    nock.disableNetConnect()
+    agent = helper.loadMockedAgent({
+      serverless_mode: {
+        enabled: true
+      },
+      app_name: ['TEST'],
+      license_key: 'license key here',
+      pipePath: customPath
+    })
+    agent.reconfigure = () => {}
+    agent.setState = () => {}
+    api = new API(agent)
+  })
+
+  afterEach(() => {
+    nock.enableNetConnect()
+    helper.unloadAgent(agent)
+  })
+
+  describe('#flushPayload', () => {
+    let logStub = null
+
+    beforeEach(() => {
+      logStub = sinon.stub(fs, 'writeFileSync').callsFake(() => {})
+    })
+
+    afterEach(() => {
+      logStub.restore()
+    })
+
+    it('compresses full payload and writes formatted to stdout', (done) => {
+      api.payload = {type: 'test payload'}
+      api.flushPayload(() => {
+        const logPayload = JSON.parse(logStub.args[0][1])
+        expect(logPayload).to.be.an('array')
+        expect(logPayload[0]).to.be.a('number')
+        expect(logPayload[1]).to.equal('NR_LAMBDA_MONITORING')
+        expect(logPayload[2]).to.be.a('string')
+
+        done()
+      })
+    })
+    it('handles very large payload and writes formatted to stdout', done => {
+      api.payload = {type: 'test payload'}
+      for (let i = 0; i < 4096; i++) {
+        api.payload[`customMetric${i}`] = Math.floor(Math.random() * 100000)
+      }
+
+      api.flushPayload(() => {
+        const logPayload = JSON.parse(logStub.getCall(0).args[1])
+        const buf = Buffer.from(logPayload[2], 'base64')
+
         zlib.gunzip(buf, (err, unpack) => {
           expect(err).to.be.null
           const payload = JSON.parse(unpack)


### PR DESCRIPTION
On some occasions, the serverless observability pipeline may benefit from the ability to write output to a named pipe instead of stdout; this adds that, with a fallback to stdout if the pipe isn't found.

Signed-off-by: mrickard <maurice@mauricerickard.com>

## Proposed Release Notes

This commit adds the ability for a serverless application using the Node.js agent to write to a named pipe instead of stdout, if the `/tmp/newrelic-telemetry` pipe is present, or if the agent or application process has defined a `pipePath`, and the pipe is present. 

## Details

This PR includes changes to the serverless collector (`lib/collector/serverless.js`), the serverless collector unit test (`test/unit/collector/serverless.test.js`), and the exceptions test (`test/integration/core/exceptions.tap.js`).
