### PR TITLE
Schedules hset check once detected command has dequeued.

### DIFF
--- a/test/versioned/redis/redis.tap.js
+++ b/test/versioned/redis/redis.tap.js
@@ -153,18 +153,9 @@ test('Redis instrumentation', {timeout: 20000}, function(t) {
           return
         }
 
-        t.comment('scheduling hset call in 2s to give time for server to process command')
-        setTimeout(() => {
-          // seeing if the value exists
-          client.get(KEY, (err, res) => {
-            console.log(err)
-            console.log(res)
-
-            t.comment('executing hset which should error')
-            // This will generate an error because `testKey` is not a hash.
-            client.hset(KEY, 'hashKey', 'foobar')
-          })
-        }, 5000)
+        t.comment('executing hset which should error')
+        // This will generate an error because `testKey` is not a hash.
+        client.hset(KEY, 'hashKey', 'foobar')
       }
     })
 

--- a/test/versioned/redis/redis.tap.js
+++ b/test/versioned/redis/redis.tap.js
@@ -13,7 +13,7 @@ var urltils = require('../../../lib/util/urltils')
 
 
 // CONSTANTS
-var DB_INDEX = 2
+var DB_INDEX = 3
 
 test('Redis instrumentation', {timeout: 20000}, function(t) {
   t.autoend()

--- a/test/versioned/redis/redis.tap.js
+++ b/test/versioned/redis/redis.tap.js
@@ -159,12 +159,12 @@ test('Redis instrumentation', {timeout: 20000}, function(t) {
           client.get(KEY, (err, res) => {
             console.log(err)
             console.log(res)
-          })
 
-          t.comment('executing hset which should error')
-          // This will generate an error because `testKey` is not a hash.
-          client.hset(KEY, 'hashKey', 'foobar')
-        }, 3000)
+            t.comment('executing hset which should error')
+            // This will generate an error because `testKey` is not a hash.
+            client.hset(KEY, 'hashKey', 'foobar')
+          })
+        }, 5000)
       }
     })
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Updated redis versioned test 'when called without a callback' to schedule `hset` execution that triggers error to give redis server time to process command once client has dequeued it.

## Links

## Details

Additional logging details from previous PR (https://github.com/newrelic/node-newrelic/pull/749) showed it was executing the command but not triggering the error. Wondering if this is a timing issue with actually having the data stored, even though the command is no-longer waiting to execute.
