### PR TITLE
Fix ignored status codes

### DIFF
--- a/lib/errors/error-collector.js
+++ b/lib/errors/error-collector.js
@@ -142,13 +142,18 @@ class ErrorCollector {
     }
 
     const isErroredTransaction = urltils.isError(this.config, transaction.statusCode)
+    const isIgnoredErrorStatusCode = urltils.isIgnoredError(
+      this.config,
+      transaction.statusCode
+    )
+
     const isExpectedErrorStatusCode = urltils.isExpectedError(
       this.config,
       transaction.statusCode
     )
 
     // collect other exceptions only if status code is not ignored
-    if (transaction.exceptions.length) {
+    if (transaction.exceptions.length && !isIgnoredErrorStatusCode) {
       for (let i = 0; i < transaction.exceptions.length; i++) {
         const exception = transaction.exceptions[i]
         if (this.collect(transaction, exception)) {

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -20,7 +20,20 @@ class Exception {
   }
 
   getErrorDetails(config) {
-    return errorHelper.extractErrorInformation(null, this.error, config)
+    const errorDetails = errorHelper.extractErrorInformation(null, this.error, config)
+    errorDetails.expected = this.isExpected(config, errorDetails)
+
+    return errorDetails
+  }
+
+  isExpected(config, {type, message}) {
+    if (!this._expected) {
+      this._expected =
+        errorHelper.isExpectedErrorClass(config, type) ||
+        errorHelper.isExpectedErrorMessage(config, type, message)
+    }
+
+    return this._expected
   }
 }
 

--- a/lib/spans/span-context.js
+++ b/lib/spans/span-context.js
@@ -21,6 +21,9 @@ class SpanContext {
       customAttributes || new PrioritizedAttributes(ATTRIBUTE_SCOPE, MAXIMUM_CUSTOM_ATTRIBUTES)
 
     this.ATTRIBUTE_PRIORITY = ATTRIBUTE_PRIORITY
+
+    this.hasError = false
+    this.errorDetails = null
   }
 
   addIntrinsicAttribute(key, value) {
@@ -35,6 +38,21 @@ class SpanContext {
       false,
       priority
     )
+  }
+
+  /**
+   * Set error details to be potentially be used to create span
+   * attributes. Attributes will be created unless the transaction
+   * ends with an ignored error status code.
+   *
+   * Last error wins.
+   */
+  setError(details) {
+    this.hasError = true
+
+    // Error details will be used to create attributes unless the transaction ends
+    // with an ignored status code.
+    this.errorDetails = details
   }
 }
 

--- a/lib/spans/span-event.js
+++ b/lib/spans/span-event.js
@@ -84,9 +84,21 @@ class SpanEvent {
    * @return {SpanEvent} The constructed event.
    */
   static fromSegment(segment, parentId = null, isRoot = false) {
+    const spanContext = segment.getSpanContext()
+
+    // Since segments already hold span agent attributes and we want to leverage
+    // filtering, we add to the segment attributes prior to processing.
+    if (spanContext.hasError && !segment.transaction.hasIgnoredErrorStatusCode()) {
+      const details = spanContext.errorDetails
+      segment.addSpanAttribute('error.message', details.message)
+      segment.addSpanAttribute('error.class', details.type)
+      if (details.expected) {
+        segment.addSpanAttribute('error.expected', details.expected)
+      }
+    }
+
     const attributes = segment.attributes.get(DESTINATIONS.SPAN_EVENT)
 
-    const spanContext = segment.getSpanContext()
     const customAttributes = spanContext.customAttributes.get(DESTINATIONS.SPAN_EVENT)
 
     let span = null
@@ -97,7 +109,6 @@ class SpanEvent {
     } else {
       span = new SpanEvent(attributes, customAttributes)
     }
-
 
     for (const [key, value] of Object.entries(spanContext.intrinsicAttributes)) {
       span.intrinsics[key] = value

--- a/lib/spans/streaming-span-event.js
+++ b/lib/spans/streaming-span-event.js
@@ -102,9 +102,21 @@ class StreamingSpanEvent {
   }
 
   static fromSegment(segment, parentId = null, isRoot = false) {
+    const spanContext = segment.getSpanContext()
+
+    // Since segments already hold span agent attributes and we want to leverage
+    // filtering, we add to the segment attributes prior to processing.
+    if (spanContext.hasError && !segment.transaction.hasIgnoredErrorStatusCode()) {
+      const details = spanContext.errorDetails
+      segment.addSpanAttribute('error.message', details.message)
+      segment.addSpanAttribute('error.class', details.type)
+      if (details.expected) {
+        segment.addSpanAttribute('error.expected', details.expected)
+      }
+    }
+
     const agentAttributes = segment.attributes.get(DESTINATIONS.SPAN_EVENT)
 
-    const spanContext = segment.getSpanContext()
     const customAttributes = spanContext.customAttributes.get(DESTINATIONS.SPAN_EVENT)
 
     const transaction = segment.transaction

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -679,7 +679,6 @@ Transaction.prototype.measure = function measure(name, scope, duration, exclusiv
 Transaction.prototype._setApdex = function _setApdex(name, duration, keyApdexInMillis) {
   var apdexStats = this.metrics.getOrCreateApdexMetric(name, null, keyApdexInMillis)
 
-
   // if we have an error-like status code, and all the errors are
   // expected, we know the status code was caused by an expected
   // error, so we will not report "frustrating".  Otherwise, we
@@ -747,19 +746,13 @@ function _linkExceptionToSegment(exception) {
     return
   }
 
-  const config = this.agent.config
-
-  // Add error attributes to the span
-  const details = exception.getErrorDetails(config)
-  segment.addSpanAttribute('error.message', details.message)
-  segment.addSpanAttribute('error.class', details.type)
-
-  const isExpected =
-    errorHelper.isExpectedErrorClass(config, details.type) ||
-    errorHelper.isExpectedErrorMessage(config, details.type, details.message)
-
-  if (isExpected) {
-    segment.addSpanAttribute('error.expected', isExpected)
+  const spanContext = segment.getSpanContext()
+  if (spanContext) {
+    // Exception attributes will be added to span unless transaction
+    // status code has been ignored. Last error wins.
+    const config = this.agent.config
+    const details = exception.getErrorDetails(config)
+    spanContext.setError(details)
   }
 
   // Add the span/segment ID to the exception as agent attributes
@@ -791,6 +784,14 @@ Transaction.prototype.addUserError = _addUserError
 function _addUserError(exception) {
   this._linkExceptionToSegment(exception)
   this.userErrors.push(exception)
+}
+
+/**
+ * Returns if the transaction's current status code is errored
+ * but considered ignored via the config.
+ */
+Transaction.prototype.hasIgnoredErrorStatusCode = function _hasIgnoredErrorStatusCode() {
+  return urltils.isIgnoredError(this.agent.config, this.statusCode)
 }
 
 /**

--- a/test/unit/errors/ignore.test.js
+++ b/test/unit/errors/ignore.test.js
@@ -5,223 +5,233 @@
 
 'use strict'
 
-// TODO: convert to normal tap style.
-// Below allows use of mocha DSL with tap runner.
-require('tap').mochaGlobals()
+const tap = require('tap')
 
 const helper = require('../../lib/agent_helper')
 const NAMES = require('../../../lib/metrics/names.js')
-const chai = require('chai')
 
-const expect  = chai.expect
+tap.test('Ignored Errors', (t) => {
+  t.autoend()
 
-describe('Ignored Errors', function() {
-  describe('when expected configuration is present', function() {
-    var agent
+  let agent = null
 
-    beforeEach(function() {
-      agent = helper.loadMockedAgent()
+  t.beforeEach((done) => {
+    agent = helper.loadMockedAgent()
+    done()
+  })
+
+  t.afterEach((done) => {
+    helper.unloadAgent(agent)
+    done()
+  })
+
+  t.test('Ignore Classes should result in no error reported', (t) => {
+    helper.runInTransaction(agent, function(tx) {
+      const errorAggr = agent.errors
+      agent.config.error_collector.capture_events = true
+      agent.config.error_collector.ignore_classes = ["Error"]
+
+      const error1 = new Error('ignored')
+      const error2 = new ReferenceError('NOT ignored')
+
+      errorAggr.add(tx, error1)
+      errorAggr.add(tx, error2)
+      tx.end()
+
+      t.equal(errorAggr.traceAggregator.errors.length, 1)
+
+      const transactionErrorMetric
+        = agent.metrics.getMetric(NAMES.ERRORS.PREFIX + tx.getFullName())
+
+      const allErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.ALL)
+      const webErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.WEB)
+      const otherErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.OTHER)
+
+      t.equal(transactionErrorMetric.callCount, 1)
+
+      t.equal(allErrorMetric.callCount, 1)
+      t.equal(webErrorMetric.callCount, 1)
+
+      t.notOk(otherErrorMetric)
+
+      t.end()
     })
+  })
 
-    afterEach(function() {
-      helper.unloadAgent(agent)
+  t.test('Ignore Classes should trump expected classes', (t) => {
+    helper.runInTransaction(agent, function(tx) {
+      const errorAggr = agent.errors
+      agent.config.error_collector.capture_events = true
+      agent.config.error_collector.ignore_classes = ["Error"]
+      agent.config.error_collector.expected_classes = ["Error"]
+
+      const error1 = new Error('ignored')
+      const error2 = new ReferenceError('NOT ignored')
+
+      errorAggr.add(tx, error1)
+      errorAggr.add(tx, error2)
+      tx.end()
+
+      t.equal(errorAggr.traceAggregator.errors.length, 1)
+
+      const transactionErrorMetric
+        = agent.metrics.getMetric(NAMES.ERRORS.PREFIX + tx.getFullName())
+
+      const allErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.ALL)
+      const webErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.WEB)
+      const otherErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.OTHER)
+
+      t.equal(transactionErrorMetric.callCount, 1)
+
+      t.equal(allErrorMetric.callCount, 1)
+      t.equal(webErrorMetric.callCount, 1)
+      t.notOk(otherErrorMetric)
+
+      t.end()
     })
+  })
 
-    it('Ignore Classes should result in no error reported', function() {
-      helper.runInTransaction(agent, function(tx) {
-        const errorAggr = agent.errors
-        agent.config.error_collector.capture_events = true
-        agent.config.error_collector.ignore_classes = ["Error"]
+  t.test('Ignore messages should result in no error reported', (t) => {
+    helper.runInTransaction(agent, function(tx) {
+      const errorAggr = agent.errors
+      agent.config.error_collector.capture_events = true
+      agent.config.error_collector.ignore_messages = {"Error":['ignored']}
 
-        const error1 = new Error('ignored')
-        const error2 = new ReferenceError('NOT ignored')
+      const error1 = new Error('ignored')
+      const error2 = new Error('not ignored')
+      const error3 = new ReferenceError('not ignored')
 
-        errorAggr.add(tx, error1)
-        errorAggr.add(tx, error2)
-        tx.end()
+      errorAggr.add(tx, error1)
+      errorAggr.add(tx, error2)
+      errorAggr.add(tx, error3)
 
-        expect(errorAggr.traceAggregator.errors.length).equals(1)
+      tx.end()
 
-        const transactionErrorMetric
-          = agent.metrics.getMetric(NAMES.ERRORS.PREFIX + tx.getFullName())
+      t.equal(errorAggr.traceAggregator.errors.length, 2)
 
-        const allErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.ALL)
-        const webErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.WEB)
-        const otherErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.OTHER)
+      const transactionErrorMetric
+        = agent.metrics.getMetric(NAMES.ERRORS.PREFIX + tx.getFullName())
 
-        expect(transactionErrorMetric.callCount).equals(1)
+      const allErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.ALL)
+      const webErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.WEB)
+      const otherErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.OTHER)
 
-        expect(allErrorMetric.callCount).equals(1)
-        expect(webErrorMetric.callCount).equals(1)
-        expect(otherErrorMetric).to.not.exist
-      })
+      t.equal(transactionErrorMetric.callCount, 2)
+
+      t.equal(allErrorMetric.callCount, 2)
+      t.equal(webErrorMetric.callCount, 2)
+      t.notOk(otherErrorMetric)
+
+      t.end()
     })
+  })
 
-    it('Ignore Classes should trump expected classes', function() {
-      helper.runInTransaction(agent, function(tx) {
-        const errorAggr = agent.errors
-        agent.config.error_collector.capture_events = true
-        agent.config.error_collector.ignore_classes = ["Error"]
-        agent.config.error_collector.expected_classes = ["Error"]
+  t.test('Ignore messages should trump expected_messages', (t) => {
+    helper.runInTransaction(agent, function(tx) {
+      const errorAggr = agent.errors
+      agent.config.error_collector.capture_events = true
+      agent.config.error_collector.ignore_messages = {"Error":['ignore']}
+      agent.config.error_collector.expected_messages = {"Error":['ignore']}
 
-        const error1 = new Error('ignored')
-        const error2 = new ReferenceError('NOT ignored')
+      const error1 = new Error('ignore')
+      const error2 = new Error('not ignore')
+      const error3 = new ReferenceError('not ignore')
 
-        errorAggr.add(tx, error1)
-        errorAggr.add(tx, error2)
-        tx.end()
+      errorAggr.add(tx, error1)
+      errorAggr.add(tx, error2)
+      errorAggr.add(tx, error3)
 
-        expect(errorAggr.traceAggregator.errors.length).equals(1)
+      tx.end()
 
-        const transactionErrorMetric
-          = agent.metrics.getMetric(NAMES.ERRORS.PREFIX + tx.getFullName())
+      t.equal(errorAggr.traceAggregator.errors.length, 2)
 
-        const allErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.ALL)
-        const webErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.WEB)
-        const otherErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.OTHER)
+      const transactionErrorMetric
+        = agent.metrics.getMetric(NAMES.ERRORS.PREFIX + tx.getFullName())
 
-        expect(transactionErrorMetric.callCount).equals(1)
+      const allErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.ALL)
+      const webErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.WEB)
+      const otherErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.OTHER)
 
-        expect(allErrorMetric.callCount).equals(1)
-        expect(webErrorMetric.callCount).equals(1)
-        expect(otherErrorMetric).to.not.exist
-      })
+      t.equal(transactionErrorMetric.callCount, 2)
+
+      t.equal(allErrorMetric.callCount, 2)
+      t.equal(webErrorMetric.callCount, 2)
+      t.notOk(otherErrorMetric)
+
+      t.end()
     })
+  })
 
-    it('Ignore messages should result in no error reported', function() {
-      helper.runInTransaction(agent, function(tx) {
-        const errorAggr = agent.errors
-        agent.config.error_collector.capture_events = true
-        agent.config.error_collector.ignore_messages = {"Error":['ignored']}
+  t.test('Ignore status code should result in 0 errors reported', (t) => {
+    helper.runInTransaction(agent, function(tx) {
+      const errorAggr = agent.errors
+      agent.config.error_collector.capture_events = true
+      agent.config.error_collector.ignore_status_codes = [500]
+      tx.statusCode = 500
 
-        const error1 = new Error('ignored')
-        const error2 = new Error('not ignored')
-        const error3 = new ReferenceError('not ignored')
+      const error1 = new Error('ignore')
+      const error2 = new Error('ignore me too')
+      const error3 = new ReferenceError('i will also be ignored')
 
-        errorAggr.add(tx, error1)
-        errorAggr.add(tx, error2)
-        errorAggr.add(tx, error3)
+      errorAggr.add(tx, error1)
+      errorAggr.add(tx, error2)
+      errorAggr.add(tx, error3)
 
-        tx.end()
+      tx.end()
 
-        expect(errorAggr.traceAggregator.errors.length).equals(2)
+      t.equal(errorAggr.traceAggregator.errors.length, 0)
 
-        const transactionErrorMetric
-          = agent.metrics.getMetric(NAMES.ERRORS.PREFIX + tx.getFullName())
+      const transactionErrorMetric
+        = agent.metrics.getMetric(NAMES.ERRORS.PREFIX + tx.getFullName())
 
-        const allErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.ALL)
-        const webErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.WEB)
-        const otherErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.OTHER)
+      const allErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.ALL)
+      const webErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.WEB)
+      const otherErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.OTHER)
 
-        expect(transactionErrorMetric.callCount).equals(2)
+      t.notOk(transactionErrorMetric)
 
-        expect(allErrorMetric.callCount).equals(2)
-        expect(webErrorMetric.callCount).equals(2)
-        expect(otherErrorMetric).to.not.exist
-      })
+      t.notOk(allErrorMetric)
+      t.notOk(webErrorMetric)
+      t.notOk(otherErrorMetric)
+
+      t.end()
     })
+  })
 
-    it('Ignore messages should trump expected_messages', function() {
-      helper.runInTransaction(agent, function(tx) {
-        const errorAggr = agent.errors
-        agent.config.error_collector.capture_events = true
-        agent.config.error_collector.ignore_messages = {"Error":['ignore']}
-        agent.config.error_collector.expected_messages = {"Error":['ignore']}
+  t.test('Ignore status code should trump expected status code', (t) => {
+    helper.runInTransaction(agent, function(tx) {
+      const errorAggr = agent.errors
+      agent.config.error_collector.capture_events = true
+      agent.config.error_collector.ignore_status_codes = [500]
+      agent.config.error_collector.expected_status_codes = [500]
+      tx.statusCode = 500
 
-        const error1 = new Error('ignore')
-        const error2 = new Error('not ignore')
-        const error3 = new ReferenceError('not ignore')
+      const error1 = new Error('ignore')
+      const error2 = new Error('also ignore')
+      const error3 = new ReferenceError('i will also be ignored')
 
-        errorAggr.add(tx, error1)
-        errorAggr.add(tx, error2)
-        errorAggr.add(tx, error3)
+      errorAggr.add(tx, error1)
+      errorAggr.add(tx, error2)
+      errorAggr.add(tx, error3)
 
-        tx.end()
+      tx.end()
 
-        expect(errorAggr.traceAggregator.errors.length).equals(2)
+      t.equal(errorAggr.traceAggregator.errors.length, 0)
 
-        const transactionErrorMetric
-          = agent.metrics.getMetric(NAMES.ERRORS.PREFIX + tx.getFullName())
+      const transactionErrorMetric
+        = agent.metrics.getMetric(NAMES.ERRORS.PREFIX + tx.getFullName())
 
-        const allErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.ALL)
-        const webErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.WEB)
-        const otherErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.OTHER)
+      const allErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.ALL)
+      const webErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.WEB)
+      const otherErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.OTHER)
 
-        expect(transactionErrorMetric.callCount).equals(2)
+      t.notOk(transactionErrorMetric)
 
-        expect(allErrorMetric.callCount).equals(2)
-        expect(webErrorMetric.callCount).equals(2)
-        expect(otherErrorMetric).to.not.exist
-      })
-    })
+      t.notOk(allErrorMetric)
+      t.notOk(webErrorMetric)
+      t.notOk(otherErrorMetric)
 
-    it('Ignore status code should result in 0 errors reported', function() {
-      helper.runInTransaction(agent, function(tx) {
-        const errorAggr = agent.errors
-        agent.config.error_collector.capture_events = true
-        agent.config.error_collector.ignore_status_codes = [500]
-        tx.statusCode = 500
-
-        const error1 = new Error('ignore')
-        const error2 = new Error('ignore me too')
-        const error3 = new ReferenceError('i will also be ignored')
-
-        errorAggr.add(tx, error1)
-        errorAggr.add(tx, error2)
-        errorAggr.add(tx, error3)
-
-        tx.end()
-
-        expect(errorAggr.traceAggregator.errors.length).equals(0)
-
-        const transactionErrorMetric
-          = agent.metrics.getMetric(NAMES.ERRORS.PREFIX + tx.getFullName())
-
-        const allErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.ALL)
-        const webErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.WEB)
-        const otherErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.OTHER)
-
-        expect(transactionErrorMetric).to.not.exist
-
-        expect(allErrorMetric).to.not.exist
-        expect(webErrorMetric).to.not.exist
-        expect(otherErrorMetric).to.not.exist
-      })
-    })
-
-    it('Ignore status code should trump expected status code', function() {
-      helper.runInTransaction(agent, function(tx) {
-        const errorAggr = agent.errors
-        agent.config.error_collector.capture_events = true
-        agent.config.error_collector.ignore_status_codes = [500]
-        agent.config.error_collector.expected_status_codes = [500]
-        tx.statusCode = 500
-
-        const error1 = new Error('ignore')
-        const error2 = new Error('also ignore')
-        const error3 = new ReferenceError('i will also be ignored')
-
-        errorAggr.add(tx, error1)
-        errorAggr.add(tx, error2)
-        errorAggr.add(tx, error3)
-
-        tx.end()
-
-        expect(errorAggr.traceAggregator.errors.length).equals(0)
-
-        const transactionErrorMetric
-          = agent.metrics.getMetric(NAMES.ERRORS.PREFIX + tx.getFullName())
-
-        const allErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.ALL)
-        const webErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.WEB)
-        const otherErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.OTHER)
-
-        expect(transactionErrorMetric).to.not.exist
-
-        expect(allErrorMetric).to.not.exist
-        expect(webErrorMetric).to.not.exist
-        expect(otherErrorMetric).to.not.exist
-      })
+      t.end()
     })
   })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Fixed bug where errors would still be collected for transactions with ignored error status codes in certain situations.

* Converted errors ignore unit tests to tap API.

## Links

* Fixes: https://github.com/newrelic/node-newrelic/issues/500

## Details

Errors should now be properly ignored regardless of when we notice the status code for the transaction.

In order to avoid capturing error attributes on span events for errors that should be ignored due to the later noticed status code, span error attributes are now created when the span is created. Error details for these attributes are added to the span context at error-time (last wins) and then used when creating a span from the segment.

The error code really could use some TLC to further simplify and de-duplicate. It has many moving pieces. Span events could use some additional love wrt overlap with streaming spans too. 
