### PR TITLE
pinned hapi17 tests to the 17 semver range

### DIFF
--- a/test/versioned/hapi/hapi-17/package.json
+++ b/test/versioned/hapi/hapi-17/package.json
@@ -9,7 +9,7 @@
       },
       "dependencies": {
         "ejs": "2.5.5",
-        "hapi": ">=17.0.0",
+        "hapi": "^17.0.0",
         "vision": "5.1"
       },
       "files": [


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Properly pinned hapi 17 versioned tests to only minor/patch versions within 17.x

## Details
This was discovered when running the versioned tests with npm 7.  It installs peer deps by default and vision@5.1.0 required hapi@17.x
