### PR TITLE
Connect harvest limit

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -544,6 +544,13 @@ Config.prototype._fromServer = function _fromServer(params, key) {
       this.logUnsupported(params, key)
       break
 
+    // DT span event harvest config limits
+    case 'span_event_harvest_config':
+      this.span_event_harvest_config = {
+        ...params[key]
+      }
+      break
+
     // These settings are not allowed from the server.
     case 'attributes.enabled':
     case 'attributes.exclude':

--- a/lib/spans/span-event-aggregator.js
+++ b/lib/spans/span-event-aggregator.js
@@ -10,7 +10,7 @@ let spanLogger = null
 const EventAggregator = require('../aggregators/event-aggregator')
 const SpanEvent = require('./span-event')
 const NAMES = require('../metrics/names')
-const LIMIT = 1000
+const { SPAN_EVENT_LIMIT } = require('../config')
 
 class SpanEventAggregator extends EventAggregator {
   constructor(opts, collector, metrics) {
@@ -64,7 +64,7 @@ class SpanEventAggregator extends EventAggregator {
    * @param {TraceSegment}  segment         - The segment to add.
    * @param {string}        [parentId=null] - The GUID of the parent span.
    *
-   * @return {bool} True if the segment was added, or false if it was discarded.
+   * @return {boolean} True if the segment was added, or false if it was discarded.
    */
   addSegment(segment, parentId, isRoot) {
     // Check if the priority would be accepted before creating the event object.
@@ -79,7 +79,61 @@ class SpanEventAggregator extends EventAggregator {
     const span = SpanEvent.fromSegment(segment, parentId || null, isRoot)
     return this.add(span, tx.priority)
   }
+
+  /**
+   * Reconfigure the `SpanEventAggregator` based on values from server
+   *
+   * @param {Config} config
+   */
+  reconfigure(config) {
+    super.reconfigure(config)
+
+    const { periodMs, limit } = this._getValidSpanConfiguration(config)
+
+    this.periodMs = periodMs
+    this.limit = limit
+    this._items.setLimit(this.limit)
+  }
+
+  /**
+   * Compares values from server vs defaults enforced in agent.
+   * Use the minimum between `1000` and `span_event_harvest_config.harvest_limit`
+   * as the number of span events during a harvest cycle
+   *
+   * @param {Config} config
+   */
+  _getValidSpanConfiguration(config) {
+    let reportPeriod = this.defaultPeriod
+    let spanLimit = SPAN_EVENT_LIMIT
+
+    if (config.span_event_harvest_config) {
+      if (config.span_event_harvest_config.report_period_ms) {
+        reportPeriod = config.span_event_harvest_config.report_period_ms
+
+        logger.debug(
+          'Using span event report period from span_event_harvest_config.report_period_ms of %s',
+          reportPeriod
+        )
+      }
+
+      if (config.span_event_harvest_config.harvest_limit) {
+        const maxSpanSamplesAllowed = config.span_event_harvest_config.harvest_limit
+
+        if (maxSpanSamplesAllowed < spanLimit) {
+          spanLimit = maxSpanSamplesAllowed
+          logger.debug(
+            'Using span event limit from span_event_harvest_config.harvest_limit of %s',
+            spanLimit
+          )
+        }
+      }
+    }
+
+    return {
+      periodMs: reportPeriod,
+      limit: spanLimit
+    }
+  }
 }
 
 module.exports = SpanEventAggregator
-module.exports.LIMIT = LIMIT

--- a/test/unit/config/config-server-side.test.js
+++ b/test/unit/config/config-server-side.test.js
@@ -485,6 +485,21 @@ tap.test('when receiving server-side configuration', (t) => {
 
       t.end()
     })
+
+    t.test('should set `span_event_harvest_config` from server', (t) => {
+      const spanEventHarvestConfig = {
+        report_period_ms: 1000,
+        harvest_limit: 10000
+      }
+      config.onConnect({
+        agent_config: {
+          span_event_harvest_config: spanEventHarvestConfig
+        }
+      })
+
+      t.same(config.span_event_harvest_config, spanEventHarvestConfig)
+      t.end()
+    })
   })
 
   t.test('when event_harvest_config is set', (t) => {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Handled setting the `span_event_harvest_config` from server and using in `SpanEventAggregator` to enforce the queue size and harvest cycle duration.

## Links
Closes #851 

## Details
The `span_event_harvest_config` is currently behind a feature flag but this code is built to work without that getting passed in by using defaults.  Also this overlaps code the @michaelgoin has done for #852 so there will definitely be conflicts