### PR TITLE
Adds destroy hook segment removal to handle non-resolved promise cleanup.

### DIFF
--- a/lib/instrumentation/core/async_hooks.js
+++ b/lib/instrumentation/core/async_hooks.js
@@ -191,6 +191,10 @@ function getPromiseResolveStyleHooks(segmentMap, agent, shim) {
       if (hookSegment === null) {
         shim.setActiveSegment(hookSegment)
       }
+    },
+    destroy: function destroyHandler(id) {
+      // Clean up any unresolved promises that have been destroyed.
+      segmentMap.delete(id)
     }
   }
 

--- a/test/integration/core/async_hooks-new-promise.js
+++ b/test/integration/core/async_hooks-new-promise.js
@@ -480,6 +480,32 @@ test("the agent's async hook", function(t) {
       })
     })
   })
+
+  t.test('cleans up unresolved promises on destroy', (t) => {
+    const agent = setupAgent(t)
+    const segmentMap = require('../../../lib/instrumentation/core/async_hooks').segmentMap
+
+    helper.runInTransaction(agent, () => {
+      /* eslint-disable no-unused-vars */
+      let promise = unresolvedPromiseFunc()
+
+      t.equal(segmentMap.size, 1)
+
+      promise = null
+
+      global.gc && global.gc()
+
+      setImmediate(() => {
+        t.equal(segmentMap.size, 0)
+
+        t.end()
+      })
+    })
+
+    function unresolvedPromiseFunc() {
+      return new Promise(() => {})
+    }
+  })
 })
 
 function checkCallMetrics(t, testMetrics) {


### PR DESCRIPTION

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Fixed issue when using the 'new_promise_tracking' feature flag where segment mapping may not get cleaned up for promises which never resolve but have all references removed (and thus get cleaned up by GC).

  Adds segment cleanup on 'destroy' when using 'new_promise_tracking' feature flag in addition to the existing 'promiseResolve' hook. Unfortunately, preventing leaks for this edge-case does come with a small amount of additional overhead due to adding another hook. Memory gains from feature flag usage should still be worth the trade-off and reduced garbage collection may offset perf/CPU impacts or event still result in net gain, depending on the application.

## Links

* Fixes: https://github.com/newrelic/node-newrelic/issues/745

## Details

I'm guessing we can't get away with getting rid of the before/after hooks with the current design but if we could get rid of one of those, we'd remove the additional impact.