### PR TITLE
Remove node v10 check from http outbound test.

### DIFF
--- a/test/unit/instrumentation/http/outbound.test.js
+++ b/test/unit/instrumentation/http/outbound.test.js
@@ -569,8 +569,7 @@ tap.test('when working with http.request', (t) => {
   t.end()
 })
 
-// TODO: seems like should probably be versioned test(s)?
-tap.test('node >= v10 api', {skip: !global.URL}, (t) => {
+tap.test('Should properly handle http(s) get and request signatures', (t) => {
   t.autoend()
 
   let agent = null


### PR DESCRIPTION
## Proposed Release Notes
* Removed node v10 check from http outbound unit test.
## Links
Closes: #513 
## Details
