### PR TITLE
removes unused listenerCount function on shim

### DIFF
--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -7,7 +7,6 @@
 
 const arity = require('../util/arity')
 const constants = require('./constants')
-const events = require('events')
 const hasOwnProperty = require('../util/properties').hasOwn
 const logger = require('../logger').child({component: 'Shim'})
 const path = require('path')

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -127,7 +127,6 @@ Shim.prototype.isNull = isNull
 Shim.prototype.toArray = toArray
 Shim.prototype.argsToArray = argsToArray
 Shim.prototype.normalizeIndex = normalizeIndex
-Shim.prototype.listenerCount = listenerCount
 Shim.prototype.once = once
 
 Shim.prototype.setInternalProperty = setInternalProperty
@@ -1693,23 +1692,6 @@ function normalizeIndex(arrayLength, idx) {
     idx = arrayLength + idx
   }
   return (idx < 0 || idx >= arrayLength) ? null : idx
-}
-
-/**
- * Retrieves the number of listeners for the given event.
- *
- * @memberof Shim.prototype
- *
- * @param {object} emitter  - The emitter to count the listeners on.
- * @param {string} event    - The event to count.
- *
- * @return {number} The number of listeners on the given event for this emitter.
- */
-function listenerCount(emitter, evnt) {
-  if (events.EventEmitter.listenerCount) {
-    return events.EventEmitter.listenerCount(emitter, evnt)
-  }
-  return emitter.listeners(evnt).length
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * removes unused `listenerCount` method on `Shim`.
 
## Links
Closes #766 

## Details
You can see in the issue originally logged, I discovered this was unused when I noticed it was using deprecated methods on `events.EventEmitter`
