### PR TITLE
Only propagates null segments on resolve to prevent reuse of transaction

### DIFF
--- a/lib/instrumentation/core/async_hooks.js
+++ b/lib/instrumentation/core/async_hooks.js
@@ -185,7 +185,12 @@ function getPromiseResolveStyleHooks(segmentMap, agent, shim) {
         return
       }
 
-      shim.setActiveSegment(hookSegment)
+      // Because the ID will no-longer be in memory until dispose to propagate the null
+      // we need to set it active here or else we may continue to propagate the wrong tree.
+      // May be some risk of setting this at the wrong time
+      if (hookSegment === null) {
+        shim.setActiveSegment(hookSegment)
+      }
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -645,9 +645,9 @@
       }
     },
     "abstract-logging": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.0.tgz",
-      "integrity": "sha512-/oA9z7JszpIioo6J6dB79LVUgJ3eD3cxkAmdCkvWWS+Y9tPtALs1rLqOekLUXUbYqM2fB9TTK0ibAyZJJOP/CA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
       "dev": true
     },
     "accepts": {
@@ -839,9 +839,9 @@
       "dev": true
     },
     "avvio": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/avvio/-/avvio-6.4.1.tgz",
-      "integrity": "sha512-jeZaUK+F7MuWSNT3VHfltskPJZKqVeTWQqBA4SDaDoLaQ0lb5TOgLeQT1BEuhTIUNISCDCGY3zjYyVmQQ48gKA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-6.5.0.tgz",
+      "integrity": "sha512-BmzcZ7gFpyFJsW8G+tfQw8vJNUboA9SDkkHLZ9RAALhvw/rplfWwni8Ee1rA11zj/J7/E5EvZmweusVvTHjWCA==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
@@ -850,12 +850,12 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         }
       }
@@ -2028,9 +2028,9 @@
       "dev": true
     },
     "fast-json-stringify": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-1.20.1.tgz",
-      "integrity": "sha512-PEPWrRZvKqI11fY2uDhLLuoapIda9wVQ2mzAj8rkBfVD7jWvOSIICL0Om1knoReIWKF5y/5bbR/GzcZANaaJfQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-1.21.0.tgz",
+      "integrity": "sha512-xY6gyjmHN3AK1Y15BCbMpeO9+dea5ePVsp3BouHCdukcx0hOHbXwFhRodhcI0NpZIgDChSeAKkHW9YjKvhwKBA==",
       "dev": true,
       "requires": {
         "ajv": "^6.11.0",
@@ -2039,9 +2039,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -2051,9 +2051,9 @@
           }
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
           "dev": true
         }
       }
@@ -2065,9 +2065,9 @@
       "dev": true
     },
     "fast-redact": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
-      "integrity": "sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.1.0.tgz",
+      "integrity": "sha512-0LkHpTLyadJavq9sRzzyqIoMZemWli77K2/MGOkafrR64B9ItrvZ9aT+jluvNDsv0YEHjSNhlMBtbokuoqii4A==",
       "dev": true
     },
     "fast-safe-stringify": {
@@ -2082,14 +2082,14 @@
       "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
     },
     "fastify": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-2.14.1.tgz",
-      "integrity": "sha512-nSL8AgIdFCpZmFwjqB5Zzv+3/1KpwwVtB/h88Q4Og8njYbkddKGpuQlQ2tHUULXPTJrLZ7wop6olzx6HEbHdpw==",
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-2.15.3.tgz",
+      "integrity": "sha512-2O+A9SjHpbH/SgDDMA+xIznhx/rDeNuwPIiZSFVU7fwOiiFfQjHmfu21jp22wMmsZ5PYKYFR+pze2TzoAUmOtw==",
       "dev": true,
       "requires": {
         "abstract-logging": "^2.0.0",
         "ajv": "^6.12.0",
-        "avvio": "^6.3.1",
+        "avvio": "^6.5.0",
         "fast-json-stringify": "^1.18.0",
         "find-my-way": "^2.2.2",
         "flatstr": "^1.0.12",
@@ -2104,9 +2104,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -2116,15 +2116,15 @@
           }
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
           "dev": true
         },
         "find-my-way": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-2.2.3.tgz",
