### PR TITLE
Add hapi 19 20

### DIFF
--- a/test/versioned/hapi/hapi-post-18/errors.tap.js
+++ b/test/versioned/hapi/hapi-post-18/errors.tap.js
@@ -189,7 +189,7 @@ tap.test('Hapi v17 error handling', function(t) {
 
     runTest(t, (errors, statusCode) => {
       t.equals(errors.length, 0, 'has no reported errors')
-      t.equals(statusCode, 200, 'has expected 200 status')
+      t.ok([200, 204].includes(statusCode), 'has expected 200 or 204 status code')
       t.end()
     })
   })

--- a/test/versioned/hapi/hapi-post-18/package.json
+++ b/test/versioned/hapi/hapi-post-18/package.json
@@ -24,6 +24,28 @@
         "segments.tap.js",
         "vhost.tap.js"
       ]
+    },
+    {
+      "engines": {
+        "node": ">=16"
+      },
+      "dependencies": {
+        "ejs": "2.5.5",
+        "@hapi/hapi": "^20.1.2",
+        "vision": "^5.0.0"
+      },
+      "files": [
+        "capture-params.tap.js",
+        "errors.tap.js",
+        "ext.tap.js",
+        "hapi.tap.js",
+        "ignoring.tap.js",
+        "plugins.tap.js",
+        "render.tap.js",
+        "router.tap.js",
+        "segments.tap.js",
+        "vhost.tap.js"
+      ]
     }
   ],
   "dependencies": {

--- a/test/versioned/hapi/hapi-post-18/package.json
+++ b/test/versioned/hapi/hapi-post-18/package.json
@@ -9,7 +9,7 @@
       },
       "dependencies": {
         "ejs": "2.5.5",
-        "@hapi/hapi": "^18.3.1",
+        "@hapi/hapi": ">=18.3.1",
         "vision": "^5.0.0"
       },
       "files": [
@@ -27,8 +27,8 @@
     }
   ],
   "dependencies": {
-    "ejs": "^2.5.5",
     "@hapi/hapi": "^18.3.1",
+    "ejs": "^2.5.5",
     "vision": "^5.0.0"
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added hapi 19 and 20 to versioned tests for Node.js `>=12` and `<16`
 * Added hapi `^20.1.2` to versioned tests for for Node.js `>=16`
 
## Links
Closes #771 

## Details
Hapi 19 and <20.1.2 crashes on Node.js 16 because of https://github.com/hapijs/hapi/issues/4208.  They fixed this and shipped a release in 20.1.2: https://github.com/hapijs/hapi/pull/4225#issuecomment-828841511. 