### PR TITLE
bump grpc-js version to v1.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -220,9 +220,9 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.4.tgz",
-      "integrity": "sha512-z+EI20HYHLd3/uERtwOqP8Q4EPhGbz5RKUpiyo6xPWfR3pcjpf8sfNvY9XytDQ4xo1wNz7NqH1kh2UBonwzbfg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.5.tgz",
+      "integrity": "sha512-CBCNwedw8McnEBq9jvoiJikws16WN0OiHFejQPovY71XkFWSiIqgvydYiDwpvIYDJmhPQ7qZNzW9BPndhXbx1Q==",
       "requires": {
         "@types/node": "^12.12.47",
         "google-auth-library": "^6.1.1",
@@ -2589,9 +2589,9 @@
       "dev": true
     },
     "google-auth-library": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.4.tgz",
-      "integrity": "sha512-q0kYtGWnDd9XquwiQGAZeI2Jnglk7NDi0cChE4tWp6Kpo/kbqnt9scJb0HP+/xqt03Beqw/xQah1OPrci+pOxw==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
+      "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
@@ -2659,21 +2659,13 @@
       "dev": true
     },
     "gtoken": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.0.tgz",
-      "integrity": "sha512-qbf6JWEYFMj3WMAluvYXl8GAiji6w8d9OmAGCbBg0xF4xD/yu6ZaO6BhoXNddRjKcOUpZD81iea1H5B45gAo1g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
+      "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
       "requires": {
         "gaxios": "^4.0.0",
         "google-p12-pem": "^3.0.3",
-        "jws": "^4.0.0",
-        "mime": "^2.2.0"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.0.tgz",
-          "integrity": "sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag=="
-        }
+        "jws": "^4.0.0"
       }
     },
     "handle-thing": {

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "newrelic-naming-rules": "./bin/test-naming-rules.js"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.2.4",
+    "@grpc/grpc-js": "^1.2.5",
     "@grpc/proto-loader": "^0.5.5",
     "@newrelic/aws-sdk": "^3.0.0",
     "@newrelic/koa": "^5.0.0",


### PR DESCRIPTION
## Proposed Release Notes

* Upgrade @grpc/grpc-js to v1.2.5 to fix non-propagation of internal http2 errors

## Links

Closes: #605 

## Details
gprc-js fix PR: https://github.com/grpc/grpc-node/pull/1658
