### PR TITLE
Remove api.custom_parameters_enabled config item

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -596,14 +596,6 @@ exports.config = () => ({
    */
   api: {
     /**
-     * Deprecated. Please use `api.custom_attributes_enabled` instead.
-     *
-     * @env NEW_RELIC_API_CUSTOM_PARAMETERS
-     */
-    // TODO: This somehow survived the v5 cut, even though
-    // it's already removed from docs site. Remove in v6.
-    custom_parameters_enabled: true,
-    /**
      * Controls for the `API.addCustomAttribute` method.
      *
      * @env NEW_RELIC_API_CUSTOM_ATTRIBUTES

--- a/lib/config/env.js
+++ b/lib/config/env.js
@@ -106,7 +106,6 @@ const ENV_MAPPING = {
   },
   api: {
     custom_attributes_enabled: 'NEW_RELIC_API_CUSTOM_ATTRIBUTES',
-    custom_parameters_enabled: 'NEW_RELIC_API_CUSTOM_PARAMETERS',
     custom_events_enabled: 'NEW_RELIC_API_CUSTOM_EVENTS',
     notice_error_enabled: 'NEW_RELIC_API_NOTICE_ERROR'
   },

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1327,10 +1327,6 @@ Config.prototype._canonicalize = function _canonicalize() {
     )
   }
 
-  this.api.custom_attributes_enabled = !this.api.custom_attributes_enabled
-    ? this.api.custom_attributes_enabled
-    : this.api.custom_parameters_enabled
-
   this.serverless_mode.enabled = this.serverless_mode.enabled
     && this.feature_flag.serverless_mode
 


### PR DESCRIPTION
## Proposed Release Notes
* **BREAKING** Removed the `api.custom_parameters_enabled configuration` item and associated environment variable `NEW_RELIC_API_CUSTOM_PARAMETERS`. Please use `api.custom_attributes_enabled` instead.

## Links
Closes: #518 
## Details
