### PR TITLE
Do not redirect preconnect

### DIFF
--- a/lib/collector/api.js
+++ b/lib/collector/api.js
@@ -12,6 +12,8 @@ const RemoteMethod = require('./remote-method')
 
 const NAMES = require('../metrics/names')
 
+const DEFAULT_PORT = 443
+
 // just to make clear what's going on
 const TO_MILLIS = 1e3
 
@@ -54,22 +56,41 @@ function CollectorAPI(agent) {
   this._agent = agent
   this._reqHeadersMap = null
 
+  const initialEndpoint = {
+    host: agent.config.host,
+    port: agent.config.port
+  }
+
   /* RemoteMethods can be reused and have little per-object state, so why not
    * save some GC time?
    */
   this._methods = {
-    redirect: new RemoteMethod('preconnect', agent.config),
-    handshake: new RemoteMethod('connect', agent.config),
-    settings: new RemoteMethod('agent_settings', agent.config),
-    errors: new RemoteMethod('error_data', agent.config),
-    metrics: new RemoteMethod('metric_data', agent.config),
-    traces: new RemoteMethod('transaction_sample_data', agent.config),
-    shutdown: new RemoteMethod('shutdown', agent.config),
-    events: new RemoteMethod('analytic_event_data', agent.config),
-    customEvents: new RemoteMethod('custom_event_data', agent.config),
-    queryData: new RemoteMethod('sql_trace_data', agent.config),
-    errorEvents: new RemoteMethod('error_event_data', agent.config),
-    spanEvents: new RemoteMethod('span_event_data', agent.config)
+    preconnect: new RemoteMethod('preconnect', agent.config, initialEndpoint),
+    connect: new RemoteMethod('connect', agent.config, initialEndpoint),
+    settings: new RemoteMethod('agent_settings', agent.config, initialEndpoint),
+    errors: new RemoteMethod('error_data', agent.config, initialEndpoint),
+    metrics: new RemoteMethod('metric_data', agent.config, initialEndpoint),
+    traces: new RemoteMethod('transaction_sample_data', agent.config, initialEndpoint),
+    shutdown: new RemoteMethod('shutdown', agent.config, initialEndpoint),
+    events: new RemoteMethod('analytic_event_data', agent.config, initialEndpoint),
+    customEvents: new RemoteMethod('custom_event_data', agent.config, initialEndpoint),
+    queryData: new RemoteMethod('sql_trace_data', agent.config, initialEndpoint),
+    errorEvents: new RemoteMethod('error_event_data', agent.config, initialEndpoint),
+    spanEvents: new RemoteMethod('span_event_data', agent.config, initialEndpoint)
+  }
+}
+
+/**
+ * Updates all methods except preconnect w/ new host/port pairs sent down from server
+ * during preconnect (via redirect_host). Preconnect does not update.
+ */
+CollectorAPI.prototype._updateEndpoints = function _updateEndpoints(endpoint) {
+  logger.trace('Updating endpoints to: ', endpoint)
+  for (const [key, remoteMethod] of Object.entries(this._methods)) {
+    // Preconnect should always use configured options, not updates from server.
+    if (key !== 'preconnect') {
+      remoteMethod.updateEndpoint(endpoint)
+    }
   }
 }
 
