### PR TITLE
Fixes resolveMx test by using example.com for a valid exchange.

### DIFF
--- a/test/integration/core/dns.tap.js
+++ b/test/integration/core/dns.tap.js
@@ -76,10 +76,10 @@ test('resolveCname', function(t) {
 test('resolveMx', function(t) {
   var agent = setupAgent(t)
   helper.runInTransaction(agent, function() {
-    // If this test breaks, blame Natalie Wolfe for adding a mailing
-    // service to encryptic.io
-    dns.resolveMx('encryptic.io', function(err) {
-      t.equal(err.code, 'ENODATA')
+    dns.resolveMx('example.com', function(err, ips) {
+      t.notOk(err)
+      t.equal(ips.length, 1)
+
       verifySegments(t, agent, 'dns.resolveMx')
     })
   })


### PR DESCRIPTION
## Proposed Release Notes

* Fixes resolveMx test by using example.com for a valid exchange.

## Links

## Details

Updated the test to point to example.com which returns an exchange. The test previously pointed at a personal domain which expired. 