### PR TITLE
Fix postgres pg module Promise based query timings

### DIFF
--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -98,7 +98,7 @@ module.exports = function initialize(agent, pgsql, moduleName, shim) {
     pgsql && pgsql.Client && pgsql.Client.prototype,
     'query',
     function wrapJSClientQuery(shim, _, __, queryArgs) {
-      // As of pg v7.0.0, Client.query supports Promises and callbacks.
+      // As of pg v7.0.0, Client.query returns a Promise from an async call.
       // pg supports event based Client.query when a Query object is passed in
       // and for pg version <7.0.0
       if (semver.satisfies(pgVersion, '>=7.0.0') &&

--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -22,12 +22,38 @@ function getQuery(shim, original, name, args) {
 }
 
 module.exports = function initialize(agent, pgsql, moduleName, shim) {
+  const pgVersion = shim.require('./package.json').version
+
   shim.setDatastore(shim.POSTGRES)
   // allows for native wrapping to not happen if not necessary
   // when env var is true
 
   if (process.env.NODE_PG_FORCE_NATIVE) {
     return instrumentPGNative(pgsql)
+  }
+
+  function wrapJSClientQuery(shim, _, __, queryArgs) {
+    // As of pg v7.0.0, Client.query returns a Promise from an async call.
+    // pg supports event based Client.query when a Query object is passed in,
+    // and works similarly in pg version <7.0.0
+    if (semver.satisfies(pgVersion, '>=7.0.0') &&
+      typeof queryArgs[0] === 'string') {
+      return {
+        callback: shim.LAST,
+        query: getQuery,
+        promise: true,
+        parameters: getInstanceParameters(shim, this),
+        internal: false
+      }
+    }
+
+    return {
+      callback: shim.LAST,
+      query: getQuery,
+      stream: 'row',
+      parameters: getInstanceParameters(shim, this),
+      internal: false
+    }
   }
 
   // wrapping for native
@@ -58,13 +84,11 @@ module.exports = function initialize(agent, pgsql, moduleName, shim) {
   }
 
   function clientPostConstructor(shim) {
-    shim.recordQuery(this, 'query', {
-      callback: shim.LAST,
-      query: getQuery,
-      stream: 'row',
-      parameters: getInstanceParameters(shim, this),
-      internal: false
-    })
+    shim.recordQuery(
+      this,
+      'query',
+      wrapJSClientQuery
+    )
 
     shim.record(this, 'connect', function pgConnectNamer() {
       return {
@@ -91,37 +115,14 @@ module.exports = function initialize(agent, pgsql, moduleName, shim) {
     })
   }
 
-  const pgVersion = shim.require('./package.json').version
-
   // wrapping for JS
   shim.recordQuery(
     pgsql && pgsql.Client && pgsql.Client.prototype,
     'query',
-    function wrapJSClientQuery(shim, _, __, queryArgs) {
-      // As of pg v7.0.0, Client.query returns a Promise from an async call.
-      // pg supports event based Client.query when a Query object is passed in
-      // and for pg version <7.0.0
-      if (semver.satisfies(pgVersion, '>=7.0.0') &&
-        typeof queryArgs[0] === 'string') {
-        return {
-          callback: shim.LAST,
-          query: getQuery,
-          promise: true,
-          parameters: getInstanceParameters(shim, this),
-          internal: false
-        }
-      }
-
-      return {
-        callback: shim.LAST,
-        query: getQuery,
-        stream: 'row',
-        parameters: getInstanceParameters(shim, this),
-        internal: false
-      }
-    }
+    wrapJSClientQuery
   )
 }
+
 
 function getInstanceParameters(shim, client) {
   return {

--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -92,13 +92,17 @@ module.exports = function initialize(agent, pgsql, moduleName, shim) {
   }
 
   const pgVersion = shim.require('./package.json').version
+
   // wrapping for JS
   shim.recordQuery(
     pgsql && pgsql.Client && pgsql.Client.prototype,
     'query',
-    function wrapJSClientQuery(shim) {
+    function wrapJSClientQuery(shim, _, __, queryArgs) {
+      // As of pg v7.0.0, Client.query supports Promises and callbacks.
+      // pg supports event based Client.query when a Query object is passed in
+      // and for pg version <7.0.0
       if (semver.satisfies(pgVersion, '>=7.0.0') &&
-      typeof arguments['3'][0] === 'string') {
+        typeof queryArgs[0] === 'string') {
         return {
           callback: shim.LAST,
           query: getQuery,

--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -5,6 +5,8 @@
 
 'use strict'
 
+const semver = require('semver')
+
 function getQuery(shim, original, name, args) {
   var config = args[0]
   var statement
@@ -89,11 +91,22 @@ module.exports = function initialize(agent, pgsql, moduleName, shim) {
     })
   }
 
+  const pgVersion = shim.require('./package.json').version
   // wrapping for JS
   shim.recordQuery(
     pgsql && pgsql.Client && pgsql.Client.prototype,
     'query',
     function wrapJSClientQuery(shim) {
+      if (semver.satisfies(pgVersion, '>=7.0.0')) {
+        return {
+          callback: shim.LAST,
+          query: getQuery,
+          promise: true,
+          parameters: getInstanceParameters(shim, this),
+          internal: false
+        }
+      }
+
       return {
         callback: shim.LAST,
         query: getQuery,

--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -97,7 +97,8 @@ module.exports = function initialize(agent, pgsql, moduleName, shim) {
     pgsql && pgsql.Client && pgsql.Client.prototype,
     'query',
     function wrapJSClientQuery(shim) {
-      if (semver.satisfies(pgVersion, '>=7.0.0')) {
+      if (semver.satisfies(pgVersion, '>=7.0.0') &&
+      typeof arguments['3'][0] === 'string') {
         return {
           callback: shim.LAST,
           query: getQuery,

--- a/test/unit/instrumentation/postgresql.test.js
+++ b/test/unit/instrumentation/postgresql.test.js
@@ -7,150 +7,153 @@
 
 // TODO: convert to normal tap style.
 // Below allows use of mocha DSL with tap runner.
-require('tap').mochaGlobals()
+const tap = require('tap')
+const test = tap.test
 
-var chai   = require('chai')
-var expect = chai.expect
-var helper = require('../../lib/agent_helper')
-var DatastoreShim = require('../../../lib/shim/datastore-shim.js')
+const helper = require('../../lib/agent_helper')
+const DatastoreShim = require('../../../lib/shim/datastore-shim.js')
 
-describe("agent instrumentation of PostgreSQL", function() {
-  var agent = null
-  var initialize = null
-  var shim = null
+let agent = null
+let initialize = null
+let shim = null
+const originalShimRequire = DatastoreShim.prototype.require
 
-  before(function() {
+test("Lazy loading of native PG client", (t) => {
+  t.autoend()
+
+  t.beforeEach(function() {
     agent = helper.loadMockedAgent()
     initialize = require('../../../lib/instrumentation/pg')
+
+    // stub out the require function so semver check does not break in pg instrumentation.
+    // Need to return a non-null value for version.
+    DatastoreShim.prototype.require = () => {
+      return {
+        version: 'anything'
+      }
+    }
+
+    shim = new DatastoreShim(agent, 'postgres')
   })
 
-  after(function() {
+  t.afterEach(function() {
     helper.unloadAgent(agent)
+
+    // Restore stubbed require
+    DatastoreShim.prototype.require = originalShimRequire
   })
 
-  describe("lazy loading of native PG client", function() {
-    before(function() {
-      shim = new DatastoreShim(agent, 'postgres')
-    })
-
-    function getMockModuleNoNative() {
-      function PG(clientConstructor) {
-        this.Client = clientConstructor
-      }
-
-      function DefaultClient() {}
-      DefaultClient.prototype.query = function() {}
-      function NativeClient() {}
-      NativeClient.prototype.query = function() {}
-
-      var mockPg = new PG(DefaultClient)
-      mockPg.__defineGetter__("native", function() {
-        return null
-      })
-      return mockPg
+  function getMockModuleNoNative() {
+    function PG(clientConstructor) {
+      this.Client = clientConstructor
     }
 
-    function getMockModule() {
-      function PG(clientConstructor) {
-        this.Client = clientConstructor
-      }
+    function DefaultClient() {}
+    DefaultClient.prototype.query = function() {}
+    function NativeClient() {}
+    NativeClient.prototype.query = function() {}
 
-      function DefaultClient() {}
-      DefaultClient.prototype.query = function() {}
-      function NativeClient() {}
-      NativeClient.prototype.query = function() {}
+    const mockPg = new PG(DefaultClient)
+    mockPg.__defineGetter__("native", function() {
+      return null
+    })
+    return mockPg
+  }
 
-      var mockPg = new PG(DefaultClient)
-      mockPg.__defineGetter__("native", function() {
-        delete mockPg.native
-        mockPg.native = new PG(NativeClient)
-        return mockPg.native
-      })
-      return mockPg
+  function getMockModule() {
+    function PG(clientConstructor) {
+      this.Client = clientConstructor
     }
 
-    it("instruments when native getter is called", function() {
-      var mockPg = getMockModule()
+    function DefaultClient() {}
+    DefaultClient.prototype.query = function() {}
+    function NativeClient() {}
+    NativeClient.prototype.query = function() {}
 
-      initialize(agent, mockPg, 'pg', shim)
-
-      var pg = mockPg.native
-      expect(pg.Client.__NR_original.name).equal('NativeClient')
-
-      var pg = mockPg
-      expect(pg.Client.name).equal('DefaultClient')
+    const mockPg = new PG(DefaultClient)
+    mockPg.__defineGetter__("native", function() {
+      delete mockPg.native
+      mockPg.native = new PG(NativeClient)
+      return mockPg.native
     })
+    return mockPg
+  }
 
-    it("does not fail when getter is called multiple times", function() {
-      var mockPg = getMockModule()
+  t.test("instruments when native getter is called", (t) => {
+    const mockPg = getMockModule()
 
-      initialize(agent, mockPg, 'pg', shim)
-      var pg1 = mockPg.native
+    initialize(agent, mockPg, 'pg', shim)
 
-      initialize(agent, mockPg, 'pg', shim)
-      var pg2 = mockPg.native
+    let pg = mockPg.native
+    t.equal(pg.Client.__NR_original.name, 'NativeClient')
 
-      expect(pg1).equal(pg2)
-    })
+    pg = mockPg
+    t.equal(pg.Client.name, 'DefaultClient')
 
-    it("does not throw when no native module is found", function() {
-      var mockPg = getMockModuleNoNative()
-
-      initialize(agent, mockPg, 'pg', shim)
-      expect(function pleaseDoNotThrow() {
-        mockPg.native
-      }).to.not.throw()
-    })
-
-    it("does not interfere with non-native instrumentation", function() {
-      var mockPg = getMockModule()
-
-      initialize(agent, mockPg, 'pg', shim)
-      var nativeClient = mockPg.native
-      expect(nativeClient.Client.__NR_original.name).equal('NativeClient')
-      var defaultClient = mockPg
-      expect(defaultClient.Client.name).equal('DefaultClient')
-
-      initialize(agent, mockPg, 'pg', shim)
-      var nativeClient = mockPg.native
-      expect(nativeClient.Client.__NR_original.name).equal('NativeClient')
-      var defaultClient = mockPg
-      expect(defaultClient.Client.name).equal('DefaultClient')
-    })
-
-    it("when pg modules is refreshed in cache", function() {
-      var mockPg = getMockModule()
-
-      // instrument once
-      initialize(agent, mockPg, 'pg', shim)
-      var pg1 = mockPg.native
-      expect(pg1.Client.__NR_original.name).equal('NativeClient')
-
-      // simulate deleting from module cache
-      mockPg = getMockModule()
-      initialize(agent, mockPg, 'pg', shim)
-      var pg2 = mockPg.native
-      expect(pg2.Client.__NR_original.name).equal('NativeClient')
-
-      expect(pg1).not.equal(pg2)
-    })
+    t.end()
   })
 
-  describe("for each operation", function() {
-    it("should update the global database aggregate statistics")
-    it("should also update the global web aggregate statistics")
-    it("should update the aggregate statistics for the operation type")
-    it("should update the aggregate statistics for the specific query")
-    it("should update the scoped aggregate statistics for the operation type")
+  t.test("does not fail when getter is called multiple times", (t) => {
+    let mockPg = getMockModule()
+
+    initialize(agent, mockPg, 'pg', shim)
+    const pg1 = mockPg.native
+
+    initialize(agent, mockPg, 'pg', shim)
+    const pg2 = mockPg.native
+
+    t.equal(pg1, pg2)
+
+    t.end()
   })
 
-  describe("should instrument", function() {
-    it("INSERT")
-    it("SELECT")
-    it("UPDATE")
-    it("DELETE")
-    it("EXPLAIN")
-    it("ALTER TABLE")
-    it("DROP TABLE")
+  t.test("does not throw when no native module is found", (t) => {
+    const mockPg = getMockModuleNoNative()
+
+    initialize(agent, mockPg, 'pg', shim)
+    t.doesNotThrow(function pleaseDoNotThrow() {
+      mockPg.native
+    })
+
+    t.end()
   })
+
+  t.test("does not interfere with non-native instrumentation", (t) => {
+    const mockPg = getMockModule()
+
+    initialize(agent, mockPg, 'pg', shim)
+    let nativeClient = mockPg.native
+    t.equal(nativeClient.Client.__NR_original.name, 'NativeClient')
+    let defaultClient = mockPg
+    t.equal(defaultClient.Client.name, 'DefaultClient')
+
+    initialize(agent, mockPg, 'pg', shim)
+    nativeClient = mockPg.native
+    t.equal(nativeClient.Client.__NR_original.name, 'NativeClient')
+    defaultClient = mockPg
+    t.equal(defaultClient.Client.name, 'DefaultClient')
+
+    t.end()
+  })
+
+  t.test("when pg modules is refreshed in cache", (t) => {
+    let mockPg = getMockModule()
+
+    // instrument once
+    initialize(agent, mockPg, 'pg', shim)
+    const pg1 = mockPg.native
+    t.equal(pg1.Client.__NR_original.name, 'NativeClient')
+
+    // simulate deleting from module cache
+    mockPg = getMockModule()
+    initialize(agent, mockPg, 'pg', shim)
+    const pg2 = mockPg.native
+    t.equal(pg2.Client.__NR_original.name, 'NativeClient')
+
+    t.not(pg1, pg2)
+
+    t.end()
+  })
+
+  t.end()
 })

--- a/test/versioned/pg/pg-post-7/pg.common.js
+++ b/test/versioned/pg/pg-post-7/pg.common.js
@@ -373,7 +373,7 @@ module.exports = function runTests(name, clientFactory) {
             const metrics = finalTx.metrics.getMetric('Datastore/operation/Postgres/select')
 
             t.ok(metrics.total > 2.0,
-              'Submittable style Query pg_sleep of 2 seconds should result in near 2 sec timing')
+              'Submittable style Query pg_sleep of 2 seconds should result in > 2 sec timing')
 
             t.end()
           })
@@ -414,7 +414,7 @@ module.exports = function runTests(name, clientFactory) {
           const metrics = finalTx.metrics.getMetric('Datastore/operation/Postgres/select')
 
           t.ok(metrics.total > 2.0,
-            'Promise style query pg_sleep of 2 seconds should result in near 2 sec timing')
+            'Promise style query pg_sleep of 2 seconds should result in > 2 sec timing')
 
           t.end()
         } catch (err) {
@@ -459,7 +459,7 @@ module.exports = function runTests(name, clientFactory) {
             const metrics = finalTx.metrics.getMetric('Datastore/operation/Postgres/select')
 
             t.ok(metrics.total > 2.0,
-              'Callback style query pg_sleep of 2 seconds should result in near 2 sec timing')
+              'Callback style query pg_sleep of 2 seconds should result in > 2 sec timing')
 
             t.end()
           })

--- a/test/versioned/pg/pg-post-7/pg.common.js
+++ b/test/versioned/pg/pg-post-7/pg.common.js
@@ -5,21 +5,21 @@
 
 'use strict'
 
-var a = require('async')
-var tap = require('tap')
-var params = require('../../../lib/params')
-var helper = require('../../../lib/agent_helper')
-var findSegment = require('../../../lib/metrics_helper').findSegment
-var test = tap.test
-var getMetricHostName = require('../../../lib/metrics_helper').getMetricHostName
+const a = require('async')
+const tap = require('tap')
+const params = require('../../../lib/params')
+const helper = require('../../../lib/agent_helper')
+const findSegment = require('../../../lib/metrics_helper').findSegment
+const test = tap.test
+const getMetricHostName = require('../../../lib/metrics_helper').getMetricHostName
 
 module.exports = function runTests(name, clientFactory) {
   // constants for table creation and db connection
-  var TABLE = 'testTable-post'
-  var TABLE_PREPARED = '"' + TABLE + '"'
-  var PK = 'pk_column'
-  var COL = 'test_column'
-  var CON_OBJ = {
+  const TABLE = 'testTable-post'
+  const TABLE_PREPARED = '"' + TABLE + '"'
+  const PK = 'pk_column'
+  const COL = 'test_column'
+  const CON_OBJ = {
     user: params.postgres_user,
     password: params.postgres_pass,
     host: params.postgres_host,
@@ -32,17 +32,17 @@ module.exports = function runTests(name, clientFactory) {
    * then recreation of a testing table
    */
   function postgresSetup() {
-    var pg = clientFactory()
-    var setupClient = new pg.Client(CON_OBJ)
+    const pg = clientFactory()
+    const setupClient = new pg.Client(CON_OBJ)
 
     return new Promise((resolve, reject) => {
       setupClient.connect(function(err) {
         if (err) {
           reject(err)
         }
-        var tableDrop = 'DROP TABLE IF EXISTS ' + TABLE_PREPARED
+        const tableDrop = 'DROP TABLE IF EXISTS ' + TABLE_PREPARED
 
-        var tableCreate =
+        const tableCreate =
           'CREATE TABLE ' + TABLE_PREPARED + ' (' +
             PK + ' integer PRIMARY KEY, ' +
             COL + ' text' +
@@ -72,17 +72,17 @@ module.exports = function runTests(name, clientFactory) {
   }
 
   function verifyMetrics(t, segment, selectTable) {
-    var transaction = segment.transaction
-    var agent = transaction.agent
+    const transaction = segment.transaction
+    const agent = transaction.agent
     selectTable = selectTable || TABLE
     t.equal(
       Object.keys(transaction.metrics.scoped).length, 0,
       'should not have any scoped metrics'
     )
 
-    var unscoped = transaction.metrics.unscoped
+    const unscoped = transaction.metrics.unscoped
 
-    var expected = {
+    const expected = {
       'Datastore/all': 2,
       'Datastore/allWeb': 2,
       'Datastore/Postgres/all': 2,
@@ -94,12 +94,12 @@ module.exports = function runTests(name, clientFactory) {
     expected['Datastore/statement/Postgres/' + TABLE + '/insert'] = 1
     expected['Datastore/statement/Postgres/' + selectTable + '/select'] = 1
 
-    var metricHostName = getMetricHostName(agent, params.postgres_host)
-    var hostId = metricHostName + '/' + params.postgres_port
+    const metricHostName = getMetricHostName(agent, params.postgres_host)
+    const hostId = metricHostName + '/' + params.postgres_port
     expected['Datastore/instance/Postgres/' + hostId] = 2
 
-    var expectedNames = Object.keys(expected)
-    var unscopedNames = Object.keys(unscoped)
+    const expectedNames = Object.keys(expected)
+    const unscopedNames = Object.keys(unscoped)
 
     expectedNames.forEach(function(expectedName) {
       t.ok(unscoped[expectedName], 'should have unscoped metric ' + expectedName)
@@ -118,19 +118,19 @@ module.exports = function runTests(name, clientFactory) {
   }
 
   function verifyTrace(t, segment, selectTable) {
-    var transaction = segment.transaction
+    const transaction = segment.transaction
     selectTable = selectTable || TABLE
-    var trace = transaction.trace
+    const trace = transaction.trace
 
     t.ok(trace, 'trace should exist')
     t.ok(trace.root, 'root element should exist')
 
-    var setSegment = findSegment(
+    const setSegment = findSegment(
       trace.root,
       'Datastore/statement/Postgres/' + TABLE + '/insert'
     )
 
-    var getSegment = findSegment(
+    const getSegment = findSegment(
       trace.root,
       'Datastore/statement/Postgres/' + selectTable + '/select'
     )
@@ -150,17 +150,17 @@ module.exports = function runTests(name, clientFactory) {
   }
 
   function verifyInstanceParameters(t, segment) {
-    var transaction = segment.transaction
-    var agent = transaction.agent
-    var trace = transaction.trace
+    const transaction = segment.transaction
+    const agent = transaction.agent
+    const trace = transaction.trace
 
-    var setSegment = findSegment(
+    const setSegment = findSegment(
       trace.root,
       'Datastore/statement/Postgres/' + TABLE + '/insert'
     )
     const attributes = setSegment.getAttributes()
 
-    var metricHostName = getMetricHostName(agent, params.postgres_host)
+    const metricHostName = getMetricHostName(agent, params.postgres_host)
     t.equals(
       attributes.host,
       metricHostName,
@@ -184,7 +184,7 @@ module.exports = function runTests(name, clientFactory) {
   }
 
   function verifySlowQueries(t, agent) {
-    var metricHostName = getMetricHostName(agent, params.postgres_host)
+    const metricHostName = getMetricHostName(agent, params.postgres_host)
 
     t.equals(agent.queries.samples.size, 1, 'should have one slow query')
     for (let sample of agent.queries.samples.values()) {
@@ -215,13 +215,13 @@ module.exports = function runTests(name, clientFactory) {
   test('Postgres instrumentation: ' + name, function(t) {
     t.autoend()
 
-    var agent = null
-    var pg = null
+    let agent = null
+    let pg = null
 
     t.beforeEach(function() {
       // the pg module has `native` lazy getter that is removed after first call,
       // so in order to re-instrument, we need to remove the pg module from the cache
-      var pgName = require.resolve('pg')
+      const pgName = require.resolve('pg')
       delete require.cache[pgName]
 
       agent = helper.instrumentMockedAgent()
@@ -237,7 +237,7 @@ module.exports = function runTests(name, clientFactory) {
     })
 
     t.test('simple query with prepared statement', function(t) {
-      var client = new pg.Client(CON_OBJ)
+      const client = new pg.Client(CON_OBJ)
 
       t.teardown(function() {
         client.end()
@@ -245,13 +245,13 @@ module.exports = function runTests(name, clientFactory) {
 
       t.notOk(agent.getTransaction(), 'no transaction should be in play')
       helper.runInTransaction(agent, function transactionInScope(tx) {
-        var transaction = agent.getTransaction()
+        const transaction = agent.getTransaction()
         t.ok(transaction, 'transaction should be visible')
         t.equal(tx, transaction, 'We got the same transaction')
 
-        var colVal = 'Hello'
-        var pkVal = 111
-        var insQuery = 'INSERT INTO ' + TABLE_PREPARED + ' (' + PK + ',' +  COL
+        const colVal = 'Hello'
+        const pkVal = 111
+        let insQuery = 'INSERT INTO ' + TABLE_PREPARED + ' (' + PK + ',' +  COL
         insQuery += ') VALUES($1, $2);'
 
         client.connect(function(error) {
@@ -267,7 +267,7 @@ module.exports = function runTests(name, clientFactory) {
             t.ok(agent.getTransaction(), 'transaction should still be visible')
             t.ok(ok, 'everything should be peachy after setting')
 
-            var selQuery = 'SELECT * FROM ' + TABLE_PREPARED + ' WHERE '
+            let selQuery = 'SELECT * FROM ' + TABLE_PREPARED + ' WHERE '
             selQuery += PK + '=' + pkVal + ';'
 
             client.query(selQuery, function(error, value) {
@@ -287,19 +287,160 @@ module.exports = function runTests(name, clientFactory) {
       })
     })
 
+    t.test('Promise style query', function(t) {
+      const client = new pg.Client(CON_OBJ)
+
+      t.teardown(function() {
+        client.end()
+      })
+
+      helper.runInTransaction(agent, async function transactionInScope(tx) {
+        const transaction = agent.getTransaction()
+        t.ok(transaction, 'transaction should be visible')
+        t.equal(tx, transaction, 'We got the same transaction')
+
+        const colVal = 'Hello'
+        const pkVal = 111
+        let insQuery = 'INSERT INTO ' + TABLE_PREPARED + ' (' + PK + ',' +  COL
+        insQuery += ') VALUES($1, $2);'
+
+        try {
+          await client.connect()
+        } catch (err) {
+          t.error(err)
+        }
+
+        try {
+          const results = await client.query(insQuery, [pkVal, colVal])
+
+          t.ok(agent.getTransaction(), 'transaction should still be visible')
+          t.ok(results, 'everything should be peachy after setting')
+
+          let selQuery = 'SELECT * FROM ' + TABLE_PREPARED + ' WHERE '
+          selQuery += PK + '=' + pkVal + ';'
+
+          const selectResults = await client.query(selQuery)
+
+          t.ok(agent.getTransaction(), 'transaction should still still be visible')
+          t.equal(selectResults.rows[0][COL], colVal, 'Postgres client should still work')
+          transaction.end()
+          verify(t, agent.tracer.getSegment())
+          t.end()
+        } catch (err) {
+          t.error(err)
+          t.end()
+        }
+      })
+    })
+
+    t.test('Submittable style Query', function(t) {
+      // see bottom of this page https://node-postgres.com/guides/upgrading
+      const client = new pg.Client(CON_OBJ)
+
+      t.teardown(function() {
+        client.end()
+      })
+
+      t.notOk(agent.getTransaction(), 'no transaction should be in play')
+      helper.runInTransaction(agent, function transactionInScope(tx) {
+        const transaction = agent.getTransaction()
+        t.ok(transaction, 'transaction should be visible')
+        t.equal(tx, transaction, 'We got the same transaction')
+
+        const colVal = 'Hello'
+        const pkVal = 111
+        let insQuery = 'INSERT INTO ' + TABLE_PREPARED + ' (' + PK + ',' +  COL
+        insQuery += ') VALUES($1, $2);'
+
+        client.connect(function(error) {
+          if (!t.error(error)) {
+            return t.end()
+          }
+
+          client.query(new pg.Query(insQuery, [pkVal, colVal], function(error, ok) {
+            if (!t.error(error)) {
+              return t.end()
+            }
+
+            t.ok(agent.getTransaction(), 'transaction should still be visible')
+            t.ok(ok, 'everything should be peachy after setting')
+
+            let selQuery = 'SELECT * FROM ' + TABLE_PREPARED + ' WHERE '
+            selQuery += PK + '=' + pkVal + ';'
+
+            client.query(new pg.Query(selQuery), function(error, value) {
+              if (!t.error(error)) {
+                return t.end()
+              }
+
+              t.ok(agent.getTransaction(), 'transaction should still still be visible')
+              t.equals(value.rows[0][COL], colVal, 'Postgres client should still work')
+
+              transaction.end()
+              verify(t, agent.tracer.getSegment())
+              t.end()
+            })
+          }))
+        })
+      })
+    })
+
+    t.test('Promise style query timings', function(t) {
+      const client = new pg.Client(CON_OBJ)
+
+      t.teardown(function() {
+        client.end()
+      })
+
+      helper.runInTransaction(agent, async function transactionInScope(tx) {
+        const transaction = agent.getTransaction()
+        t.ok(transaction, 'transaction should be visible')
+        t.equal(tx, transaction, 'We got the same transaction')
+
+        try {
+          await client.connect()
+        } catch (err) {
+          t.error(err)
+        }
+
+        try {
+          const selQuery = 'SELECT pg_sleep(2), now() as peep;'
+
+          const selectResults = await client.query(selQuery)
+
+          t.ok(agent.getTransaction(), 'transaction should still still be visible')
+          t.ok(selectResults, 'Postgres client should still work')
+          transaction.end()
+          const segment = agent.tracer.getSegment()
+
+          const finalTx = segment.transaction
+
+          const metrics = finalTx.metrics.getMetric('Datastore/operation/Postgres/select')
+
+          t.ok(metrics.total > 2.0,
+            'pg_sleep of 2 seconds should result in near 2 sec timing')
+
+          t.end()
+        } catch (err) {
+          t.error(err)
+          t.end()
+        }
+      })
+    })
+
     t.test('client pooling query', function(t) {
       t.plan(39)
       t.notOk(agent.getTransaction(), 'no transaction should be in play')
       helper.runInTransaction(agent, function transactionInScope(tx) {
-        var transaction = agent.getTransaction()
+        const transaction = agent.getTransaction()
         t.ok(transaction, 'transaction should be visible')
         t.equal(tx, transaction, 'We got the same transaction')
 
-        var colVal = 'World!'
-        var pkVal = 222
-        var insQuery = 'INSERT INTO ' + TABLE_PREPARED + ' (' + PK + ',' +  COL
+        const colVal = 'World!'
+        const pkVal = 222
+        let insQuery = 'INSERT INTO ' + TABLE_PREPARED + ' (' + PK + ',' +  COL
         insQuery += ') VALUES(' + pkVal + ",'" + colVal + "');"
-        var pool = new pg.Pool(CON_OBJ)
+        const pool = new pg.Pool(CON_OBJ)
         pool.query(insQuery, function(error, ok) {
           if (!t.error(error)) {
             return t.end()
@@ -308,7 +449,7 @@ module.exports = function runTests(name, clientFactory) {
           t.ok(agent.getTransaction(), 'transaction should still be visible')
           t.ok(ok, 'everything should be peachy after setting')
 
-          var selQuery = 'SELECT * FROM ' + TABLE_PREPARED + ' WHERE '
+          let selQuery = 'SELECT * FROM ' + TABLE_PREPARED + ' WHERE '
           selQuery += PK + '=' + pkVal + ';'
 
           pool.query(selQuery, function(error, value) {
@@ -332,16 +473,16 @@ module.exports = function runTests(name, clientFactory) {
 
       t.notOk(agent.getTransaction(), 'no transaction should be in play')
       helper.runInTransaction(agent, function transactionInScope(tx) {
-        var transaction = agent.getTransaction()
+        const transaction = agent.getTransaction()
         t.ok(transaction, 'transaction should be visible')
         t.equal(tx, transaction, 'We got the same transaction')
 
-        var colVal = 'World!'
-        var pkVal = 222
-        var insQuery = 'INSERT INTO ' + TABLE_PREPARED + ' (' + PK + ',' +  COL
+        const colVal = 'World!'
+        const pkVal = 222
+        let insQuery = 'INSERT INTO ' + TABLE_PREPARED + ' (' + PK + ',' +  COL
         insQuery += ') VALUES(' + pkVal + ",'" + colVal + "');"
 
-        var pool = null
+        let pool = null
         if (pg.Pool) {
           pool = new pg.Pool(CON_OBJ)
         } else {
@@ -361,7 +502,7 @@ module.exports = function runTests(name, clientFactory) {
             t.ok(agent.getTransaction(), 'transaction should still be visible')
             t.ok(ok, 'everything should be peachy after setting')
 
-            var selQuery = 'SELECT * FROM ' + TABLE_PREPARED + ' WHERE '
+            let selQuery = 'SELECT * FROM ' + TABLE_PREPARED + ' WHERE '
             selQuery += PK + '=' + pkVal + ';'
 
             client.query(selQuery, function(error, value) {
@@ -388,17 +529,17 @@ module.exports = function runTests(name, clientFactory) {
     // https://github.com/newrelic/node-newrelic/pull/223
     t.test('query using an config object with `text` getter instead of property', (t) => {
       t.plan(3)
-      var client = new pg.Client(CON_OBJ)
+      const client = new pg.Client(CON_OBJ)
 
       t.teardown(function() {
         client.end()
       })
 
       helper.runInTransaction(agent, function() {
-        var transaction = agent.getTransaction()
+        const transaction = agent.getTransaction()
 
-        var colVal = 'Sianara'
-        var pkVal = 444
+        const colVal = 'Sianara'
+        const pkVal = 444
 
         function CustomConfigClass() {
           this._text = 'INSERT INTO ' + TABLE_PREPARED + ' (' + PK + ',' +  COL
@@ -414,7 +555,7 @@ module.exports = function runTests(name, clientFactory) {
         })
 
         // create a config instance
-        var config = new CustomConfigClass()
+        const config = new CustomConfigClass()
 
         client.connect(function(error) {
           if (!t.error(error)) {
@@ -426,7 +567,7 @@ module.exports = function runTests(name, clientFactory) {
               return t.end()
             }
 
-            var segment = findSegment(
+            const segment = findSegment(
               transaction.trace.root,
               'Datastore/statement/Postgres/' + TABLE + '/insert'
             )
@@ -442,14 +583,14 @@ module.exports = function runTests(name, clientFactory) {
       agent.config.transaction_tracer.record_sql = 'raw'
       agent.config.slow_sql.enabled = true
 
-      var client = new pg.Client(CON_OBJ)
+      const client = new pg.Client(CON_OBJ)
 
       t.teardown(function() {
         client.end()
       })
 
       helper.runInTransaction(agent, function() {
-        var transaction = agent.getTransaction()
+        const transaction = agent.getTransaction()
         client.connect(function(error) {
           if (!t.error(error)) {
             return t.end()
@@ -480,14 +621,14 @@ module.exports = function runTests(name, clientFactory) {
       agent.config.datastore_tracer.instance_reporting.enabled = false
       agent.config.datastore_tracer.database_name_reporting.enabled = false
 
-      var client = new pg.Client(CON_OBJ)
+      const client = new pg.Client(CON_OBJ)
 
       t.teardown(function() {
         client.end()
       })
 
       helper.runInTransaction(agent, function() {
-        var transaction = agent.getTransaction()
+        const transaction = agent.getTransaction()
         client.connect(function(error) {
           if (!t.error(error)) {
             return t.end()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
* Fixed issue where Promise based `pg.Client.query` timings were always in sub-millisecond range.
## Links
* Closes: #786 
## Details
For this work, I had to support instrumentation/recordQuery timings for Callback, Promise and 'Submittable' style pg.Client.query function calls. Submittable style calls are documented at the bottom of this [pg document](https://node-postgres.com/guides/upgrading).  The different styles are outlined below:
Callback:
`client.query('select * from stuff', function cb (err, data) {})`

Promise:
`const data = await client.query('select * from stuff')`

Submittable:
```
const query = client.query(new Query('select * from stuff'))
query.on('row', () => {})
query.on('end', () => {})
```

When the pg library was updated to version 7.0, they dropped support for the event based row output on the query function call except for the case of the Submittable style call. Based on the upgrade document, `pg` team does not recommend using the Submittable style but it's still supported.
