### PR TITLE
Adds active transaction check for parentSegment to promise tracking

### DIFF
--- a/lib/instrumentation/core/async_hooks.js
+++ b/lib/instrumentation/core/async_hooks.js
@@ -50,19 +50,27 @@ function tryAsyncHooks(agent, shim) {
 
   // this map is reused to track the segment that was active when
   // the before callback is called to be replaced in the after callback
-  var segmentMap = new Map()
+  const segmentMap = new Map()
   module.exports.segmentMap = segmentMap
 
   var hook = asyncHooks.createHook({
     init: function initHook(id, type, triggerId, promiseWrap) {
-      var transaction = agent.getTransaction()
-      var parentSegment = segmentMap.get(triggerId)
-
-      if (!parentSegment && !transaction || type !== 'PROMISE') {
+      if (type !== 'PROMISE') {
         return
       }
 
-      var activeSegment = shim.getActiveSegment() || parentSegment
+      const parentSegment = segmentMap.get(triggerId)
+
+      if (parentSegment && !parentSegment.transaction.isActive()) {
+        // Stop propagating if the transaction was ended.
+        return
+      }
+
+      if (!parentSegment && !agent.getTransaction()) {
+        return
+      }
+
+      const activeSegment = shim.getActiveSegment() || parentSegment
       if (promiseWrap && promiseWrap.promise) {
         promiseWrap.promise.__NR_id = id
       }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Agent no longer propagates segments for promises via async-hooks when the transaction associated with the parentSegment has ended.

  This change reduces the amount of context tracking work needed for certain rare edge-case scenarios involving promises.

## Links

## Details

Also moved type check up earlier for faster short-circuiting (as well as just checking agent.getTransaction() in the if statement). These are unlikely to have a noticeable impact but given the frequency of execution of the hooks and added check, seemed good to go ahead and do.