### PR TITLE
fix: Check for named pipe before each payload write

### DIFF
--- a/lib/collector/serverless.js
+++ b/lib/collector/serverless.js
@@ -39,7 +39,6 @@ class ServerlessCollector {
     }
     this.payload = {}
     this.pipePath = pipePath || process.env.NEWRELIC_PIPE_PATH || defaultPipePath
-    this.shouldUsePipe = fs.existsSync(this.pipePath)
   }
 
   /**
@@ -256,7 +255,6 @@ class ServerlessCollector {
       fs.writeFileSync(this.pipePath, payload)
       return true
     } catch (e) {
-      this.shouldUsePipe = false
       logger.warn('Error attempting to write to pipe, falling back to stdout', e)
       return false
     }
@@ -294,7 +292,7 @@ class ServerlessCollector {
       payload
     ]) + '\n'
 
-    const didUsePipe = this.shouldUsePipe && this.flushToPipeSync(serializedPayload)
+    const didUsePipe = fs.existsSync(this.pipePath) && this.flushToPipeSync(serializedPayload)
 
     if (!didUsePipe) {
       this.flushToStdOut(serializedPayload, payload.length, sync)

--- a/lib/collector/serverless.js
+++ b/lib/collector/serverless.js
@@ -292,7 +292,10 @@ class ServerlessCollector {
       payload
     ]) + '\n'
 
-    const didUsePipe = fs.existsSync(this.pipePath) && this.flushToPipeSync(serializedPayload)
+    if (this.shouldUsePipe === undefined) {
+      this.shouldUsePipe = fs.existsSync(this.pipePath)
+    }
+    const didUsePipe = this.shouldUsePipe && this.flushToPipeSync(serializedPayload)
 
     if (!didUsePipe) {
       this.flushToStdOut(serializedPayload, payload.length, sync)


### PR DESCRIPTION
Signed-off-by: mrickard <maurice@mauricerickard.com>

The addition of writing to a named pipe included a check for the pipe from the serverless collector's constructor. In practice, this is susceptible to a race condition, so there would be times when the pipe's been created after the constructor exits. Given that the agent currently writes one payload (and any future additional payloads are likely to be limited in number), this solves the problem of the race condition with minimal effect on performance. 

Tagging @michaelgoin for visibility.