### PR TITLE
fixed connect to properly set transaction name with url of route

### DIFF
--- a/lib/instrumentation/connect.js
+++ b/lib/instrumentation/connect.js
@@ -14,7 +14,7 @@ module.exports = function initialize(agent, connect, moduleName, shim) {
   shim.setFramework(shim.CONNECT)
 
   shim.setRouteParser(function parseRoute(shim, fn, fnName, route) {
-    return route.url
+    return route
   })
 
   var proto =

--- a/test/versioned/connect/error-intercept.tap.js
+++ b/test/versioned/connect/error-intercept.tap.js
@@ -95,16 +95,6 @@ test('intercepting errors with connect 2', function (t) {
         return next() // will never get here
       }
 
-      var stubRes = {
-        headers: {},
-        setHeader: function (name, value) {
-          stubRes.headers[name] = value
-        },
-        end: function () {
-          stubRes._end = agent.tracer.slice(arguments)
-        }
-      }
-
       app.use(wiggleware)
 
       var http = require('http')

--- a/test/versioned/connect/package.json
+++ b/test/versioned/connect/package.json
@@ -11,7 +11,8 @@
         "connect": ">=1.0.0"
       },
       "files": [
-        "error-intercept.tap.js"
+        "error-intercept.tap.js",
+        "route.tap.js"
       ]
     }
   ],

--- a/test/versioned/connect/route.tap.js
+++ b/test/versioned/connect/route.tap.js
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { test } = require('tap')
+const helper = require('../../lib/agent_helper')
+
+// connect is a loudmouth without this
+process.env.NODE_ENV = 'test'
+
+test('transaction tests', function (t) {
+  t.autoend()
+
+  t.test('should properly name transaction from route name', function (t) {
+    t.plan(10)
+    const agent = helper.instrumentMockedAgent()
+    let server
+    agent.once('transactionFinished', function (transaction) {
+      t.equal(transaction.name, 'WebTransaction/Connect/GET//foo')
+      t.equal(transaction.url, '/foo', 'URL is left alone')
+      t.equal(transaction.verb, 'GET', 'HTTP method is GET')
+      t.equal(transaction.statusCode, 200, 'status code is OK')
+      t.ok(transaction.trace, 'transaction has trace')
+      const web = transaction.trace.root.children[0]
+      t.ok(web, 'trace has web segment')
+      t.equal(web.name, transaction.name, 'segment name and transaction name match')
+      t.equal(web.partialName, 'Connect/GET//foo', 'should have partial name for apdex')
+
+      server.close()
+    })
+
+    t.teardown(() => {
+      helper.unloadAgent(agent)
+    })
+
+    helper.runInTransaction(agent, function () {
+      var connect = require('connect')
+      var app = connect()
+
+      function middleware(req, res) {
+        t.ok(agent.getTransaction(), 'transaction should be available')
+        res.end('foo')
+      }
+
+      app.use('/foo', middleware)
+      server = createServerAndMakeRequest({ url: '/foo', expectedData: 'foo', t, app })
+    })
+  })
+
+  t.test('should default to `/` when no route is specified', function (t) {
+    t.plan(10)
+    const agent = helper.instrumentMockedAgent()
+    let server
+    agent.once('transactionFinished', function (transaction) {
+      t.equal(transaction.name, 'WebTransaction/Connect/GET//')
+      t.equal(transaction.url, '/foo', 'URL is left alone')
+      t.equal(transaction.verb, 'GET', 'HTTP method is GET')
+      t.equal(transaction.statusCode, 200, 'status code is OK')
+      t.ok(transaction.trace, 'transaction has trace')
+      const web = transaction.trace.root.children[0]
+      t.ok(web, 'trace has web segment')
+      t.equal(web.name, transaction.name, 'segment name and transaction name match')
+      t.equal(web.partialName, 'Connect/GET//', 'should have partial name for apdex')
+
+      server.close()
+    })
+
+    t.teardown(() => {
+      helper.unloadAgent(agent)
+    })
+
+    helper.runInTransaction(agent, function () {
+      var connect = require('connect')
+      var app = connect()
+
+      function middleware(req, res) {
+        t.ok(agent.getTransaction(), 'transaction should be available')
+        res.end('root')
+      }
+
+      app.use(middleware)
+      server = createServerAndMakeRequest({ url: '/foo', expectedData: 'root', t, app })
+    })
+  })
+})
+
+/**
+ * Sets up HTTP server and binds a connect instance
+ * It then makes a request to specified url and asserts the response
+ * data is correct
+ *
+ * @param {Object} params
+ * @param {string} params.url url to make request
+ * @param {string} params.expectedData expected response data
+ * @param {tap.Test} t
+ * @param {Object} app connect app
+ * @return {http.Server}
+ */
+function createServerAndMakeRequest({ url, expectedData, t, app }) {
+  const http = require('http')
+  const server = http.createServer(app).listen(0, function () {
+    var req = http.request(
+      {
+        port: server.address().port,
+        host: 'localhost',
+        path: url,
+        method: 'GET'
+      },
+      function onResponse(res) {
+        res.on('data', function (data) {
+          t.equal(data.toString(), expectedData, 'should respond with proper data')
+        })
+      }
+    )
+    req.end()
+  })
+  return server
+}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Support using `connect` to route middleware calls.

## Links
Closes #846 

## Details
I added router tests which we lacked before which would've shown this never worked.  In the issue I logged, our docs state we don't support the router but honestly I have no idea why.  This fix is trivial.
