### PR TITLE
add support for mongo connection strings that are to a cluster, added…

### DIFF
--- a/lib/instrumentation/mongodb/common.js
+++ b/lib/instrumentation/mongodb/common.js
@@ -5,9 +5,8 @@
 
 'use strict'
 const { CURSOR_OPS, COLLECTION_OPS, DB_OPS } = require('./constants')
-const { URL } = require('url')
-
 const common = module.exports
+common.NR_ATTRS = Symbol('NR_ATTRS')
 
 /**
  * Instruments all methods from constants.CURSOR_OPS on a given
@@ -24,7 +23,7 @@ common.instrumentCursor = function instrumentCursor(shim, Cursor) {
     }
 
     shim.recordQuery(proto, 'each', common.makeQueryDescFunc(shim, 'each'))
-    shim.recordOperation(proto, 'pipe')
+    shim.recordOperation(proto, 'pipe', { opaque: true })
   }
 }
 
@@ -97,23 +96,55 @@ common.captureAttributesOnStarted = function captureAttributesOnStarted(shim, in
     // out of an excess of caution.
     const connId = evnt.connectionId
     if (connId) {
-      // Mongo sticks the path to the domain socket in the "host" slot, but we
-      // want it in the "port", so if we have a domain socket we need to change
-      // the order of our parameters.
-      if (typeof connId === 'string') {
-        const parts = connId.split(':')
-        if (parts.length && parts[0][0] === '/') {
-          shim.captureInstanceAttributes('localhost', parts[0], evnt.databaseName)
-        } else {
-          shim.captureInstanceAttributes(parts[0], parts[1], evnt.databaseName)
-        }
+      // used in v3 when connection is a cluster pool
+      if (typeof connId === 'number') {
+        setHostPort(shim, evnt.address, evnt.databaseName, this.$MongoClient)
+        // used in v3 when connection is to 1 host
+      } else if (typeof connId === 'string') {
+        setHostPort(shim, connId, evnt.databaseName)
+        // v2 contains `domainSocket`, get socket connection from `host`
       } else if (connId.domainSocket) {
         shim.captureInstanceAttributes('localhost', connId.host, evnt.databaseName)
+        // v2 remote connection get `host` `port` from respective properties
       } else {
         shim.captureInstanceAttributes(connId.host, connId.port, evnt.databaseName)
       }
     }
   })
+}
+
+/**
+ * Extracts the host and port from a connection string
+ * This also handles if connection string is a domain socket
+ * Mongo sticks the path to the domain socket in the "host" slot, but we
+ * want it in the "port", so if we have a domain socket we need to change
+ * the order of our parameters.
+ *
+ * @param {Shim} shim
+ * @param {string} connStr
+ * @param {string} db database name
+ */
+function setHostPort(shim, connStr, db, client) {
+  const parts = connStr.split(':')
+  // in v3 when running with a cluster of socket connections
+  // the address is `undefined:undefined`. we will instead attempt
+  // to get connection details from the client symbol NR_ATTRS
+  // added in `lib/instrumentation/mongodb/v3-mongo` when a client connects
+  // with a URL string
+  if (parts.includes('undefined')) {
+    try {
+      const attrs = client[common.NR_ATTRS]
+      const socket = decodeURIComponent(attrs.split(',')[0].split('mongodb://')[1])
+      shim.captureInstanceAttributes('localhost', socket, db)
+    } catch (err) {
+      shim.logger.debug(err, 'Could not extract host/port from mongo command')
+    }
+    // connected using domain socket but the "host"(e.g: /path/to/mongo-socket-port.sock)
+  } else if (parts.length && parts[0][0] === '/') {
+    shim.captureInstanceAttributes('localhost', parts[0], db)
+  } else {
+    shim.captureInstanceAttributes(parts[0], parts[1], db)
+  }
 }
 
 /**
@@ -136,13 +167,15 @@ function getInstanceAttributeParameters(shim, obj) {
     obj.s.db.s &&
     obj.s.db.s.client &&
     obj.s.db.s.client.s &&
-    obj.s.db.s.client.s.url
+    obj.s.db.s.client.s.options &&
+    obj.s.db.s.client.s.options.hosts &&
+    obj.s.db.s.client.s.options.hosts.length
   ) {
-    let { hostname: host, port } = new URL(obj.s.db.s.client.s.url)
-    if (host.endsWith('.sock')) {
-      // socket path is uri encoded
-      // decode it to properly name attrs
-      port = decodeURIComponent(host)
+    // hosts is an array but we will always pull the first for consistency
+    let [{ host, port, socketPath }] = obj.s.db.s.client.s.options.hosts
+
+    if (socketPath) {
+      port = socketPath
       host = 'localhost'
     }
     return {
@@ -160,12 +193,17 @@ function getInstanceAttributeParameters(shim, obj) {
   }
 
   function doCapture(conf, database) {
-    let host = conf.host
-    let port = conf.port
+    let host = null
+    let port = null
 
-    // If using a domain socket, mongo stores the path as the host name, but we
-    // pass it through the port value.
-    if ((conf.socketOptions && conf.socketOptions.domainSocket) || /\.sock$/.test(host)) {
+    // servers is an array but we will always pull the first for consistency
+    if (conf.servers && conf.servers.length) {
+      ;[{ host, port }] = conf.servers
+    }
+
+    // host is a domain socket. set host as localhost and use the domain
+    // socket host as the port
+    if (host && host.endsWith('.sock')) {
       port = host
       host = 'localhost'
     }
@@ -177,3 +215,5 @@ function getInstanceAttributeParameters(shim, obj) {
     }
   }
 }
+
+common.getInstanceAttributeParameters = getInstanceAttributeParameters

--- a/lib/instrumentation/mongodb/common.js
+++ b/lib/instrumentation/mongodb/common.js
@@ -123,6 +123,7 @@ common.captureAttributesOnStarted = function captureAttributesOnStarted(shim, in
  * @param {Shim} shim
  * @param {string} connStr
  * @param {string} db database name
+ * @param {Object} client mongo client instance
  */
 function setHostPort(shim, connStr, db, client) {
   const parts = connStr.split(':')

--- a/lib/instrumentation/mongodb/common.js
+++ b/lib/instrumentation/mongodb/common.js
@@ -215,5 +215,3 @@ function getInstanceAttributeParameters(shim, obj) {
     }
   }
 }
