### PR TITLE
Automate GitHub release creation

### DIFF
--- a/.github/workflows/publish-release-tag.yml
+++ b/.github/workflows/publish-release-tag.yml
@@ -10,7 +10,7 @@ on:
     # so cannot specify a tag (or arbitrary sha).
 
 jobs:
-  npm-publish:
+  publish:
     runs-on: ubuntu-latest
 
     strategy:
@@ -29,3 +29,8 @@ jobs:
     - run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    ## Not currently compat with workflow_dispatch because dispatch is branch only
+    - name: Create GitHub Release
+      run: node ./bin/create-github-release.js --tag ${{ github.ref }} --repo-owner ${{ github.repository_owner }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bin/create-github-release.js
+++ b/bin/create-github-release.js
@@ -1,0 +1,106 @@
+'use strict'
+
+const fs = require('fs')
+const {program} = require('commander')
+
+const Github = require('./github')
+const { indexOf } = require('benchmark')
+
+const DEFAULT_FILE_NAME = 'NEWS.md'
+/** e.g. v7.2.1 */
+const TAG_VALID_REGEX = /v\d+\.\d+\.\d+/
+
+program.requiredOption('--tag <tag>', 'tag name to create GitHub release for')
+program.option('--repo-owner <repoOwner>', 'repository owner', 'newrelic')
+program.option('--release-notes-file <releaseNotesFile>', 'path to release notes file', DEFAULT_FILE_NAME)
+program.option('-f --force', 'bypass validation')
+
+async function createRelease() {
+  // Parse commandline options inputs
+  program.parse()
+
+  const options = program.opts()
+
+  console.log('Script running with following options: ', JSON.stringify(options))
+
+  const github = new Github(options.repoOwner)
+
+  try {
+    logStep('Validation')
+    if (options.force) {
+      console.log('--force set. Skipping validation logic')
+    }
+
+    if (!options.force && !TAG_VALID_REGEX.exec(options.tag)) {
+      console.log('Tag arg invalid (%s). Valid tags in form: v#.#.# (e.g. v7.2.1)', options.tag)
+      stopOnError()
+    }
+
+    logStep('Get Release Notes from File')
+    const body = await getReleaseNotes(options.tag, options.releaseNotesFile)
+
+    logStep('Create Release')
+    await github.createRelease(options.tag, options.tag, body)
+
+    console.log('*** Full Run Successful ***')
+  } catch (err) {
+    if (err.status && err.status === 404) {
+      console.log('404 status error detected. For octokit, this may mean insuffient permissions.')
+      console.log('Ensure you have a valid GITHUB_TOKEN set in your env vars.')
+    }
+
+    stopOnError(err)
+  }
+}
+
+async function getReleaseNotes(tagName, releaseNotesFile) {
+  console.log('Retrieving release notes from file: ', releaseNotesFile)
+
+  const data = await readReleaseNoteFile(releaseNotesFile)
+
+  const currentVersionHeader = `### ${tagName}`
+  if (data.indexOf(currentVersionHeader) !== 0) {
+    throw new Error(`Current tag (${currentVersionHeader}) not first line of release notes.`)
+  }
+
+  const sections = data.split('### ', 2)
+  if (sections.length !== 2) {
+    throw new Error('Did not split into multiple sections. Double check notes format.')
+  }
+
+  const tagSection = sections[1]
+  // e.g. v7.1.2 (2021-02-24)\n\n
+  const headingRegex = /^v\d+\.\d+\.\d+ \(\d{4}-\d{2}-\d{2}\)\n\n/
+  const headingRemoved = tagSection.replace(headingRegex, '')
+
+  return headingRemoved
+}
+
+async function readReleaseNoteFile(file) {
+  const promise = new Promise((resolve, reject) => {
+    fs.readFile(file, 'utf8', function (err, data) {
+      if (err) {
+        return reject(err)
+      }
+
+      resolve(data)
+    })
+  })
+
+  return promise
+}
+
+function stopOnError(err) {
+  if (err) {
+    console.error(err)
+  }
+
+  console.log('Halting execution with exit code: 1')
+  process.exit(1)
+}
+
+function logStep(step) {
+  console.log(`\n ----- [Step]: ${step} -----\n`)
+}
+
+createRelease()

--- a/bin/create-github-release.js
+++ b/bin/create-github-release.js
@@ -26,21 +26,24 @@ async function createRelease() {
   const github = new Github(options.repoOwner)
 
   try {
+    const tagName = options.tag.replace('refs/tags/', '')
+    console.log('Using tag name: ', tagName)
+
     logStep('Validation')
     if (options.force) {
       console.log('--force set. Skipping validation logic')
     }
 
-    if (!options.force && !TAG_VALID_REGEX.exec(options.tag)) {
-      console.log('Tag arg invalid (%s). Valid tags in form: v#.#.# (e.g. v7.2.1)', options.tag)
+    if (!options.force && !TAG_VALID_REGEX.exec(tagName)) {
+      console.log('Tag arg invalid (%s). Valid tags in form: v#.#.# (e.g. v7.2.1)', tagName)
       stopOnError()
     }
 
     logStep('Get Release Notes from File')
-    const body = await getReleaseNotes(options.tag, options.releaseNotesFile)
+    const body = await getReleaseNotes(tagName, options.releaseNotesFile)
 
     logStep('Create Release')
-    await github.createRelease(options.tag, options.tag, body)
+    await github.createRelease(tagName, tagName, body)
 
     console.log('*** Full Run Successful ***')
   } catch (err) {

--- a/bin/github.js
+++ b/bin/github.js
@@ -25,6 +25,18 @@ class Github {
     return result.data
   }
 
+  async createRelease(tag, name, body) {
+    const result = await octokit.repos.createRelease({
+      owner: this.repoOwner,
+      repo: this.repository,
+      tag_name: tag,
+      name: name,
+      body: body
+    })
+
+    return result.data
+  }
+
   async getTagByName(name) {
     const perPage = 100
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

* Closes: https://github.com/newrelic/node-newrelic/issues/587

## Details

* Adds script which will take a tag and then automatically create a release in GitHub.
* Body of release is pulled from the release notes matching the tag.
* Adds execution of script to publish workflow which executes after npm publish.

Unfortunately, since workflow_dispatch doesn't allow setting a tag instead of a branch... that workflow will fail on manual execution for the create release. We could consider eventually adding a tag input on workflow dispatch and then executing against that for code checkout and release creation but not tackling yet.