@@ -160,7 +181,7 @@ CollectorAPI.prototype._login = function _login(callback) {
 
   const payload = [preconnectData]
 
-  methods.redirect.invoke(payload, onPreConnect)
+  methods.preconnect.invoke(payload, onPreConnect)
 
   function onPreConnect(error, response) {
     if (error || !SUCCESS.has(response.status)) {
@@ -188,8 +209,13 @@ CollectorAPI.prototype._login = function _login(callback) {
           res.redirect_host
         )
 
-        agent.config.host = parts[0]
-        agent.config.port = parts[1] || 443
+        const [host, port] = parts
+        const newEndpoint = {
+          host: host,
+          port: port || DEFAULT_PORT
+        }
+
+        self._updateEndpoints(newEndpoint)
       }
     }
 
@@ -226,7 +252,7 @@ CollectorAPI.prototype._connect = function _connect(env, callback) {
   const methods = this._methods
   const agent = this._agent
 
-  methods.handshake.invoke(env, onConnect)
+  methods.connect.invoke(env, onConnect)
 
   function onConnect(error, res) {
     if (error || !SUCCESS.has(res.status)) {
@@ -239,10 +265,11 @@ CollectorAPI.prototype._connect = function _connect(env, callback) {
     }
 
     agent.setState('connected')
+
     logger.info(
       'Connected to %s:%d with agent run ID %s.',
-      agent.config.host,
-      agent.config.port,
+      methods.connect._host,
+      methods.connect._port,
       config.agent_run_id
     )
 

--- a/lib/collector/api.js
+++ b/lib/collector/api.js
@@ -268,8 +268,8 @@ CollectorAPI.prototype._connect = function _connect(env, callback) {
 
     logger.info(
       'Connected to %s:%d with agent run ID %s.',
-      methods.connect._host,
-      methods.connect._port,
+      methods.connect.endpoint.host,
+      methods.connect.endpoint.port,
       config.agent_run_id
     )
 

--- a/lib/collector/remote-method.js
+++ b/lib/collector/remote-method.js
@@ -29,15 +29,25 @@ const USER_AGENT_FORMAT = 'NewRelic-NodeAgent/%s (nodejs %s %s-%s)'
 const ENCODING_HEADER = 'CONTENT-ENCODING'
 const DEFAULT_ENCODING = 'identity'
 
-function RemoteMethod(name, config) {
+function RemoteMethod(name, config, endpoint) {
   if (!name) {
     throw new TypeError('Must include name of method to invoke on collector.')
   }
 
   this.name = name
   this._config = config
-
   this._protocolVersion = 17
+
+  this.updateEndpoint(endpoint)
+}
+
+RemoteMethod.prototype.updateEndpoint = function updateEndpoint(endpoint) {
+  if (!endpoint) {
+    return
+  }
+
+  this._host = endpoint.host
+  this._port = endpoint.port
 }
 
 RemoteMethod.prototype.serialize = function serialize(payload, callback) {
@@ -88,8 +98,8 @@ RemoteMethod.prototype.invoke = function invoke(payload, nrHeaders, callback) {
 RemoteMethod.prototype._post = function _post(data, nrHeaders, callback) {
   var method = this
   var options = {
-    port: this._config.port,
-    host: this._config.host,
+    port: this._port,
+    host: this._host,
     compressed: this._shouldCompress(data),
     path: this._path(),
     onError: callback,
@@ -317,7 +327,7 @@ RemoteMethod.prototype._headers = function _headers(options) {
 
   var headers = {
     // select the virtual host on the server end
-    'Host': this._config.host,
+    'Host': this._host,
     'User-Agent': agent,
     'Connection': 'Keep-Alive',
     'Content-Length': byteLength(options.body),

--- a/lib/collector/remote-method.js
+++ b/lib/collector/remote-method.js
@@ -38,7 +38,7 @@ function RemoteMethod(name, config, endpoint) {
   this._config = config
   this._protocolVersion = 17
 
-  this.updateEndpoint(endpoint)
+  this.endpoint = endpoint
 }
 
 RemoteMethod.prototype.updateEndpoint = function updateEndpoint(endpoint) {
@@ -46,8 +46,7 @@ RemoteMethod.prototype.updateEndpoint = function updateEndpoint(endpoint) {
     return
   }
 
-  this._host = endpoint.host
-  this._port = endpoint.port
+  this.endpoint = endpoint
 }
 
 RemoteMethod.prototype.serialize = function serialize(payload, callback) {
@@ -98,8 +97,8 @@ RemoteMethod.prototype.invoke = function invoke(payload, nrHeaders, callback) {
 RemoteMethod.prototype._post = function _post(data, nrHeaders, callback) {
   var method = this
   var options = {
-    port: this._port,
-    host: this._host,
+    port: this.endpoint.port,
+    host: this.endpoint.host,
     compressed: this._shouldCompress(data),
     path: this._path(),
     onError: callback,
@@ -327,7 +326,7 @@ RemoteMethod.prototype._headers = function _headers(options) {
 
   var headers = {
     // select the virtual host on the server end
-    'Host': this._host,
+    'Host': this.endpoint.host,
     'User-Agent': agent,
     'Connection': 'Keep-Alive',
     'Content-Length': byteLength(options.body),

--- a/test/integration/collector-remote-method.tap.js
+++ b/test/integration/collector-remote-method.tap.js
@@ -15,18 +15,22 @@ const RemoteMethod = require('../../lib/collector/remote-method')
 
 tap.test('DataSender (callback style) talking to fake collector', (t) => {
   const config = {
-    host: 'ssl.lvh.me',
-    port: 8765,
     run_id: 1337,
     ssl: true,
     license_key: 'whatever',
     version: '0',
     max_payload_size_in_bytes: 1000000
   }
+
+  const endpoint = {
+    host: 'ssl.lvh.me',
+    port: 8765
+  }
+
   config.certificates = [
     read(join(__dirname, '../lib/ca-certificate.crt'), 'utf8')
   ]
-  const method = new RemoteMethod('preconnect', config)
+  const method = new RemoteMethod('preconnect', config, endpoint)
 
   collector({port: 8765}, (error, server) => {
     // set a reasonable server timeout for cleanup
@@ -83,17 +87,20 @@ tap.test('remote method to preconnect', (t) => {
 
   function createRemoteMethod() {
     const config = {
-      host: 'ssl.lvh.me',
-      port: 9876,
       ssl: true,
       max_payload_size_in_bytes: 1000000
+    }
+
+    const endpoint = {
+      host: 'ssl.lvh.me',
+      port: 9876
     }
 
     config.certificates = [
       read(join(__dirname, '../lib/ca-certificate.crt'), 'utf8')
     ]
 
-    const method = new RemoteMethod('preconnect', config)
+    const method = new RemoteMethod('preconnect', config, endpoint)
     return method
   }
 

--- a/test/integration/keep-alive.tap.js
+++ b/test/integration/keep-alive.tap.js
@@ -98,16 +98,19 @@ tap.test("RemoteMethod makes two requests with one connection", (t) => {
 
 function createRemoteMethod(port) {
   const config = {
-    host: 'ssl.lvh.me',
-    port: port,
     ssl: true,
     max_payload_size_in_bytes: 1000000
+  }
+
+  const endpoint = {
+    host: 'ssl.lvh.me',
+    port: port
   }
 
   config.certificates = [
     read(join(__dirname, '../lib/ca-certificate.crt'), 'utf8')
   ]
 
-  const method = new RemoteMethod('fake', config)
+  const method = new RemoteMethod('fake', config, endpoint)
   return method
 }

--- a/test/unit/collector/api-connect.test.js
+++ b/test/unit/collector/api-connect.test.js
@@ -14,8 +14,10 @@ const CollectorResponse = require('../../../lib/collector/response')
 const securityPolicies = require('../../lib/fixtures').securityPolicies
 
 const HOST = 'collector.newrelic.com'
+const REDIRECT_HOST = 'unique.newrelic.com'
 const PORT = 443
 const URL = 'https://' + HOST
+const CONNECT_URL = `https://${REDIRECT_HOST}`
 const RUN_ID = 1337
 
 const timeout = global.setTimeout
@@ -56,8 +58,9 @@ tap.test('receiving 200 response, with valid data', (t) => {
 
     redirection = nock(URL + ':443')
       .post(helper.generateCollectorPath('preconnect'))
-      .reply(200, {return_value: {redirect_host: HOST, security_policies: {}}})
-    connection = nock(URL)
+      .reply(200, {return_value: {redirect_host: REDIRECT_HOST, security_policies: {}}})
+
+    connection = nock(CONNECT_URL)
       .post(helper.generateCollectorPath('connect'))
       .reply(200, response)
 
@@ -128,9 +131,9 @@ tap.test('succeeds when given a different port number for redirect', (t) => {
 
     redirection = nock(URL + ':443')
       .post(helper.generateCollectorPath('preconnect'))
-      .reply(200, {return_value: {redirect_host: HOST + ':8089', security_policies: {}}})
+      .reply(200, {return_value: {redirect_host: REDIRECT_HOST + ':8089', security_policies: {}}})
 
-    connection = nock(URL + ':8089')
+    connection = nock(CONNECT_URL + ':8089')
       .post(helper.generateCollectorPath('connect'))
       .reply(200, response)
 
@@ -164,15 +167,50 @@ tap.test('succeeds when given a different port number for redirect', (t) => {
 
   t.test('should have the correct hostname', (t) => {
     collectorApi.connect(() => {
+      const methods = collectorApi._methods
+      Object.keys(methods).filter((key) => {
+        return key !== 'preconnect'
+      }).forEach((key) => {
+        t.equal(methods[key]._host, REDIRECT_HOST)
+      })
+
+      t.end()
+    })
+  })
+
+  t.test('should not change config host', (t) => {
+    collectorApi.connect(() => {
       t.equal(collectorApi._agent.config.host, HOST)
 
       t.end()
     })
   })
 
-  t.test('should have the correct port number', (t) => {
+  t.test('should update endpoints with correct port number', (t) => {
     collectorApi.connect(() => {
-      t.equal(collectorApi._agent.config.port, '8089')
+      const methods = collectorApi._methods
+      Object.keys(methods).filter((key) => {
+        return key !== 'preconnect'
+      }).forEach((key) => {
+        t.equal(methods[key]._port, '8089')
+      })
+
+      t.end()
+    })
+  })
+
+  t.test('should not update preconnect endpoint', (t) => {
+    collectorApi.connect(() => {
+      t.equal(collectorApi._methods.preconnect._host, HOST)
+      t.equal(collectorApi._methods.preconnect._port, 443)
+
+      t.end()
+    })
+  })
+
+  t.test('should not change config port number', (t) => {
+    collectorApi.connect(() => {
+      t.equal(collectorApi._agent.config.port, 443)
 
       t.end()
     })

--- a/test/unit/collector/api-connect.test.js
+++ b/test/unit/collector/api-connect.test.js
@@ -171,7 +171,7 @@ tap.test('succeeds when given a different port number for redirect', (t) => {
       Object.keys(methods).filter((key) => {
         return key !== 'preconnect'
       }).forEach((key) => {
-        t.equal(methods[key]._host, REDIRECT_HOST)
+        t.equal(methods[key].endpoint.host, REDIRECT_HOST)
       })
 
       t.end()
@@ -192,7 +192,7 @@ tap.test('succeeds when given a different port number for redirect', (t) => {
       Object.keys(methods).filter((key) => {
         return key !== 'preconnect'
       }).forEach((key) => {
-        t.equal(methods[key]._port, '8089')
+        t.equal(methods[key].endpoint.port, '8089')
       })
 
       t.end()
@@ -201,8 +201,8 @@ tap.test('succeeds when given a different port number for redirect', (t) => {
 
   t.test('should not update preconnect endpoint', (t) => {
     collectorApi.connect(() => {
-      t.equal(collectorApi._methods.preconnect._host, HOST)
-      t.equal(collectorApi._methods.preconnect._port, 443)
+      t.equal(collectorApi._methods.preconnect.endpoint.host, HOST)
+      t.equal(collectorApi._methods.preconnect.endpoint.port, 443)
 
       t.end()
     })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Fixed bug where agent would attempt to call the 'preconnect' endpoint on the redirect host returned by the previous 'preconnect' call when reconnecting to the New Relic servers.

  The 'preconnect' calls will now always use the original agent configuration value. Subsequent endpoints (connect, harvest endpoints, etc.) will continue to leverage the new redirect host value returned by 'preconnect.' The original config values are no-longer overridden.

## Links

* Fixes: https://github.com/newrelic/node-newrelic/issues/462

## Details

Given this impacts our initial handshake and continued functioning, this is slightly higher risk than say instrumentation changes.

When the new redirect-host comes in, all RemoteMethod instances except 'preconnect' are now updated with the new host and port endpoint values. The endpoint is not stored separately (currently) than the RemoteMethods.

Long-term, I'd like to see potentially having a single place to update. I don't think we need instances per method but rather can have a RemoteMethods like class that has all the shared logic and when you call the appropriate function in passes in the appropriate path details, etc.
