### PR TITLE
Change to https protocol in homepage of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "debugging",
     "profiling"
   ],
-  "homepage": "http://github.com/newrelic/node-newrelic",
+  "homepage": "https://github.com/newrelic/node-newrelic",
   "engines": {
     "node": ">=12.0.0",
     "npm": ">=6.0.0"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed the `homepage` field in package.json to use `https` in the link to the github repo

## Links

## Details

I think this will fix the `URL` field display when downstream services, such as `yarn outdated` consume this, newrelic was the odd one out of a sample in a project I was looking at:

![Screen Shot 2021-07-28 at 23 31 13](https://user-images.githubusercontent.com/1217010/127331234-c33e5387-5453-43e5-97b1-4df8218ee728.png)

