### PR TITLE
Pin mongodb versioned tests <4

### DIFF
--- a/test/versioned/mongodb/package.json
+++ b/test/versioned/mongodb/package.json
@@ -42,7 +42,7 @@
         "node": ">=10"
       },
       "dependencies": {
-        "mongodb": ">=3.3.0"
+        "mongodb": ">=3.3.0 <4.0.0"
       },
       "files": [
         "collection-find.tap.js",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
* Pinned mongodb versioned tests to <4.0.0.
## Links

## Details
Mongodb 4.0.0 was released on 7/13/2021 and is breaking one of the versioned tests. There seems to be several breaking changes in the [changelog](https://github.com/mongodb/node-mongodb-native/blob/v4.0.0/HISTORY.md) that may have to be addressed with a focused effort.