### PR TITLE
Support .js .cjs and custom config filename

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -32,18 +32,6 @@ const DEFAULT_MAX_PAYLOAD_SIZE_IN_BYTES = 1000000
 const DEFAULT_CONFIG_PATH = require.resolve('./default')
 const SPAN_EVENT_LIMIT = 1000
 const BASE_CONFIG_PATH = require.resolve('../../newrelic')
-const CONFIG_FILENAMES = [
-  process.env.NEW_RELIC_CONFIG_FILENAME,
-  'newrelic.js',
-  'newrelic.cjs'
-].filter(Boolean)
-const CONFIG_FILE_LOCATIONS = [
-  process.env.NEW_RELIC_HOME,
-  process.cwd(),
-  process.env.HOME,
-  path.join(__dirname, '../../../..') // above node_modules
-].filter(Boolean)
-
 const HAS_ARBITRARY_KEYS = new Set([
   'ignore_messages',
   'expected_messages',
@@ -58,9 +46,22 @@ const exists = fs.existsSync || path.existsSync
 let logger = null // Lazy-loaded in `initialize`.
 let _configInstance = null
 
+const getConfigFileNames = () => [
+  process.env.NEW_RELIC_CONFIG_FILENAME,
+  'newrelic.js',
+  'newrelic.cjs'
+].filter(Boolean)
+
+const getConfigFileLocations = () => [
+  process.env.NEW_RELIC_HOME,
+  process.cwd(),
+  process.env.HOME,
+  path.join(__dirname, '../../../..') // above node_modules
+].filter(Boolean)
+
 // the REPL has no main module
 if (process.mainModule && process.mainModule.filename) {
-  CONFIG_FILE_LOCATIONS.splice(2, 0, path.dirname(process.mainModule.filename))
+  getConfigFileLocations().splice(2, 0, path.dirname(process.mainModule.filename))
 }
 
 function isTruthular(setting) {
@@ -93,8 +94,8 @@ function fromObjectList(setting) {
 }
 
 function _findConfigFile() {
-  const configFileCandidates = CONFIG_FILE_LOCATIONS.reduce((files, configPath) => {
-    const configFiles = CONFIG_FILENAMES.map(filename => 
+  const configFileCandidates = getConfigFileLocations().reduce((files, configPath) => {
+    const configFiles = getConfigFileNames().map(filename => 
       path.join(path.resolve(configPath), filename)
     )
 

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -32,13 +32,17 @@ const DEFAULT_MAX_PAYLOAD_SIZE_IN_BYTES = 1000000
 const DEFAULT_CONFIG_PATH = require.resolve('./default')
 const SPAN_EVENT_LIMIT = 1000
 const BASE_CONFIG_PATH = require.resolve('../../newrelic')
-const DEFAULT_FILENAME = 'newrelic.js'
+const CONFIG_FILENAMES = [
+  process.env.NEW_RELIC_CONFIG_FILENAME,
+  'newrelic.js',
+  'newrelic.cjs'
+].filter(Boolean)
 const CONFIG_FILE_LOCATIONS = [
   process.env.NEW_RELIC_HOME,
   process.cwd(),
   process.env.HOME,
   path.join(__dirname, '../../../..') // above node_modules
-]
+].filter(Boolean)
 
 const HAS_ARBITRARY_KEYS = new Set([
   'ignore_messages',
@@ -89,19 +93,15 @@ function fromObjectList(setting) {
 }
 
 function _findConfigFile() {
-  var candidate
-  var filepath
+  const configFileCandidates = CONFIG_FILE_LOCATIONS.reduce((files, configPath) => {
+    const configFiles = CONFIG_FILENAMES.map(filename => 
+      path.join(path.resolve(configPath), filename)
+    )
 
+    return files.concat(configFiles)
+  }, [])
 
-  for (var i = 0; i < CONFIG_FILE_LOCATIONS.length; i++) {
-    candidate = CONFIG_FILE_LOCATIONS[i]
-    if (!candidate) continue
-
-    filepath = path.join(path.resolve(candidate), DEFAULT_FILENAME)
-    if (!exists(filepath)) continue
-
-    return fs.realpathSync(filepath)
-  }
+  return configFileCandidates.find(exists)
 }
 
 function Config(config) {

--- a/test/unit/config/config.test.js
+++ b/test/unit/config/config.test.js
@@ -1350,25 +1350,27 @@ describe('the agent configuration', function() {
     const createSampleConfig = (filename) => {
       CONFIG_PATH = path.join(DESTDIR, filename)
 
-      var config = fs.readFileSync(
-        path.join(__dirname, '../../../lib/config/default.js')
-      )
+      const config = {
+        app_name: filename
+      }
 
-      fs.writeFileSync(CONFIG_PATH, config)
+      fs.writeFileSync(CONFIG_PATH, `exports.config = ${JSON.stringify(config)}`)
     }
 
     it('should load the default newrelic.js config file', function() {
-      createSampleConfig("newrelic.js")
+      const filename = "newrelic.js"
+      createSampleConfig(filename)
 
       const configuration = Config.initialize()
-      expect(configuration.newrelic_home).equal(DESTDIR)
+      expect(configuration.app_name).equal(filename)
     })
 
     it('should load the default newrelic.cjs config file', function() {
-      createSampleConfig("newrelic.cjs")
+      const filename = "newrelic.cjs"
+      createSampleConfig(filename)
 
       const configuration = Config.initialize()
-      expect(configuration.newrelic_home).equal(DESTDIR)
+      expect(configuration.app_name).equal(filename)
     })
 
     it('should load config when overriding the default with NEW_RELIC_CONFIG_FILENAME', function() {
@@ -1377,7 +1379,7 @@ describe('the agent configuration', function() {
       createSampleConfig(filename)
 
       const configuration = Config.initialize()
-      expect(configuration.newrelic_home).equal(DESTDIR)
+      expect(configuration.app_name).equal(filename)
     })
   })
 


### PR DESCRIPTION

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

- default support for config files named `newrelic.js` and `newrelic.cjs`. Config file name can also be specified with the NEW_RELIC_CONFIG_FILENAME environment variable.

## Links

Fixes: https://github.com/newrelic/node-newrelic/issues/344

## Details

We need to have the newrelic config file end with `.cjs` since our package using newrelic is of type module. This will also give users the ability to specify an arbitrary config file name instead of being limited to only `newrelic.js`
