### PR TITLE
The NEW_RELIC_NO_CONFIG_FILE env var is now not needed to run the agent without config file

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1635,6 +1635,8 @@ function initialize(config) {
 
   var filepath = _findConfigFile()
   if (!filepath) {
+    logger.info('No configuration file found, deferring to environment variables.')
+
     config = new Config(Object.create(null))
     if (config.newrelic_home) delete config.newrelic_home
     return config

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1616,11 +1616,9 @@ Config.prototype.getAggregatorConfig = function getAggregatorConfig(method) {
  *   5. If this module is installed as a dependency, the directory above the
  *      node_modules folder in which newrelic is installed.
  *
- * For configuration via environment (useful on Joyent, Azure, Heroku, or
- * other PaaS offerings), set NEW_RELIC_NO_CONFIG_FILE to something truthy
- * and read README.md for details on what configuration variables are
- * necessary, as well as a complete enumeration of the other available
- * variables.
+ * When node process environment varaibles and a config file are used,
+ * the environment variables will override their corresponding
+ * configuration file settings.
  *
  * @param {object} config Optional configuration to be used in place of a
  *                        config file.
@@ -1635,16 +1633,11 @@ function initialize(config) {
 
   if (config) return new Config(config)
 
-  if (isTruthular(process.env.NEW_RELIC_NO_CONFIG_FILE)) {
+  var filepath = _findConfigFile()
+  if (!filepath) {
     config = new Config(Object.create(null))
     if (config.newrelic_home) delete config.newrelic_home
     return config
-  }
-
-  var filepath = _findConfigFile()
-  if (!filepath) {
-    _noConfigFile()
-    return null
   }
 
   var userConf
@@ -1668,34 +1661,6 @@ function initialize(config) {
   config.validateFlags()
 
   return config
-}
-
-function _noConfigFile() {
-  const mainpath = path.resolve(path.join(process.cwd(), DEFAULT_FILENAME))
-  // If agent was loaded with -r flag, default to the path of the file being executed
-  const mainModule = process.mainModule && process.mainModule.filename || process.argv[1]
-  const altpath = path.resolve(
-    path.dirname(mainModule),
-    DEFAULT_FILENAME
-  )
-
-  let locations = mainpath
-  if (mainpath !== altpath) {
-    locations += ' or ' + altpath
-  }
-
-  const errorMessage = [
-    'Unable to find New Relic module configuration. A base configuration file',
-    `can be copied from ${BASE_CONFIG_PATH}`,
-    `and put at ${locations}.`,
-    'If you are not using file-based configuration, please set the environment',
-    'variable `NEW_RELIC_NO_CONFIG_FILE=true`.'
-  ].join(' ')
-
-  logger.error(errorMessage)
-  /* eslint-disable no-console */
-  console.error(errorMessage)
-  /* eslint-enable no-console */
 }
 
 /**

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1098,6 +1098,8 @@ Config.prototype._fromEnvironment = function _fromEnvironment(metadata, data) {
     if (typeof node === 'string') {
       var setting = process.env[node]
       if (setting) {
+        logger.debug(`${node} environment variable set.`)
+
         if (ENV.LIST_VARS.has(node)) {
           let split = ENV.LIST_VARS_CUSTOM_DELIMITERS[node] || /,/
           data[value] = setting.split(split).map(function trimVal(k) {
@@ -1633,13 +1635,17 @@ function initialize(config) {
 
   if (config) return new Config(config)
 
+  if (isTruthular(process.env.NEW_RELIC_NO_CONFIG_FILE)) {
+    logger.info('NEW_RELIC_NO_CONFIG_FILE set, deferring to environment variables.')
+
+    return createNewConfigObject(config)
+  }
+
   var filepath = _findConfigFile()
   if (!filepath) {
     logger.info('No configuration file found, deferring to environment variables.')
 
-    config = new Config(Object.create(null))
-    if (config.newrelic_home) delete config.newrelic_home
-    return config
+    return createNewConfigObject(config)
   }
 
   var userConf
@@ -1648,12 +1654,16 @@ function initialize(config) {
   } catch (error) {
     logger.error(error)
 
-    throw new Error([
+    logger.warn([
       `Unable to read configuration file "${filepath}".`,
       `A base configuration file can be copied from ${BASE_CONFIG_PATH}`,
       'and renamed to "newrelic.js" in the directory from which you will start',
-      'your application.'
+      'your application. Attempting to start agent using environment variables.'
     ].join('\n'))
+  }
+
+  if (!userConf) {
+    return createNewConfigObject(config)
   }
 
   config = new Config(userConf)
@@ -1662,6 +1672,15 @@ function initialize(config) {
 
   config.validateFlags()
 
+  return config
+}
+
+/**
+ * This helper function creates an empty configuration object
+ */
+function createNewConfigObject(config) {
+  config = new Config(Object.create(null))
+  if (config.newrelic_home) delete config.newrelic_home
   return config
 }
 

--- a/test/integration/logger.tap.js
+++ b/test/integration/logger.tap.js
@@ -38,7 +38,6 @@ tap.test('logger', function(t) {
       process.chdir(DIRNAME)
 
       process.env.NEW_RELIC_LOG = 'stdout'
-      process.env.NEW_RELIC_NO_CONFIG_FILE = 'true'
 
       t.doesNotThrow(function() {
         t.ok(require('../../lib/logger'), 'requiring logger returned a logging object')

--- a/test/unit/config/config.test.js
+++ b/test/unit/config/config.test.js
@@ -1287,23 +1287,6 @@ describe('the agent configuration', function() {
       var configuration = Config.initialize()
       expect(configuration.newrelic_home).equal(DESTDIR)
     })
-
-    it('should ignore the configuration file completely when so directed', function() {
-      process.env.NEW_RELIC_NO_CONFIG_FILE = 'true'
-      process.env.NEW_RELIC_HOME = '/xxxnoexist/nofile'
-
-      var configuration
-      expect(function envTest() {
-        configuration = Config.initialize()
-      }).not.throws()
-
-      should.not.exist(configuration.newrelic_home)
-      expect(configuration.error_collector &&
-             configuration.error_collector.enabled).equal(true)
-
-      delete process.env.NEW_RELIC_NO_CONFIG_FILE
-      delete process.env.NEW_RELIC_HOME
-    })
   })
 
   describe('when loading options via constructor', function() {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
* The `NEW_RELIC_NO_CONFIG_FILE` environment variable is no longer needed to run the agent without a configuration file.
  * If a configuration file is used with agent configuration environment variables, the environment variables will override the corresponding configuration file settings.
## Links
Closes: #627 
## Details
There are a few environment variables that do not have a corresponding configuration file setting, but those are set by the environment they run in (ie AWS Lambda).