### PR TITLE
feature-flag: clean up segment references on promise resolve

### DIFF
--- a/lib/feature_flags.js
+++ b/lib/feature_flags.js
@@ -15,7 +15,8 @@ exports.prerelease = {
   fastify_instrumentation: false,
   // Starts by defaulting true as introducing for deprecation/removal purposes.
   // Will eventually set false prior full removal of feature.
-  certificate_bundle: true
+  certificate_bundle: true,
+  new_promise_tracking: false
 }
 
 // flags that are no longer used for released features

--- a/lib/instrumentation/core/async_hooks.js
+++ b/lib/instrumentation/core/async_hooks.js
@@ -53,7 +53,13 @@ function tryAsyncHooks(agent, shim) {
   const segmentMap = new Map()
   module.exports.segmentMap = segmentMap
 
-  const hookHandlers = getStandardHooks(segmentMap, agent, shim)
+  let hookHandlers = getStandardHooks(segmentMap, agent, shim)
+
+  if (agent.config.feature_flag.new_promise_tracking) {
+    logger.info('Enabling new promise tracking style via new_promise_tracking feature flag.')
+    hookHandlers = getPromiseResolveStyleHooks(segmentMap, agent, shim)
+  }
+
   const hook = asyncHooks.createHook(hookHandlers)
   hook.enable()
 
@@ -115,6 +121,71 @@ function getStandardHooks(segmentMap, agent, shim) {
     },
     destroy: function destHook(id) {
       segmentMap.delete(id)
+    }
+  }
+
+  return hooks
+}
+
+function getPromiseResolveStyleHooks(segmentMap, agent, shim) {
+  const hooks = {
+    init: function initHook(id, type, triggerId, asyncResource) {
+      if (type !== 'PROMISE') {
+        return
+      }
+
+      let parentSegment = segmentMap.get(triggerId)
+
+      if (parentSegment && !parentSegment.transaction.isActive()) {
+        // Stop propagating if the transaction was ended.
+        return
+      }
+
+      if (!parentSegment && !agent.getTransaction()) {
+        return
+      }
+
+      const activeSegment = shim.getActiveSegment() || parentSegment
+      if (asyncResource && asyncResource.promise) {
+        asyncResource.promise.__NR_id = id
+      }
+
+      segmentMap.set(id, activeSegment)
+    },
+
+    before: function beforeHook(id) {
+      const hookSegment = segmentMap.get(id)
+
+      if (!hookSegment) {
+        return
+      }
+
+      segmentMap.set(id, shim.getActiveSegment())
+      shim.setActiveSegment(hookSegment)
+    },
+    after: function afterHook(id) {
+      const hookSegment = segmentMap.get(id)
+
+      // hookSegment is the segment that was active before the promise
+      // executed. If the promise is executing before a segment has been
+      // restored, hookSegment will be null and should be restored. Thus
+      // undefined is the only invalid value here.
+      if (hookSegment === undefined) {
+        return
+      }
+
+      segmentMap.set(id, shim.getActiveSegment())
+      shim.setActiveSegment(hookSegment)
+    },
+    promiseResolve: function promiseResolveHandler(id) {
+      const hookSegment = segmentMap.get(id)
+      segmentMap.delete(id)
+
+      if (hookSegment === undefined) {
+        return
+      }
+
+      shim.setActiveSegment(hookSegment)
     }
   }
 

--- a/lib/instrumentation/core/async_hooks.js
+++ b/lib/instrumentation/core/async_hooks.js
@@ -40,7 +40,7 @@ function initialize(agent, shim) {
 }
 
 function tryAsyncHooks(agent, shim) {
-  var asyncHooks = null
+  let asyncHooks = null
   try {
     asyncHooks = require('async_hooks')
   } catch (e) {
@@ -53,7 +53,19 @@ function tryAsyncHooks(agent, shim) {
   const segmentMap = new Map()
   module.exports.segmentMap = segmentMap
 
-  var hook = asyncHooks.createHook({
+  const hookHandlers = getStandardHooks(segmentMap, agent, shim)
+  const hook = asyncHooks.createHook(hookHandlers)
+  hook.enable()
+
+  agent.on('unload', function disableHook() {
+    hook.disable()
+  })
+
+  return true
+}
+
+function getStandardHooks(segmentMap, agent, shim) {
+  const hooks = {
     init: function initHook(id, type, triggerId, promiseWrap) {
       if (type !== 'PROMISE') {
         return
@@ -78,7 +90,7 @@ function tryAsyncHooks(agent, shim) {
     },
 
     before: function beforeHook(id) {
-      var hookSegment = segmentMap.get(id)
+      const hookSegment = segmentMap.get(id)
 
       if (!hookSegment) {
         return
@@ -88,7 +100,7 @@ function tryAsyncHooks(agent, shim) {
       shim.setActiveSegment(hookSegment)
     },
     after: function afterHook(id) {
-      var hookSegment = segmentMap.get(id)
+      const hookSegment = segmentMap.get(id)
 
       // hookSegment is the segment that was active before the promise
       // executed. If the promise is executing before a segment has been
@@ -104,11 +116,7 @@ function tryAsyncHooks(agent, shim) {
     destroy: function destHook(id) {
       segmentMap.delete(id)
     }
-  }).enable()
+  }
 
-  agent.on('unload', function disableHook() {
-    hook.disable()
-  })
-
-  return true
+  return hooks
 }

--- a/test/integration/core/async_hooks-new-promise.js
+++ b/test/integration/core/async_hooks-new-promise.js
@@ -1,0 +1,566 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const test = require('tap').test
+const helper = require('../../lib/agent_helper')
+const asyncHooks = require('async_hooks')
+
+test('await', function(t) {
+  const agent = setupAgent(t)
+
+  helper.runInTransaction(agent, async function(txn) {
+    let transaction = agent.getTransaction()
+    t.equal(
+      transaction && transaction.id,
+      txn.id,
+      'should start in a transaction'
+    )
+
+    // await Promise.resolve("i'll be back")
+
+    const segmentMap = require('../../../lib/instrumentation/core/async_hooks').segmentMap
+
+    const promise = new Promise((resolve) => {
+      // don't immediately resolve so logic can kick in.
+      setImmediate(resolve)
+    })
+
+    // There may be extra promises in play
+    const promiseId = [...segmentMap.keys()].pop()
+
+    await promise
+
+    t.notOk(segmentMap.has(promiseId), 'should have removed segment for promise after resolve')
+
+    transaction = agent.getTransaction()
+    t.equal(
+      transaction && transaction.id,
+      txn.id,
+      'should resume in the same transaction after await'
+    )
+
+    txn.end()
+
+    // Let the loop iterate to clear the microtask queue
+    setImmediate(() => {
+      t.equal(segmentMap.size, 0, 'should clear segments after all promises resolved')
+      t.end()
+    })
+  })
+})
+
+test("the agent's async hook", function(t) {
+  class TestResource extends asyncHooks.AsyncResource {
+    constructor(id) {
+      super('PROMISE', id)
+    }
+
+    doStuff(callback) {
+      process.nextTick(() => {
+        if (this.runInAsyncScope) {
+          this.runInAsyncScope(callback)
+        } else {
+          this.emitBefore()
+          callback()
+          this.emitAfter()
+        }
+      })
+    }
+  }
+
+  t.autoend()
+  t.test('does not crash on multiple resolve calls', function(t) {
+    const agent = setupAgent(t)
+    helper.runInTransaction(agent, function() {
+      t.doesNotThrow(function() {
+        new Promise(function(res) {
+          res()
+          res()
+        }).then(t.end)
+      })
+    })
+  })
+
+  t.test(
+    'does not restore a segment for a resource created outside a transaction',
+    function(t) {
+      const agent = setupAgent(t)
+      const res = new TestResource(1)
+      helper.runInTransaction(agent, function() {
+        const root = agent.tracer.segment
+        const segmentMap =
+          require('../../../lib/instrumentation/core/async_hooks').segmentMap
+
+        t.equal(segmentMap.size, 0, 'no segments should be tracked')
+        res.doStuff(function() {
+          t.ok(agent.tracer.segment, 'should be in a transaction')
+          t.equal(
+            agent.tracer.segment.name,
+            root.name,
+            'loses transaction state for resources created outside of a transaction'
+          )
+          t.end()
+        })
+      })
+    }
+  )
+
+  t.test('restores context in inactive transactions', function(t) {
+    const agent = setupAgent(t)
+    helper.runInTransaction(agent, function(txn) {
+      const res = new TestResource(1)
+      const root = agent.tracer.segment
+      txn.end()
+      res.doStuff(function() {
+        t.equal(
+          agent.tracer.segment,
+          root,
+          'the hooks restore a segment when its transaction has been ended'
+        )
+        t.end()
+      })
+    })
+  })
+
+  /**
+   * Represents same test as 'parent promises persist perspective to problematic progeny'
+   * from async_hooks.js.
+   *
+   * This specific use case is not currently supported with the implementation that clears
+   * segment references on promise resolve.
+   */
+  t.test(
+    'parent promises that are already resolved DO NOT persist to continuations ' +
+    'scheduled after a timer async hop.',
+    function(t) {
+      const agent = setupAgent(t)
+      const tasks = []
+      const intervalId = setInterval(() => {
+        while (tasks.length) {
+          tasks.pop()()
+        }
+      }, 10)
+
+      t.tearDown(() => {
+        clearInterval(intervalId)
+      })
+
+      helper.runInTransaction(agent, function(txn) {
+        t.ok(txn, 'transaction should not be null')
+
+        const p = Promise.resolve()
+
+        tasks.push(() => {
+          p.then(() => {
+            const tx = agent.getTransaction()
+            t.notEqual(
+              tx ? tx.id : null, txn.id,
+              'If this failed, this use case now works! Time to switch to "t.equal"'
+            )
+            t.end()
+          })
+        })
+      })
+    }
+  )
+
+  /**
+   * Variation of 'parent promises persist perspective to problematic progeny' from async_hooks.js.
+   *
+   * For unresolved parent promises, persistance should stil work as expected.
+   */
+  t.test('unresolved parent promises persist perspective to problematic progeny', function(t) {
+    const agent = setupAgent(t)
+    const tasks = []
+    const intervalId = setInterval(() => {
+      while (tasks.length) {
+        tasks.pop()()
+      }
+    }, 10)
+
+    t.tearDown(() => {
+      clearInterval(intervalId)
+    })
+
+    helper.runInTransaction(agent, function(txn) {
+      t.ok(txn, 'transaction should not be null')
+
+      let parentResolve = null
+      const p = new Promise((resolve) => {
+        parentResolve = resolve
+      })
+
+      tasks.push(() => {
+        p.then(() => {
+          const tx = agent.getTransaction()
+          t.equal(tx ? tx.id : null, txn.id)
+
+          t.end()
+        })
+
+        // resolve parent after continuation scheduled
+        parentResolve()
+      })
+    })
+  })
+
+  /**
+   * Represents same test as 'maintains transaction context' from async_hooks.js.
+   *
+   * Combination of a timer that does not propagate state and the new resolve
+   * mechanism that clears (and sets hook as active) causes this to fail.
+   */
+  t.test('DOES NOT maintain transaction context', function(t) {
+    const agent = setupAgent(t)
+    const tasks = []
+    const intervalId = setInterval(() => {
+      while (tasks.length) {
+        tasks.pop()()
+      }
+    }, 10)
+
+    t.tearDown(() => {
+      clearInterval(intervalId)
+    })
+
+    helper.runInTransaction(agent, function(txn) {
+      t.ok(txn, 'transaction should not be null')
+      const segment = txn.trace.root
+      agent.tracer.bindFunction(one, segment)()
+
+      const wrapperTwo = agent.tracer.bindFunction(function() {
+        return two()
+      }, segment)
+
+      const wrapperThree = agent.tracer.bindFunction(function() {
+        return three()
+      }, segment)
+
+      function one() {
+        return new Promise(executor)
+          .then(() => {
+            const tx = agent.getTransaction()
+            t.equal(tx ? tx.id : null, txn.id)
+            t.end()
+          })
+      }
+
+      function executor(resolve) {
+        tasks.push(() => {
+          next().then(() => {
+            const tx = agent.getTransaction()
+            t.notEqual(
+              tx ? tx.id : null,
+              txn.id,
+              'If this failed, this use case now works! Time to switch to "t.equal"'
+            )
+            resolve()
+          })
+        })
+      }
+
+      function next() {
+        return Promise.resolve(wrapperTwo())
+      }
+
+      function two() {
+        return nextTwo()
+      }
+
+      function nextTwo() {
+        return Promise.resolve(wrapperThree())
+      }
+
+      function three() {}
+    })
+  })
+
+  t.test('maintains transaction context for unresolved promises', function(t) {
+    const agent = setupAgent(t)
+    const tasks = []
+    const intervalId = setInterval(() => {
+      while (tasks.length) {
+        tasks.pop()()
+      }
+    }, 10)
+
+    t.tearDown(() => {
+      clearInterval(intervalId)
+    })
+
+    helper.runInTransaction(agent, function(txn) {
+      t.ok(txn, 'transaction should not be null')
+      const segment = txn.trace.root
+      agent.tracer.bindFunction(one, segment)()
+
+      const wrapperTwo = agent.tracer.bindFunction(function() {
+        return two()
+      }, segment)
+
+      const wrapperThree = agent.tracer.bindFunction(function() {
+        return three()
+      }, segment)
+
+      function one() {
+        return new Promise(executor)
+          .then(() => {
+            const tx = agent.getTransaction()
+            t.equal(tx ? tx.id : null, txn.id)
+            t.end()
+          })
+      }
+
+      function executor(resolve) {
+        setImmediate(() => {
+          next().then(() => {
+            const tx = agent.getTransaction()
+            t.equal(tx ? tx.id : null, txn.id)
+            resolve()
+          })
+        })
+      }
+
+      function next() {
+        return new Promise((resolve) => {
+          const val = wrapperTwo()
+          setImmediate(() => {
+            resolve(val)
+          })
+        })
+      }
+
+      function two() {
+        return nextTwo()
+      }
+
+      function nextTwo() {
+        return new Promise((resolve) => {
+          const val = wrapperThree()
+          setImmediate(() => {
+            resolve(val)
+          })
+        })
+      }
+
+      function three() {}
+    })
+  })
+
+  t.test('stops propagation on transaction end', function(t) {
+    const agent = setupAgent(t)
+
+    helper.runInTransaction(agent, function(txn) {
+      t.ok(txn, 'transaction should not be null')
+      const segment = txn.trace.root
+      agent.tracer.bindFunction(one, segment)()
+
+      function one() {
+        return new Promise((done) => {
+          const currentSegment = agent.tracer.segment
+          t.ok(currentSegment, 'should have propagated a segment')
+          txn.end()
+
+          done()
+        }).then(() => {
+          const currentSegment = agent.tracer.segment
+          t.notOk(currentSegment, 'should not have a propagated segment')
+          t.end()
+        })
+      }
+    })
+  })
+
+  t.test('loses transaction context', function(t) {
+    const agent = setupAgent(t)
+    const tasks = []
+    const intervalId = setInterval(() => {
+      while (tasks.length) {
+        tasks.pop()()
+      }
+    }, 10)
+
+    t.tearDown(() => {
+      clearInterval(intervalId)
+    })
+
+    helper.runInTransaction(agent, function(txn) {
+      t.ok(txn, 'transaction should not be null')
+      const segment = txn.trace.root
+      agent.tracer.bindFunction(one, segment)()
+
+      const wrapperTwo = agent.tracer.bindFunction(function() {
+        return two()
+      }, segment)
+
+      function one() {
+        return new Promise(executor)
+          .then(() => {
+            const tx = agent.getTransaction()
+            t.equal(tx ? tx.id : null, txn.id)
+            t.end()
+          })
+      }
+
+      function executor(resolve) {
+        tasks.push(() => {
+          next().then(() => {
+            const tx = agent.getTransaction()
+            // We know tx will be null here because no promise was returned
+            // If this test fails, that's actually a good thing,
+            // so throw a party/update Koa.
+            t.equal(tx, null)
+            resolve()
+          })
+        })
+      }
+
+      function next() {
+        return Promise.resolve(wrapperTwo())
+      }
+
+      function two() {
+        // No promise is returned to reinstate transaction context
+      }
+    })
+  })
+
+  t.test('handles multientry callbacks correctly', function(t) {
+    const agent = setupAgent(t)
+    const segmentMap = require('../../../lib/instrumentation/core/async_hooks').segmentMap
+    helper.runInTransaction(agent, function() {
+      const root = agent.tracer.segment
+
+      const aSeg = agent.tracer.createSegment('A')
+      agent.tracer.segment = aSeg
+      const resA = new TestResource(1)
+
+      const bSeg = agent.tracer.createSegment('B')
+      agent.tracer.segment = bSeg
+      const resB = new TestResource(2)
+
+      agent.tracer.segment = root
+
+      t.equal(segmentMap.size, 2, 'all resources should create an entry on init')
+
+      resA.doStuff(() => {
+        t.equal(
+          agent.tracer.segment.name,
+          aSeg.name,
+          'runInAsyncScope should restore the segment active when a resource was made'
+        )
+
+        resB.doStuff(() => {
+          t.equal(
+            agent.tracer.segment.name,
+            bSeg.name,
+            'runInAsyncScope should restore the segment active when a resource was made'
+          )
+
+          t.end()
+        })
+        t.equal(
+          agent.tracer.segment.name,
+          aSeg.name,
+          'runInAsyncScope should restore the segment active when a callback was called'
+        )
+      })
+      t.equal(
+        agent.tracer.segment.name,
+        root.name,
+        'root should be restored after we are finished'
+      )
+      resA.doStuff(() => {
+        t.equal(
+          agent.tracer.segment.name,
+          aSeg.name,
+          'runInAsyncScope should restore the segment active when a resource was made'
+        )
+      })
+    })
+  })
+})
+
+function checkCallMetrics(t, testMetrics) {
+  // Tap also creates promises, so these counts don't quite match the tests.
+  const TAP_COUNT = 1
+
+  t.equal(testMetrics.initCalled - TAP_COUNT, 2, 'two promises were created')
+  t.equal(testMetrics.beforeCalled, 1, 'before hook called for all async promises')
+  t.equal(
+    testMetrics.beforeCalled,
+    testMetrics.afterCalled,
+    'before should be called as many times as after'
+  )
+
+  if (global.gc) {
+    global.gc()
+    return setTimeout(function() {
+      t.equal(
+        testMetrics.initCalled - TAP_COUNT,
+        testMetrics.destroyCalled,
+        'all promises created were destroyed'
+      )
+      t.end()
+    }, 10)
+  }
+  t.end()
+}
+
+test('promise hooks', function(t) {
+  t.autoend()
+  const testMetrics = {
+    initCalled: 0,
+    beforeCalled: 0,
+    afterCalled: 0,
+    destroyCalled: 0
+  }
+
+  const promiseIds = {}
+  const hook = asyncHooks.createHook({
+    init: function initHook(id, type) {
+      if (type === 'PROMISE') {
+        promiseIds[id] = true
+        testMetrics.initCalled++
+      }
+    },
+    before: function beforeHook(id) {
+      if (promiseIds[id]) {
+        testMetrics.beforeCalled++
+      }
+    },
+    after: function afterHook(id) {
+      if (promiseIds[id]) {
+        testMetrics.afterCalled++
+      }
+    },
+    destroy: function destHook(id) {
+      if (promiseIds[id]) {
+        testMetrics.destroyCalled++
+      }
+    }
+  })
+  hook.enable()
+
+  t.test('are only called once during the lifetime of a promise', function(t) {
+    new Promise(function(res) {
+      setTimeout(res, 10)
+    }).then(function() {
+      setImmediate(checkCallMetrics, t, testMetrics)
+    })
+  })
+})
+
+function setupAgent(t) {
+  const agent = helper.instrumentMockedAgent({
+    feature_flag: {await_support: true}
+  })
+  t.tearDown(function() {
+    helper.unloadAgent(agent)
+  })
+
+  return agent
+}

--- a/test/integration/core/async_hooks-new-promise.js
+++ b/test/integration/core/async_hooks-new-promise.js
@@ -20,8 +20,6 @@ test('await', function(t) {
       'should start in a transaction'
     )
 
-    // await Promise.resolve("i'll be back")
-
     const segmentMap = require('../../../lib/instrumentation/core/async_hooks').segmentMap
 
     const promise = new Promise((resolve) => {
@@ -77,9 +75,9 @@ test("the agent's async hook", function(t) {
     const agent = setupAgent(t)
     helper.runInTransaction(agent, function() {
       t.doesNotThrow(function() {
-        new Promise(function(res) {
-          res()
-          res()
+        new Promise(function(resolve) {
+          resolve()
+          resolve()
         }).then(t.end)
       })
     })
@@ -89,14 +87,14 @@ test("the agent's async hook", function(t) {
     'does not restore a segment for a resource created outside a transaction',
     function(t) {
       const agent = setupAgent(t)
-      const res = new TestResource(1)
+      const testResource = new TestResource(1)
       helper.runInTransaction(agent, function() {
         const root = agent.tracer.segment
         const segmentMap =
           require('../../../lib/instrumentation/core/async_hooks').segmentMap
 
         t.equal(segmentMap.size, 0, 'no segments should be tracked')
-        res.doStuff(function() {
+        testResource.doStuff(function() {
           t.ok(agent.tracer.segment, 'should be in a transaction')
           t.equal(
             agent.tracer.segment.name,
@@ -112,10 +110,10 @@ test("the agent's async hook", function(t) {
   t.test('restores context in inactive transactions', function(t) {
     const agent = setupAgent(t)
     helper.runInTransaction(agent, function(txn) {
-      const res = new TestResource(1)
+      const testResource = new TestResource(1)
       const root = agent.tracer.segment
       txn.end()
-      res.doStuff(function() {
+      testResource.doStuff(function() {
         t.equal(
           agent.tracer.segment,
           root,
@@ -546,8 +544,8 @@ test('promise hooks', function(t) {
   hook.enable()
 
   t.test('are only called once during the lifetime of a promise', function(t) {
-    new Promise(function(res) {
-      setTimeout(res, 10)
+    new Promise(function(resolve) {
+      setTimeout(resolve, 10)
     }).then(function() {
       setImmediate(checkCallMetrics, t, testMetrics)
     })

--- a/test/integration/core/async_hooks-new-promise.tap.js
+++ b/test/integration/core/async_hooks-new-promise.tap.js
@@ -6,7 +6,10 @@
 'use strict'
 
 const exec = require('child_process').execSync
-exec('node --expose-gc ./async_hooks.js', {
-  stdio: 'inherit',
-  cwd: __dirname
-})
+exec(
+  'NEW_RELIC_FEATURE_FLAG_NEW_PROMISE_TRACKING=1 node --expose-gc ./async_hooks-new-promise.js',
+  {
+    stdio: 'inherit',
+    cwd: __dirname
+  }
+)

--- a/test/unit/feature_flag.test.js
+++ b/test/unit/feature_flag.test.js
@@ -35,7 +35,8 @@ var used = [
   'dt_format_w3c',
   'unreleased',
   'fastify_instrumentation',
-  'certificate_bundle'
+  'certificate_bundle',
+  'new_promise_tracking'
 ]
 
 describe('feature flags', function() {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Added new feature-flag 'new_promise_tracking' which enables cleaning up of segment references on native promise resolve instead of destroy. Includes usage of async-await. This can be enabled via `feature_flag: { new_promise_tracking: true }` in the config file or `NEW_RELIC_FEATURE_FLAG_NEW_PROMISE_TRACKING=1` in your ENV vars.

  Applications with heavy promise usage or high-throughput applications with some promise usage should see moderate to high reduction in memory usage and may see a slight reduction in CPU usage. A bump in throughput may also be noticed in some cases. Results will vary by application.
  
  If you are experiencing high overhead levels with your promise usage and the agent attached, we recommend testing your application with  'new_promise_tracking' set to true to see if overhead is reduced. You'll also want to verify your data is still being captured correctly in case it falls into a known or unknown limitation of this approach.  **NOTE: chaining of promise continuations onto an already resolved promise across an async hop (scheduled timer) will result in state-loss with this new functionality turned on. This is a less-common use-case but worth considering with your applications.**

## Links

* Closes: https://github.com/newrelic/node-newrelic/issues/711

## Details

The 'destroy' event for promises is not invoked until a promise has been garbage collected. This means customers holding onto promises, the agent indirectly or other means may keep our segments in the segmentMap for an extra long amount of time. Even when references are quickly removed, we wait for the next GC (not necessarily immediate) to remove references our segment tree/transaction/etc. so they can be cleaned up.

When the feature flag is enabled, we now remove segments from the segment map when they are resolved. While customer's could still trigger us to leak by not resolving a promise, this greatly speeds up our clean-up of transaction related objects from memory and reduces our chance to grow an existing memory leak or introduce a new leak via indirect reference.

Unfortunately, since we will have cleaned out a promise on resolve... if you schedule a continuation on a resolved promise, it won't be able to pull up the parent segment associated with the resolved parent promise. As such, if you've made a hop w/o state you may lose transaction state. Theoretically, you could also end up with a different parent than the current racking, in this scenario, if a segment is in context but different than the parent would have been.

This seem pretty niche and may be best solved via targeted instrumentation VS trying to solve the world via async-hooks.

Also, if we were all in on async-hooks. Especially, using the executionAsyncResource now available... we may support more of this style of scenario while maybe even reducing the amount of hooks (and thus overhead) needed. That's a bigger effort as some state consolidation refactoring is likely needed first, etc.

This hopefully is a step towards seeing some wins in some of our existing scenarios. If we see consistent enough success without unknown limitations that are deemed critical, we can look to make this the default functionality in a future major release. 

-----

It's worth noting I tried to optimize for ripping code out in the future for a single implementation, so some opportunities for code re-use were not leveraged as they would have hindered the cleanup instead of help.

-----

### Stress Test

Here are some stress test numbers from my local machine. These are in no-way 'official' nor do they represent a particular customer's real-world scenario. They should be a good indicator for potential wins, however.

* koa
* koa-router
* axios (external calls)
* async-await

Multiple middleware doing nothing 
|          | Response Time | Throughput | CPU Utilization | Memory Usage |
|----------|---------------|------------|-----------------|--------------|
| Original | 0.171 ms      | 117k rpm   | 88.45%          | 119.7 MB     |
| New      | 0.155 ms      | 124k rpm   | 84.45%          | 114.5 MB     |

Multiple middleware, small timer delays 
|          | Response Time | Throughput | CPU Utilization | Memory Usage |
|----------|---------------|------------|-----------------|--------------|
| Original | 3.59 ms       | 78.3k rpm   | 76.13%          | 154.5 MB    |
| New      | 3.26 ms       | 88.7k rpm   | 73.13%          | 114.2 MB    |

Multiple middleware, external call 
|          | Response Time | Throughput | CPU Utilization | Memory Usage |
|----------|---------------|------------|-----------------|--------------|
| Original | 30.7 ms       | 11.6k rpm   | 36.49%         | 984.2 MB     |
| New      | 28.6 ms       | 12.5k rpm   | 35.93%         | 105.7 MB     |

Multiple middleware, external call that errors 
|          | Response Time | Throughput | CPU Utilization | Memory Usage |
|----------|---------------|------------|-----------------|--------------|
| Original | 30.7 ms       | 11.6k rpm   | 42.05%         | 1.1 GB       |
| New      | 30.4 ms       | 11.7k rpm   | 39.17%         | 113.4 MB     |