### PR TITLE
setImmediate no longer binds/propagates segments for an ended transaction

### DIFF
--- a/lib/instrumentation/core/timers.js
+++ b/lib/instrumentation/core/timers.js
@@ -61,7 +61,12 @@ function initialize(agent, timers, moduleName, shim) {
 
   function wrapSetImmediate(shim, fn) {
     return function wrappedSetImmediate() {
-      const args = shim.argsToArray.apply(shim, arguments)
+      const segment = shim.getActiveSegment()
+      if (!segment) {
+        return fn.apply(this, arguments)
+      }
+
+      const args = shim.argsToArray.apply(shim, arguments, segment)
       shim.bindSegment(args, shim.FIRST)
 
       return fn.apply(this, args)

--- a/test/integration/core/timers.tap.js
+++ b/test/integration/core/timers.tap.js
@@ -92,6 +92,20 @@ tap.test('setImmediate', function testSetImmediate(t) {
       })
     })
   })
+
+  t.test('should not propagate segments for ended transaction', (t) => {
+    const agent = setupAgent(t)
+
+    t.notOk(agent.getTransaction(), 'should not start in a transaction')
+    helper.runInTransaction(agent, (transaction) => {
+      transaction.end()
+
+      setImmediate(() => {
+        t.notOk(agent.tracer.segment, 'should not have segment for ended transaction')
+        t.end()
+      })
+    })
+  })
 })
 
 tap.test('setInterval', function testSetInterval(t) {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Stopped binding/propagating segments via `setImmediate` for ended transactions.

## Links

* Closes: https://github.com/newrelic/node-newrelic/issues/579

## Details

Straightforward spot-fix for setImmediate. Going to set up a follow-up story to look at doing this in general for our various binding/wrapping methods. Seems if the associated transaction has ended we should be doing as little work as possible. Handling these cases obviously are a bit more edge-case but we don't control the environments we run in and we want to clean up our memory usage quickly and not do unnecessary work.