### PR TITLE
Uses unique DB index for redis tests to avoid conflicts

### DIFF
--- a/test/lib/agent_helper.js
+++ b/test/lib/agent_helper.js
@@ -246,9 +246,9 @@ const helper = module.exports = {
    * @param {function} callback
    *  The operations to be performed while the server is running.
    */
-  bootstrapRedis: (redis, dbIndex, callback) => {
+  flushRedisDb: (redis, dbIndex, callback) => {
     if (!callback) {
-      // bootstrapRedis(dbIndex, callback)
+      // flushRedisDb(dbIndex, callback)
       callback = dbIndex
       dbIndex = redis
       redis = require('redis')

--- a/test/versioned/ioredis/ioredis-3.tap.js
+++ b/test/versioned/ioredis/ioredis-3.tap.js
@@ -17,16 +17,20 @@ tap.test('ioredis instrumentation', function(t) {
   var agent, redisClient
 
   t.beforeEach(function(done) {
-    setup(t, function(a, client) {
-      agent = a
-      redisClient = client
+    setup(t, function(error, result) {
+      if (error) {
+        return done(error)
+      }
+
+      agent = result.agent
+      redisClient = result.client
       done()
     })
   })
 
   t.afterEach(function(done) {
-    helper.unloadAgent(agent)
-    redisClient.disconnect()
+    agent && helper.unloadAgent(agent)
+    redisClient && redisClient.disconnect()
     done()
   })
 
@@ -100,7 +104,10 @@ tap.test('ioredis instrumentation', function(t) {
 
 function setup(t, callback) {
   helper.flushRedisDb(DB_INDEX, (error) => {
-    t.error(error)
+    if (error) {
+      return callback(error)
+    }
+
     var agent = helper.instrumentMockedAgent()
 
     // remove from cache, so that the bluebird library that ioredis uses gets
@@ -111,6 +118,6 @@ function setup(t, callback) {
     var Redis = require('ioredis')
     var client = new Redis(params.redis_port, params.redis_host)
 
-    callback(agent, client)
+    callback(null, {agent, client})
   })
 }

--- a/test/versioned/ioredis/ioredis-3.tap.js
+++ b/test/versioned/ioredis/ioredis-3.tap.js
@@ -10,10 +10,8 @@ const helper = require('../../lib/agent_helper')
 const assertMetrics = require('../../lib/metrics_helper').assertMetrics
 const params = require('../../lib/params')
 
-
-// CONSTANTS
+// Indicates unique database in Redis. 0-15 supported.
 const DB_INDEX = 4
-
 
 tap.test('ioredis instrumentation', function(t) {
   var agent, redisClient
@@ -101,7 +99,7 @@ tap.test('ioredis instrumentation', function(t) {
 
 
 function setup(t, callback) {
-  helper.bootstrapRedis(DB_INDEX, function cb_bootstrapRedis(error) {
+  helper.flushRedisDb(DB_INDEX, (error) => {
     t.error(error)
     var agent = helper.instrumentMockedAgent()
 

--- a/test/versioned/ioredis/ioredis-3.tap.js
+++ b/test/versioned/ioredis/ioredis-3.tap.js
@@ -5,14 +5,14 @@
 
 'use strict'
 
-var tap = require('tap')
-var helper = require('../../lib/agent_helper')
-var assertMetrics = require('../../lib/metrics_helper').assertMetrics
-var params = require('../../lib/params')
+const tap = require('tap')
+const helper = require('../../lib/agent_helper')
+const assertMetrics = require('../../lib/metrics_helper').assertMetrics
+const params = require('../../lib/params')
 
 
 // CONSTANTS
-var DB_INDEX = 2
+const DB_INDEX = 4
 
 
 tap.test('ioredis instrumentation', function(t) {

--- a/test/versioned/ioredis/ioredis.tap.js
+++ b/test/versioned/ioredis/ioredis.tap.js
@@ -10,7 +10,7 @@ const helper = require('../../lib/agent_helper')
 const assertMetrics = require('../../lib/metrics_helper').assertMetrics
 const params = require('../../lib/params')
 
-const DB_INDEX = 2
+const DB_INDEX = 3
 
 tap.test('ioredis instrumentation', (t) => {
   let agent = null

--- a/test/versioned/ioredis/ioredis.tap.js
+++ b/test/versioned/ioredis/ioredis.tap.js
@@ -26,13 +26,24 @@ tap.test('ioredis instrumentation', (t) => {
 
       agent = helper.instrumentMockedAgent()
 
+      let Redis = null
       try {
-        const Redis = require('ioredis')
-        redisClient = new Redis(params.redis_port, params.redis_host)
+        Redis = require('ioredis')
       } catch (err) {
         return done(err)
       }
-      done()
+
+      redisClient = new Redis(params.redis_port, params.redis_host)
+
+      redisClient.once('ready', () => {
+        redisClient.select(DB_INDEX, (err) => {
+          if (err) {
+            return done(err)
+          }
+
+          done()
+        })
+      })
     })
   })
 

--- a/test/versioned/ioredis/ioredis.tap.js
+++ b/test/versioned/ioredis/ioredis.tap.js
@@ -10,6 +10,7 @@ const helper = require('../../lib/agent_helper')
 const assertMetrics = require('../../lib/metrics_helper').assertMetrics
 const params = require('../../lib/params')
 
+// Indicates unique database in Redis. 0-15 supported.
 const DB_INDEX = 3
 
 tap.test('ioredis instrumentation', (t) => {
@@ -18,7 +19,7 @@ tap.test('ioredis instrumentation', (t) => {
 
   t.autoend()
   t.beforeEach((done) => {
-    helper.bootstrapRedis(DB_INDEX, function(error) {
+    helper.flushRedisDb(DB_INDEX, (error) => {
       if (error) {
         return done(error)
       }

--- a/test/versioned/ioredis/ioredis.tap.js
+++ b/test/versioned/ioredis/ioredis.tap.js
@@ -37,8 +37,8 @@ tap.test('ioredis instrumentation', (t) => {
   })
 
   t.afterEach((done) => {
-    helper.unloadAgent(agent)
-    redisClient.disconnect()
+    agent && helper.unloadAgent(agent)
+    redisClient && redisClient.disconnect()
     done()
   })
 

--- a/test/versioned/redis/redis.tap.js
+++ b/test/versioned/redis/redis.tap.js
@@ -5,15 +5,15 @@
 
 'use strict'
 
-var tap = require('tap')
-var test = tap.test
-var helper = require('../../lib/agent_helper')
-var params = require('../../lib/params')
-var urltils = require('../../../lib/util/urltils')
+const tap = require('tap')
+const test = tap.test
+const helper = require('../../lib/agent_helper')
+const params = require('../../lib/params')
+const urltils = require('../../../lib/util/urltils')
 
 
 // CONSTANTS
-var DB_INDEX = 2
+const DB_INDEX = 2
 
 test('Redis instrumentation', {timeout: 20000}, function(t) {
   t.autoend()

--- a/test/versioned/redis/redis.tap.js
+++ b/test/versioned/redis/redis.tap.js
@@ -27,7 +27,7 @@ test('Redis instrumentation', {timeout: 20000}, function(t) {
   t.beforeEach(function(done) {
     helper.flushRedisDb(DB_INDEX, (error) => {
       if (error) {
-        return t.fail(error)
+        return done(error)
       }
 
       agent = helper.instrumentMockedAgent()
@@ -53,8 +53,8 @@ test('Redis instrumentation', {timeout: 20000}, function(t) {
   })
 
   t.afterEach(function(done) {
-    client.end({flush: false})
-    helper.unloadAgent(agent)
+    client && client.end({flush: false})
+    agent && helper.unloadAgent(agent)
     done()
   })
 

--- a/test/versioned/redis/redis.tap.js
+++ b/test/versioned/redis/redis.tap.js
@@ -12,7 +12,7 @@ const params = require('../../lib/params')
 const urltils = require('../../../lib/util/urltils')
 
 
-// CONSTANTS
+// Indicates unique database in Redis. 0-15 supported.
 const DB_INDEX = 2
 
 test('Redis instrumentation', {timeout: 20000}, function(t) {
@@ -25,7 +25,7 @@ test('Redis instrumentation', {timeout: 20000}, function(t) {
   var client
 
   t.beforeEach(function(done) {
-    helper.bootstrapRedis(DB_INDEX, function cb_bootstrapRedis(error) {
+    helper.flushRedisDb(DB_INDEX, (error) => {
       if (error) {
         return t.fail(error)
       }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Updated redis versioned tests to use unique DB indexes per file to avoid collisions and flushing of in-progress tests.

## Links

## Details

All of the redis tests use the same DB index and regularly the same keys. At the start of each test file, the redis DB index is cleared for the test, instead of say cleaning up after each key operation. While currently (just for versioned tests) this would be fine as I believe we run the individual files in series for a single suite, the causes issues when ioredis and redis tests are both running because they run in parallel. We'd also have issues if these were integration tests all all files run in parallel.

I discovered this while debugging the current flicker by accidentally making things worse. Turns out one of the ioredis test files was clearing the DB mid-test for one of the redis tests.

Given the current setup, the easy/quick fix was to give each file a unique DB index (essentially a unique namespace). 0-15 are valid. If we had a large suite of redis test files, we may instead want to consider unique keys and cleaning up just the key/operation after each test.

I also cleaned up some error handling (for examplew hen your redis docker container is not up) so that each file will display this in a meaningful way and not show a bunch of random failures.

Lastly, I ran into an odd situation where the cleanup code for ioredis-3 to remove the ioredis ref wasn't good enough. Loading ioredis was throwing due to trying to redifine Promise. Unsure if this is a specific version issue or what but would only occur when manually running the file in a certain state (would pass as a full versioned run). Don't know why my changes might impact that or if maybe just bad luck with where versions ended up during my testing, but I updated the clearing to clear all ioredis references from the require cache and that did the trick. I print out the number cleared via tap comments in case there's more weirdness in the future.
