### PR TITLE
Stops calling send() on streaming span aggregator on initial harvest.

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -293,8 +293,11 @@ Agent.prototype.forceHarvestAll = function forceHarvestAll(callback) {
   promises.push(metricPromise)
 
   // TODO: plumb config through to aggregators so they can do their own checking.
-  if (agent.config.distributed_tracing.enabled &&
-      agent.config.span_events.enabled) {
+  if (
+    agent.config.distributed_tracing.enabled &&
+    agent.config.span_events.enabled &&
+    !agent.spanEventAggregator.isStream // Not valid to send on streaming aggregator
+  ) {
     const spanPromise = new Promise((resolve) => {
       agent.spanEventAggregator.once(
         'finished span_event_data data send.',

--- a/lib/spans/streaming-span-event-aggregator.js
+++ b/lib/spans/streaming-span-event-aggregator.js
@@ -55,8 +55,6 @@ class StreamingSpanEventAggregator extends Aggregator {
   }
 
   send() {
-    // Only log once started. This will get invoked on initial harvest
-    // prior to start which we'll just ignore.
     if (this.started) {
       logger.warnOnce('SEND_WARNING', SEND_WARNING)
     }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Removed initial harvest send() call on streaming span event aggregator to prevent warning in logs.

## Links

## Details

Longer-term, would be nice if the code was restructured so we didn't need to check for streaming VS non streaming but going with the minimal effort for now.