### PR TITLE
Converts span-event-aggregator unit tests to use tap API.

### DIFF
--- a/test/unit/spans/span-event-aggregator.test.js
+++ b/test/unit/spans/span-event-aggregator.test.js
@@ -5,25 +5,24 @@
 
 'use strict'
 
-// TODO: convert to normal tap style.
-// Below allows use of mocha DSL with tap runner.
-require('tap').mochaGlobals()
+const tap = require('tap')
+const sinon = require('sinon')
 
-const expect = require('chai').expect
 const helper = require('../../lib/agent_helper')
 const SpanEventAggregator = require('../../../lib/spans/span-event-aggregator')
 const Metrics = require('../../../lib/metrics')
-const sinon = require('sinon')
 const logger = require('../../../lib/logger')
 
 const RUN_ID = 1337
 const LIMIT = 1000
 
-describe('SpanAggregator', () => {
+tap.test('SpanAggregator', (t) => {
+  t.autoend()
+
   let spanEventAggregator = null
   let agent = null
 
-  beforeEach(() => {
+  t.beforeEach(() => {
     spanEventAggregator = new SpanEventAggregator(
       {
         runId: RUN_ID,
@@ -39,18 +38,19 @@ describe('SpanAggregator', () => {
     })
   })
 
-  afterEach(() => {
+  t.afterEach(() => {
     spanEventAggregator = null
     helper.unloadAgent(agent)
   })
 
-  it('should set the correct default method', () => {
+  t.test('should set the correct default method', (t) => {
     const method = spanEventAggregator.method
+    t.equal(method, 'span_event_data')
 
-    expect(method).to.equal('span_event_data')
+    t.end()
   })
 
-  it('should add a span event from the given segment', (done) => {
+  t.test('should add a span event from the given segment', (t) => {
     helper.runInTransaction(agent, (tx) => {
       tx.priority = 42
       tx.sample = true
@@ -58,45 +58,48 @@ describe('SpanAggregator', () => {
       setTimeout(() => {
         const segment = agent.tracer.getSegment()
 
-        expect(spanEventAggregator).to.have.length(0)
+        t.equal(spanEventAggregator.length, 0)
+
         spanEventAggregator.addSegment(segment, 'p')
-        expect(spanEventAggregator).to.have.length(1)
+        t.equal(spanEventAggregator.length, 1)
 
         const event = spanEventAggregator.getEvents()[0]
 
-        expect(event).to.have.property('intrinsics')
-        expect(event.intrinsics).to.have.property('name', segment.name)
-        expect(event.intrinsics).to.have.property('parentId', 'p')
+        t.ok(event.intrinsics)
+        t.equal(event.intrinsics.name, segment.name)
+        t.equal(event.intrinsics.parentId, 'p')
 
-        done()
+        t.end()
       }, 10)
     })
   })
 
-  it('should default the parent id', (done) => {
+  t.test('should default the parent id', (t) => {
     helper.runInTransaction(agent, (tx) => {
       tx.priority = 42
       tx.sample = true
 
       setTimeout(() => {
         const segment = agent.tracer.getSegment()
-        expect(spanEventAggregator).to.have.length(0)
+        t.equal(spanEventAggregator.length, 0)
+
         spanEventAggregator.addSegment(segment)
-        expect(spanEventAggregator).to.have.length(1)
+        t.equal(spanEventAggregator.length, 1)
 
         const event = spanEventAggregator.getEvents()[0]
 
-        expect(event).to.have.property('intrinsics')
-        expect(event.intrinsics).to.have.property('name', segment.name)
-        expect(event.intrinsics).to.have.property('parentId', null)
-        expect(event.intrinsics).to.not.have.property('grandparentId')
+        t.ok(event.intrinsics)
+        t.equal(event.intrinsics.name, segment.name)
+        t.equal(event.intrinsics.parentId, null)
 
-        done()
+        t.notOk(event.intrinsics.grandparentId)
+
+        t.end()
       }, 10)
     })
   })
 
-  it('should indicate if the segment is accepted', (done) => {
+  t.test('should indicate if the segment is accepted', (t) => {
     const METRIC_NAMES = {
       SEEN: '/SEEN',
       SENT: '/SENT',
@@ -122,41 +125,41 @@ describe('SpanAggregator', () => {
       setTimeout(() => {
         const segment = agent.tracer.getSegment()
 
-        expect(spanEventAggregator).to.have.length(0)
-        expect(spanEventAggregator).to.have.property('seen', 0)
+        t.equal(spanEventAggregator.length, 0)
+        t.equal(spanEventAggregator.seen, 0)
 
         // First segment is added regardless of priority.
-        expect(spanEventAggregator.addSegment(segment)).to.be.true
-        expect(spanEventAggregator).to.have.length(1)
-        expect(spanEventAggregator).to.have.property('seen', 1)
+        t.equal(spanEventAggregator.addSegment(segment), true)
+        t.equal(spanEventAggregator.length, 1)
+        t.equal(spanEventAggregator.seen, 1)
 
         // Higher priority should be added.
         tx.priority = 100
-        expect(spanEventAggregator.addSegment(segment)).to.be.true
-        expect(spanEventAggregator).to.have.length(1)
-        expect(spanEventAggregator).to.have.property('seen', 2)
+        t.equal(spanEventAggregator.addSegment(segment), true)
+        t.equal(spanEventAggregator.length, 1)
+        t.equal(spanEventAggregator.seen, 2)
         const event1 = spanEventAggregator.getEvents()[0]
 
         // Lower priority should not be added.
         tx.priority = 1
-        expect(spanEventAggregator.addSegment(segment)).to.be.false
-        expect(spanEventAggregator).to.have.length(1)
-        expect(spanEventAggregator).to.have.property('seen', 3)
+        t.equal(spanEventAggregator.addSegment(segment), false)
+        t.equal(spanEventAggregator.length, 1)
+        t.equal(spanEventAggregator.seen, 3)
         const event2 = spanEventAggregator.getEvents()[0]
 
         const metric = metrics.getMetric(METRIC_NAMES.SEEN)
 
-        expect(metric.callCount).to.equal(3)
+        t.equal(metric.callCount, 3)
 
         // Shouldn't change the event in the aggregator.
-        expect(event1).to.equal(event2)
+        t.equal(event1, event2)
 
-        done()
+        t.end()
       }, 10)
     })
   })
 
-  it('_toPayloadSync() should return json format of data', (done) => {
+  t.test('_toPayloadSync() should return json format of data', (t) => {
     helper.runInTransaction(agent, (tx) => {
       tx.priority = 1
       tx.sample = true
@@ -170,23 +173,23 @@ describe('SpanAggregator', () => {
 
         const [runId, metrics, events] = payload
 
-        expect(runId).to.equal(RUN_ID)
+        t.equal(runId, RUN_ID)
 
-        expect(metrics).to.have.property('reservoir_size')
-        expect(metrics).to.have.property('events_seen')
-        expect(metrics.reservoir_size).to.equal(LIMIT)
-        expect(metrics.events_seen).to.equal(1)
+        t.ok(metrics.reservoir_size)
+        t.ok(metrics.events_seen)
+        t.equal(metrics.reservoir_size, LIMIT)
+        t.equal(metrics.events_seen, 1)
 
-        expect(events[0]).to.exist
-        expect(events[0]).to.have.property('intrinsics')
-        expect(events[0].intrinsics.type).to.equal('Span')
+        t.ok(events[0])
+        t.ok(events[0].intrinsics)
+        t.equal(events[0].intrinsics.type, 'Span')
 
-        done()
+        t.end()
       }, 10)
     })
   })
 
-  it('should log span trace data when traceEnabled', () => {
+  t.test('should log span trace data when traceEnabled', (t) => {
     let ct = 0
     const fakeLogger = {
       traceEnabled: () => true,
@@ -208,10 +211,12 @@ describe('SpanAggregator', () => {
     spanEventAgg.send()
     logger.child.restore()
 
-    expect(ct).to.equal(1)
+    t.equal(ct, 1)
+
+    t.end()
   })
 
-  it('should not log span trace data when !traceEnabled', () => {
+  t.test('should not log span trace data when !traceEnabled', (t) => {
     let ct = 0
     const fakeLogger = {
       traceEnabled: () => false,
@@ -233,6 +238,7 @@ describe('SpanAggregator', () => {
     spanEventAgg.send()
     logger.child.restore()
 
-    expect(ct).to.equal(0)
+    t.equal(ct, 0)
+    t.end()
   })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Converted span-event-aggregator unit tests to use tap API.

## Links

## Details

Figured convert this real quick separate from the upcoming work that will touch these tests.