-          "integrity": "sha512-C7dxfbX8pV1maLd31ygkBEOaD51Ls4dROuHjeSQZf1FeQinUzq3UA/kSPecLSDy9iAQufd8w1zgp7j64kyLdhw==",
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-2.2.5.tgz",
+          "integrity": "sha512-GjRZZlGcGmTh9t+6Xrj5K0YprpoAFCAiCPgmAH9Kb09O4oX6hYuckDfnDipYj+Q7B1GtYWSzDI5HEecNYscLQg==",
           "dev": true,
           "requires": {
             "fast-decode-uri-component": "^1.0.0",
@@ -2147,24 +2147,13 @@
             "forwarded": "~0.1.2",
             "ipaddr.js": "1.9.1"
           }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
         }
       }
     },
     "fastq": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -4443,9 +4432,9 @@
       }
     },
     "pino-std-serializers": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
-      "integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.5.0.tgz",
+      "integrity": "sha512-wXqbqSrIhE58TdrxxlfLwU9eDhrzppQDvGhBEr1gYbzzM4KKo3Y63gSjiDXRKLVS2UOXdPNR2v+KnQgNrs+xUg==",
       "dev": true
     },
     "pirates": {
@@ -4980,9 +4969,9 @@
       "dev": true
     },
     "rfdc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
-      "integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
       "dev": true
     },
     "rimraf": {
@@ -5056,9 +5045,9 @@
       }
     },
     "secure-json-parse": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.1.0.tgz",
-      "integrity": "sha512-GckO+MS/wT4UogDyoI/H/S1L0MCcKS1XX/vp48wfmU7Nw4woBmb8mIpu4zPBQjKlRT88/bt9xdoV4111jPpNJA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.4.0.tgz",
+      "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg==",
       "dev": true
     },
     "select-hose": {
@@ -5143,9 +5132,9 @@
       "dev": true
     },
     "set-cookie-parser": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.5.tgz",
-      "integrity": "sha512-LkSDwseogN5l6TerqGzFzL9mUDTxSq3hX2b5AaynjC1nSCNWiDypEgHatfc0v6KcnfgV3/6F6h4ABh6igjzlQQ==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
+      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
       "dev": true
     },
     "setprototypeof": {
@@ -5491,9 +5480,9 @@
       "dev": true
     },
     "string-similarity": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.1.tgz",
-      "integrity": "sha512-v36MJzloekKVvKAsYi6O/qpn2mIuvwEFIT9Gx3yg4spkNjXYsk7yxc37g4ZTyMVIBvt/9PZGxnqEtme8XHK+Mw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
+      "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
       "dev": true
     },
     "string-width": {
@@ -6879,9 +6868,9 @@
       "dev": true
     },
     "tiny-lru": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-7.0.2.tgz",
-      "integrity": "sha512-cmc9OOwmnAJtyFBYaznKR3abypEhWecarFrvS5db6qwSgoaDUWV0JX+mdh6B9wN60Wux3+gE1vjzxkoqxFBjqw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-7.0.6.tgz",
+      "integrity": "sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==",
       "dev": true
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "commander": "^7.0.0",
     "eslint": "^6.8.0",
     "express": "*",
-    "fastify": "^2.14.1",
+    "fastify": "^2.15.3",
     "generic-pool": "^3.6.1",
     "glob": "^7.1.2",
     "got": "^8.0.1",

