### PR TITLE
Fixes infinite tracing reconnect handling

### DIFF
--- a/lib/grpc/connection.js
+++ b/lib/grpc/connection.js
@@ -233,12 +233,14 @@ class GrpcConnection extends EventEmitter {
    * @param {ClientDuplexStreamImpl} stream
    */
   _setupSpanStreamObservers(stream) {
-    // listen for responses from server and log
-    if (logger.traceEnabled()) {
-      stream.on('data', function data(response) {
+    // Node streams require all data sent by the server to be read before the end
+    // (or status in this case) event gets fired. As such, we have to subscribe even
+    // if we are not going to use the data.
+    stream.on('data', function data(response) {
+      if (logger.traceEnabled()) {
         logger.trace("gRPC span response stream: %s", JSON.stringify(response))
-      })
-    }
+      }
+    })
 
     // listen for status that indicate stream has ended,
     // and we need to disconnect

--- a/test/integration/grpc/reconnect.tap.js
+++ b/test/integration/grpc/reconnect.tap.js
@@ -24,6 +24,7 @@ const protoLoader = require('@grpc/proto-loader')
 const MetricAggregator = require('../../../lib/metrics/metric-aggregator')
 const MetricMapper = require('../../../lib/metrics/mapper')
 const MetricNormalizer = require('../../../lib/metrics/normalizer')
+const StreamingSpanEvent = require('../../../lib/spans/streaming-span-event')
 
 const helper = require('../../lib/agent_helper')
 
@@ -90,6 +91,93 @@ tap.test(
           'ClientDuplexStreamImpl',
           'connected and received ClientDuplexStreamImpl'
         )
+      })
+
+      connection.on('disconnected', () => {
+        countDisconnects++
+        t.ok(true, 'disconnected')
+
+        // if we've disconnected twice, the test is done
+        // mark the state as permanantly closed in order to
+        // avoid further automatic reconnects (skipping
+        // _setState to avoid an additional disconnect event)
+        if (countDisconnects > 1) {
+          connection._state = 3 // replace with actual fake enum
+
+          t.equals(serverConnections, 2)
+          // Ends the test
+          resolve()
+        }
+      })
+
+      connection.setConnectionDetails().connectSpans()
+    })
+  }
+)
+
+/**
+ * With Node streams, when the server sends back data and we are not subscribed to the
+ * data event, the status event never fires thus preventing reconnects. This results in
+ * us being pinned to a bad stream and throwing 'ERR_STREAM_WRITE_AFTER_END' errors.
+ */
+tap.test(
+  'Should reconnect even when data sent back',
+  {skip:isUnsupportedNodeVersion},
+  async t => {
+    // one assert for the initial connection
+    // a second assert for the disconnect
+    // a third assert for the reconnection
+    // a fourth assert for the disconnect
+    // a fifth assert for server connection count
+    t.plan(5)
+
+    let serverConnections = 0
+
+    const recordSpan = (stream) => {
+      serverConnections++
+
+      // drain reads to make sure everything finishes properly
+      stream.on('data', () => {
+        // Writing data critical for triggering bug.
+        stream.write({messages_seen: 1})
+
+        // end the stream -- sends back a STATUS OK
+        stream.end()
+      })
+    }
+
+    const sslOpts = await setupSsl()
+    const port = await setupServer(t, sslOpts, recordSpan)
+
+    // Currently test-only configuration
+    const origEnv = process.env.NEWRELIC_GRPCCONNECTION_CA
+    process.env.NEWRELIC_GRPCCONNECTION_CA = sslOpts.ca
+    t.teardown(() => {
+      process.env.NEWRELIC_GRPCCONNECTION_CA = origEnv
+    })
+
+    return new Promise((resolve) => {
+      const metrics = createMetricAggregatorForTests()
+
+      const traceObserverConfig = {
+        host: 'ssl.lvh.me',
+        port: port
+      }
+
+      // very short backoff to trigger the reconnect in 1 second
+      const backoffs = {initialSeconds: 0, seconds:1}
+      const connection = new GrpcConnection(traceObserverConfig, metrics, backoffs)
+
+      let countDisconnects = 0
+
+      connection.on('connected', (callStream) => {
+        t.equals(
+          callStream.constructor.name,
+          'ClientDuplexStreamImpl',
+          'connected and received ClientDuplexStreamImpl'
+        )
+
+        callStream.write(new StreamingSpanEvent())
       })
 
       connection.on('disconnected', () => {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Fixed bug where the agent failed to reconnect to Infinite Tracing grpc streams on Status OK at higher log levels.
 
  Node streams require all data be consumed for the end/status events to fire. We were only reading data at lower log levels where we'd use/log the data. This resulted in a failure to reconnect and 'ERR_STREAM_WRITE_AFTER_END' errors. The agent now always listens to the 'data' event, even if not logging, and will also reconnect (with 15 second delay) on any 'ERR_STREAM_WRITE_AFTER_END' error.

## Links

* Fixes: https://github.com/newrelic/node-newrelic/issues/620
* https://nodejs.org/api/stream.html#stream_event_end

## Details
