### PR TITLE
Remove node <=9.x.x version checks on http instrumentation

### DIFF
--- a/lib/instrumentation/core/http.js
+++ b/lib/instrumentation/core/http.js
@@ -27,8 +27,6 @@ const DESTS = require('../../config/attribute-filter').DESTINATIONS
  * CONSTANTS
  *
  */
-const SHOULD_WRAP_HTTPS = psemver.satisfies('>=9.0.0 || 8.9.0')
-const SHOULD_FORMAT_ARGS = psemver.satisfies('>=10.0.0')
 const NR_CONNECTION_PROP = '__NR__connection'
 const NEWRELIC_ID_HEADER = 'x-newrelic-id'
 const NEWRELIC_APP_DATA_HEADER = 'x-newrelic-app-data'
@@ -413,36 +411,33 @@ function urlToOptions(_url) {
 }
 
 function wrapRequest(agent, request) {
-  // URL as a global was not added until Node v10
-  const URLClass = global.URL ? global.URL : url.URL
+  const URLClass = global.URL
+
   return function wrappedRequest(input, options, cb) {
     let reqArgs = arguments
-    if (SHOULD_FORMAT_ARGS) {
-      // Support new function signatures in Node v10+. If the first argument is a URL,
-      // merge it into the options object. This code is copied from Node internals.
-      if (typeof input === 'string') {
-        const urlStr = input
-        input = urlToOptions(new URLClass(urlStr))
-      } else if (input.constructor && input.constructor.name === 'URL') {
-        input = urlToOptions(input)
-      } else {
-        cb = options
-        options = input
-        input = null
-      }
 
-      if (typeof options === 'function') {
-        cb = options
-        options = input || {}
-      } else {
-        options = Object.assign(input || {}, options)
-      }
-
-      reqArgs = [options, cb]
+    // If the first argument is a URL, merge it into the options object.
+    // This code is copied from Node internals.
+    if (typeof input === 'string') {
+      const urlStr = input
+      input = urlToOptions(new URLClass(urlStr))
+    } else if (input.constructor && input.constructor.name === 'URL') {
+      input = urlToOptions(input)
     } else {
-      // Node v8 function signature had options as the first argument
+      cb = options
       options = input
+      input = null
     }
+
+    if (typeof options === 'function') {
+      cb = options
+      options = input || {}
+    } else {
+      options = Object.assign(input || {}, options)
+    }
+
+    reqArgs = [options, cb]
+
 
     // Don't pollute metrics and calls with NR connections
     const internalOnly = options && options[NR_CONNECTION_PROP]
@@ -523,28 +518,19 @@ module.exports = function initialize(agent, http, moduleName) {
 
   var agentProto = http && http.Agent && http.Agent.prototype
 
-  // As of node 0.8, http.request() is the right way to originate outbound
-  // requests. From 0.11 until 9, the `https` module simply called through to
-  // the `http` methods, so to prevent double-instrumenting we need to check
-  // what module we're instrumenting and what version of Node we're on. This
-  // change originally also appeared in 8.9.0 but was reverted in 8.9.1.
-  //
-  // TODO: Remove `SHOULD_WRAP_HTTPS` after deprecating Node <9.
-  if (SHOULD_WRAP_HTTPS || !IS_HTTPS) {
-    shimmer.wrapMethod(
-      http,
-      'http',
-      'request',
-      wrapRequest.bind(null, agent)
-    )
+  shimmer.wrapMethod(
+    http,
+    'http',
+    'request',
+    wrapRequest.bind(null, agent)
+  )
 
-    shimmer.wrapMethod(
-      http,
-      'http',
-      'get',
-      wrapRequest.bind(null, agent)
-    )
-  }
+  shimmer.wrapMethod(
+    http,
+    'http',
+    'get',
+    wrapRequest.bind(null, agent)
+  )
 
   shimmer.wrapMethod(
     agentProto,

--- a/lib/instrumentation/core/http.js
+++ b/lib/instrumentation/core/http.js
@@ -15,7 +15,6 @@ const util = require('util')
 const url = require('url')
 const urltils = require('../../util/urltils')
 const properties = require('../../util/properties')
-const psemver = require('../../util/process-version')
 const headerAttributes = require('../../header-attributes')
 const headerProcessing = require('../../header-processing')
 

--- a/lib/instrumentation/core/http.js
+++ b/lib/instrumentation/core/http.js
@@ -410,16 +410,12 @@ function urlToOptions(_url) {
 }
 
 function wrapRequest(agent, request) {
-  const URLClass = global.URL
-
   return function wrappedRequest(input, options, cb) {
-    let reqArgs = arguments
-
     // If the first argument is a URL, merge it into the options object.
     // This code is copied from Node internals.
     if (typeof input === 'string') {
       const urlStr = input
-      input = urlToOptions(new URLClass(urlStr))
+      input = urlToOptions(new URL(urlStr))
     } else if (input.constructor && input.constructor.name === 'URL') {
       input = urlToOptions(input)
     } else {
@@ -435,7 +431,7 @@ function wrapRequest(agent, request) {
       options = Object.assign(input || {}, options)
     }
 
-    reqArgs = [options, cb]
+    let reqArgs = [options, cb]
 
 
     // Don't pollute metrics and calls with NR connections


### PR DESCRIPTION
## Proposed Release Notes
* **BREAKING** strictly uses `global.URL` class in http core instrumentation
* **BREAKING** removes Nodejs 8.x.x - 9.x.x checks
## Links
Closes: #511 
## Details
