### PR TITLE
explictly set monitorCommands to true so we can properly set attrs on…

### DIFF
--- a/lib/instrumentation/mongodb/v4-mongo.js
+++ b/lib/instrumentation/mongodb/v4-mongo.js
@@ -59,12 +59,14 @@ function cmdStartedHandler(shim, evnt) {
 }
 
 /**
- * function executed when client.connect is called to add
+ * function executed when client.connect is called
+ * enable APM(monitorCommands) and add the
  * `commandStarted` listener
  *
  * @param {Shim} shim
  */
 function wrapConnect(shim) {
+  this.monitorCommands = true
   this.on('commandStarted', cmdStartedHandler.bind(this, shim))
   return { callback: shim.LAST }
 }


### PR DESCRIPTION
… mongo operations in v4.1

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Explicitly enabled APM for mongo instrumentation(client.monitorCommands = true)

## Details
In v4.1 mongodb set the APM flag(monitorCommands) to default to false.  [See](https://github.com/mongodb/node-mongodb-native/pull/2926/files).  We rely on add appropriate attributes to a segment via the `commandStarted` event on all mongo commands.  To verify this works across all versions run

```sh
VERSIONED_MODE=minor npm run versioned-tests mongodb
```
