### PR TITLE
Adds golden-path release note generation script.

### DIFF
--- a/bin/generate-release-notes.js
+++ b/bin/generate-release-notes.js
@@ -1,0 +1,94 @@
+'use strict'
+
+const fs = require('fs')
+const github = require('./github')
+
+const FILE_NAME = 'NEWS.md'
+const PROPOSED_NOTES_HEADER = 'Proposed Release Notes'
+const NEXT_VERSION_HEADER = '### vNext (TBD):'
+
+async function generateReleaseNotes() {
+  try {
+    const latestRelease = await github.getLatestRelease()
+    console.log(`The latest release is: ${latestRelease.name} published: ${latestRelease.published_at}`)
+    console.log(`Tag: ${latestRelease.tag_name}, Target: ${latestRelease.target_commitish}`)
+
+    const tag = await github.getTagByName(latestRelease.tag_name)
+    console.log('The tag commit sha is: ', tag.commit.sha)
+
+    const commit = await github.getCommit(tag.commit.sha)
+    const commitDate = commit.commit.committer.date
+
+    console.log(`Finding merged pull requests since: ${commitDate}`)
+
+    const mergedPullRequests = await github.getMergedPullRequestsSince(commitDate)
+    console.log(`Found ${mergedPullRequests.length}`)
+
+    const releaseNoteData = mergedPullRequests.map((pr) => {
+      const parts = pr.body.split(/(?:^|\n)##\s*/g)
+      const {1: proposedReleaseNotes} = parts
+
+      const titleRemoved = proposedReleaseNotes.replace(PROPOSED_NOTES_HEADER, '')
+      return {
+        notes: titleRemoved,
+        url: pr.html_url
+      }
+    })
+
+    const finalData = releaseNoteData.reduce((result, currentValue) => {
+      result.notes += '\n\n' + currentValue.notes.trim()
+      result.links += `* PR: ${currentValue.url}\n`
+      return result
+    }, {
+      notes: '',
+      links: ''
+    })
+
+    await updateReleaseNotes(FILE_NAME, finalData.notes)
+
+    console.log('*** [SUCCESS] ***')
+  } catch(err) {
+    console.log('! [FAILURE] !')
+    console.error(err)
+  }
+}
+
+function updateReleaseNotes(file, newNotes) {
+  const promise = new Promise((resolve, reject) => {
+    fs.readFile(file, 'utf8', function (err, data) {
+      if (err) {
+        return reject(err)
+      }
+
+      if (data.startsWith(NEXT_VERSION_HEADER)) {
+        const errMessage = [
+          `${file} already contains '${NEXT_VERSION_HEADER}'`,
+          'Delete existing vNext release notes (if desired) and run again'
+        ].join('\n')
+
+        return reject(new Error(errMessage))
+      }
+
+      const newContent = [
+        NEXT_VERSION_HEADER,
+        newNotes,
+        '\n\n',
+        data
+      ].join('')
+
+      fs.writeFile(file, newContent, 'utf8', function (err) {
+        if (err) {
+          return reject(err)
+        }
+
+        console.log(`Added new release notes to ${file} under the ${NEXT_VERSION_HEADER}`)
+
+        resolve()
+      })
+    })
+  })
+
+  return promise
+}
+
+generateReleaseNotes()

--- a/bin/generate-release-notes.js
+++ b/bin/generate-release-notes.js
@@ -37,12 +37,14 @@ async function generateReleaseNotes() {
 
     const finalData = releaseNoteData.reduce((result, currentValue) => {
       result.notes += '\n\n' + currentValue.notes.trim()
-      result.links += `* PR: ${currentValue.url}\n`
+      result.links += `\n\n* PR: ${currentValue.url}\n`
       return result
     }, {
       notes: '',
       links: ''
     })
+
+    console.log('Final data: ', JSON.stringify(finalData))
 
     await updateReleaseNotes(FILE_NAME, finalData.notes)
 

--- a/bin/github.js
+++ b/bin/github.js
@@ -1,0 +1,106 @@
+'use strict'
+
+const { Octokit } = require("@octokit/rest")
+
+const repoOwner = 'newrelic'
+const repository = 'node-newrelic'
+
+if (!process.env.GITHUB_TOKEN) {
+  console.log('GITHUB_TOKEN recommended to be set in ENV')
+}
+
+const octokit = new Octokit({
+  auth: process.env.GITHUB_TOKEN,
+})
+
+async function getLatestRelease() {
+  const result = await octokit.repos.getLatestRelease({
+    owner: repoOwner,
+    repo: repository
+  })
+
+  return result.data
+}
+
+async function getTagByName(name) {
+  const perPage = 100
+
+  let pageNum = 1
+
+  let result = null
+  do {
+    result = await octokit.repos.listTags({
+      owner: repoOwner,
+      repo: repository,
+      per_page: perPage,
+      page: pageNum
+    })
+
+    const found = result.data.find((tag) => {
+      return tag.name === name
+    })
+
+    if (found) {
+      return found
+    }
+
+    pageNum++
+  } while (result.data.length === perPage) // there *might* be more data
+
+  return null
+}
+
+async function getCommit(sha) {
+  const result = await octokit.repos.getCommit({
+    owner: repoOwner,
+    repo: repository,
+    ref: sha
+  })
+
+  return result.data
+}
+
+async function getMergedPullRequestsSince(date) {
+  const perPage = 50
+
+  const comparisonDate = new Date(date)
+
+  let pageNum = 1
+  const mergedPullRequests = []
+  let result = null
+  let hadData = false
+
+  do {
+    result = await octokit.pulls.list({
+      owner: repoOwner,
+      repo: repository,
+      state: 'closed',
+      sort: 'updated',
+      direction: 'desc',
+      per_page: perPage,
+      page: pageNum
+    })
+
+    const mergedPrs = result.data.filter((pr) => {
+      return pr.merged_at && new Date(pr.merged_at) > comparisonDate
+    })
+
+    mergedPullRequests.push(...mergedPrs)
+    // Since we are going by 'updated' on query but merged on filter,
+    // there's a chance some boundaries are off. While in super extreme
+    // cases we could still miss some it is unlikely given we are grabbing
+    // large pages.
+    hadData = mergedPrs.length > 0
+
+    pageNum++
+  } while (result.data.length === perPage && hadData) // might be more in next batch
+
+  return mergedPullRequests
+}
+
+module.exports = {
+  getLatestRelease,
+  getTagByName,
+  getCommit,
+  getMergedPullRequestsSince
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -383,6 +383,131 @@
         }
       }
     },
