### PR TITLE
Do not throw error when headers is string passed into acceptDistributedTraceHeaders

### DIFF
--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -879,14 +879,14 @@ Transaction.prototype.getIntrinsicAttributes = function getIntrinsicAttributes()
  */
 Transaction.prototype.acceptDistributedTraceHeaders = acceptDistributedTraceHeaders
 function acceptDistributedTraceHeaders(transportType, headers) {
-  const transport = TRANSPORT_TYPES_SET[transportType] ? transportType : TRANSPORT_TYPES.UNKNOWN
-
-  if (typeof headers !== 'object') {
+  if (headers == null || typeof headers !== 'object') {
     logger.trace(
       'Ignoring distributed trace headers for transaction %s. Headers not passed in as object.',
       this.id)
     return
   }
+
+  const transport = TRANSPORT_TYPES_SET[transportType] ? transportType : TRANSPORT_TYPES.UNKNOWN
 
   // assumes header keys already lowercase
   const traceparent = headers[TRACE_CONTEXT_PARENT_HEADER]

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -895,6 +895,7 @@ function acceptDistributedTraceHeaders(transportType, headers) {
     const payload = headers[NEWRELIC_TRACE_HEADER]
     this._acceptDistributedTracePayload(payload, transport)
   } else {
+    this.agent.recordSupportability('DistributedTrace/AcceptPayload/Ignored/Null')
     logger.trace('No trace context or newrelic DT payload in headers for transaction %s', this.id)
   }
 }

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -889,11 +889,13 @@ function acceptDistributedTraceHeaders(transportType, headers) {
     // assumes header keys already lowercase
     const tracestate = headers[TRACE_CONTEXT_STATE_HEADER]
     this.acceptTraceContextPayload(traceparent, tracestate, transport)
-  } else if (NEWRELIC_TRACE_HEADER in headers) {
+  } else if (headers[NEWRELIC_TRACE_HEADER]) {
     logger.trace('Accepting newrelic DT payload for transaction %s', this.id)
     // assumes header keys already lowercase
     const payload = headers[NEWRELIC_TRACE_HEADER]
     this._acceptDistributedTracePayload(payload, transport)
+  } else {
+    logger.trace('No trace context or newrelic DT payload in headers for transaction %s', this.id)
   }
 }
 

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -881,6 +881,13 @@ Transaction.prototype.acceptDistributedTraceHeaders = acceptDistributedTraceHead
 function acceptDistributedTraceHeaders(transportType, headers) {
   const transport = TRANSPORT_TYPES_SET[transportType] ? transportType : TRANSPORT_TYPES.UNKNOWN
 
+  if (typeof headers !== 'object') {
+    logger.trace(
+      'Ignoring distributed trace headers for transaction %s. Headers not passed in as object.',
+      this.id)
+    return
+  }
+
   // assumes header keys already lowercase
   const traceparent = headers[TRACE_CONTEXT_PARENT_HEADER]
 
@@ -889,14 +896,11 @@ function acceptDistributedTraceHeaders(transportType, headers) {
     // assumes header keys already lowercase
     const tracestate = headers[TRACE_CONTEXT_STATE_HEADER]
     this.acceptTraceContextPayload(traceparent, tracestate, transport)
-  } else if (headers[NEWRELIC_TRACE_HEADER]) {
+  } else if (NEWRELIC_TRACE_HEADER in headers) {
     logger.trace('Accepting newrelic DT payload for transaction %s', this.id)
     // assumes header keys already lowercase
     const payload = headers[NEWRELIC_TRACE_HEADER]
     this._acceptDistributedTracePayload(payload, transport)
-  } else {
-    this.agent.recordSupportability('DistributedTrace/AcceptPayload/Ignored/Null')
-    logger.trace('No trace context or newrelic DT payload in headers for transaction %s', this.id)
   }
 }
 

--- a/test/lib/cross_agent_tests/distributed_tracing/distributed_tracing.json
+++ b/test/lib/cross_agent_tests/distributed_tracing/distributed_tracing.json
@@ -988,7 +988,9 @@
         "major_version": 0,
         "minor_version": 1,
         "transport_type": "HTTP",
-        "inbound_payloads": null,
+        "inbound_payloads": [
+            null
+        ],
         "intrinsics": {
             "target_events": ["Transaction"],
             "common":{

--- a/test/unit/transaction.test.js
+++ b/test/unit/transaction.test.js
@@ -1139,6 +1139,30 @@ describe('Transaction', function() {
       })
     })
 
+    it('should not throw error when headers is a string', () => {
+      const trustedAccountKey = '123'
+
+      agent.config.distributed_tracing.enabled = true
+      agent.config.trusted_account_key = trustedAccountKey
+      agent.config.span_events.enabled = true
+
+      helper.runInTransaction(agent, function(txn) {
+        var childSegment = txn.trace.add('child')
+        childSegment.start()
+
+        const headers = 'JUST A STRING'
+
+        expect(function() {
+          txn.acceptDistributedTraceHeaders('HTTP', headers)
+        }).not.throws()
+
+        expect(txn.isDistributedTrace).to.be.null
+        expect(txn.acceptedDistributedTrace).to.be.null
+
+        txn.end()
+      })
+    })
+
     it('should only accept the first tracecontext', () => {
       agent.config.distributed_tracing.enabled = true
       agent.config.trusted_account_key = '1'
@@ -1729,7 +1753,7 @@ tap.test('requestd', (t) => {
 
     // force a segment in context
     agent.tracer.segment = new Segment(transaction, 'test segment')
-    
+
     transaction.finalizeNameFromUri('/some/random/path', 200)
 
     const segment = transaction.agent.tracer.getSegment()


### PR DESCRIPTION
## Proposed Release Notes
* Fixed issue where a call to `transaction.acceptDistributedTraceHeaders` would throw an error when the `headers` parameter is a string.

## Links
Closes: #637 

## Details
