### PR TITLE
Remove dt methods

### DIFF
--- a/examples/api/distributed-tracing/example1-background.js
+++ b/examples/api/distributed-tracing/example1-background.js
@@ -3,23 +3,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-var newrelic = require('newrelic')
+const newrelic = require('newrelic')
+
 // Give the agent some time to start up.
 setTimeout(runTest, 2000)
 
 function runTest() {
   newrelic.startWebTransaction('Custom web transaction', function() {
     // Call newrelic.getTransaction to retrieve a handle on the current transaction.
-    var transactionHandle = newrelic.getTransaction()
+    let transactionHandle = newrelic.getTransaction()
 
     // Generate the payload right before creating the linked transaction.
-    var payload = transactionHandle.createDistributedTracePayload()
-    var jsonPayload = payload.text()
+    let headers = {}
+    transactionHandle.insertDistributedTraceHeaders(headers)
 
     newrelic.startBackgroundTransaction('Background task', function executeTransaction() {
-      var backgroundHandle = newrelic.getTransaction()
+      let backgroundHandle = newrelic.getTransaction()
       // Link the nested transaction by accepting the payload with the background transaction's handle
-      backgroundHandle.acceptDistributedTracePayload(jsonPayload)
+      backgroundHandle.acceptDistributedTraceHeaders(headers)
       // End the transactions
       backgroundHandle.end(transactionHandle.end)
     })

--- a/lib/transaction/dt-payload.js
+++ b/lib/transaction/dt-payload.js
@@ -13,7 +13,7 @@ const DT_VERSION_MINOR = 1
 module.exports = class DistributedTracePayload {
   /**
    * The class reponsible for producing distributed trace payloads.
-   * Created by calling {@link TransactionHandle#createDistributedTracePayload}.
+   * Created by calling {@link TransactionHandle#_createDistributedTracePayload}.
    *
    * @constructor
    */

--- a/lib/transaction/handle.js
+++ b/lib/transaction/handle.js
@@ -5,9 +5,7 @@
 
 'use strict'
 
-const util = require('util')
 const logger = require('../logger').child({component: 'transactionHandle'})
-const DistributedTracePayloadStub = require('./dt-payload').Stub
 
 const NAMES = require('../../lib/metrics/names')
 
@@ -61,7 +59,6 @@ class TransactionHandle {
    */
   acceptDistributedTraceHeaders(transportType, headers) {
     incrementApiSupportMetric(this._metrics, 'acceptDistributedTraceHeaders')
-
     return this._transaction.acceptDistributedTraceHeaders(transportType, headers)
   }
 
@@ -71,47 +68,9 @@ class TransactionHandle {
    */
   insertDistributedTraceHeaders(headers) {
     incrementApiSupportMetric(this._metrics, 'insertDistributedTraceHeaders')
-
     return this._transaction.insertDistributedTraceHeaders(headers)
   }
-
-  /**
-  *
-  * Proxy method for Transaction#createDistrubtedTracePayload.
-  *
-  * @returns {DistributedTracePayload} The created payload object.
-  *
-  */
-  createDistributedTracePayload() {
-    return this._transaction.createDistributedTracePayload()
-  }
-
-  /**
-  *
-  * Proxy method for Transaction#acceptDistributedTracePayload
-  *
-  * @param {String} The payload to accept as the parent to the current trace
-  *
-  */
-  acceptDistributedTracePayload(payload) {
-    return this._transaction.acceptDistributedTracePayload(payload)
-  }
 }
-
-// TODO: Fully remove functions in future Major release. v7.0.0?
-TransactionHandle.prototype.acceptDistributedTracePayload = util.deprecate(
-  TransactionHandle.prototype.acceptDistributedTracePayload,
-  'TransactionHandle#acceptDistributedTracePayload has been deprecated! ' +
-  'Please use TransactionHandle#acceptDistributedTraceHeaders ' +
-  'which supports multiple distributed trace formats.'
-)
-
-TransactionHandle.prototype.createDistributedTracePayload = util.deprecate(
-  TransactionHandle.prototype.createDistributedTracePayload,
-  'TransactionHandle#createDistributedTracePayload has been deprecated! ' +
-  'Please use TransactionHandle#insertDistributedTraceHeaders ' +
-  'which supports multiple distributed trace formats.'
-)
 
 module.exports = TransactionHandle
 
@@ -145,19 +104,6 @@ module.exports.Stub = class TransactionHandleStub {
 
   isSampled() {
     logger.debug("No transaction found when calling Transaction.isSampled")
-  }
-
-  createDistributedTracePayload() {
-    logger.debug(
-      "No transaction found when calling Transaction.createDistributedTracePayload"
-    )
-    return new DistributedTracePayloadStub()
-  }
-
-  acceptDistributedTracePayload() {
-    logger.debug(
-      "No transaction found when calling Transaction.acceptDistributedTracePayload"
-    )
   }
 
   acceptDistributedTraceHeaders() {

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -929,7 +929,7 @@ function insertDistributedTraceHeaders(headers) {
   }
 
   try {
-    const newrelicFormatData = this.createDistributedTracePayload().httpSafe()
+    const newrelicFormatData = this._createDistributedTracePayload().httpSafe()
     headers[NEWRELIC_TRACE_HEADER] = newrelicFormatData
     logger.trace('Added outbound request distributed tracing headers in transaction %s', this.id)
   } catch (error) {
@@ -993,8 +993,8 @@ function acceptTraceContextPayload(traceparent, tracestate, transport) {
  * @param {object} payload                - The distributed trace payload to accept.
  * @param {string} [transport='Unknown']  - The transport type that delivered the payload.
  */
-Transaction.prototype.acceptDistributedTracePayload = acceptDistributedTracePayload
-function acceptDistributedTracePayload(payload, transport) {
+Transaction.prototype._acceptDistributedTracePayload = _acceptDistributedTracePayload
+function _acceptDistributedTracePayload(payload, transport) {
   if (!payload) {
     this.agent.recordSupportability('DistributedTrace/AcceptPayload/Ignored/Null')
     return
@@ -1089,11 +1089,6 @@ function acceptDistributedTracePayload(payload, transport) {
     return
   }
 
-  // TODO: This should be removable / covered by acceptDistributedTraceHeaders
-  // once the Transaction#acceptDistributedTracePayload API that directly invokes
-  // this acceptDistributedTracePayload is fully removed in a future Major version.
-  transport = TRANSPORT_TYPES_SET[transport] ? transport : TRANSPORT_TYPES.UNKNOWN
-
   this.parentType = data.ty
   this.parentApp = data.ap
   this.parentAcct = data.ac
@@ -1163,9 +1158,9 @@ Transaction.prototype._getParsedPayload = function _getParsedPayload(payload) {
 /**
  * Creates a distributed trace payload.
  */
-Transaction.prototype.createDistributedTracePayload = createDistributedTracePayload
+Transaction.prototype._createDistributedTracePayload = _createDistributedTracePayload
 
-function createDistributedTracePayload() {
+function _createDistributedTracePayload() {
   const config = this.agent.config
   const accountId = config.account_id
   const appId = config.primary_application_id
@@ -1184,11 +1179,6 @@ function createDistributedTracePayload() {
 
     return new DTPayloadStub()
   }
-
-  // TODO: This should be removable / covered by insertDistributedTraceHeaders
-  // once the Transaction#createDistributedTracePayload API that directly invokes
-  // this createDistributedTracePayload is fully removed in a future Major version.
-  this._calculatePriority()
 
   const currSegment = this.agent.tracer.getSegment()
   const data = {

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -886,19 +886,14 @@ function acceptDistributedTraceHeaders(transportType, headers) {
 
   if (traceparent) {
     logger.trace('Accepting trace context DT payload for transaction %s', this.id)
-
     // assumes header keys already lowercase
     const tracestate = headers[TRACE_CONTEXT_STATE_HEADER]
-
     this.acceptTraceContextPayload(traceparent, tracestate, transport)
-  } else {
+  } else if (NEWRELIC_TRACE_HEADER in headers) {
+    logger.trace('Accepting newrelic DT payload for transaction %s', this.id)
     // assumes header keys already lowercase
     const payload = headers[NEWRELIC_TRACE_HEADER]
-    if (payload) {
-      logger.trace('Accepting newrelic DT payload for transaction %s', this.id)
-
-      this.acceptDistributedTracePayload(payload, transport)
-    }
+    this._acceptDistributedTracePayload(payload, transport)
   }
 }
 

--- a/test/unit/analytics_events.test.js
+++ b/test/unit/analytics_events.test.js
@@ -154,9 +154,9 @@ describe('Analytics events', function() {
       agent.config.primary_application_id = 'test'
       agent.config.account_id = 1
       trans = new Transaction(agent)
-      const payload = trans.createDistributedTracePayload().text()
+      const payload = trans._createDistributedTracePayload().text()
       trans.isDistributedTrace = null
-      trans.acceptDistributedTracePayload(payload)
+      trans._acceptDistributedTracePayload(payload)
       trans.end()
 
       const events = getTransactionEvents(agent)

--- a/test/unit/api/api-transaction-handle.test.js
+++ b/test/unit/api/api-transaction-handle.test.js
@@ -41,17 +41,9 @@ tap.test('Agent API - transaction handle', (t) => {
     t.type(handle.end, 'function')
     t.type(handle.ignore, 'function')
 
-    // Deprecated.
-    t.type(handle.createDistributedTracePayload, 'function')
-    t.type(handle.acceptDistributedTracePayload, 'function')
-
     t.type(handle.acceptDistributedTraceHeaders, 'function')
     t.type(handle.insertDistributedTraceHeaders, 'function')
     t.type(handle.isSampled, 'function')
-
-    const payload = handle.createDistributedTracePayload()
-    t.type(payload.httpSafe, 'function')
-    t.type(payload.text, 'function')
 
     t.end()
   })
@@ -84,26 +76,26 @@ tap.test('Agent API - transaction handle', (t) => {
     })
   })
 
-  t.test("should have a method to create a distributed trace payload", (t) => {
+  t.test("should have a method to insert distributed trace headers", (t) => {
     helper.runInTransaction(agent, function() {
       const handle = api.getTransaction()
 
-      t.type(handle.createDistributedTracePayload, 'function')
+      t.type(handle.insertDistributedTraceHeaders, 'function')
       agent.config.cross_process_id = '1234#5678'
 
-      const distributedTracePayload = handle.createDistributedTracePayload()
+      const headers = {}
+      handle.insertDistributedTraceHeaders(headers)
 
-      t.type(distributedTracePayload.text, 'function')
-      t.type(distributedTracePayload.httpSafe, 'function')
+      t.type(headers.traceparent, 'string')
 
       t.end()
     })
   })
 
-  t.test("should have a method for accepting a distributed trace payload", (t) => {
+  t.test("should have a method for accepting distributed trace headers", (t) => {
     helper.runInTransaction(agent, function() {
       const handle = api.getTransaction()
-      t.type(handle.acceptDistributedTracePayload, 'function')
+      t.type(handle.acceptDistributedTraceHeaders, 'function')
       t.end()
     })
   })

--- a/test/unit/db/trace.test.js
+++ b/test/unit/db/trace.test.js
@@ -40,9 +40,9 @@ describe('SQL trace', function() {
       agent.config.account_id = 1
       agent.config.simple_compression = true
       helper.runInTransaction(agent, function(tx) {
-        const payload = tx.createDistributedTracePayload().text()
+        const payload = tx._createDistributedTracePayload().text()
         tx.isDistributedTrace = null
-        tx.acceptDistributedTracePayload(payload)
+        tx._acceptDistributedTracePayload(payload)
         agent.queries.add(
           tx.trace.root,
           'postgres',

--- a/test/unit/error_events.test.js
+++ b/test/unit/error_events.test.js
@@ -60,9 +60,9 @@ test('Error events', (t) => {
       agent.config.primary_application_id = 'test'
       agent.config.account_id = 1
       helper.runInTransaction(agent, function(tx) {
-        const payload = tx.createDistributedTracePayload().text()
+        const payload = tx._createDistributedTracePayload().text()
         tx.isDistributedTrace = null
-        tx.acceptDistributedTracePayload(payload)
+        tx._acceptDistributedTracePayload(payload)
         const error = new Error('some error')
         const customAttributes = {}
         const timestamp = 0
@@ -93,9 +93,9 @@ test('Error events', (t) => {
       agent.config.primary_application_id = 'test'
       agent.config.account_id = 1
       helper.runInTransaction(agent, function(tx) {
-        const payload = tx.createDistributedTracePayload().text()
+        const payload = tx._createDistributedTracePayload().text()
         tx.isDistributedTrace = null
-        tx.acceptDistributedTracePayload(payload)
+        tx._acceptDistributedTracePayload(payload)
         const error = new Error('some error')
         const customAttributes = {}
         const timestamp = 0

--- a/test/unit/errors/error-collector.test.js
+++ b/test/unit/errors/error-collector.test.js
@@ -1336,10 +1336,10 @@ describe('Errors', function() {
         agent.config.distributed_tracing.enabled = true
         agent.config.primary_application_id = 'test'
         agent.config.account_id = 1
-        var transaction = createTransaction(agent, 200)
-        var payload = transaction.createDistributedTracePayload().text()
+        let transaction = createTransaction(agent, 200)
+        let payload = transaction._createDistributedTracePayload().text()
         transaction.isDistributedTrace = null
-        transaction.acceptDistributedTracePayload(payload)
+        transaction._acceptDistributedTracePayload(payload)
 
         var error = new Error('some error')
         aggregator.add(transaction, error)

--- a/test/unit/metrics-recorder/distributed-trace.test.js
+++ b/test/unit/metrics-recorder/distributed-trace.test.js
@@ -57,9 +57,9 @@ describe('recordDistributedTrace', () => {
 
   describe('when a trace payload was received', () => {
     it('records metrics with payload information', () => {
-      const payload = tx.createDistributedTracePayload().text()
+      const payload = tx._createDistributedTracePayload().text()
       tx.isDistributedTrace = null
-      tx.acceptDistributedTracePayload(payload, 'HTTP')
+      tx._acceptDistributedTracePayload(payload, 'HTTP')
 
       record({
         tx,
@@ -92,9 +92,9 @@ describe('recordDistributedTrace', () => {
 
     describe('and transaction errors exist', () => {
       it('includes error-related metrics', () => {
-        const payload = tx.createDistributedTracePayload().text()
+        const payload = tx._createDistributedTracePayload().text()
         tx.isDistributedTrace = null
-        tx.acceptDistributedTracePayload(payload, 'HTTP')
+        tx._acceptDistributedTracePayload(payload, 'HTTP')
 
         tx.exceptions.push('some error')
 

--- a/test/unit/metrics-recorder/http.test.js
+++ b/test/unit/metrics-recorder/http.test.js
@@ -80,9 +80,9 @@ describe("recordWeb", function() {
         agent.config.primary_application_id = '5677',
         agent.config.trusted_account_key = '1234'
 
-        const payload = trans.createDistributedTracePayload().text()
+        const payload = trans._createDistributedTracePayload().text()
         trans.isDistributedTrace = null
-        trans.acceptDistributedTracePayload(payload, 'HTTP')
+        trans._acceptDistributedTracePayload(payload, 'HTTP')
 
         record({
           transaction: trans,

--- a/test/unit/trace.test.js
+++ b/test/unit/trace.test.js
@@ -234,9 +234,9 @@ describe('Trace', function() {
     agent.config.primary_application_id = 'test'
     agent.config.account_id = 1
     helper.runInTransaction(agent, function(tx) {
-      const payload = tx.createDistributedTracePayload().text()
+      const payload = tx._createDistributedTracePayload().text()
       tx.isDistributedTrace = null
-      tx.acceptDistributedTracePayload(payload)
+      tx._acceptDistributedTracePayload(payload)
       tx.end()
       const attributes = tx.trace.intrinsics
       expect(attributes.traceId).to.equal(tx.traceId)

--- a/test/unit/transaction.test.js
+++ b/test/unit/transaction.test.js
@@ -681,7 +681,7 @@ describe('Transaction', function() {
     })
   })
 
-  describe('acceptDistributedTracePayload', function() {
+  describe('_acceptDistributedTracePayload', function() {
     var tx = null
 
     beforeEach(function() {
@@ -701,7 +701,7 @@ describe('Transaction', function() {
     })
 
     it('records supportability metric if no payload was passed', function() {
-      tx.acceptDistributedTracePayload(null)
+      tx._acceptDistributedTracePayload(null)
       expect(tx.agent.recordSupportability.args[0][0]).to.equal(
         'DistributedTrace/AcceptPayload/Ignored/Null'
       )
@@ -712,7 +712,7 @@ describe('Transaction', function() {
         tx.isDistributedTrace = true
         tx.parentId = 'exists'
 
-        tx.acceptDistributedTracePayload({})
+        tx._acceptDistributedTracePayload({})
         expect(tx.agent.recordSupportability.args[0][0]).to.equal(
           'DistributedTrace/AcceptPayload/Ignored/Multiple'
         )
@@ -721,7 +721,7 @@ describe('Transaction', function() {
       it('records `CreateBeforeAccept` metric if parentId does not exist', function() {
         tx.isDistributedTrace = true
 
-        tx.acceptDistributedTracePayload({})
+        tx._acceptDistributedTracePayload({})
         expect(tx.agent.recordSupportability.args[0][0]).to.equal(
           'DistributedTrace/AcceptPayload/Ignored/CreateBeforeAccept'
         )
@@ -741,7 +741,7 @@ describe('Transaction', function() {
         ti: Date.now() - 1
       }
 
-      tx.acceptDistributedTracePayload({v: [0, 1], d: data})
+      tx._acceptDistributedTracePayload({v: [0, 1], d: data})
 
       expect(tx.agent.recordSupportability.args[0][0]).to.equal(
         'DistributedTrace/AcceptPayload/Exception'
@@ -761,7 +761,7 @@ describe('Transaction', function() {
         ti: Date.now() - 1
       }
 
-      tx.acceptDistributedTracePayload({v: [0, 1], d: data})
+      tx._acceptDistributedTracePayload({v: [0, 1], d: data})
 
       expect(tx.agent.recordSupportability.args[0][0]).to.equal(
         'DistributedTrace/AcceptPayload/Exception'
@@ -781,13 +781,13 @@ describe('Transaction', function() {
         ti: Date.now() - 1
       }
 
-      tx.acceptDistributedTracePayload({v: [0, 1], d: data})
+      tx._acceptDistributedTracePayload({v: [0, 1], d: data})
 
       expect(tx.isDistributedTrace).to.be.true
     })
 
     it('fails if payload version is above agent-supported version', function() {
-      tx.acceptDistributedTracePayload({v: [1, 0]})
+      tx._acceptDistributedTracePayload({v: [1, 0]})
       expect(tx.agent.recordSupportability.args[0][0]).to.equal(
         'DistributedTrace/AcceptPayload/ParseException'
       )
@@ -804,7 +804,7 @@ describe('Transaction', function() {
         ti: Date.now()
       }
 
-      tx.acceptDistributedTracePayload({
+      tx._acceptDistributedTracePayload({
         v: [0, 1],
         d: data
       })
@@ -815,7 +815,7 @@ describe('Transaction', function() {
     })
 
     it('fails if payload data is missing required keys', function() {
-      tx.acceptDistributedTracePayload({
+      tx._acceptDistributedTracePayload({
         v: [0, 1],
         d: {
           ac: 1
@@ -839,7 +839,7 @@ describe('Transaction', function() {
         ti: Date.now()
       }
 
-      tx.acceptDistributedTracePayload({v: [0, 1], d: data})
+      tx._acceptDistributedTracePayload({v: [0, 1], d: data})
       expect(tx.sampled).to.be.true
       expect(tx.priority).to.equal(data.pr)
       // Should not truncate accepted priority
@@ -857,7 +857,7 @@ describe('Transaction', function() {
         ti: Date.now()
       }
 
-      tx.acceptDistributedTracePayload({v: [0, 1], d: data})
+      tx._acceptDistributedTracePayload({v: [0, 1], d: data})
       expect(tx.priority).to.equal(null)
       expect(tx.sampled).to.equal(null)
     })
@@ -872,7 +872,7 @@ describe('Transaction', function() {
         ti: Date.now() - 1
       }
 
-      tx.acceptDistributedTracePayload({v: [0, 1], d: data})
+      tx._acceptDistributedTracePayload({v: [0, 1], d: data})
       expect(tx.agent.recordSupportability.args[0][0]).to.equal(
         'DistributedTrace/AcceptPayload/Success'
       )
@@ -894,7 +894,7 @@ describe('Transaction', function() {
         ti: Date.now() + 1000
       }
 
-      tx.acceptDistributedTracePayload({v: [0, 1], d: data})
+      tx._acceptDistributedTracePayload({v: [0, 1], d: data})
       expect(tx.agent.recordSupportability.args[0][0]).to.equal(
         'DistributedTrace/AcceptPayload/Success'
       )
@@ -952,7 +952,7 @@ describe('Transaction', function() {
     })
   })
 
-  describe('createDistributedTracePayload', function() {
+  describe('_createDistributedTracePayload', function() {
     var tx = null
 
     beforeEach(function() {
@@ -976,7 +976,7 @@ describe('Transaction', function() {
     it('should not create payload when DT disabled', function() {
       tx.agent.config.distributed_tracing.enabled = false
 
-      const payload = tx.createDistributedTracePayload().text()
+      const payload = tx._createDistributedTracePayload().text()
       expect(payload).to.equal('')
       expect(tx.agent.recordSupportability.callCount).to.equal(0)
       expect(tx.isDistributedTrace).to.not.be.true
@@ -985,34 +985,24 @@ describe('Transaction', function() {
     it('should create payload when DT enabled and CAT disabled', function() {
       tx.agent.config.cross_application_tracer.enabled = false
 
-      const payload = tx.createDistributedTracePayload().text()
+      const payload = tx._createDistributedTracePayload().text()
 
       expect(payload).to.not.be.null
       expect(payload).to.not.equal('')
-    })
-
-    it('generates a priority for entry-point transactions', () => {
-      expect(tx.priority).to.equal(null)
-      expect(tx.sampled).to.equal(null)
-
-      tx.createDistributedTracePayload()
-
-      expect(tx.priority).to.be.a('number')
-      expect(tx.sampled).to.be.a('boolean')
     })
 
     it('does not change existing priority', () => {
       tx.priority = 999
       tx.sampled = false
 
-      tx.createDistributedTracePayload()
+      tx._createDistributedTracePayload()
 
       expect(tx.priority).to.equal(999)
       expect(tx.sampled).to.be.false
     })
 
     it('sets the transaction as sampled if the trace is chosen', function() {
-      const payload = JSON.parse(tx.createDistributedTracePayload().text())
+      const payload = JSON.parse(tx._createDistributedTracePayload().text())
       expect(payload.d.sa).to.equal(tx.sampled)
       expect(payload.d.pr).to.equal(tx.priority)
     })
@@ -1020,7 +1010,8 @@ describe('Transaction', function() {
     it('adds the current span id as the parent span id', function() {
       agent.config.span_events.enabled = true
       agent.tracer.segment = tx.trace.root
-      const payload = JSON.parse(tx.createDistributedTracePayload().text())
+      tx.sampled = true
+      const payload = JSON.parse(tx._createDistributedTracePayload().text())
       expect(payload.d.id).to.equal(tx.trace.root.id)
       agent.tracer.segment = null
       agent.config.span_events.enabled = false
@@ -1031,14 +1022,14 @@ describe('Transaction', function() {
       tx._calculatePriority()
       tx.sampled = false
       agent.tracer.segment = tx.trace.root
-      const payload = JSON.parse(tx.createDistributedTracePayload().text())
+      const payload = JSON.parse(tx._createDistributedTracePayload().text())
       expect(payload.d.id).to.be.undefined
       agent.tracer.segment = null
       agent.config.span_events.enabled = false
     })
 
     it('returns stringified payload object', function() {
-      const payload = tx.createDistributedTracePayload().text()
+      const payload = tx._createDistributedTracePayload().text()
       expect(typeof payload).to.equal('string')
       expect(tx.agent.recordSupportability.args[0][0]).to.equal(
         'DistributedTrace/CreatePayload/Success'
@@ -1369,6 +1360,18 @@ describe('Transaction', function() {
 
       agent.tracer.segment = null
     })
+
+    it('generates a priority for entry-point transactions', () => {
+      const tx = new Transaction(agent)
+
+      expect(tx.priority).to.equal(null)
+      expect(tx.sampled).to.equal(null)
+
+      tx.insertDistributedTraceHeaders({})
+
+      expect(tx.priority).to.be.a('number')
+      expect(tx.sampled).to.be.a('boolean')
+    })
   })
 
   describe('acceptTraceContextPayload', () => {
@@ -1486,16 +1489,6 @@ describe('Transaction', function() {
       tx = new Transaction(agent)
     })
 
-    it('generates a priority for entry-point transactions', () => {
-      expect(tx.priority).to.equal(null)
-      expect(tx.sampled).to.equal(null)
-
-      tx.addDistributedTraceIntrinsics(attributes)
-
-      expect(tx.priority).to.be.a('number')
-      expect(tx.sampled).to.be.a('boolean')
-    })
-
     it('does not change existing priority', () => {
       tx.priority = 999
       tx.sampled = false
@@ -1523,9 +1516,9 @@ describe('Transaction', function() {
       tx.agent.config.trusted_account_key = '5678'
       tx.agent.config.distributed_tracing.enabled = true
 
-      const payload = tx.createDistributedTracePayload().text()
+      const payload = tx._createDistributedTracePayload().text()
       tx.isDistributedTrace = false
-      tx.acceptDistributedTracePayload(payload, 'AMQP')
+      tx._acceptDistributedTracePayload(payload, 'AMQP')
 
       tx.addDistributedTraceIntrinsics(attributes)
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
* **BREAKING** Removed deprecated Distributed Tracing API methods

## Links
#510 

## Details
`createDistributedTracePayload()` and `acceptDistributedTracePayload()` were on the `TransactionHandle` class and intended to be used by end users. Methods by the same name were also on the `Transaction` class itself, and called by both the methods on the `TransactionHandle` class and by the `insertDistributedTraceHeaders()` and `acceptDistributedTraceHeaders()` on the `Transaction` class. These "headers" methods can accept W3C Trace Context headers and New Relic DT headers.

The "payload" methods were deprecated and are now removed from the API/`TransactionHandle`. End users should use the "headers" methods.

When processing New Relic DT headers, the "headers" methods use the the "payload" methods internally. This PR adds an underscore to the "payload" methods to indicate that they are only internally used by the new "headers" methods on the `Transaction` class. As such, many tests that used the "payload" methods have been updated. Some were updated to use the "headers" methods where possible.