### PR TITLE
Adds script to auto-update NEWS.md version header from vNext.

### DIFF
--- a/bin/update-changelog-version.js
+++ b/bin/update-changelog-version.js
@@ -1,0 +1,66 @@
+'use strict'
+
+/**
+ * Executed as a part of the "version" step of npm version.
+ * Updates the placeholder release note header with the incremented version
+ * from running npm version
+ */
+
+const fs = require('fs')
+const packageInfo = require('../package.json')
+
+const FILE_NAME = 'NEWS.md'
+const NEXT_VERSION_HEADER = '### vNext (TBD):'
+
+const SUCCESS_MSG = '*** [SUCCESS] ***'
+const FAIL_MSG = '! [FAILURE] !'
+
+updateChangelogVersion()
+
+async function updateChangelogVersion() {
+  try {
+    await updateHeader(FILE_NAME)
+
+    console.log(SUCCESS_MSG)
+  } catch (err) {
+    console.log(FAIL_MSG)
+    console.error(err)
+  }
+}
+
+function updateHeader(file) {
+  const promise = new Promise((resolve, reject) => {
+    fs.readFile(file, 'utf8', (err, data) => {
+      if (err) {
+        return reject(err)
+      }
+
+      // toISOString() will always return UTC time
+      const todayFormatted = new Date().toISOString().split('T')[0]
+      const version = `v${packageInfo.version}`
+      const newChangelogHeader = `### ${version} (${todayFormatted})`
+
+      console.log('Updating vNext header to: ', newChangelogHeader)
+
+      if (!data.startsWith(NEXT_VERSION_HEADER)) {
+        const err = new Error(`Failed to find next version header in form: '${NEXT_VERSION_HEADER}'`)
+        return reject(err)
+      }
+
+      const modified = data.replace(
+        NEXT_VERSION_HEADER,
+        newChangelogHeader
+      )
+
+      fs.writeFile(file, modified, 'utf8', (err) => {
+        if (err) {
+          return reject (err)
+        }
+
+        console.log(SUCCESS_MSG)
+      })
+    })
+  })
+
+  return promise
+}

--- a/package.json
+++ b/package.json
@@ -136,7 +136,9 @@
     "unit": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/unit\\/.*\\.test\\.js)$' --timeout=180 --no-coverage",
     "update-cross-agent-tests": "./bin/update-cats.sh",
     "versioned-tests": "./bin/run-versioned-tests.sh",
-    "versioned": "npm run prepare-test && time ./bin/run-versioned-tests.sh"
+    "update-changelog-version": "node ./bin/update-changelog-version",
+    "versioned": "npm run prepare-test && time ./bin/run-versioned-tests.sh",
+    "version": "npm run update-changelog-version && git add ./NEWS.md"
   },
   "bin": {
     "newrelic-naming-rules": "./bin/test-naming-rules.js"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details

When npm version is ran, the package.json version gets updated and then executes our 'version' script in package.json.

Example when running `npm version patch` w/ some release notes:

```
Updating vNext header to:  ### v7.1.1 (2021-01-26)
*** [SUCCESS] ***
```
