### PR TITLE
Fixes transaction trace request uri handling.

### DIFF
--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -108,7 +108,7 @@ class Attributes {
   addAttribute(destinations, key, value, truncateExempt = false) {
     if (this.attributeCount + 1 > this.limit) {
       return logger.debug(
-        `Maximum number of custom attributes have been added.  
+        `Maximum number of custom attributes have been added.
         Dropping attribute ${key} with ${value} type.`
       )
     }
@@ -150,6 +150,18 @@ class Attributes {
         this.addAttribute(destinations, key, attrs[key])
       }
     }
+  }
+
+  /**
+   * Returns true if a given key is valid for any of the
+   * provided destinations.
+   *
+   * @param {DESTINATIONS} destinations
+   * @param {string} key
+   */
+  hasValidDestination(destinations, key) {
+    const validDestinations = this.filter(destinations, key)
+    return !!validDestinations
   }
 }
 

--- a/lib/prioritized-attributes.js
+++ b/lib/prioritized-attributes.js
@@ -139,6 +139,18 @@ class PrioritizedAttributes {
     }
   }
 
+  /**
+   * Returns true if a given key is valid for any of the
+   * provided destinations.
+   *
+   * @param {DESTINATIONS} destinations
+   * @param {string} key
+   */
+  hasValidDestination(destinations, key) {
+    const validDestinations = this.filter(destinations, key)
+    return !!validDestinations
+  }
+
   _getDroppableAttributeKey(incomingPriority) {
     // There will never be anything lower priority to drop
     if (incomingPriority === ATTRIBUTE_PRIORITY.LOW) {

--- a/lib/transaction/trace/index.js
+++ b/lib/transaction/trace/index.js
@@ -15,6 +15,8 @@ var {DESTINATIONS} = require('../../config/attribute-filter')
 var FROM_MILLIS = 1e-3
 const ATTRIBUTE_SCOPE = 'transaction'
 
+const REQUEST_URI_KEY = 'request.uri'
+const UNKNOWN_URI_PLACEHOLDER = '/Unknown'
 
 /**
  * A Trace holds the root of the Segment graph and produces the final
@@ -293,11 +295,13 @@ Trace.prototype._generatePayload = function _generatePayload(data) {
     syntheticsResourceId = this.transaction.syntheticsData.resourceId
   }
 
+  const requestUri = this._getRequestUri()
+
   return [
     this.root.timer.start, // start
     this.transaction.getResponseTimeInMillis(),  // response time
     this.transaction.getFullName(),              // path
-    this.transaction.url,  // request.uri
+    requestUri,  // request.uri
     data,                   // encodedCompressedData
     this.transaction.id,    // guid
     null,                   // reserved for future use
@@ -305,6 +309,25 @@ Trace.prototype._generatePayload = function _generatePayload(data) {
     null,                   // xraySessionId
     syntheticsResourceId    // synthetics resource id
   ]
+}
+
+/**
+ * Returns the transaction URL if attribute is not exluded globally or
+ * for transaction traces. Returns '/Unknown' if included but not known.
+ *
+ * The URI on a trace is a special attribute. It is included as a positional field,
+ * not as an "agent attribute", to avoid having to decompress on the backend.
+ * But it still needs to be gaited by the same attribute exclusion/inclusion
+ * rules so sensitive information can be removed.
+ */
+Trace.prototype._getRequestUri = function _getRequestUri() {
+  const canAddUri = this.attributes.hasValidDestination(DESTINATIONS.TRANS_TRACE, REQUEST_URI_KEY)
+  let requestUri = null // must be null if excluded
+  if (canAddUri) {
+    requestUri = this.transaction.url || UNKNOWN_URI_PLACEHOLDER
+  }
+
+  return requestUri
 }
 
 /**

--- a/test/unit/attributes.test.js
+++ b/test/unit/attributes.test.js
@@ -208,6 +208,65 @@ tap.test('#get', (t) => {
   })
 })
 
+tap.test('#hasValidDestination', (t) => {
+  t.autoend()
+
+  let agent = null
+
+  t.beforeEach((done) => {
+    agent = helper.loadMockedAgent()
+    done()
+  })
+
+  t.afterEach((done) => {
+    helper.unloadAgent(agent)
+    done()
+  })
+
+  t.test('should return true if single destination valid', (t) => {
+    const attributes = new Attributes(TRANSACTION_SCOPE)
+    const hasDestination = attributes.hasValidDestination(DESTINATIONS.TRANS_EVENT, 'testAttr')
+
+    t.equal(hasDestination, true)
+    t.end()
+  })
+
+  t.test('should return true if all destinations valid', (t) => {
+    const attributes = new Attributes(TRANSACTION_SCOPE)
+    const destinations = DESTINATIONS.TRANS_EVENT | DESTINATIONS.TRANS_TRACE
+    const hasDestination = attributes.hasValidDestination(destinations, 'testAttr')
+
+    t.equal(hasDestination, true)
+    t.end()
+  })
+
+  t.test('should return true if only one destination valid', (t) => {
+    const attributeName = 'testAttr'
+    agent.config.transaction_events.attributes.exclude = [attributeName]
+    agent.config.emit('transaction_events.attributes.exclude')
+
+    const attributes = new Attributes(TRANSACTION_SCOPE)
+    const destinations = DESTINATIONS.TRANS_EVENT | DESTINATIONS.TRANS_TRACE
+    const hasDestination = attributes.hasValidDestination(destinations, attributeName)
+
+    t.equal(hasDestination, true)
+    t.end()
+  })
+
+  t.test('should return false if no valid destinations', (t) => {
+    const attributeName = 'testAttr'
+    agent.config.attributes.exclude = [attributeName]
+    agent.config.emit('attributes.exclude')
+
+    const attributes = new Attributes(TRANSACTION_SCOPE)
+    const destinations = DESTINATIONS.TRANS_EVENT | DESTINATIONS.TRANS_TRACE
+    const hasDestination = attributes.hasValidDestination(destinations, attributeName)
+
+    t.equal(hasDestination, false)
+    t.end()
+  })
+})
+
 tap.test('#reset', (t) => {
   t.autoend()
 

--- a/test/unit/prioritized-attributes.test.js
+++ b/test/unit/prioritized-attributes.test.js
@@ -444,6 +444,65 @@ tap.test('#get', (t) => {
   })
 })
 
+tap.test('#hasValidDestination', (t) => {
+  t.autoend()
+
+  let agent = null
+
+  t.beforeEach((done) => {
+    agent = helper.loadMockedAgent()
+    done()
+  })
+
+  t.afterEach((done) => {
+    helper.unloadAgent(agent)
+    done()
+  })
+
+  t.test('should return true if single destination valid', (t) => {
+    const attributes = new PrioritizedAttributes(TRANSACTION_SCOPE)
+    const hasDestination = attributes.hasValidDestination(DESTINATIONS.TRANS_EVENT, 'testAttr')
+
+    t.equal(hasDestination, true)
+    t.end()
+  })
+
+  t.test('should return true if all destinations valid', (t) => {
+    const attributes = new PrioritizedAttributes(TRANSACTION_SCOPE)
+    const destinations = DESTINATIONS.TRANS_EVENT | DESTINATIONS.TRANS_TRACE
+    const hasDestination = attributes.hasValidDestination(destinations, 'testAttr')
+
+    t.equal(hasDestination, true)
+    t.end()
+  })
+
+  t.test('should return true if only one destination valid', (t) => {
+    const attributeName = 'testAttr'
+    agent.config.transaction_events.attributes.exclude = [attributeName]
+    agent.config.emit('transaction_events.attributes.exclude')
+
+    const attributes = new PrioritizedAttributes(TRANSACTION_SCOPE)
+    const destinations = DESTINATIONS.TRANS_EVENT | DESTINATIONS.TRANS_TRACE
+    const hasDestination = attributes.hasValidDestination(destinations, attributeName)
+
+    t.equal(hasDestination, true)
+    t.end()
+  })
+
+  t.test('should return false if no valid destinations', (t) => {
+    const attributeName = 'testAttr'
+    agent.config.attributes.exclude = [attributeName]
+    agent.config.emit('attributes.exclude')
+
+    const attributes = new PrioritizedAttributes(TRANSACTION_SCOPE)
+    const destinations = DESTINATIONS.TRANS_EVENT | DESTINATIONS.TRANS_TRACE
+    const hasDestination = attributes.hasValidDestination(destinations, attributeName)
+
+    t.equal(hasDestination, false)
+    t.end()
+  })
+})
+
 tap.test('#reset', (t) => {
   t.autoend()
 

--- a/test/unit/trace.test.js
+++ b/test/unit/trace.test.js
@@ -718,6 +718,98 @@ describe('Trace', function() {
   })
 })
 
+tap.test('should set URI to null when request.uri attribute is excluded globally', (t) => {
+  const URL = '/test'
+
+  const agent = helper.loadMockedAgent({
+    attributes: {
+      exclude: ['request.uri']
+    }
+  })
+
+  t.tearDown(() => {
+    helper.unloadAgent(agent)
+  })
+
+  const transaction = new Transaction(agent)
+  transaction.url  = URL
+  transaction.verb = 'GET'
+
+  const trace = transaction.trace
+
+  trace.end()
+
+  trace.generateJSON(function(err, traceJSON) {
+    if (err) {
+      t.error(err)
+    }
+
+    const {3: requestUri} = traceJSON
+    t.notOk(requestUri)
+
+    t.end()
+  })
+})
+
+tap.test('should set URI to null when request.uri attribute is exluded from traces', (t) => {
+  const URL = '/test'
+
+  const agent = helper.loadMockedAgent({
+    transaction_tracer: {
+      attributes: {
+        exclude: ['request.uri']
+      }
+    }
+  })
+
+  t.tearDown(() => {
+    helper.unloadAgent(agent)
+  })
+
+  const transaction = new Transaction(agent)
+  transaction.url  = URL
+  transaction.verb = 'GET'
+
+  const trace = transaction.trace
+
+  trace.end()
+
+  trace.generateJSON(function(err, traceJSON) {
+    if (err) {
+      t.error(err)
+    }
+
+    const {3: requestUri} = traceJSON
+    t.notOk(requestUri)
+
+    t.end()
+  })
+})
+
+tap.test('should set URI to /Unknown when URL is not known/set on transaction', (t) => {
+  const agent = helper.loadMockedAgent()
+
+  t.tearDown(() => {
+    helper.unloadAgent(agent)
+  })
+
+  const transaction = new Transaction(agent)
+  const trace = transaction.trace
+
+  trace.end()
+
+  trace.generateJSON(function(err, traceJSON) {
+    if (err) {
+      t.error(err)
+    }
+
+    const {3: requestUri} = traceJSON
+    t.equal(requestUri, '/Unknown')
+
+    t.end()
+  })
+})
+
 function makeTrace(agent, callback) {
   var DURATION = 33
   var URL = '/test?test=value'


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* **Security fix:** Resolves an issue where transaction traces will still capture the request URI when the Node.js agent is configured to exclude the 'request.uri' attribute. This can be problematic for certain customers in environments where sensitive information is included in the URI. See security bulletin [NR20-02](https://docs.newrelic.com/docs/security/new-relic-security/security-bulletins/security-bulletin-nr20-02).

  The request URI will now be excluded from transaction traces if the 'request.uri' attribute has been set to be excluded at either the top-level 'attributes.exclude' configuration or at the 'transaction_tracer.attributes.exclude' configuration. 

## Links

## Details

This impacts all versions of the agent that I am aware of.

It will now set the URI to `null` when the attribute has been disabled either at the top level or for transaction traces. It will also set the URI to '/Unknown' when there is no `transaction.url` per the spec.