### PR TITLE
Change prepare workflow working to allow major releases.

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Type of release. patch or minor (major not yet supported)'
+        description: 'Type of release. patch or minor (major if breaking)'
         required: true
         default: 'patch'
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details

Missed updating the workflow in the prepare-script update. Updates wording to not flag major as unsupported (but still somewhat show not standard i.e. for breaking changes.)