### PR TITLE
Adds workflow for publishing to npm when a v* tag is pushed to the repo.

### DIFF
--- a/.github/workflows/publish-release-tag.yml
+++ b/.github/workflows/publish-release-tag.yml
@@ -6,7 +6,8 @@ on:
       - 'v*' # Push events to matching v*, e.g. v1.0, v20.15.10
   workflow_dispatch:
     # Allow manual trigger for non-standard cases.
-    # Unfortunately only allows branches are refs, currently (Jan 2021).
+    # (Jan 2021): Currently only allows branches as refs,
+    # so cannot specify a tag (or arbitrary sha).
 
 jobs:
   npm-publish:

--- a/.github/workflows/publish-release-tag.yml
+++ b/.github/workflows/publish-release-tag.yml
@@ -1,0 +1,30 @@
+name: Publish Release Tag
+
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, e.g. v1.0, v20.15.10
+  workflow_dispatch:
+    # Allow manual trigger for non-standard cases.
+    # Unfortunately only allows branches are refs, currently (Jan 2021).
+
+jobs:
+  npm-publish:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1 # https://github.com/actions/setup-node
+      with:
+        node-version: ${{ matrix.node-version }}
+        registry-url: 'https://registry.npmjs.org'
+    - name: Install Dependencies
+      run: npm ci
+    - run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Added workflow for publishing to npm when a v* tag is pushed to the repo.

## Links

## Details

Auto-publishes when a new tag is pushed in the form v*. 

Can also trigger manually via workflow dispatch but there's one big limitation. Via the UI, only branches are available as ref. So if we ever need to manually publish we'll need to do from a branch. Could do main if clean/same version but may want ot create a branch from the tag being released and then publish that... if comes up. Hopefully longer-term GitHub will expand this (I think they may have already via the workflow dispatch API).

Could potentially modify the checkout action to take a param for ref to enable setting to a tag or such.
