### PR TITLE
Clears error collections on transaction end after processing.

### DIFF
--- a/lib/instrumentation/core/http.js
+++ b/lib/instrumentation/core/http.js
@@ -267,6 +267,11 @@ function wrapResponseEnd(agent, proto) {
         return end.apply(this, arguments)
       }
 
+      if (!txInfo.transaction.isActive()) {
+        logger.trace('wrappedResEnd invoked for ended transaction implying multiple invocations.')
+        return end.apply(this, arguments)
+      }
+
       // If an error happened, add it to the aggregator.
       if (txInfo.error) {
         if (!txInfo.errorHandled || urltils.isError(agent.config, this.statusCode)) {

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -225,7 +225,26 @@ Transaction.prototype.end = function end() {
   }
 
   this.agent.emit('transactionFinished', this)
+
+  // Do after emit so all post-processing can complete
+  this._cleanUneededReferences()
+
   return this
+}
+
+/**
+ * Cleans up references that will not be used later for processing such as
+ * transaction traces.
+ *
+ * Errors won't be needed for later processing but can contain extra details we
+ * don't want to hold in memory. Particularly, axios errors can result in indirect
+ * references to promises which will prevent them from being destroyed and result
+ * in a memory leak. This is due to the TraceSegment not getting removed from the
+ * async-hooks segmentMap because 'destroy' never fires.
+ */
+Transaction.prototype._cleanUneededReferences = function _cleanUneededReferences() {
+  this.userErrors = null
+  this.exceptions = null
 }
 
 /**

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -787,6 +787,11 @@ function _linkExceptionToSegment(exception) {
 Transaction.prototype.addException = _addException
 
 function _addException(exception) {
+  if (!this.isActive()) {
+    logger.trace('Transaction is not active. Not capturing error: ', exception)
+    return
+  }
+
   this._linkExceptionToSegment(exception)
   this.exceptions.push(exception)
 }
@@ -801,6 +806,11 @@ function _addException(exception) {
 Transaction.prototype.addUserError = _addUserError
 
 function _addUserError(exception) {
+  if (!this.isActive()) {
+    logger.trace('Transaction is not active. Not capturing user error: ', exception)
+    return
+  }
+
   this._linkExceptionToSegment(exception)
   this.userErrors.push(exception)
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Fixed issue where capturing axios request errors could result in a memory leak.

  The agent now clears error references on transaction end, which are not used for later processing. Errors returned from 'axios' requests contain a reference to the request object which deeper down has a handle to a promise in `handleRequestError`. The TraceSegment associated with that promise has a handle to the transaction, which through the error capture ultimately kept the promise in memory and prevented it from being destroyed to free-up the TraceSegment from the segment map. This change also has the benefit of  freeing up some memory early for transactions held onto for transaction traces.

* Added active transaction check to `wrappedResEnd` to prevent unecessary work for ended transactions in the case of multiple `Response.prototype.end()` invocations.

## Links

* Closes: https://github.com/newrelic/node-newrelic/issues/710

## Details

Ideally, I'd like to avoid holding onto user errors passed-in at all. Unfortunately, this requires touching several place and doesn't play well with our duplicate error detection. The duplicate detection uses the object itself as a key to avoid situations such as an end user calling `noticeError(error)` on the same instance twice on accident. 

It may be worth considering if that safety mechanism isn't something we want/need to keep around. I'm not sure if any other agents do similar but I don't remember anything like that from my previous team. 

I'm going to submit a separate issue to dig into this further.

While this change has the benefit of also just freeing up some memory sooner... there is some risk in clearing things off the transaction as we might in the future attempt to do something with this information later after transaction end. Unlikely at this point but calling out. More likely would be haphazardly adding something that is used by transaction traces in here to clear out as well.
