### PR TITLE
Capture http.statusCode on web response of async invoked lambda

### DIFF
--- a/lib/serverless/aws-lambda.js
+++ b/lib/serverless/aws-lambda.js
@@ -129,7 +129,6 @@ class AwsLambda {
       const segmentRecorder = isApiGatewayLambdaProxy ? recordWeb : recordBackground
       const segment = shim.createSegment(functionName, segmentRecorder)
       transaction.baseSegment = segment
-      
       // resultProcessor is used to execute additional logic based on the
       // payload supplied to the callback.
       let resultProcessor
@@ -180,7 +179,6 @@ class AwsLambda {
       shim.agent.setLambdaArn(context.invokedFunctionArn)
 
       shim.agent.setLambdaFunctionVersion(context.functionVersion)
-      
       segment.addSpanAttributes(awsAttributes)
 
       segment.start()
@@ -194,7 +192,7 @@ class AwsLambda {
         throw err
       }
       if (shim.isPromise(res)) {
-        res = lambdaInterceptPromise(res, txnEnder)
+        res = lambdaInterceptPromise(res, resultProcessor, txnEnder)
       }
       return res
     }
@@ -202,8 +200,12 @@ class AwsLambda {
     // In order to capture error events
     // we need to store the error in uncaughtException
     // otherwise the transaction will end before they are captured
-    function lambdaInterceptPromise(prom, cb) {
+    function lambdaInterceptPromise(prom, resultProcessor, cb) {
       return prom.then(function onThen(arg) {
+        // check if we are in web transaction
+        if (resultProcessor) {
+          resultProcessor(arg)
+        }
         cb()
         return arg
       }, function onCatch(err) {
@@ -397,7 +399,7 @@ function setWebResponse(transaction, response) {
       responseCode
     )
 
-    const segment = transaction.agent.tracer.getSegment()
+    const segment = transaction.baseSegment
 
     segment.addSpanAttribute('http.statusCode', responseCode)
   }

--- a/lib/serverless/aws-lambda.js
+++ b/lib/serverless/aws-lambda.js
@@ -202,7 +202,6 @@ class AwsLambda {
     // otherwise the transaction will end before they are captured
     function lambdaInterceptPromise(prom, resultProcessor, cb) {
       return prom.then(function onThen(arg) {
-        // check if we are in web transaction
         if (resultProcessor) {
           resultProcessor(arg)
         }
@@ -399,6 +398,9 @@ function setWebResponse(transaction, response) {
       responseCode
     )
 
+    // We are adding http.statusCode to base segment as
+    // we found in testing async invoked lambdas, the
+    // active segement is not available at this point.
     const segment = transaction.baseSegment
 
     segment.addSpanAttribute('http.statusCode', responseCode)

--- a/test/unit/serverless/aws-lambda.test.js
+++ b/test/unit/serverless/aws-lambda.test.js
@@ -401,6 +401,47 @@ describe('AwsLambda.patchLambdaHandler', () => {
       }
     })
 
+    it('should capture response status code in async lambda', (done) => {
+      agent.on('transactionFinished', confirmAgentAttribute)
+
+      const apiGatewayProxyEvent = lambdaSampleEvents.apiGatewayProxyEvent
+
+      const wrappedHandler = awsLambda.patchLambdaHandler(() => {
+
+        return new Promise((resolve, reject) => {
+          resolve(
+            {
+              status: 200,
+              statusCode: 200,
+              statusDescription: "Success",
+              isBase64Encoded: false,
+              headers: {}
+            }
+          )
+        })
+      })
+
+      wrappedHandler(apiGatewayProxyEvent, stubContext, stubCallback)
+
+      function confirmAgentAttribute(transaction) {
+        const agentAttributes = transaction.trace.attributes.get(ATTR_DEST.TRANS_EVENT)
+        const segment = transaction.baseSegment
+        const spanAttributes = segment.attributes.get(ATTR_DEST.SPAN_EVENT)
+
+        expect(agentAttributes).to.have.property(
+          'http.statusCode',
+          '200'
+        )
+
+        expect(spanAttributes).to.have.property(
+          'http.statusCode',
+          '200'
+        )
+
+        done()
+      }
+    })
+
     it('should capture response headers', (done) => {
       agent.on('transactionFinished', confirmAgentAttribute)
 

--- a/test/unit/serverless/aws-lambda.test.js
+++ b/test/unit/serverless/aws-lambda.test.js
@@ -407,8 +407,7 @@ describe('AwsLambda.patchLambdaHandler', () => {
       const apiGatewayProxyEvent = lambdaSampleEvents.apiGatewayProxyEvent
 
       const wrappedHandler = awsLambda.patchLambdaHandler(() => {
-
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve) => {
           resolve(
             {
               status: 200,


### PR DESCRIPTION
## Proposed Release Notes
* Fixes a bug where the `http.statusCode` attribute was not being captured for an async invoked lambda.
## Links
* Closes: #554 
## Details
