### PR TITLE
Add certificate_bundle feature flag to enable deprecation and removal efforts

### DIFF
--- a/lib/collector/http-agents.js
+++ b/lib/collector/http-agents.js
@@ -103,14 +103,27 @@ function proxyOptions(config) {
     proxy_url: proxy_url
   }
 
-  // merge user certificates with built-in certs
-
   if (config.certificates && config.certificates.length > 0) {
-    logger.info(
-      'Using a proxy with a special cert. This enables our cert bundle which, combined ' +
-      'with some versions of node, exacerbates a leak in node core TLS.'
-    )
-    opts.certificates = config.certificates.concat(certificates)
+    opts.certificates = config.certificates
+
+    // merge user certificates with built-in certs
+    if (config.feature_flag.certificate_bundle) {
+      logger.info(
+        'Using a proxy with a special cert. This enables our cert bundle which, combined ' +
+        'with some versions of node, exacerbates a leak in node core TLS.'
+      )
+
+      const certWarningMessage = [
+        'Deprecation Warning: The certificate bundle included by New Relic will be ',
+        'disabled by default and then fully removed in later major versions. We recommend ',
+        'testing with the certificate_bundle feature flag set to `false` to determine if ',
+        'you will need to modify your environment or setup your own appropriate bundle. ',
+        'Example configuration: feature_flag: { certificate_bundle: false }.'
+      ].join('')
+      logger.warnOnce('CERT_WARNING', certWarningMessage)
+
+      opts.certificates = config.certificates.concat(certificates)
+    }
   }
 
   return opts

--- a/lib/collector/remote-method.js
+++ b/lib/collector/remote-method.js
@@ -263,10 +263,24 @@ RemoteMethod.prototype._request = function _request(options) {
     request = https.request(requestOptions)
   } else {
     if (this._config.certificates && this._config.certificates.length > 0) {
-      logger.debug(
-        'Adding custom certificate to the cert bundle.'
-      )
-      requestOptions.ca = this._config.certificates.concat(certificates)
+      requestOptions.ca = this._config.certificates
+
+      if (this._config.feature_flag.certificate_bundle) {
+        logger.debug(
+          'Adding custom certificate to the cert bundle.'
+        )
+
+        const certWarningMessage = [
+          'Deprecation Warning: The certificate bundle included by New Relic will be ',
+          'disabled by default and then fully removed in later major versions. We recommend ',
+          'testing with the certificate_bundle feature flag set to `false` to determine if ',
+          'you will need to modify your environment or setup your own appropriate bundle. ',
+          'Example configuration: feature_flag: { certificate_bundle: false }.'
+        ].join('')
+        logger.warnOnce('CERT_WARNING', certWarningMessage)
+
+        requestOptions.ca = this._config.certificates.concat(certificates)
+      }
     }
     request = https.request(requestOptions)
   }

--- a/lib/feature_flags.js
+++ b/lib/feature_flags.js
@@ -12,7 +12,10 @@ exports.prerelease = {
   serverless_mode: true, // TODO: Move to released & remove code checks next Major.
   promise_segments: false,
   reverse_naming_rules: false,
-  fastify_instrumentation: false
+  fastify_instrumentation: false,
+  // Starts by defaulting true as introducing for deprecation/removal purposes.
+  // Will eventually set false prior full removal of feature.
+  certificate_bundle: true
 }
 
 // flags that are no longer used for released features

--- a/lib/feature_flags.js
+++ b/lib/feature_flags.js
@@ -9,7 +9,7 @@
 exports.prerelease = {
   express5: false,
   await_support: true,
-  serverless_mode: true,
+  serverless_mode: true, // TODO: Move to released & remove code checks next Major.
   promise_segments: false,
   reverse_naming_rules: false,
   fastify_instrumentation: false

--- a/test/integration/collector-remote-method.tap.js
+++ b/test/integration/collector-remote-method.tap.js
@@ -19,7 +19,8 @@ tap.test('DataSender (callback style) talking to fake collector', (t) => {
     ssl: true,
     license_key: 'whatever',
     version: '0',
-    max_payload_size_in_bytes: 1000000
+    max_payload_size_in_bytes: 1000000,
+    feature_flag: {}
   }
 
   const endpoint = {
@@ -88,7 +89,8 @@ tap.test('remote method to preconnect', (t) => {
   function createRemoteMethod() {
     const config = {
       ssl: true,
-      max_payload_size_in_bytes: 1000000
+      max_payload_size_in_bytes: 1000000,
+      feature_flag: {}
     }
 
     const endpoint = {

--- a/test/integration/keep-alive.tap.js
+++ b/test/integration/keep-alive.tap.js
@@ -99,7 +99,8 @@ tap.test("RemoteMethod makes two requests with one connection", (t) => {
 function createRemoteMethod(port) {
   const config = {
     ssl: true,
-    max_payload_size_in_bytes: 1000000
+    max_payload_size_in_bytes: 1000000,
+    feature_flag: {}
   }
 
   const endpoint = {

--- a/test/unit/feature_flag.test.js
+++ b/test/unit/feature_flag.test.js
@@ -34,7 +34,8 @@ var used = [
   'synthetics',
   'dt_format_w3c',
   'unreleased',
-  'fastify_instrumentation'
+  'fastify_instrumentation',
+  'certificate_bundle'
 ]
 
 describe('feature flags', function() {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Added feature flag to allow disabling of certificate bundle usage.

  **Deprecation Warning:** The certificate bundle included by New Relic will be disabled by default and then fully removed in later major versions. We recommend testing with the certificate_bundle feature flag set to `false` to determine if you will need to modify your environment or setup your own appropriate bundle. Example configuration: `feature_flag: { certificate_bundle: false }`

## Links

* Closes: https://github.com/newrelic/node-newrelic/issues/664

## Details
