### PR TITLE
Improves clarity of what went wrong with no log file or disabled agent.

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,8 +76,10 @@ function initialize() {
     // just pipes to stdout.
     logger = require('./lib/logger')
 
-    if (!config || !config.agent_enabled) {
-      logger.info('Module not enabled in configuration; not starting.')
+    if (!config) {
+      logger.info('No configuration detected. Not starting.')
+    } else if (!config.agent_enabled) {
+      logger.info('Module disabled in configuration. Not starting.')
     } else {
       agent = createAgent(config)
       addStartupSupportabilities(agent)

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1667,17 +1667,20 @@ function _noConfigFile() {
 
   let locations = mainpath
   if (mainpath !== altpath) {
-    locations += ' or\n' + altpath
+    locations += ' or ' + altpath
   }
 
-  /* eslint-disable no-console */
-  console.error([
+  const errorMessage = [
     'Unable to find New Relic module configuration. A base configuration file',
     `can be copied from ${BASE_CONFIG_PATH}`,
     `and put at ${locations}.`,
     'If you are not using file-based configuration, please set the environment',
     'variable `NEW_RELIC_NO_CONFIG_FILE=true`.'
-  ].join('\n'))
+  ].join(' ')
+
+  logger.error(errorMessage)
+  /* eslint-disable no-console */
+  console.error(errorMessage)
   /* eslint-enable no-console */
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Improved clarity of logging between 'no log file' or disabled agent startup issues.

  * Logs no-config file error to initialized logger (stdout) in addition to existing console.error() logging. 
  * Adds specific message to no config file separate from being disabled.

## Links

* Fixes: https://github.com/newrelic/node-newrelic/issues/612

## Details

We did have existing logging around what went wrong when no config file but it is likely in some/many cases New Relic logs were particularly parsed out of an applications stdout logging and thus the message would not be seen. As such, also logged to our logger stream.

Due to the config being loaded by logger and agent loading process, what was being logged twice just to console will now be logged twice to console and logged twice to the logger stream. While ideally this would be 1 of each, tackling this problem is a bigger undertaking that would delay getting clarity here. This *should* be an improvement, even if extreme department of redundancy department vibes.

More in here that could use some restructuring and cleaning up but keeping this one simple/targeted.

No log file example output (console only):

```
Unable to find New Relic module configuration. A base configuration file can be copied from /node-newrelic/newrelic.js and put at /expressApp/newrelic.js or /expressApp/bin/newrelic.js. If you are not using file-based configuration, please set the environment variable `NEW_RELIC_NO_CONFIG_FILE=true`.
Unable to find New Relic module configuration. A base configuration file can be copied from /node-newrelic/newrelic.js and put at /expressApp/newrelic.js or /expressApp/bin/newrelic.js. If you are not using file-based configuration, please set the environment variable `NEW_RELIC_NO_CONFIG_FILE=true`.
{"v":0,"level":50,"name":"newrelic_bootstrap","hostname":"C02T62BKGTDY","pid":65643,"time":"2021-02-25T00:55:44.303Z","msg":"Unable to find New Relic module configuration. A base configuration file can be copied from /node-newrelic/newrelic.js and put at /expressApp/newrelic.js or /expressApp/bin/newrelic.js. If you are not using file-based configuration, please set the environment variable `NEW_RELIC_NO_CONFIG_FILE=true`."}
{"v":0,"level":30,"name":"newrelic_bootstrap","hostname":"C02T62BKGTDY","pid":65643,"time":"2021-02-25T00:55:44.307Z","msg":"Using New Relic for Node.js. Agent version: 7.1.2; Node version: v14.15.5."}
{"v":0,"level":50,"name":"newrelic_bootstrap","hostname":"C02T62BKGTDY","pid":65643,"time":"2021-02-25T00:55:44.311Z","msg":"Unable to find New Relic module configuration. A base configuration file can be copied from /node-newrelic/newrelic.js and put at /expressApp/newrelic.js or /expressApp/bin/newrelic.js. If you are not using file-based configuration, please set the environment variable `NEW_RELIC_NO_CONFIG_FILE=true`."}
{"v":0,"level":30,"name":"newrelic_bootstrap","hostname":"C02T62BKGTDY","pid":65643,"time":"2021-02-25T00:55:44.311Z","msg":"No configuration detected. Not starting."}
```

`agent_enabled: false` example output (log file only):

```
{"v":0,"level":30,"name":"newrelic","hostname":"C02T62BKGTDY","pid":75555,"time":"2021-02-25T18:30:20.358Z","msg":"Using New Relic for Node.js. Agent version: 7.1.2; Node version: v14.15.5."}
{"v":0,"level":30,"name":"newrelic","hostname":"C02T62BKGTDY","pid":75555,"time":"2021-02-25T18:30:20.363Z","msg":"Module disabled in configuration. Not starting."}
```
