### PR TITLE
Bumps redis versioned test timeout to 20s.

### DIFF
--- a/test/versioned/redis/redis.tap.js
+++ b/test/versioned/redis/redis.tap.js
@@ -15,7 +15,7 @@ var urltils = require('../../../lib/util/urltils')
 // CONSTANTS
 var DB_INDEX = 2
 
-test('Redis instrumentation', {timeout : 10000}, function(t) {
+test('Redis instrumentation', {timeout: 20000}, function(t) {
   t.autoend()
 
   var METRIC_HOST_NAME = null
@@ -144,12 +144,13 @@ test('Redis instrumentation', {timeout : 10000}, function(t) {
         // the command callback is executed, if exists. Since we don't have a callback,
         // we wait for the command to be removed from the queue.
         if (client.commandQueueLength > 0) {
-          t.comment('set command still in command queue. scheduling retry')
+          t.comment('set command still in command queue. scheduling retry in 100ms')
 
           setTimeout(triggerError, 100)
           return
         }
 
+        t.comment('executing hset which should error')
         // This will generate an error because `testKey` is not a hash.
         client.hset('testKey', 'hashKey', 'foobar')
       }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Bumped timeout for redis versioned tests.

## Links

## Details

Looks like a few failures I could track down were hitting the 10K timeout while only having attempted the polling retry once. As such bumping the timeout. I doubled to just be done with it. If it still fails at this timeout, will try a different approach altogether.

I added some additional commenting for when the hset is actually executed to confirm nothing unexpected is happening. 