### PR TITLE
Bumped grpc-js version to ^1.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -220,9 +220,9 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.2.tgz",
-      "integrity": "sha512-iK/T984Ni6VnmlQK/LJdUk+VsXSaYIWkgzJ0LyOcxN2SowAmoRjG28kS7B1ui/q/MAv42iM3051WBt5QorFxmg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.4.tgz",
+      "integrity": "sha512-z+EI20HYHLd3/uERtwOqP8Q4EPhGbz5RKUpiyo6xPWfR3pcjpf8sfNvY9XytDQ4xo1wNz7NqH1kh2UBonwzbfg==",
       "requires": {
         "@types/node": "^12.12.47",
         "google-auth-library": "^6.1.1",
@@ -490,9 +490,9 @@
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/node": {
-      "version": "12.19.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.9.tgz",
-      "integrity": "sha512-yj0DOaQeUrk3nJ0bd3Y5PeDRJ6W0r+kilosLA+dzF3dola/o9hxhMSg2sFvVcA2UHS5JSOsZp4S0c1OEXc4m1Q=="
+      "version": "12.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz",
+      "integrity": "sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw=="
     },
     "@tyriar/fibonacci-heap": {
       "version": "2.0.9",
@@ -2452,9 +2452,9 @@
       "dev": true
     },
     "google-auth-library": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.3.tgz",
-      "integrity": "sha512-m9mwvY3GWbr7ZYEbl61isWmk+fvTmOt0YNUfPOUY2VH8K5pZlAIWJjxEi0PqR3OjMretyiQLI6GURMrPSwHQ2g==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.4.tgz",
+      "integrity": "sha512-q0kYtGWnDd9XquwiQGAZeI2Jnglk7NDi0cChE4tWp6Kpo/kbqnt9scJb0HP+/xqt03Beqw/xQah1OPrci+pOxw==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
@@ -2522,9 +2522,9 @@
       "dev": true
     },
     "gtoken": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.1.0.tgz",
-      "integrity": "sha512-4d8N6Lk8TEAHl9vVoRVMh9BNOKWVgl2DdNtr3428O75r3QFrF/a5MMu851VmK0AA8+iSvbwRv69k5XnMLURGhg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.0.tgz",
+      "integrity": "sha512-qbf6JWEYFMj3WMAluvYXl8GAiji6w8d9OmAGCbBg0xF4xD/yu6ZaO6BhoXNddRjKcOUpZD81iea1H5B45gAo1g==",
       "requires": {
         "gaxios": "^4.0.0",
         "google-p12-pem": "^3.0.3",
@@ -2533,9 +2533,9 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.4.7",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
-          "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA=="
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.0.tgz",
+          "integrity": "sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "newrelic-naming-rules": "./bin/test-naming-rules.js"
   },
   "dependencies": {
-    "@grpc/grpc-js": "1.2.2",
+    "@grpc/grpc-js": "^1.2.4",
     "@grpc/proto-loader": "^0.5.5",
     "@newrelic/aws-sdk": "^3.0.0",
     "@newrelic/koa": "^5.0.0",


### PR DESCRIPTION
## Proposed Release Notes

* Bumped grpc-js version to ^1.2.4. 

  Now allows minor and patch auto-updates.

## Links

* Closes: https://github.com/newrelic/node-newrelic/issues/583

## Details

We've yet to encounter any fundamental issues with grpc-js updates past the 1.x version. Seems time to loosen that restriction and reduce some toil. We can revisit if an issue occurs.