### PR TITLE
Remove deprecated http response attributes

### DIFF
--- a/lib/instrumentation/core/http.js
+++ b/lib/instrumentation/core/http.js
@@ -172,16 +172,7 @@ function wrapEmitWithTransaction(agent, emit, isHTTPS) {
 
       if (response) {
         if (response.statusCode != null) {
-          /*
-          TODO: remove with next major release
-          httpResponseCode attribute is deprecated
-          */
           var responseCode = String(response.statusCode)
-          transaction.trace.attributes.addAttribute(
-            DESTS.TRANS_COMMON,
-            'httpResponseCode',
-            responseCode
-          )
 
           if (/^\d+$/.test(responseCode)) {
             transaction.trace.attributes.addAttribute(
@@ -191,16 +182,6 @@ function wrapEmitWithTransaction(agent, emit, isHTTPS) {
             )
               
             segment.addSpanAttribute('http.statusCode', responseCode)
-
-            /*
-            TODO: remove with next major release
-            response.status attribute is deprecated
-            */
-            transaction.trace.attributes.addAttribute(
-              DESTS.TRANS_COMMON,
-              'response.status',
-              responseCode
-            )
           }
         }
 
@@ -212,16 +193,6 @@ function wrapEmitWithTransaction(agent, emit, isHTTPS) {
           )
 
           segment.addSpanAttribute('http.statusText', response.statusMessage)
-
-          /*
-            TODO: remove with next major release
-            httpResponseMessage attribute is deprecated
-          */
-          transaction.trace.attributes.addAttribute(
-            DESTS.TRANS_COMMON,
-            'httpResponseMessage',
-            response.statusMessage
-          )
         }
 
         var headers = response.getHeaders()

--- a/lib/serverless/aws-lambda.js
+++ b/lib/serverless/aws-lambda.js
@@ -389,26 +389,8 @@ function setWebResponse(transaction, response) {
   transaction.statusCode = response.statusCode
 
   const responseCode = String(response.statusCode)
-  /*
-  TODO: remove with next major release
-  httpResponseCode attribute is deprecated
-  */
-  transaction.trace.attributes.addAttribute(
-    ATTR_DEST.TRANS_COMMON,
-    'httpResponseCode',
-    responseCode
-  )
 
   if (/^\d+$/.test(responseCode)) {
-    /*
-    TODO: remove with next major release
-    response.status attribute is deprecated
-    */
-    transaction.trace.attributes.addAttribute(
-      ATTR_DEST.TRANS_COMMON,
-      'response.status',
-      responseCode)
-
     transaction.trace.attributes.addAttribute(
       ATTR_DEST.TRANS_COMMON,
       'http.statusCode',

--- a/test/integration/transaction/errors.tap.js
+++ b/test/integration/transaction/errors.tap.js
@@ -52,22 +52,9 @@ test('errors in web transactions should gather the query params', function(t) {
       'should have no custom attributes'
     )
 
-    // agent/query parameters
-    // on older versions of node the content length and response message
-    // will be omitted
-    let expectedValue = 11
-    let keys = ['response.headers.contentLength', 'httpResponseMessage']
-    for (let i = 0; i < keys.length; i++) {
-      let key = keys[i]
-      let value = attributes.agentAttributes[key]
-      if (value) {
-        expectedValue++
-      }
-    }
-
     t.equal(
       Object.keys(attributes.agentAttributes).length,
-      expectedValue,
+      9,
       'should have collected the query, request, and response params'
     )
     t.equal(
@@ -136,21 +123,9 @@ test('multiple errors in web transactions should gather the query params', funct
         'should have no custom attributes'
       )
 
-      // agent/query parameters
-      // on older versions of node the content length and response message
-      // will be omitted
-      let expectedValue = 11
-      let keys = ['response.headers.contentLength', 'httpResponseMessage']
-      for (let i = 0; i < keys.length; i++) {
-        let key = keys[i]
-        let value = attributes.agentAttributes[key]
-        if (value) {
-          expectedValue++
-        }
-      }
       t.equal(
         Object.keys(attributes.agentAttributes).length,
-        expectedValue,
+        9,
         'should have collected the query, request, and response params'
       )
       t.equal(
@@ -229,21 +204,9 @@ test('errors in web transactions should gather and merge custom params', functio
       'replace custom param from after error'
     )
 
-    // agent/query parameters
-    // on older versions of node the content length and response message
-    // will be omitted
-    let expectedValue = 9
-    let keys = ['response.headers.contentLength', 'httpResponseMessage']
-    for (let i = 0; i < keys.length; i++) {
-      let key = keys[i]
-      let value = attributes.agentAttributes[key]
-      if (value) {
-        expectedValue++
-      }
-    }
     t.equal(
       Object.keys(attributes.agentAttributes).length,
-      expectedValue,
+      7,
       'should have collected the query, request, and response params'
     )
   })
@@ -335,21 +298,9 @@ test('multiple errors in web tx should gather and merge custom params', function
       t.equal(ua.preErrorKeep, true, 'kept custom param from before error')
       t.equal(ua.postErrorKeep, 2, 'kept custom param from after error')
 
-      // agent/query parameters
-      // on older versions of node the content length and response message
-      // will be omitted
-      let expectedValue = 9
-      let keys = ['response.headers.contentLength', 'httpResponseMessage']
-      for (let i = 0; i < keys.length; i++) {
-        let key = keys[i]
-        let value = attributes.agentAttributes[key]
-        if (value) {
-          expectedValue++
-        }
-      }
       t.equal(
         Object.keys(attributes.agentAttributes).length,
-        expectedValue,
+        7,
         'should have collected the query, request, and response params'
       )
     })

--- a/test/lib/fixtures.js
+++ b/test/lib/fixtures.js
@@ -10,8 +10,8 @@ module.exports = {
   httpAttributes: [
     'request.headers.host',
     'request.method',
-    'response.status',
-    'httpResponseCode'
+    'http.statusCode',
+    'http.statusText'
   ],
   // Default security policies
   securityPolicies: function() {

--- a/test/unit/serverless/aws-lambda.test.js
+++ b/test/unit/serverless/aws-lambda.test.js
@@ -388,22 +388,12 @@ describe('AwsLambda.patchLambdaHandler', () => {
         const spanAttributes = segment.attributes.get(ATTR_DEST.SPAN_EVENT)
 
         expect(agentAttributes).to.have.property(
-          'httpResponseCode',
-          '200'
-        )
-
-        expect(agentAttributes).to.have.property(
-          'response.status',
+          'http.statusCode',
           '200'
         )
 
         expect(spanAttributes).to.have.property(
-          'httpResponseCode',
-          '200'
-        )
-
-        expect(spanAttributes).to.have.property(
-          'response.status',
+          'http.statusCode',
           '200'
         )
 


### PR DESCRIPTION
## Proposed Release Notes
* Removed deprecated httpResponseCode, response.status and httpResponseMessage http response attributes.

## Links

Closes: #508 
