### PR TITLE
Defaults the application name when running in serverless mode.

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1188,6 +1188,20 @@ Config.prototype._DTManuallySet = function _DTManuallySet(inputConfig) {
  */
 Config.prototype._enforceServerless = function _enforceServerless(inputConfig) {
   if (this.serverless_mode.enabled) {
+    // Application name is not currently leveraged by our Lambda product (March 2021).
+    // Defaulting the name removes burden on customers to set while avoiding
+    // breaking should it be used in the future.
+    if (!this.app_name || this.app_name.length === 0) {
+      const namingSource = process.env.AWS_LAMBDA_FUNCTION_NAME
+        ? 'process.env.AWS_LAMBDA_FUNCTION_NAME'
+        : 'DEFAULT'
+
+      const name = process.env.AWS_LAMBDA_FUNCTION_NAME || 'Serverless Application'
+      this.app_name = [name]
+
+      logger.info('Auto-naming serverless application to [\'%s\'] from: %s', name, namingSource)
+    }
+
     // Explicitly disable old CAT in serverless_mode
     if (this.cross_application_tracer.enabled) {
       this.cross_application_tracer.enabled = false

--- a/test/unit/config/config.test.js
+++ b/test/unit/config/config.test.js
@@ -581,6 +581,24 @@ describe('the agent configuration', function() {
       })
     })
 
+    it('should pick up ignored error classes', function() {
+      idempotentEnv(
+        {'NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERRORS': 'Error, AnotherError'},
+        (tc) => {
+          should.exist(tc.error_collector.ignore_classes)
+          expect(tc.error_collector.ignore_classes).eql(['Error', 'AnotherError'])
+        })
+    })
+
+    it('should pick up expected error classes', function() {
+      idempotentEnv(
+        {'NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERRORS': 'QError, AnotherError'},
+        (tc) => {
+          should.exist(tc.error_collector.expected_classes)
+          expect(tc.error_collector.expected_classes).eql(['QError', 'AnotherError'])
+        })
+    })
+
     describe('serverless mode', () => {
       it('should should disable when feature flag false', () => {
         idempotentEnv({
@@ -648,22 +666,21 @@ describe('the agent configuration', function() {
         }
       )
 
-      it('should pick up ignored error classes', function() {
-        idempotentEnv(
-          {'NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERRORS': 'Error, AnotherError'},
-          (tc) => {
-            should.exist(tc.error_collector.ignore_classes)
-            expect(tc.error_collector.ignore_classes).eql(['Error', 'AnotherError'])
-          })
+      it('should pick app name from AWS_LAMBDA_FUNCTION_NAME', function() {
+        idempotentEnv({
+          NEW_RELIC_SERVERLESS_MODE_ENABLED: true,
+          AWS_LAMBDA_FUNCTION_NAME: 'MyLambdaFunc'
+        }, function(tc) {
+          should.exist(tc.app_name)
+          expect(tc.applications()).eql(['MyLambdaFunc'])
+        })
       })
 
-      it('should pick up expected error classes', function() {
-        idempotentEnv(
-          {'NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERRORS': 'QError, AnotherError'},
-          (tc) => {
-            should.exist(tc.error_collector.expected_classes)
-            expect(tc.error_collector.expected_classes).eql(['QError', 'AnotherError'])
-          })
+      it('should default generic app name when no AWS_LAMBDA_FUNCTION_NAME', function() {
+        idempotentEnv({NEW_RELIC_SERVERLESS_MODE_ENABLED: true}, function(tc) {
+          should.exist(tc.app_name)
+          expect(tc.applications()).eql(['Serverless Application'])
+        })
       })
     })
   })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Removed requirement to configure application name when running in AWS Lambda (serverless mode).

  Application name is not currently leveraged by New Relic for Lambda invocations. The agent now defaults the application name in serverless mode to remove the requirement of end-user configuration while handling cases if it were to be leveraged in the future. 

## Links

* Closes: https://github.com/newrelic/node-newrelic/issues/477

## Details
