### PR TITLE
Removes host from identifier override sent to connect endpoint

### DIFF
--- a/lib/collector/facts.js
+++ b/lib/collector/facts.js
@@ -64,14 +64,7 @@ function facts(agent, callback) {
       }
     }
 
-    // TODO:  After reconfiguring agent startup to wait for the server to start
-    //        or for the first transaction, add the `port` for the server too.
-    // NOTE: The concat is necessary to prevent sort from happening in-place.
-    results.identifier = [
-      'nodejs',
-      results.host,
-      results.app_name.concat([]).sort().join(',')
-    ].join(':')
+    results.identifier = getIdentifierOverride(results.app_name)
 
     const ipAddresses = getAllIPAddresses()
     if (ipAddresses.length) {
@@ -111,4 +104,25 @@ function getAllIPAddresses() {
 
     return addresses
   }, [])
+}
+
+/**
+ * Creates an identifier override to support customers who have multiple agents on the
+ * same host with the first app name that is identical.
+ * https://github.com/newrelic/node-newrelic/commit/c0901e6807a50ac3969d79ab48c31c8e0232a6b5#r18254962
+ * https://source.datanerd.us/collector-collective/connect-service/blob/1470c21109393a5b43c8788da88a37f41a300b98/src/main/java/com/nr/collector/methods/Connect.java#L1424-L1431
+ *
+ * IMPORTANT: we do not include host as it has negative consequences and is unnecessary.
+ * On the server, the host will still be used as part of the key to determine if two agent
+ * connections are the same real agent or a separate one.
+ * https://github.com/newrelic/node-newrelic/issues/654
+ */
+function getIdentifierOverride(appNames) {
+  const identifier = [
+    'nodejs',
+    // NOTE: The concat is necessary to prevent sort from happening in-place.
+    appNames.concat([]).sort().join(',')
+  ].join(':')
+
+  return identifier
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Fixed bug where applications with multiple names on a dynamically named host (UUID like) would have instances consolidated, losing per-host breakdowns.

  Removed 'host' from agent 'identifier' override to prevent server safety mechanism from kicking in. Host will still be used to identify unique agent instances, so was unnecessary to include as part of the identifier. This also resulted in additional processing overhead on the back-end. The identifier override is still kept in place with multiple application names to continue to allow uniquely identifying instances on the same host with multiple application names where the first name may be identical. For example `app_name['myName', 'unique1']` and `app_name['myName', 'unique2']`. These names would consolidate down into a single instance on the same host without the identifier override.

## Links

* Fixes: https://github.com/newrelic/node-newrelic/issues/654
* https://github.com/newrelic/node-newrelic/commit/c0901e6807a50ac3969d79ab48c31c8e0232a6b5#r18254962
* https://newrelic.slack.com/archives/C0511B24H/p1614618798048500

## Details

While researching the various pieces involved, I found the default identifier also uses the 'dispatcher' from the environment data instead of 'nodejs'. For a web app, this would be 'http'. 

So no custom identifier would look like 'http:MyExpressApp' where our override will look like: 'nodejs:MyExpressApp'.

Given we don't know of any additional issues, I'm going to leave our deviation for now to limit what changes and (hopefully) reduce surface area of issues resulting from this change.

Going to flag this as a risk: medium given we are changing an area that was implemented due to a previous issue. All signs seem to point toward this continuing to solve the problem but changing potential instance identification mechanisms is more dangerous than usual and we should be aware.

See the linked GitHub issue for further details.
