### PR TITLE
provide logic to check proxy settings and log a warning when a miscon…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ out
 .vscode
 .nyc_output
 test/**/package-lock.json
+coverage/
 
 # Needed for testing
 !test/integration/moduleLoading/node_modules

--- a/lib/collector/api.js
+++ b/lib/collector/api.js
@@ -117,6 +117,22 @@ CollectorAPI.prototype.connect = function connect(callback) {
     this._reqHeadersMap = null
   }
 
+  /**
+   * Checks if proxy is configured to connect via `proxy_host` and `proxy_port`
+   * and if error code is EPROTO or ECONNRESET. This is an indication their proxy
+   * server only accepts HTTP connections, and we should provide an actionable warning to
+   * fix the misconfiguration by setting `proxy` to a fully qualified URL
+   *
+   * @param {Error} error
+   * @returns {Boolean}
+   */
+  function isProxyMisconfigured(error) {
+    const config = api._agent.config || {}
+    return error &&
+      ['EPROTO', 'ECONNRESET'].includes(error.code) &&
+      config.proxy_host && config.proxy_port && !config.proxy
+  }
+
   function retry(error, response) {
     metric.incrementCallCount()
 
@@ -141,6 +157,14 @@ CollectorAPI.prototype.connect = function connect(callback) {
         ' Relic. If the problem persists, please contact support@newrelic.com.' +
         ' (status code %s)',
         response.status
+      )
+    } else if (isProxyMisconfigured(error)) {
+      logger.warn(
+        error,
+        'Your proxy server appears to be configured to accept connections over http. ' +
+        'When setting `proxy_host` and `proxy_port` New Relic attempts to connect over' +
+        'SSL(https). If your proxy is configured to accept connections over http, try ' +
+        'setting `proxy` to a fully qualified URL(e.g http://proxy-host:8080).'
       )
     }
 

