### PR TITLE
Filters out PR that created release tag commit on merge.

### DIFF
--- a/bin/prepare-release.js
+++ b/bin/prepare-release.js
@@ -238,9 +238,17 @@ async function generateReleaseNotes() {
   console.log(`Finding merged pull requests since: ${commitDate}`)
 
   const mergedPullRequests = await github.getMergedPullRequestsSince(commitDate)
-  console.log(`Found ${mergedPullRequests.length}`)
 
-  const releaseNoteData = mergedPullRequests.map((pr) => {
+  const filteredPullRequests = mergedPullRequests.filter((pr) => {
+    // Sometimes the commit for the PR the tag is set to has an earlier time than
+    // the PR merge time and we'll pull in release note PRs. Filters those out.
+
+    return pr.merge_commit_sha !== tag.commit.sha
+  })
+
+  console.log(`Found ${filteredPullRequests.length}`)
+
+  const releaseNoteData = filteredPullRequests.map((pr) => {
     const parts = pr.body.split(/(?:^|\n)##\s*/g)
 
     // If only has one part, not in appropriate format.


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details

In some cases, appears the commit date can be earlier than the same PR's merge date which resulted in the PR coming back for the 'merged after' query. This filters that out.