--- a/test/integration/fastify/errors.tap.js
+++ b/test/integration/fastify/errors.tap.js
@@ -1,4 +1,10 @@
+/*
+ * Copyright 2021 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 'use strict'
+
 const tap = require('tap')
 const request = require('request')
 const helper  = require('../../lib/agent_helper')

--- a/test/integration/fastify/naming.tap.js
+++ b/test/integration/fastify/naming.tap.js
@@ -1,4 +1,10 @@
+/*
+ * Copyright 2021 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 'use strict'
+
 const tap = require('tap')
 const requestClient = require('request')
 const helper  = require('../../lib/agent_helper')

--- a/test/integration/fastify/new-state-tracking.tap.js
+++ b/test/integration/fastify/new-state-tracking.tap.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const http = require('http')
+
+const helper  = require('../../lib/agent_helper')
+
+const originalSetImmediate = setImmediate
+
+tap.test('fastify with new state tracking', (t) => {
+  t.autoend()
+
+  let agent = null
+  let fastify = null
+
+  t.beforeEach((done) => {
+    agent = helper.instrumentMockedAgent({
+      feature_flag: {
+        fastify_instrumentation: true,
+        new_promise_tracking: true
+      }
+    })
+
+    fastify = require('fastify')()
+
+    done()
+  })
+
+  t.afterEach((done) => {
+    helper.unloadAgent(agent)
+    fastify.close()
+
+    done()
+  })
+
+  t.test('should not reuse transactions via normal usage', async(t) => {
+    fastify.get('/', async() => {
+      return { hello: 'world' }
+    })
+
+    await fastify.listen(0)
+
+    const port = fastify.server.address().port
+    const url = `http://localhost:${port}/`
+
+    let transactions = []
+    agent.on('transactionFinished', (transaction) => {
+      transactions.push(transaction)
+    })
+
+    await makeRequestPromise(url)
+    await makeRequestPromise(url)
+
+    t.equal(transactions.length, 2)
+  })
+
+  t.test('should not reuse transactions with non-awaited promise', async(t) => {
+    fastify.get('/', async() => {
+      doWork() // fire-and-forget promise
+      return { hello: 'world' }
+    })
+
+    function doWork() {
+      return new Promise((resolve) => {
+        // async hop w/o context tracking
+        originalSetImmediate(resolve)
+      })
+    }
+
+    await fastify.listen(0)
+
+    const port = fastify.server.address().port
+    const url = `http://localhost:${port}/`
+
+    let transactions = []
+    agent.on('transactionFinished', (transaction) => {
+      transactions.push(transaction)
+    })
+
+    await makeRequestPromise(url)
+    await makeRequestPromise(url)
+
+    t.equal(transactions.length, 2)
+  })
+})
+
+function makeRequest(url, cb) {
+  http.get(url, (res) => {
+    res.resume()
+    res.on('end', () => {
+      cb()
+    })
+  })
+}
+
+function makeRequestPromise(url) {
+  return new Promise((resolve) => {
+    makeRequest(url, resolve)
+  })
+}

--- a/test/versioned/fastify/integration.tap.js
+++ b/test/versioned/fastify/integration.tap.js
@@ -3,3 +3,5 @@
 require('../../integration/fastify/naming.tap.js')
 
 require('../../integration/fastify/errors.tap.js')
+
+require('../../integration/fastify/new-state-tracking.tap.js')


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Fixed issue with 'new_promise_tracking' feature flag functionality where segments for ended transactions would get propagated in certain cases by promises that had no continuations scheduled (via await or manually).

## Links

* Likely same problem as: https://github.com/newrelic/node-newrelic/issues/729

## Details

~While the code to reproduce this locally is pretty straightforward, I cannot get a test to reproduce this. I'm wondering if the underlying test framework implementation is having an impact. I'll continue to poke at it but I figured it was better get something out there to resolve than hold-off given this is being a feature-flag anyways. I'm hoping this resolves the one issue we've seen (linked above) but it may not as haven't seen all the details there yet.~

Was able to get tests going by using an existing framework (fastify in this case). Koa would have worked as well, but that is in an external module.