-
-common.getInstanceAttributeParameters = getInstanceAttributeParameters

--- a/lib/instrumentation/mongodb/v3-mongo.js
+++ b/lib/instrumentation/mongodb/v3-mongo.js
@@ -9,7 +9,8 @@ const {
   captureAttributesOnStarted,
   instrumentCollection,
   instrumentCursor,
-  instrumentDb
+  instrumentDb,
+  NR_ATTRS
 } = require('./common')
 
 /**
@@ -31,6 +32,23 @@ function queryParser(operation) {
 }
 
 /**
+ * Records the `mongo.MongoClient.connect` operations. It also adds the first arg of connect(url)
+ * to a Symbol on the MongoClient to be used later to extract the host/port in cases where the topology
+ * is a cluster of domain sockets
+ *
+ * @param {Shim} shim
+ * @param {Object} mongodb resolved package
+ */
+function instrumentClient(shim, mongodb) {
+  shim.recordOperation(mongodb.MongoClient, 'connect', function wrappedConnect(shim, _, __, args) {
+    // Add the connection url to the MongoClient to retrieve later in the `lib/instrumentation/mongo/common`
+    // captureAttributesOnStarted listener
+    this[NR_ATTRS] = args[0]
+    return { callback: shim.LAST }
+  })
+}
+
+/**
  * Registers relevant instrumentation for mongo >= 3.0.6
  * In 3.0.6 they refactored their "APM" module which removed
  * a lot of niceities around instrumentation classes.
@@ -44,6 +62,7 @@ function queryParser(operation) {
  */
 module.exports = function instrument(shim, mongodb) {
   shim.setParser(queryParser)
+  instrumentClient(shim, mongodb)
   const instrumenter = mongodb.instrument(Object.create(null), () => {})
   captureAttributesOnStarted(shim, instrumenter)
   instrumentCursor(shim, mongodb.Cursor)

--- a/lib/instrumentation/mongodb/v4-mongo.js
+++ b/lib/instrumentation/mongodb/v4-mongo.js
@@ -36,15 +36,14 @@ function cmdStartedHandler(shim, evnt) {
   if (evnt.connectionId) {
     let [host, port] = evnt.address.split(':')
 
-    // connection via socket get port from client.url
-    // which looks like "mongodb://%2Ftmp%2Fmongodb-27017.sock"
+    // connection via socket get port from 1st host
+    // socketPath property
+    // which looks like mongodb:///tmp/mongodb-27017.sock"
     if (['undefined'].includes(host, port)) {
       host = 'localhost'
-      // socket path is uri encoded
-      // decode it to properly name attrs
-      const socketPath = this.s.url.split(':')
-      if (socketPath.length && socketPath[1].startsWith('//')) {
-        port = decodeURIComponent(socketPath[1].substr(2))
+      const hosts = this.s.options.hosts
+      if (hosts && hosts.length && hosts[0].socketPath) {
+        port = hosts[0].socketPath
       }
     } else if (host === '127.0.0.1') {
       host = 'localhost'

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "newrelic",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.2.11",

--- a/test/versioned/mongodb/collection-index.tap.js
+++ b/test/versioned/mongodb/collection-index.tap.js
@@ -45,7 +45,7 @@ common.test('indexes', function indexesTest(t, collection, verify) {
   collection.indexes(function done(err, data) {
     t.error(err)
     var result = data && data[0]
-    // this will fail if running mongodb > 4.3.1
+    // this will fail if running a mongodb server > 4.3.1
     // https://jira.mongodb.org/browse/SERVER-41696
     t.same(
       result,

--- a/test/versioned/mongodb/common.js
+++ b/test/versioned/mongodb/common.js
@@ -53,14 +53,22 @@ function connectV2(mongodb, path) {
   })
 }
 
-function connectV3(mongodb, host) {
+function connectV3(mongodb, host, replicaSet = false) {
   return new Promise((resolve, reject) => {
     if (host) {
       host = encodeURIComponent(host)
     } else {
       host = params.mongodb_host + ':' + params.mongodb_port
     }
-    mongodb.MongoClient.connect('mongodb://' + host, function (err, client) {
+
+    let connString = `mongodb://${host}`
+    let options = {}
+
+    if (replicaSet) {
+      connString = `mongodb://${host},${host},${host}`
+      options = { useNewUrlParser: true, useUnifiedTopology: true }
+    }
+    mongodb.MongoClient.connect(connString, options, function (err, client) {
       if (err) {
         reject(err)
       }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added support for properly setting the `host` and `port` for mongodb requests that are to cluster.
 
## Links
Closes #860 

## Details
I added 2 additional suites of tests for a cluster configuration. One with host/port and one with domain sockets.  

**Note**: To run the domain socket tests you have to have `mongod` on your local machine and run locally before running

```
NPM7=1 npm run versioned-tests mongodb
```
Also, if you use a newer version of `mongod` it will fail on some tests because it assumes you're running v2 so some commands may not be available.  