--- a/lib/collector/api.js
+++ b/lib/collector/api.js
@@ -127,7 +127,7 @@ CollectorAPI.prototype.connect = function connect(callback) {
    * @returns {Boolean}
    */
   function isProxyMisconfigured(error) {
-    const config = api._agent.config || {}
+    const config = api._agent.config
     return error &&
       ['EPROTO', 'ECONNRESET'].includes(error.code) &&
       config.proxy_host && config.proxy_port && !config.proxy
@@ -162,7 +162,7 @@ CollectorAPI.prototype.connect = function connect(callback) {
       logger.warn(
         error,
         'Your proxy server appears to be configured to accept connections over http. ' +
-        'When setting `proxy_host` and `proxy_port` New Relic attempts to connect over' +
+        'When setting `proxy_host` and `proxy_port` New Relic attempts to connect over ' +
         'SSL(https). If your proxy is configured to accept connections over http, try ' +
         'setting `proxy` to a fully qualified URL(e.g http://proxy-host:8080).'
       )

--- a/test/unit/collector/api-connect.test.js
+++ b/test/unit/collector/api-connect.test.js
@@ -628,7 +628,7 @@ tap.test('retries on receiving invalid license key (401)', (t) => {
   }
 })
 
-tap('retries on misconfigured proxy', (t) => {
+tap.test('retries on misconfigured proxy', (t) => {
   const sandbox = sinon.createSandbox()
   const loggerMock = require('../mocks/logger')(sandbox)
   const CollectorApiTest = proxyquire('../../../lib/collector/api', {
@@ -686,19 +686,24 @@ tap('retries on misconfigured proxy', (t) => {
     done()
   })
 
-  t('should log warning when proxy is misconfigured', (t) => {
+  t.test('should log warning when proxy is misconfigured', (t) => {
     testConnect(t, () => {
+      const expectErrorMsg = 'Your proxy server appears to be configured to accept connections over http. \
+When setting `proxy_host` and `proxy_port` New Relic attempts to connect over SSL(https). If your \
+proxy is configured to accept connections over http, try setting `proxy` to a fully qualified URL\
+(e.g http://proxy-host:8080).'
+
       t.deepEqual(loggerMock.warn.args, [
         [
           error,
-          'Your proxy server appears to be configured to accept connections over http. When setting `proxy_host` and `proxy_port` New Relic attempts to connect over SSL(https). If your proxy is configured to accept connections over http, try setting `proxy` to a fully qualified URL(e.g http://proxy-host:8080).'
+          expectErrorMsg
         ]
       ], 'Proxy misconfigured message correct')
       t.end()
     })
   })
 
-  t('should not log warning when proxy is configured properly but still get EPROTO', (t) => {
+  t.test('should not log warning when proxy is configured properly but still get EPROTO', (t) => {
     collectorApi._agent.config.proxy = 'http://test-proxy-server:8080'
     testConnect(t, () => {
       t.deepEqual(loggerMock.warn.args, [], 'Proxy misconfigured message not logged')

--- a/test/unit/collector/api-connect.test.js
+++ b/test/unit/collector/api-connect.test.js
@@ -7,6 +7,8 @@
 
 const tap = require('tap')
 const nock = require('nock')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
 
 const helper = require('../../lib/agent_helper')
 const CollectorApi = require('../../../lib/collector/api')
@@ -571,13 +573,6 @@ tap.test('retries on receiving invalid license key (401)', (t) => {
   let collectorApi = null
   let agent = null
 
-  const error = {
-    exception: {
-      message: 'Invalid license key. Please contact support@newrelic.com.',
-      error_type: 'NewRelic::Agent::LicenseException'
-    }
-  }
-
   let failure = null
   let success = null
   let connect = null
@@ -591,7 +586,7 @@ tap.test('retries on receiving invalid license key (401)', (t) => {
     collectorApi = new CollectorApi(agent)
 
     const preconnectURL = helper.generateCollectorPath('preconnect')
-    failure = nock(URL).post(preconnectURL).times(5).reply(401, error)
+    failure = nock(URL).post(preconnectURL).times(5).reply(401)
     success = nock(URL).post(preconnectURL).reply(200, {return_value: {}})
     connect = nock(URL)
       .post(helper.generateCollectorPath('connect'))
@@ -628,6 +623,94 @@ tap.test('retries on receiving invalid license key (401)', (t) => {
       t.ok(success.isDone())
       t.ok(connect.isDone())
 
+      cb()
+    })
+  }
+})
+
+tap('retries on misconfigured proxy', (t) => {
+  const sandbox = sinon.createSandbox()
+  const loggerMock = require('../mocks/logger')(sandbox)
+  const CollectorApiTest = proxyquire('../../../lib/collector/api', {
+    '../logger': {
+      child: sandbox.stub().callsFake(() => loggerMock)
+    }
+  })
+  t.autoend()
+
+  let collectorApi = null
+  let agent = null
+
+  const error = {
+    code: 'EPROTO'
+  }
+
+  let failure = null
+  let success = null
+  let connect = null
+
+  t.beforeEach((done) => {
+    fastSetTimeoutIncrementRef()
+
+    nock.disableNetConnect()
+
+    agent = setupMockedAgent()
+    agent.config.proxy_port = '8080'
+    agent.config.proxy_host = 'test-proxy-server'
+    collectorApi = new CollectorApiTest(agent)
+
+    const preconnectURL = helper.generateCollectorPath('preconnect')
+    failure = nock(URL).post(preconnectURL).times(1).replyWithError(error)
+    success = nock(URL).post(preconnectURL).reply(200, {return_value: {}})
+    connect = nock(URL)
+      .post(helper.generateCollectorPath('connect'))
+      .reply(200, {return_value: {agent_run_id: 31338}})
+
+    done()
+  })
+
+  t.afterEach((done) => {
+    sandbox.resetHistory()
+    restoreSetTimeout()
+
+    if (!nock.isDone()) {
+      /* eslint-disable no-console */
+      console.error('Cleaning pending mocks: %j', nock.pendingMocks())
+      /* eslint-enable no-console */
+      nock.cleanAll()
+    }
+
+    nock.enableNetConnect()
+    helper.unloadAgent(agent)
+
+    done()
+  })
+
+  t('should log warning when proxy is misconfigured', (t) => {
+    testConnect(t, () => {
+      t.deepEqual(loggerMock.warn.args, [
+        [
+          error,
+          'Your proxy server appears to be configured to accept connections over http. When setting `proxy_host` and `proxy_port` New Relic attempts to connect over SSL(https). If your proxy is configured to accept connections over http, try setting `proxy` to a fully qualified URL(e.g http://proxy-host:8080).'
+        ]
+      ], 'Proxy misconfigured message correct')
+      t.end()
+    })
+  })
+
+  t('should not log warning when proxy is configured properly but still get EPROTO', (t) => {
+    collectorApi._agent.config.proxy = 'http://test-proxy-server:8080'
+    testConnect(t, () => {
+      t.deepEqual(loggerMock.warn.args, [], 'Proxy misconfigured message not logged')
+      t.end()
+    })
+  })
+
+  function testConnect(t, cb) {
+    collectorApi.connect(() => {
+      t.ok(failure.isDone())
+      t.ok(success.isDone())
+      t.ok(connect.isDone())
       cb()
     })
   }

--- a/test/unit/collector/api-connect.test.js
+++ b/test/unit/collector/api-connect.test.js
@@ -688,10 +688,10 @@ tap.test('retries on misconfigured proxy', (t) => {
 
   t.test('should log warning when proxy is misconfigured', (t) => {
     testConnect(t, () => {
-      const expectErrorMsg = 'Your proxy server appears to be configured to accept connections over http. \
-When setting `proxy_host` and `proxy_port` New Relic attempts to connect over SSL(https). If your \
-proxy is configured to accept connections over http, try setting `proxy` to a fully qualified URL\
-(e.g http://proxy-host:8080).'
+      const expectErrorMsg = 'Your proxy server appears to be configured to accept connections \
+over http. When setting `proxy_host` and `proxy_port` New Relic attempts to connect over \
+SSL(https). If your proxy is configured to accept connections over http, try setting `proxy` \
+to a fully qualified URL(e.g http://proxy-host:8080).'
 
       t.deepEqual(loggerMock.warn.args, [
         [

--- a/test/unit/facts.test.js
+++ b/test/unit/facts.test.js
@@ -14,7 +14,7 @@ const expect = chai.expect
 const helper = require('../lib/agent_helper')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
-const loggerMock = require('./mocks/logger')();
+const loggerMock = require('./mocks/logger')()
 const facts = proxyquire('../../lib/collector/facts', {
   '../logger': {
     child: sinon.stub().callsFake(() => loggerMock)

--- a/test/unit/facts.test.js
+++ b/test/unit/facts.test.js
@@ -14,10 +14,7 @@ const expect = chai.expect
 const helper = require('../lib/agent_helper')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
-const loggerMock = {
-  trace: sinon.stub(),
-  debug: sinon.stub()
-}
+const loggerMock = require('./mocks/logger')();
 const facts = proxyquire('../../lib/collector/facts', {
   '../logger': {
     child: sinon.stub().callsFake(() => loggerMock)

--- a/test/unit/mocks/logger.js
+++ b/test/unit/mocks/logger.js
@@ -1,0 +1,10 @@
+'use strict'
+const sinon = require('sinon')
+
+module.exports = (sandbox = sinon) => ({
+  trace: sandbox.stub(),
+  info: sandbox.stub(),
+  debug: sandbox.stub(),
+  warn: sandbox.stub(),
+  error: sandbox.stub()
+})


### PR DESCRIPTION
…figuration has possibly occurred

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Handle a proxy misconfiguration of collector and log an actionable warning message

## Links
Closes: #742 

## Details
 * To test agent with proxy server you can use this repo for the proxy https://github.com/bizob2828/node-proxy-server.
 *  Set `proxy_host` and `proxy_port` and watch the message occur
```
{"v":0,"level":40,"name":"newrelic","hostname":"C02F81D3MD6P","pid":33186,"time":"2021-05-03T14:39:06.028Z","msg":"Your proxy server appears to be configured to accept connections over http. When setting `proxy_host` and `proxy_port` New Relic attempts to connect over SSL(https). If your proxy is configured to accept connections over http, try setting `proxy` to a fully qualified URL(e.g http://proxy-host:8080).","component":"collector_api","errno":-100,"code":"EPROTO","syscall":"write","stack":"Error: write EPROTO 4429278720:error:1408F10B:SSL routines:ssl3_get_record:wrong version number:../deps/openssl/openssl/ssl/record/ssl3_record.c:332:\n\n    at WriteWrap.onWriteComplete [as oncomplete] (internal/stream_base_commons.js:94:16)\n    at WriteWrap.callbackTrampoline (internal/async_hooks.js:131:14)","message":"write EPROTO 4429278720:error:1408F10B:SSL routines:ssl3_get_record:wrong version number:../deps/openssl/openssl/ssl/record/ssl3_record.c:332:\n"}
```