### PR TITLE
fix: Check for named pipe before each flush

### DIFF
--- a/lib/collector/serverless.js
+++ b/lib/collector/serverless.js
@@ -292,10 +292,7 @@ class ServerlessCollector {
       payload
     ]) + '\n'
 
-    if (this.shouldUsePipe === undefined) {
-      this.shouldUsePipe = fs.existsSync(this.pipePath)
-    }
-    const didUsePipe = this.shouldUsePipe && this.flushToPipeSync(serializedPayload)
+    const didUsePipe = fs.existsSync(this.pipePath) && this.flushToPipeSync(serializedPayload)
 
     if (!didUsePipe) {
       this.flushToStdOut(serializedPayload, payload.length, sync)


### PR DESCRIPTION
Signed-off-by: mrickard <maurice@mauricerickard.com>

There may be some situations in which a named pipe's presence (or absence) changes during an invocation; checking for that before flushing output would guarantee that the payload is written to the correct output. (Submitted in advance of a discussion on best approach.)