### PR TITLE
Release v7.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,37 @@
+### 7.0.0 (2020-11-09):
+
+* Drop Node v8.x support and add Node v14.x
+  * Removed Node v8.x and added v14.x to CI
+  * Adds check that minimum Node version is >= 10
+  * Sets Node engine to >= 10 and < 15
+  * BREAKING Dropped support for Node v8.x HTTP get() function signature
+    * strictly uses global.URL class in http core instrumentation
+    * removes Nodejs 8.x - 9.x checks
+  * Update New Relic Dependencies to versions with updated Node version support
+    * @newrelic/aws-sdk v3.0.0
+    * @newrelic/koa v5.0.0
+    * @newrelic/native-metrics v6.0.0
+    * @newrelic/superagent v4.0.0
+    * @newrelic/test-utilities v5.0.0
+
+* BREAKING Removed deprecated setIgnoreTransaction API method
+
+* BREAKING Removed deprecated httpResponseCode, response.status and
+  httpResponseMessage http response attributes
+
+* BREAKING Removed the api.custom_parameters_enabled configuration item and
+  associated environment variable NEW_RELIC_API_CUSTOM_PARAMETERS. Please use
+  api.custom_attributes_enabled instead
+
+* BREAKING Removed deprecated Distributed Tracing API methods
+
+* Removed deprecation warning for invalid config items, ignored_params and
+  capture_params. Use attributes.exclude and attributes.enabled instead
+
+* Added additional logging to W3C Trace Context header creation.
+
+* Upgrade @newrelic/koa from 4.0.0 to 4.1.0
+
 ### 6.14.0 (2020-10-28):
 
 * Updated README for consistency.

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,16 +14,16 @@
     * @newrelic/superagent v4.0.0
     * @newrelic/test-utilities v5.0.0
 
-* BREAKING Removed deprecated setIgnoreTransaction API method
+* **BREAKING** Removed deprecated setIgnoreTransaction API method
 
-* BREAKING Removed deprecated httpResponseCode, response.status and
+* **BREAKING** Removed deprecated httpResponseCode, response.status and
   httpResponseMessage http response attributes
 
-* BREAKING Removed the api.custom_parameters_enabled configuration item and
+* **BREAKING** Removed the api.custom_parameters_enabled configuration item and
   associated environment variable NEW_RELIC_API_CUSTOM_PARAMETERS. Please use
   api.custom_attributes_enabled instead
 
-* BREAKING Removed deprecated Distributed Tracing API methods,
+* **BREAKING** Removed deprecated Distributed Tracing API methods,
   createDistributedTracePayload() and acceptDistributedTracePayload()
 
 * Finalized removal of ignored_params and capture_params

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,8 +30,6 @@
 
 * Added additional logging to W3C Trace Context header creation.
 
-* Upgrade @newrelic/koa from 4.0.0 to 4.1.0
-
 ### 6.14.0 (2020-10-28):
 
 * Updated README for consistency.

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,8 @@
   associated environment variable NEW_RELIC_API_CUSTOM_PARAMETERS. Please use
   api.custom_attributes_enabled instead
 
-* BREAKING Removed deprecated Distributed Tracing API methods
+* BREAKING Removed deprecated Distributed Tracing API methods,
+  createDistributedTracePayload() and acceptDistributedTracePayload()
 
 * Finalized removal of ignored_params and capture_params
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,13 @@
 ### 7.0.0 (2020-11-09):
 
-* Drop Node v8.x support and add Node v14.x
-  * Removed Node v8.x and added v14.x to CI
-  * Adds check that minimum Node version is >= 10
-  * Sets Node engine to >= 10 and < 15
-  * BREAKING Dropped support for Node v8.x HTTP get() function signature
+* Added official parity support for Node 14
+
+* Dropped Node v8.x support. For further information on our support policy,
+  see: https://docs.newrelic.com/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.
+  * Removed Node v8.x from CI
+  * Adds check that minimum Node version is >=10 and warns if >=15
+  * Sets Node engine to >=10
+  * **BREAKING** Dropped support for Node v8.x HTTP get() function signature
     * strictly uses global.URL class in http core instrumentation
     * removes Nodejs 8.x - 9.x checks
   * Update New Relic Dependencies to versions with updated Node version support

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,10 +25,9 @@
 
 * BREAKING Removed deprecated Distributed Tracing API methods
 
-* Removed deprecation warning for invalid config items, ignored_params and
-  capture_params. Use attributes.exclude and attributes.enabled instead
+* Finalized removal of ignored_params and capture_params
 
-* Added additional logging to W3C Trace Context header creation.
+* Added additional logging to W3C Trace Context header creation
 
 ### 6.14.0 (2020-10-28):
 

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Fri Nov 06 2020 11:02:30 GMT-0800 (Pacific Standard Time)",
+  "lastUpdated": "Mon Nov 09 2020 13:48:47 GMT-0800 (Pacific Standard Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeDev": true,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Added official parity support for Node 14

* Dropped Node v8.x support. For further information on our support policy,
  see: https://docs.newrelic.com/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.
  * Removed Node v8.x from CI
  * Adds check that minimum Node version is >=10 and warns if >=15
  * Sets Node engine to >=10
  * **BREAKING** Dropped support for Node v8.x HTTP get() function signature
    * strictly uses global.URL class in http core instrumentation
    * removes Nodejs 8.x - 9.x checks
  * Update New Relic Dependencies to versions with updated Node version support
    * @newrelic/aws-sdk v3.0.0
    * @newrelic/koa v5.0.0
    * @newrelic/native-metrics v6.0.0
    * @newrelic/superagent v4.0.0
    * @newrelic/test-utilities v5.0.0

* **BREAKING** Removed deprecated setIgnoreTransaction API method

* **BREAKING** Removed deprecated httpResponseCode, response.status and
  httpResponseMessage http response attributes

* **BREAKING** Removed the api.custom_parameters_enabled configuration item and
  associated environment variable NEW_RELIC_API_CUSTOM_PARAMETERS. Please use
  api.custom_attributes_enabled instead

* **BREAKING** Removed deprecated Distributed Tracing API methods,
  createDistributedTracePayload() and acceptDistributedTracePayload()

* Finalized removal of ignored_params and capture_params

* Added additional logging to W3C Trace Context header creation

## Links

## Details
