### PR TITLE
Release v7.0.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 ### 7.0.1 (2020-11-07):
 
-* Fixed a bug where spans sent to infinite tracing from an internal queue were not properly formatted.
-* Update @grpc/grpc-js to version v1.2.0.
+* Fixed a bug where spans queued up during backpressure situations would be improperly formatted and ultimately dropped when sent to an Infinite Tracing trace observer.
+* Updated @grpc/grpc-js to version v1.2.0.
 * Updated tap to clear up npm audit issues around lodash sub-dependency.
 
 ### 7.0.0 (2020-11-09):

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+### 7.0.1 (2020-11-07):
+
+* Fixed a bug where spans sent to infinite tracing from an internal queue were not properly formatted.
+* Update @grpc/grpc-js to version v1.2.0.
+* Updated tap to clear up npm audit issues around lodash sub-dependency.
+
 ### 7.0.0 (2020-11-09):
 
 * Added official parity support for Node 14


### PR DESCRIPTION
## Proposed Release Notes
* Fixed a bug where spans queued up during backpressure situations would be improperly formatted and ultimately dropped when sent to an Infinite Tracing trace observer.
* Updated @grpc/grpc-js to version v1.2.0.
* Updated tap to clear up npm audit issues around lodash sub-dependency.

## Links
https://github.com/newrelic/node-newrelic/pull/551
https://github.com/newrelic/node-newrelic/pull/550
https://github.com/newrelic/node-newrelic/pull/548
https://github.com/newrelic/node-newrelic/pull/545
https://github.com/newrelic/node-newrelic/pull/542