+    "@octokit/auth-token": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.2.5.tgz",
+      "integrity": "sha512-+DCtPykGnvXKWWQI0E1XD+CCeWSBhB6kwItXqfFmNBlIlhczuDPbg+P6BtLnVBaRJDAjv+1mrUJuRsFSjktopg==",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.4.12",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.11.tgz",
+      "integrity": "sha512-fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.9.tgz",
+      "integrity": "sha512-c+0yofIugUNqo+ktrLaBlWSbjSq/UF8ChAyxQzbD3X74k1vAuyLKdDJmPwVExUFSp6+U1FzWe+3OkeRsIqV0vg==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-3.2.0.tgz",
+      "integrity": "sha512-X7yW/fpzF3uTAE+LbPD3HEeeU+/49o0V4kNA/yv8jQ3BDpFayv/osTOhY1y1mLXljW2bOJcOCSGZo4jFKPJ6Vw==",
+      "dev": true
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.8.2.tgz",
+      "integrity": "sha512-i3DzGnPMAS2PKseLQZm68pQONm2r3MvdYW365bpBcHvMSqNf3RGYavgS5ZXFbMmMkaj4RFgTgBuA2Hotobwg5g==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.5.0"
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz",
+      "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==",
+      "dev": true
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.8.0.tgz",
+      "integrity": "sha512-2zRpXDveJH8HsXkeeMtRW21do8wuSxVn1xXFdvhILyxlLWqGQrdJUA1/dk5DM7iAAYvwT/P3bDOLs90yL4S2AA==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.5.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.13",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.13.tgz",
+      "integrity": "sha512-WcNRH5XPPtg7i1g9Da5U9dvZ6YbTffw9BN2rVezYiE7couoSyaRsw0e+Tl8uk1fArHE7Dn14U7YqUDy59WaqEw==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "once": "^1.4.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
+      "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "18.0.15",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.15.tgz",
+      "integrity": "sha512-MBlZl0KeuvFMJ3210hG5xhh/jtYmMDLd5WmO49Wg4Rfg0odeivntWAyq3KofJDP2G8jskCaaOaZBKo0TeO9tFA==",
+      "dev": true,
+      "requires": {
+        "@octokit/core": "^3.2.3",
+        "@octokit/plugin-paginate-rest": "^2.6.2",
+        "@octokit/plugin-request-log": "^1.0.2",
+        "@octokit/plugin-rest-endpoint-methods": "4.8.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.5.1.tgz",
+      "integrity": "sha512-meP0U3ker/Nkzfif/q7JAK2LSOnuV+72F8mgfruwVX4iTQBgkShh5LSrdI9F7aC2hF3a/8AePfYh4SLzu1RuxA==",
+      "dev": true,
+      "requires": {
+        "@octokit/openapi-types": "^3.2.0",
+        "@types/node": ">= 8"
+      }
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -766,6 +891,12 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
+      "dev": true
     },
     "benchmark": {
       "version": "2.1.4",
@@ -1432,6 +1563,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
     },
     "destroy": {
@@ -2998,6 +3135,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "dev": true
     },
     "is-promise": {
@@ -6928,6 +7071,12 @@
           }
         }
       }
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -161,6 +161,8 @@
   "devDependencies": {
     "@newrelic/proxy": "^2.0.0",
     "@newrelic/test-utilities": "^5.0.0",
+    "@octokit/rest": "^18.0.15",
+    "JSV": "~4.0.2",
     "architect": "*",
     "benchmark": "^2.1.4",
     "bluebird": "^3.4.7",
@@ -173,7 +175,6 @@
     "got": "^8.0.1",
     "http-errors": "^1.7.3",
     "jsdoc": "^3.6.3",
-    "JSV": "~4.0.2",
     "memcached": ">=0.2.8",
     "minami": "^1.1.1",
     "mongodb": "^3.3.3",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details

Added golden-path release note generation script intended for manual run.

Grabs PR's merged since the last release in GitHub and then inserts new release notes into News.md.

Last release date determined from the date of the commit associated with the tag of the release, instead of date release was 'published' to avoid missing changes that may happen mid-process.

Long-term, will probably add ability to manually set a release or tag to handle non-standard cases such as having most recently published an emergency backport.

To run: `node ./bin/generate-release-notes.js`

As this evolves and potentially is made more generic, more of the hard-coded details should be parameterized.