### PR TITLE
Removed deprecation warnings invalid config items

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1025,15 +1025,6 @@ Config.prototype._fromPassed = function _fromPassed(external, internal, arbitrar
       return
     }
 
-    // TODO: remove in v6
-    if (key === 'ignored_params') {
-      warnDeprecated(key, 'attributes.exclude')
-    }
-
-    if (key === 'capture_params') {
-      warnDeprecated(key, 'attributes.enabled')
-    }
-
     try {
       var node = external[key]
     } catch (err) {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1040,14 +1040,6 @@ Config.prototype._fromPassed = function _fromPassed(external, internal, arbitrar
       internal[key] = node
     }
   }, this)
-
-  function warnDeprecated(key, replacement) {
-    logger.warn(
-      'Config key %s is deprecated, please use %s instead',
-      key,
-      replacement
-    )
-  }
 }
 
 /**


### PR DESCRIPTION
## Proposed Release Notes
* Removed deprecation warning for invalid config items, `ignored_params` and `capture_params`.  Use `attributes.exclude` and `attributes.enabled` instead.
## Links
Closes: #509 
## Details
