### PR TITLE
add husky install as prepare script to properly bootstrap husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
     "update-cross-agent-tests": "./bin/update-cats.sh",
     "versioned-tests": "./bin/run-versioned-tests.sh",
     "update-changelog-version": "node ./bin/update-changelog-version",
-    "versioned": "npm run prepare-test && time ./bin/run-versioned-tests.sh"
+    "versioned": "npm run prepare-test && time ./bin/run-versioned-tests.sh",
+    "prepare": "husky install"
   },
   "bin": {
     "newrelic-naming-rules": "./bin/test-naming-rules.js"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Properly bootstrap husky as a `prepare` script

## Details
husky changed their bootstrap process in v6.  It is now recommended to add a prepare script that creates the hooks when running `husky install`.  Prepare runs after every `npm install`.
