### PR TITLE
Fixes loading config from the main module's directory

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -56,13 +56,12 @@ const getConfigFileLocations = () => [
   process.env.NEW_RELIC_HOME,
   process.cwd(),
   process.env.HOME,
-  path.join(__dirname, '../../../..') // above node_modules
+  path.join(__dirname, '../../../..'), // above node_modules
+  // the REPL has no main module
+  process.mainModule && process.mainModule.filename
+    ? path.dirname(process.mainModule.filename)
+    : undefined
 ].filter(Boolean)
-
-// the REPL has no main module
-if (process.mainModule && process.mainModule.filename) {
-  getConfigFileLocations().splice(2, 0, path.dirname(process.mainModule.filename))
-}
 
 function isTruthular(setting) {
   if (setting == null) {


### PR DESCRIPTION
## Proposed Release Notes

- Fix loading config from the main module's directory.

## Links

N/A

## Details

Hey 👋  - thanks for your work on this package!

Prior to v7.5.0 config files stored at the same filepath as the main module's filename would be correctly loaded, however [this commit](https://github.com/newrelic/node-newrelic/commit/3931f69cbc66629d65423b6419d69f5f7f3cdf0d) introduced a regression on the behaviour by no longer including the `path.dirname(process.mainModule.filename)` in the config file location candidates.

The effect of this is that if the New Relic config file is stored in the same directory as the main module, it may not be loaded in. My workaround for the time being will be to manually set the `NEW_RELIC_HOME` env var to my main module's directory.

This fix addresses the regression, and adds some additional test coverage.