### PR TITLE
Update New Relic dependencies

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -494,7 +494,7 @@ This product includes source derived from [@grpc/proto-loader](https://github.co
 
 ### @newrelic/aws-sdk
 
-This product includes source derived from [@newrelic/aws-sdk](https://github.com/newrelic/node-newrelic-aws-sdk) ([v2.0.0](https://github.com/newrelic/node-newrelic-aws-sdk/tree/v2.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-aws-sdk/blob/v2.0.0/LICENSE):
+This product includes source derived from [@newrelic/aws-sdk](https://github.com/newrelic/node-newrelic-aws-sdk) ([v3.0.0](https://github.com/newrelic/node-newrelic-aws-sdk/tree/v3.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-aws-sdk/blob/v3.0.0/LICENSE):
 
 ```
                                  Apache License
@@ -702,7 +702,7 @@ This product includes source derived from [@newrelic/aws-sdk](https://github.com
 
 ### @newrelic/koa
 
-This product includes source derived from [@newrelic/koa](https://github.com/newrelic/node-newrelic-koa) ([v4.0.0](https://github.com/newrelic/node-newrelic-koa/tree/v4.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-koa/blob/v4.0.0/LICENSE):
+This product includes source derived from [@newrelic/koa](https://github.com/newrelic/node-newrelic-koa) ([v5.0.0](https://github.com/newrelic/node-newrelic-koa/tree/v5.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-koa/blob/v5.0.0/LICENSE):
 
 ```
 Apache License
@@ -911,7 +911,7 @@ Apache License
 
 ### @newrelic/superagent
 
-This product includes source derived from [@newrelic/superagent](https://github.com/newrelic/node-newrelic-superagent) ([v3.0.0](https://github.com/newrelic/node-newrelic-superagent/tree/v3.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-superagent/blob/v3.0.0/LICENSE):
+This product includes source derived from [@newrelic/superagent](https://github.com/newrelic/node-newrelic-superagent) ([v4.0.0](https://github.com/newrelic/node-newrelic-superagent/tree/v4.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-superagent/blob/v4.0.0/LICENSE):
 
 ```
                                  Apache License
@@ -1323,7 +1323,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ## optionalDependencies
 
 ### @newrelic/native-metrics
-This product includes source derived from [@newrelic/native-metrics](https://github.com/newrelic/node-native-metrics) ([v5.3.0](https://github.com/newrelic/node-native-metrics/tree/v5.3.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-native-metrics/blob/v5.3.0/LICENSE):
+This product includes source derived from [@newrelic/native-metrics](https://github.com/newrelic/node-native-metrics) ([v6.0.0](https://github.com/newrelic/node-native-metrics/tree/v6.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-native-metrics/blob/v6.0.0/LICENSE):
 
 ```
                                  Apache License
@@ -1548,7 +1548,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ### @newrelic/test-utilities
 
-This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v4.0.0](https://github.com/newrelic/node-test-utilities/tree/v4.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v4.0.0/LICENSE):
+This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v5.0.0](https://github.com/newrelic/node-test-utilities/tree/v5.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v5.0.0/LICENSE):
 
 ```
                                  Apache License

--- a/package-lock.json
+++ b/package-lock.json
@@ -477,22 +477,22 @@
       }
     },
     "@newrelic/aws-sdk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-2.0.0.tgz",
-      "integrity": "sha512-dHqR8a48w6Mq9ECtaObN3nS/ZeiZl3YZ3QMrP4WCVXdTaQcfbrISrd5sJcRX6WPwoPeI1m4ZFp36JsWDiXklAg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-3.0.0.tgz",
+      "integrity": "sha512-8sS0MBrvmdCOVsCe7NpNReKU06fhNnvsT60+VmzZNbv1nqPNbtOuUVERzukF/85XWU7Lk/r+ikUyGHX+Emlb4w=="
     },
     "@newrelic/koa": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-4.0.0.tgz",
-      "integrity": "sha512-OVOlKUDCY4+clAAZ7TdCPsXmuIR0/VM7+GLicyl7BsYT/XFMYItt2gCwgzvEkOxMjojk6CrnRoDjzE2BcYhAOw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-5.0.0.tgz",
+      "integrity": "sha512-4jzRXnUe38gQkZI8K4tWQ6CNdCNTi5uKILf1dTkyT6LpGxzDSLPwVyJ6xtMSMzr8SjIPG7lyNoWe42q8wFA7jg==",
       "requires": {
         "methods": "^1.1.2"
       }
     },
     "@newrelic/native-metrics": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-5.3.0.tgz",
-      "integrity": "sha512-GF3AIUz6vGzTLeXtQPlwA54LHlQbmKjIxtwY+SKaiFebyL/C7eD1mwW+9sL07B93DIUcs+pEc/OnHei314mNWg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-6.0.0.tgz",
+      "integrity": "sha512-EUdlsv25dEMT+8SOV02Xfk2E3UTo2fH33lVmnv/CSllH6+ljJDAfG0Ib5zY92Qmaj+oiThbfRpSYOlUfH+Uuiw==",
       "optional": true,
       "requires": {
         "nan": "^2.14.1",
@@ -500,9 +500,9 @@
       },
       "dependencies": {
         "nan": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+          "version": "2.14.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+          "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
           "optional": true
         }
       }
@@ -519,17 +519,17 @@
       }
     },
     "@newrelic/superagent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-3.0.0.tgz",
-      "integrity": "sha512-ihWTSkjOtYWsWe2CHWDSBeXwpLgHHeYJ9qCbBV9gzyTc4xPk7OrblBIZzpQqmAu5qnF3zbI+K/Celya80Y0bKQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-4.0.0.tgz",
+      "integrity": "sha512-n4iNrsV0908yHNZPNof7rm/mffclHaIxprCCWk15b4IRJik2VrtuIrK3mboUgNdv5pX4P7EZytY/D6kJgFkDGw==",
       "requires": {
         "methods": "^1.1.2"
       }
     },
     "@newrelic/test-utilities": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-4.0.0.tgz",
-      "integrity": "sha512-hZAhbh5hWZ5xPaGRy6/8xxd7xjMCB1uOFefK/hBymk0+umGa14sB3Uq7738RwIkCKy3pRWKC+CbzVU8nm2NVQA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-5.0.0.tgz",
+      "integrity": "sha512-w5JlPFrFi1I2nojOd/lB2LLL6EQrGtzVFsxBnzj33KRUB6aan5oZeGBHGbGO1iHpYvvotYluQa/oukmjF0wiFA==",
       "dev": true,
       "requires": {
         "async": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -144,9 +144,9 @@
   "dependencies": {
     "@grpc/grpc-js": "1.1.7",
     "@grpc/proto-loader": "^0.5.5",
-    "@newrelic/aws-sdk": "^2.0.0",
-    "@newrelic/koa": "^4.0.0",
-    "@newrelic/superagent": "^3.0.0",
+    "@newrelic/aws-sdk": "^3.0.0",
+    "@newrelic/koa": "^5.0.0",
+    "@newrelic/superagent": "^4.0.0",
     "@tyriar/fibonacci-heap": "^2.0.7",
     "async": "^3.2.0",
     "concat-stream": "^2.0.0",
@@ -156,11 +156,11 @@
     "semver": "^5.3.0"
   },
   "optionalDependencies": {
-    "@newrelic/native-metrics": "^5.3.0"
+    "@newrelic/native-metrics": "^6.0.0"
   },
   "devDependencies": {
     "@newrelic/proxy": "^2.0.0",
-    "@newrelic/test-utilities": "^4.0.0",
+    "@newrelic/test-utilities": "^5.0.0",
     "JSV": "~4.0.2",
     "architect": "*",
     "benchmark": "^2.1.4",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Wed Oct 28 2020 11:06:05 GMT-0700 (Pacific Daylight Time)",
+  "lastUpdated": "Fri Nov 06 2020 11:02:30 GMT-0800 (Pacific Standard Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeDev": true,
@@ -28,41 +28,41 @@
       "licenseTextSource": "file",
       "publisher": "Google Inc."
     },
-    "@newrelic/aws-sdk@2.0.0": {
+    "@newrelic/aws-sdk@3.0.0": {
       "name": "@newrelic/aws-sdk",
-      "version": "2.0.0",
-      "range": "^2.0.0",
-      "licenses": "Apache-2.0",
-      "repoUrl": "https://github.com/newrelic/node-newrelic-aws-sdk",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-aws-sdk/tree/v2.0.0",
-      "licenseFile": "node_modules/@newrelic/aws-sdk/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic-aws-sdk/blob/v2.0.0/LICENSE",
-      "licenseTextSource": "file",
-      "publisher": "New Relic Node.js agent team",
-      "email": "nodejs@newrelic.com"
-    },
-    "@newrelic/koa@4.0.0": {
-      "name": "@newrelic/koa",
-      "version": "4.0.0",
-      "range": "^4.0.0",
-      "licenses": "Apache-2.0",
-      "repoUrl": "https://github.com/newrelic/node-newrelic-koa",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-koa/tree/v4.0.0",
-      "licenseFile": "node_modules/@newrelic/koa/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic-koa/blob/v4.0.0/LICENSE",
-      "licenseTextSource": "file",
-      "publisher": "New Relic Node.js agent team",
-      "email": "nodejs@newrelic.com"
-    },
-    "@newrelic/superagent@3.0.0": {
-      "name": "@newrelic/superagent",
       "version": "3.0.0",
       "range": "^3.0.0",
       "licenses": "Apache-2.0",
+      "repoUrl": "https://github.com/newrelic/node-newrelic-aws-sdk",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-aws-sdk/tree/v3.0.0",
+      "licenseFile": "node_modules/@newrelic/aws-sdk/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic-aws-sdk/blob/v3.0.0/LICENSE",
+      "licenseTextSource": "file",
+      "publisher": "New Relic Node.js agent team",
+      "email": "nodejs@newrelic.com"
+    },
+    "@newrelic/koa@5.0.0": {
+      "name": "@newrelic/koa",
+      "version": "5.0.0",
+      "range": "^5.0.0",
+      "licenses": "Apache-2.0",
+      "repoUrl": "https://github.com/newrelic/node-newrelic-koa",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-koa/tree/v5.0.0",
+      "licenseFile": "node_modules/@newrelic/koa/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic-koa/blob/v5.0.0/LICENSE",
+      "licenseTextSource": "file",
+      "publisher": "New Relic Node.js agent team",
+      "email": "nodejs@newrelic.com"
+    },
+    "@newrelic/superagent@4.0.0": {
+      "name": "@newrelic/superagent",
+      "version": "4.0.0",
+      "range": "^4.0.0",
+      "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic-superagent",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-superagent/tree/v3.0.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-superagent/tree/v4.0.0",
       "licenseFile": "node_modules/@newrelic/superagent/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic-superagent/blob/v3.0.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic-superagent/blob/v4.0.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js Agent Team",
       "email": "nodejs@newrelic.com"
@@ -171,15 +171,15 @@
       "email": "nathan@tootallnate.net",
       "url": "http://n8.io/"
     },
-    "@newrelic/test-utilities@4.0.0": {
+    "@newrelic/test-utilities@5.0.0": {
       "name": "@newrelic/test-utilities",
-      "version": "4.0.0",
-      "range": "^4.0.0",
+      "version": "5.0.0",
+      "range": "^5.0.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-test-utilities",
-      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v4.0.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v5.0.0",
       "licenseFile": "node_modules/@newrelic/test-utilities/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v4.0.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v5.0.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
## Proposed Release Notes

* **BREAKING** Update New Relic Dependencies dropping support for Node v8 and adding support for Node v14
  * `@newrelic/aws-sdk` v3.0.0
  * `@newrelic/koa` v5.0.0
  * `@newrelic/native-metrics` v6.0.0
  * `@newrelic/superagent` v4.0.0
  * `@newrelic/test-utilities` v5.0.0

## Links
Closes: #515 
## Details
