### PR TITLE
added new feature flag to remove the promise destroy hook

### DIFF
--- a/lib/feature_flags.js
+++ b/lib/feature_flags.js
@@ -13,7 +13,8 @@ exports.prerelease = {
   reverse_naming_rules: false,
   fastify_instrumentation: false,
   certificate_bundle: false,
-  new_promise_tracking: false
+  new_promise_tracking: false,
+  unresolved_promise_cleanup: true
 }
 
 // flags that are no longer used for released features

--- a/lib/instrumentation/core/async_hooks.js
+++ b/lib/instrumentation/core/async_hooks.js
@@ -191,9 +191,16 @@ function getPromiseResolveStyleHooks(segmentMap, agent, shim) {
       if (hookSegment === null) {
         shim.setActiveSegment(hookSegment)
       }
-    },
-    destroy: function destroyHandler(id) {
-      // Clean up any unresolved promises that have been destroyed.
+    }
+  }
+
+  // Clean up any unresolved promises that have been destroyed.
+  // This defaults to true but does have a significant performance impact
+  // when customers have a lot of promises.
+  // See: https://github.com/newrelic/node-newrelic/issues/760
+  if (agent.config.feature_flag.unresolved_promise_cleanup) {
+    logger.info('Adding destroy hook to clean up unresolved promises.')
+    hooks.destroy = function destroyHandler(id) {
       segmentMap.delete(id)
     }
   }

--- a/test/integration/core/async_hooks-new-promise-unresolved.tap.js
+++ b/test/integration/core/async_hooks-new-promise-unresolved.tap.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const exec = require('child_process').execSync
+exec(
+  'NEW_RELIC_FEATURE_FLAG_NEW_PROMISE_TRACKING=1 NEW_RELIC_FEATURE_FLAG_UNRESOLVED_PROMISE_CLEANUP=false node --expose-gc ./async_hooks-new-promise.js',
+  {
+    stdio: 'inherit',
+    cwd: __dirname
+  }
+)

--- a/test/integration/core/async_hooks-new-promise.js
+++ b/test/integration/core/async_hooks-new-promise.js
@@ -467,6 +467,8 @@ test("the agent's async hook", function (t) {
     })
   })
 
+  // if `feature_flaog.unresolved_promise_cleanup` is set to false
+  // this will not clean up promises on destroy
   t.test('cleans up unresolved promises on destroy', (t) => {
     const agent = setupAgent(t)
     const segmentMap = require('../../../lib/instrumentation/core/async_hooks').segmentMap
@@ -482,7 +484,11 @@ test("the agent's async hook", function (t) {
       global.gc && global.gc()
 
       setImmediate(() => {
-        t.equal(segmentMap.size, 0)
+        if (agent.config.feature_flag.unresolved_promise_cleanup) {
+          t.equal(segmentMap.size, 0)
+        } else {
+          t.equal(segmentMap.size, 1)
+        }
 
         t.end()
       })

--- a/test/unit/feature_flag.test.js
+++ b/test/unit/feature_flag.test.js
@@ -36,7 +36,8 @@ var used = [
   'unreleased',
   'fastify_instrumentation',
   'certificate_bundle',
-  'new_promise_tracking'
+  'new_promise_tracking',
+  'unresolved_promise_cleanup'
 ]
 
 describe('feature flags', function () {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

 * Added a new feature flag `unresolved_promise_cleanup` that defaults to true only when `new_promise_tracking` feature flag is set to `true`.  If disabled, this will help with performance of agent when an application has a lot of promises.  To disable set in your config `feature_flag.unresolved_promise_cleanup` to `false` or pass in the env var of `NEW_RELIC_FEATURE_FLAG_UNRESOLVED_PROMISE_CLEANUP=false` when starting application with agent. 

    **WARNING**: If you set `unresolved_promise_cleanup` to `false`, failure to resolve all promises in your application will result in memory leaks even if those promises are garbage collected

 

## Links
Closes #848 

## Details
Due to the tap test structure the title of the test cannot be changed https://github.com/newrelic/node-newrelic/pull/849/files#diff-1c796fb285ebfee00baa615e11db39290c7b0f1d9854054f53aff51ae84842a5R472. I'm open to suggestions.  This also defaults to true so no impact on current customers however we should tell support about this new feature flag and if a customer is seeing slow perf with agent they can turn set `new_promise_tracking`  to `true` and set `unresolved_promise_cleanup` to `false`
