### PR TITLE
Set agent to 'started' upon completing reconnect to New Relic servers

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -241,7 +241,6 @@ Agent.prototype.start = function start(callback) {
 
     if (agent.collector.isConnected()) {
       agent.onConnect()
-      agent.setState('started')
       const config = response.payload
 
       if (agent.config.no_immediate_harvest) {
@@ -450,18 +449,28 @@ Agent.prototype.startAggregators = function startAggregators() {
   }
 }
 
+/**
+ * Completes any final setup upon full connection to New Relic
+ * servers and sets the agent state to 'started'.
+ */
 Agent.prototype.onConnect = function onConnect() {
-  this.metrics.reconfigure(this.config)
-  this.errors.reconfigure(this.config)
-  this.traces.reconfigure(this.config)
-  this.queries.reconfigure(this.config)
-  this.spanEventAggregator.reconfigure(this.config)
-  this.transactionEventAggregator.reconfigure(this.config)
-  this.customEventAggregator.reconfigure(this.config)
+  this._reconfigureAggregators(this.config)
 
   if (this.config.certificates && this.config.certificates.length > 0) {
     this.metrics.getOrCreateMetric(NAMES.FEATURES.CERTIFICATES).incrementCallCount()
   }
+
+  this.setState('started')
+}
+
+Agent.prototype._reconfigureAggregators = function _reconfigureAggregators(config) {
+  this.metrics.reconfigure(config)
+  this.errors.reconfigure(config)
+  this.traces.reconfigure(config)
+  this.queries.reconfigure(config)
+  this.spanEventAggregator.reconfigure(config)
+  this.transactionEventAggregator.reconfigure(config)
+  this.customEventAggregator.reconfigure(config)
 }
 
 /**

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -441,9 +441,9 @@ Agent.prototype.onConnect = function onConnect(shouldImmediatelyHarvest, callbac
     this.metrics.getOrCreateMetric(NAMES.FEATURES.CERTIFICATES).incrementCallCount()
   }
 
-  this.setState('started')
-
   this._scheduleHarvests(shouldImmediatelyHarvest, callback)
+
+  this.setState('started')
 }
 
 Agent.prototype._reconfigureAggregators = function _reconfigureAggregators(config) {

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -240,31 +240,12 @@ Agent.prototype.start = function start(callback) {
     }
 
     if (agent.collector.isConnected()) {
-      agent.onConnect()
       const config = response.payload
 
-      if (agent.config.no_immediate_harvest) {
-        agent.startAggregators()
+      const shouldImmediatelyHarvest = !agent.config.no_immediate_harvest
+      agent.onConnect(shouldImmediatelyHarvest, () => {
         callback(null, config)
-      } else {
-        // For data collection that streams immediately, dont delay capture/sending until
-        // the harvest of everything else has completed.
-        agent.startStreaming()
-
-        // Harvest immediately for quicker data display, but after at least 1
-        // second or the collector will throw away the data.
-        //
-        // NOTE: this setTimeout is deliberately NOT unref'd due to it being
-        // the last step in the Agent startup process
-        setTimeout(function afterTimeout() {
-          logger.info(`Starting initial ${INITIAL_HARVEST_DELAY_MS}ms harvest.`)
-
-          agent.forceHarvestAll(function afterAllAggregatorsSend() {
-            agent.startAggregators()
-            callback(null, config)
-          })
-        }, INITIAL_HARVEST_DELAY_MS)
-      }
+      })
     } else {
       callback(new Error('Collector did not connect and did not error'))
     }
@@ -453,7 +434,7 @@ Agent.prototype.startAggregators = function startAggregators() {
  * Completes any final setup upon full connection to New Relic
  * servers and sets the agent state to 'started'.
  */
-Agent.prototype.onConnect = function onConnect() {
+Agent.prototype.onConnect = function onConnect(shouldImmediatelyHarvest, callback) {
   this._reconfigureAggregators(this.config)
 
   if (this.config.certificates && this.config.certificates.length > 0) {
@@ -461,6 +442,8 @@ Agent.prototype.onConnect = function onConnect() {
   }
 
   this.setState('started')
+
+  this._scheduleHarvests(shouldImmediatelyHarvest, callback)
 }
 
 Agent.prototype._reconfigureAggregators = function _reconfigureAggregators(config) {
@@ -471,6 +454,34 @@ Agent.prototype._reconfigureAggregators = function _reconfigureAggregators(confi
   this.spanEventAggregator.reconfigure(config)
   this.transactionEventAggregator.reconfigure(config)
   this.customEventAggregator.reconfigure(config)
+}
+
+Agent.prototype._scheduleHarvests = function _scheduleHarvests(shouldImmediatelyHarvest, callback) {
+  if (!shouldImmediatelyHarvest) {
+    this.startAggregators()
+    setImmediate(callback)
+    return
+  }
+
+  const agent = this
+
+  // For data collection that streams immediately, dont delay capture/sending until
+  // the harvest of everything else has completed.
+  agent.startStreaming()
+
+  // Harvest immediately for quicker data display, but after at least 1
+  // second or the collector will throw away the data.
+  //
+  // NOTE: this setTimeout is deliberately NOT unref'd due to it being
+  // the last step in the Agent startup process
+  setTimeout(function afterTimeout() {
+    logger.info(`Starting initial ${INITIAL_HARVEST_DELAY_MS}ms harvest.`)
+
+    agent.forceHarvestAll(function afterAllAggregatorsSend() {
+      agent.startAggregators()
+      callback()
+    })
+  }, INITIAL_HARVEST_DELAY_MS)
 }
 
 /**

--- a/lib/collector/api.js
+++ b/lib/collector/api.js
@@ -515,9 +515,10 @@ CollectorAPI.prototype.restart = function restart(callback) {
   var api = this
   this.shutdown(function reconnect() {
     api.connect(function afterConnect() {
-      api._agent.onConnect()
-      api._agent.startAggregators()
-      return callback.apply(null, arguments)
+      const shouldImmediatelyHarvest = false
+      api._agent.onConnect(shouldImmediatelyHarvest, () => {
+        callback()
+      })
     })
   })
 }

--- a/lib/collector/api.js
+++ b/lib/collector/api.js
@@ -516,9 +516,7 @@ CollectorAPI.prototype.restart = function restart(callback) {
   this.shutdown(function reconnect() {
     api.connect(function afterConnect() {
       const shouldImmediatelyHarvest = false
-      api._agent.onConnect(shouldImmediatelyHarvest, () => {
-        callback()
-      })
+      api._agent.onConnect(shouldImmediatelyHarvest, callback)
     })
   })
 }

--- a/test/integration/api/shutdown.tap.js
+++ b/test/integration/api/shutdown.tap.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const nock = require('nock')
+
+const helper = require('../../lib/agent_helper')
+const API = require('../../../api')
+
+// This key is hardcoded in the agent helper
+const EXPECTED_LICENSE_KEY = 'license key here'
+const TEST_DOMAIN = 'test-collector.newrelic.com'
+const TEST_COLLECTOR_URL = `https://${TEST_DOMAIN}`
+
+// TODO: should work after the agent has restarted
+tap.test('#shutdown', (t) => {
+  t.autoend()
+
+  let agent = null
+  let api = null
+
+  t.beforeEach(() => {
+    nock.disableNetConnect()
+
+    agent = helper.loadMockedAgent({
+      license_key: EXPECTED_LICENSE_KEY,
+      host: TEST_DOMAIN
+    })
+
+    agent.config.no_immediate_harvest = true
+
+    api = new API(agent)
+  })
+
+  t.afterEach((t) => {
+    helper.unloadAgent(agent)
+
+    if (!nock.isDone()) {
+      /* eslint-disable no-console */
+      console.error('Cleaning pending mocks: %j', nock.pendingMocks())
+      /* eslint-enable no-console */
+      nock.cleanAll()
+
+      t.fail('Failed to hit all expected endpoints.')
+    }
+
+    nock.enableNetConnect()
+  })
+
+  t.test('should force harvest and callback after agent restart', (t) => {
+    setupConnectionEndpoints('run-id-1')
+    agent.start((error) => {
+      t.error(error)
+
+      setupConnectionEndpoints('run-id-2')
+      agent.collector.restart(() => {
+        setupShutdownEndpoints('run-id-2')
+        api.shutdown({ collectPendingData: true }, (error) => {
+          t.error(error)
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+
+function setupShutdownEndpoints(runId) {
+  // Final harvest
+  nockRequest('metric_data', runId).reply(200)
+
+  nockRequest('shutdown', runId).reply(200)
+}
+
+function setupConnectionEndpoints(runId) {
+  return {
+    preconnect: nockRequest('preconnect').reply(200, {return_value: TEST_DOMAIN}),
+    connect: nockRequest('connect').reply(200, {
+      return_value: {
+        agent_run_id: runId
+      }
+    }),
+    settings: nockRequest('agent_settings', runId).reply(200, {return_value: []})
+  }
+}
+
+function nockRequest(endpointMethod, runId) {
+  const relativepath = helper.generateCollectorPath(endpointMethod, runId)
+  return nock(TEST_COLLECTOR_URL).post(relativepath)
+}

--- a/test/integration/newrelic-response-handling.tap.js
+++ b/test/integration/newrelic-response-handling.tap.js
@@ -61,6 +61,7 @@ function createStatusCodeTest(testCase) {
 
     let disconnected = false
     let connecting = false
+    let started = false
 
     let agent = null
 
@@ -74,6 +75,7 @@ function createStatusCodeTest(testCase) {
       startEndpoints = setupConnectionEndpoints()
       disconnected = false
       connecting = false
+      started = false
 
       agent = helper.loadMockedAgent({
         license_key: 'license key here',
@@ -144,6 +146,10 @@ function createStatusCodeTest(testCase) {
             connecting = true
           })
 
+          agent.on('started', () => {
+            started = true
+          })
+
           if (testCase.restart) {
             restartEndpoints = setupConnectionEndpoints()
           }
@@ -190,6 +196,7 @@ function createStatusCodeTest(testCase) {
           } else if (testCase.restart) {
             subTest.ok(disconnected, 'should have disconnected')
             subTest.ok(connecting, 'should have started reconnecting')
+            subTest.ok(started, 'should have set agent to started')
 
             subTest.ok(restartEndpoints.preconnect.isDone(), 'requested preconnect')
             subTest.ok(restartEndpoints.connect.isDone(), 'requested connect')

--- a/test/unit/agent/agent.test.js
+++ b/test/unit/agent/agent.test.js
@@ -291,10 +291,11 @@ tap.test('#onConnect should reconfigure all the aggregators', (t) => {
     }
   }
   mock.expects('reconfigure').exactly(EXPECTED_AGG_COUNT)
-  agent.onConnect()
-  mock.verify()
+  agent.onConnect(false, () => {
+    mock.verify()
 
-  t.end()
+    t.end()
+  })
 })
 
 tap.test('when starting', (t) => {
@@ -705,7 +706,8 @@ tap.test('when connected', (t) => {
   t.test('should update the metric apdexT value after connect', (t) => {
     t.equal(agent.metrics._apdexT, 0.1)
 
-    process.nextTick(function cb_nextTick() {
+    agent.config.apdex_t = 0.666
+    agent.onConnect(false, () => {
       t.ok(agent.metrics._apdexT)
 
       t.equal(agent.metrics._apdexT, 0.666)
@@ -713,9 +715,6 @@ tap.test('when connected', (t) => {
 
       t.end()
     })
-
-    agent.config.apdex_t = 0.666
-    agent.onConnect()
   })
 
   t.test('should reset the config and metrics normalizer on connection', (t) => {
@@ -930,56 +929,56 @@ tap.test('when event_harvest_config updated on connect with a valid config', (t)
   })
 
   t.test('should generate ReportPeriod supportability', (t) => {
-    agent.onConnect()
+    agent.onConnect(false, () => {
+      const expectedMetricName = 'Supportability/EventHarvest/ReportPeriod'
 
-    const expectedMetricName = 'Supportability/EventHarvest/ReportPeriod'
+      const metric = agent.metrics.getMetric(expectedMetricName)
 
-    const metric = agent.metrics.getMetric(expectedMetricName)
+      t.ok(metric)
+      t.equal(metric.total, validHarvestConfig.report_period_ms)
 
-    t.ok(metric)
-    t.equal(metric.total, validHarvestConfig.report_period_ms)
-
-    t.end()
+      t.end()
+    })
   })
 
   t.test('should generate AnalyticEventData/HarvestLimit supportability', (t) => {
-    agent.onConnect()
+    agent.onConnect(false, () => {
+      const expectedMetricName =
+        'Supportability/EventHarvest/AnalyticEventData/HarvestLimit'
 
-    const expectedMetricName =
-      'Supportability/EventHarvest/AnalyticEventData/HarvestLimit'
+      const metric = agent.metrics.getMetric(expectedMetricName)
 
-    const metric = agent.metrics.getMetric(expectedMetricName)
+      t.ok(metric)
+      t.equal(metric.total, validHarvestConfig.harvest_limits.analytic_event_data)
 
-    t.ok(metric)
-    t.equal(metric.total, validHarvestConfig.harvest_limits.analytic_event_data)
-
-    t.end()
+      t.end()
+    })
   })
 
   t.test('should generate CustomEventData/HarvestLimit supportability', (t) => {
-    agent.onConnect()
+    agent.onConnect(false, () => {
+      const expectedMetricName =
+        'Supportability/EventHarvest/CustomEventData/HarvestLimit'
 
-    const expectedMetricName =
-      'Supportability/EventHarvest/CustomEventData/HarvestLimit'
+      const metric = agent.metrics.getMetric(expectedMetricName)
 
-    const metric = agent.metrics.getMetric(expectedMetricName)
+      t.ok(metric)
+      t.equal(metric.total, validHarvestConfig.harvest_limits.custom_event_data)
 
-    t.ok(metric)
-    t.equal(metric.total, validHarvestConfig.harvest_limits.custom_event_data)
-
-    t.end()
+      t.end()
+    })
   })
 
   t.test('should generate ErrorEventData/HarvestLimit supportability', (t) => {
-    agent.onConnect()
+    agent.onConnect(false, () => {
+      const expectedMetricName =
+        'Supportability/EventHarvest/ErrorEventData/HarvestLimit'
 
-    const expectedMetricName =
-      'Supportability/EventHarvest/ErrorEventData/HarvestLimit'
+      const metric = agent.metrics.getMetric(expectedMetricName)
 
-    const metric = agent.metrics.getMetric(expectedMetricName)
-
-    t.ok(metric)
-    t.equal(metric.total, validHarvestConfig.harvest_limits.error_event_data)
-    t.end()
+      t.ok(metric)
+      t.equal(metric.total, validHarvestConfig.harvest_limits.error_event_data)
+      t.end()
+    })
   })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Fixed bug where `API.shutdown` would not harvest or keep process active effectively after an agent restart.

  The agent will now correctly update its state to 'started' after a reconnect has completed.

## Links

* Fixes: https://github.com/newrelic/node-newrelic/issues/789

## Details

Did a minor refactor to consolidate the agent's handling of connection to try to avoid similar issues in the future.

Flagging as 'medium' risk because this is a code path that can impact all data. I have manually tested on a few flavors of application as well as added additional test coverage but worth extra care in review.