### PR TITLE
Fixes infinite tracing reconnect memory leak

### DIFF
--- a/lib/grpc/connection.js
+++ b/lib/grpc/connection.js
@@ -14,14 +14,14 @@ const util = require('util')
 
 const connectionStates = require('./connection/states')
 
-const protoOptions = {keepCase: true,
+const PROTO_OPTIONS = {keepCase: true,
   longs: String,
   enums: String,
   defaults: true,
   oneofs: true
 }
 
-const pathProtoDefinition = __dirname +
+const PROTO_DEFINITION_PATH = __dirname +
   '../../../lib/grpc/endpoints/infinite-tracing/v1.proto'
 
 const DEFAULT_RECONNECT_DELAY_MS = 15 * 1000
@@ -54,11 +54,13 @@ class GrpcConnection extends EventEmitter {
     this._metrics = metrics
     this._setState(connectionStates.disconnected)
 
-    this._endpoint = this.getTraceObserverEndpoint(traceObserverConfig)
     this._licensekey = null
     this._runId = null
     this._requestHeadersMap = null
 
+    this._endpoint = this.getTraceObserverEndpoint(traceObserverConfig)
+
+    this._client = null
     this.stream = null
   }
 
@@ -320,25 +322,47 @@ class GrpcConnection extends EventEmitter {
    * a stream for further writing.
    */
   _connectSpans() {
-    const packageDefinition = protoLoader.loadSync(pathProtoDefinition, protoOptions)
-
-    const serviceDefinition = grpc.loadPackageDefinition(
-      packageDefinition
-    ).com.newrelic.trace.v1
-
-    const credentials = this._generateCredentials(grpc)
-    const client = new serviceDefinition.IngestService(
-      this._endpoint,
-      credentials
-    )
+    if (!this._client) {
+      // Only create once to avoid potential memory leak.
+      // We create here (currently) for consistent error handling.
+      this._client = this._createClient(this._endpoint)
+    }
 
     const metadata =
       this._getMetadata(this._licenseKey, this._runId, this._requestHeadersMap, process.env)
 
-    const stream = client.recordSpan(metadata)
+    const stream = this._client.recordSpan(metadata)
     this._setupSpanStreamObservers(stream)
 
     return stream
+  }
+
+  /**
+   * Creates gRPC service client to use for establishing gRPC streams.
+   *
+   * WARNING: creating a client more than once can result in a memory leak.
+   * ChannelImplementation and related objects will stay in memory even after
+   * the stream is closed and we do not have a handle to the client. Currently
+   * impacting grpc-js@1.2.11 and several earlier versions.
+   */
+  _createClient(endpoint) {
+    logger.trace('Creating gRPC client for: ', endpoint)
+
+    const packageDefinition = protoLoader.loadSync(PROTO_DEFINITION_PATH, PROTO_OPTIONS)
+
+    const protoDescriptor = grpc.loadPackageDefinition(
+      packageDefinition
+    )
+
+    const traceApi = protoDescriptor.com.newrelic.trace.v1
+
+    const credentials = this._generateCredentials(grpc)
+    const client = new traceApi.IngestService(
+      endpoint,
+      credentials
+    )
+
+    return client
   }
 }
 

--- a/lib/spans/create-span-event-aggregator.js
+++ b/lib/spans/create-span-event-aggregator.js
@@ -72,6 +72,7 @@ function createStandardAggregator(config, collector, metrics) {
 }
 
 function validateInfiniteTracing(trace_observer) {
+  // TODO: Remove semver check when Node 10 support dropped.
   if (!psemver.satisfies('>=10.10.0')) {
     logger.warn(
       'Infinite tracing disabled: this version of Node is not supported (must be >=10.10.0)'

--- a/test/integration/grpc/reconnect.tap.js
+++ b/test/integration/grpc/reconnect.tap.js
@@ -28,6 +28,7 @@ const StreamingSpanEvent = require('../../../lib/spans/streaming-span-event')
 
 const helper = require('../../lib/agent_helper')
 
+// TODO: Remove test version check when Node 10 support dropped.
 const isUnsupportedNodeVersion =
   GrpcConnection.message === '@grpc/grpc-js only works on Node ^8.13.0 || >=10.10.0'
 

--- a/test/integration/infinite-tracing-connection.tap.js
+++ b/test/integration/infinite-tracing-connection.tap.js
@@ -43,6 +43,7 @@ const packageDefinition = protoLoader.loadSync(
 
 const infiniteTracingService = grpc.loadPackageDefinition(packageDefinition).com.newrelic.trace.v1
 
+// TODO: remove unsupported checks when Node 10 support dropped.
 const isGrpcSupportedVersion = semver.satisfies(process.version, '>=10.10.0')
 
 tap.test('Inifinite tracing - Connection Handling', { skip: !isGrpcSupportedVersion },  (t) => {

--- a/test/unit/grpc/connection.test.js
+++ b/test/unit/grpc/connection.test.js
@@ -59,6 +59,7 @@ const createMetricAggregatorForTests = () => {
   return metrics
 }
 
+// TODO: remove unsupported checks when Node 10 support dropped.
 const isUnsupportedNodeVersion =
   GrpcConnection.message === '@grpc/grpc-js only works on Node ^8.13.0 || >=10.10.0'
 
@@ -155,11 +156,14 @@ tap.test('grpc connection error handling', (test) => {
   test.test('should catch error when proto loader fails', (t) => {
     const stub = sinon.stub(protoLoader, 'loadSync').returns({})
 
+    t.tearDown(() => {
+      stub.restore()
+    })
+
     const connection = new GrpcConnection(fakeTraceObserverConfig)
 
     connection.on('disconnected', () => {
       t.equal(connection._state, connectionStates.disconnected)
-      stub.restore()
       t.end()
     })
 
@@ -169,13 +173,14 @@ tap.test('grpc connection error handling', (test) => {
   test.test('should catch error when loadPackageDefinition returns invalid service definition',
     (t) => {
       const stub = sinon.stub(grpcApi, 'loadPackageDefinition').returns({})
+      t.tearDown(() => {
+        stub.restore()
+      })
 
       const connection = new GrpcConnection(fakeTraceObserverConfig)
 
       connection.on('disconnected', () => {
         t.equal(connection._state, connectionStates.disconnected)
-
-        stub.restore()
 
         t.end()
       })

--- a/test/unit/spans/create-span-event-aggregator.test.js
+++ b/test/unit/spans/create-span-event-aggregator.test.js
@@ -15,6 +15,7 @@ const createSpanEventAggregator = require('../../../lib/spans/create-span-event-
 
 const VALID_HOST = 'infinite-tracing.test'
 
+// TODO: remove unsupported checks when Node 10 support dropped.
 const isGrpcSupportedVersion = semver.satisfies(process.version, '>=10.10.0')
 
 tap.test('should return standard when trace observer not configured', (t) => {

--- a/test/unit/trace.test.js
+++ b/test/unit/trace.test.js
@@ -918,6 +918,7 @@ function makeTrace(agent, callback) {
   })
 }
 
+// TODO: remove unsupported checks when Node 10 support dropped.
 const isGrpcSupportedVersion = semver.satisfies(process.version, '>=10.10.0')
 tap.test('infinite tracing', {skip: !isGrpcSupportedVersion}, (t) => {
   t.autoend()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Fixed memory leak introduced when Infinite Tracing is enabled.

  When Infinite Tracing endpoints reconnected they would instantiate a new gRPC client prior to calling `client.recordSpan()`. It appears several objects created by grpc-js (`ChannelImplementation` and child objects, promises, etc.) are held in memory indefinitely due to scheduled timers even when the client is no-longer referenced and the associated stream closed. We now avoid this situation by only creating the client once and then reusing it to establish new stream connections. 

## Links

* Fixes: https://github.com/newrelic/node-newrelic/issues/725

## Details

I could think of any meaningful tests that would catch/prevent reintroducing the issue in a meaningful way. So relying on code comments for now.

Fixed a couple tests that when they would throw would impact downstream tests due to not reverting stubs.

Also added some comments of places to remove checks when we drop Node 10 support later this year.
