### PR TITLE
refactor dropTestCollections in mongo versioned tests

### DIFF
--- a/test/versioned/mongodb/collection-common.js
+++ b/test/versioned/mongodb/collection-common.js
@@ -272,16 +272,14 @@ function populate(db, collection) {
  * Bootstrap a running MongoDB instance by dropping all the collections used
  * by tests.
  * @param {*} mongodb MongoDB module to execute commands on.
- * @param {*} collections Collections to drop for test.
+ * @param {Array} collections Collections to drop for test.
  */
 async function dropTestCollections(mongodb, collections) {
   if (!collections.length) {
     return
   }
 
-  const res = await common.connect(mongodb)
-  const client = res.client
-  const db = res.db
+  const { client, db } = await common.connect(mongodb)
 
   const dropCollectionPromises = collections.map(async (collection) => {
     try {

--- a/test/versioned/mongodb/collection-common.js
+++ b/test/versioned/mongodb/collection-common.js
@@ -291,6 +291,9 @@ async function dropTestCollections(mongodb, collections) {
     }
   })
 
-  await Promise.all(dropCollectionPromises)
-  await common.close(client, db)
+  try {
+    await Promise.all(dropCollectionPromises)
+  } finally {
+    await common.close(client, db)
+  }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Refactored `dropTestCollections` in mongo versioned tests to await for all `dropCollection` operations to be finished before closing connection and returning.

## Details
We've had intermittent failures in CI around mongo tests. Most are around collections already existing, I think this is the culprit
