### PR TITLE
Fixes bug where truncated segments/spans would not have appropriate category

### DIFF
--- a/lib/spans/span-event.js
+++ b/lib/spans/span-event.js
@@ -9,7 +9,7 @@ const Config = require('../config')
 const {truncate} = require('../util/byte-limit')
 
 const {DESTINATIONS} = require('../config/attribute-filter')
-const NAMES = require('../metrics/names')
+
 const HTTP_LIBRARY = 'http'
 const CLIENT_KIND = 'client'
 const CATEGORIES = {
@@ -17,6 +17,9 @@ const CATEGORIES = {
   DATASTORE: 'datastore',
   GENERIC: 'generic'
 }
+
+const EXTERNAL_REGEX = /^(?:Truncated\/)?External\//
+const DATASTORE_REGEX = /^(?:Truncated\/)?Datastore\//
 
 const EMPTY_USER_ATTRS = Object.freeze(Object.create(null))
 
@@ -200,7 +203,7 @@ class HttpSpanEvent extends SpanEvent {
   }
 
   static testSegment(segment) {
-    return segment.name.startsWith(NAMES.EXTERNAL.PREFIX)
+    return EXTERNAL_REGEX.test(segment.name)
   }
 }
 
@@ -259,7 +262,7 @@ class DatastoreSpanEvent extends SpanEvent {
   }
 
   static testSegment(segment) {
-    return segment.name.startsWith(NAMES.DB.PREFIX)
+    return DATASTORE_REGEX.test(segment.name)
   }
 }
 

--- a/lib/spans/streaming-span-event.js
+++ b/lib/spans/streaming-span-event.js
@@ -10,7 +10,7 @@ const {truncate} = require('../util/byte-limit')
 const Config = require('../config')
 
 const {DESTINATIONS} = require('../config/attribute-filter')
-const NAMES = require('../metrics/names')
+
 const HTTP_LIBRARY = 'http'
 const CLIENT_KIND = 'client'
 const CATEGORIES = {
@@ -18,6 +18,9 @@ const CATEGORIES = {
   DATASTORE: 'datastore',
   GENERIC: 'generic'
 }
+
+const EXTERNAL_REGEX = /^(?:Truncated\/)?External\//
+const DATASTORE_REGEX = /^(?:Truncated\/)?Datastore\//
 
 /**
  * Specialized span event class for use with infinite streaming.
@@ -200,7 +203,7 @@ class StreamingHttpSpanEvent extends StreamingSpanEvent {
   }
 
   static isHttpSegment(segment) {
-    return segment.name.startsWith(NAMES.EXTERNAL.PREFIX)
+    return EXTERNAL_REGEX.test(segment.name)
   }
 }
 
@@ -269,7 +272,7 @@ class StreamingDatastoreSpanEvent extends StreamingSpanEvent {
   }
 
   static isDatastoreSegment(segment) {
-    return segment.name.startsWith(NAMES.DB.PREFIX)
+    return DATASTORE_REGEX.test(segment.name)
   }
 }
 

--- a/test/unit/spans/span-event.test.js
+++ b/test/unit/spans/span-event.test.js
@@ -324,4 +324,41 @@ tap.test('fromSegment()', (t) => {
       }, 10)
     })
   })
+
+  t.test('should handle truncated http spans', (t) => {
+    helper.runInTransaction(agent, (transaction) => {
+      https.get('https://example.com?foo=bar', (res) => {
+        transaction.end() // prematurely end to truncate
+
+        res.resume()
+        res.on('end', () => {
+          const segment = transaction.trace.root.children[0]
+          t.ok(segment.name.startsWith('Truncated'))
+
+          const span = SpanEvent.fromSegment(segment)
+          t.ok(span)
+          t.ok(span instanceof SpanEvent)
+          t.ok(span instanceof SpanEvent.HttpSpanEvent)
+
+          t.end()
+        })
+      })
+    })
+  })
+
+  t.test('should handle truncated datastore spans', (t) => {
+    helper.runInTransaction(agent, (transaction) => {
+      const segment = transaction.trace.root.add('Datastore/operation/something')
+      transaction.end() // end before segment to trigger truncate
+
+      t.ok(segment.name.startsWith('Truncated'))
+
+      const span = SpanEvent.fromSegment(segment)
+      t.ok(span)
+      t.ok(span instanceof SpanEvent)
+      t.ok(span instanceof SpanEvent.DatastoreSpanEvent)
+
+      t.end()
+    })
+  })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Fixed bug where truncated http (external) or datastore segments would generate generic spans instead of appropriate http or datastore spans.

## Links

* fixes: https://github.com/newrelic/node-newrelic/issues/439

## Details

Don't know for sure if datastore operations are impacted (harder to repro) but seemed possible so have a somewhat manufactured test case.

A digression: these tests aren't really unit tests and should be moved to integration tests at some point.

I think a more ideal way to handle this would be for a segment's span context to have the category set when we determine a segment is an external or a datastore. That being said, the datastore instrumentation didn't really lend itself to this in a straightforward manner. So still looking at segment names which is a bit brittle.

On the plus side, the regex approach is faster than the string search even with the extra truncated check. So not making things worse.

```
Truncated startswith OR x 9,128,685 ops/sec ±0.49% (93 runs sampled)
Truncated Regex test x 30,493,176 ops/sec ±0.26% (93 runs sampled)
Regular Regex test x 31,840,454 ops/sec ±3.18% (88 runs sampled)
Regular startswith x 17,677,031 ops/sec ±1.91% (83 runs sampled)
Fastest is Regular Regex test
```