### PR TITLE
ported conglomerate-shim, datastore-shim, message-shim, and promise-shim

### DIFF
--- a/test/unit/shim/conglomerate-shim.test.js
+++ b/test/unit/shim/conglomerate-shim.test.js
@@ -5,13 +5,9 @@
 
 'use strict'
 
-// TODO: convert to normal tap style.
-// Below allows use of mocha DSL with tap runner.
-require('tap').mochaGlobals()
-
+const { test } = require('tap')
 const ConglomerateShim = require('../../../lib/shim/conglomerate-shim')
 const DatastoreShim = require('../../../lib/shim/datastore-shim')
-const { expect } = require('chai')
 const helper = require('../../lib/agent_helper')
 const MessageShim = require('../../../lib/shim/message-shim')
 const PromiseShim = require('../../../lib/shim/promise-shim')
@@ -19,69 +15,55 @@ const Shim = require('../../../lib/shim/shim')
 const TransactionShim = require('../../../lib/shim/transaction-shim')
 const WebFrameworkShim = require('../../../lib/shim/webframework-shim')
 
-describe('ConglomerateShim', () => {
+test('ConglomerateShim', (t) => {
+  t.autoend()
   let agent = null
   let shim = null
 
-  beforeEach(() => {
+  t.beforeEach(() => {
     agent = helper.loadMockedAgent()
     shim = new ConglomerateShim(agent, 'test-module')
   })
 
-  afterEach(() => {
+  t.afterEach(() => {
     helper.unloadAgent(agent)
     agent = null
     shim = null
   })
 
-  describe('constructor', () => {
-    it('should require an agent parameter', () => {
-      expect(() => new ConglomerateShim()).to.throw(
-        Error,
-        /^Shim must be initialized with .*? agent/
-      )
-    })
-    it('should require a module name parameter', () => {
-      expect(() => new ConglomerateShim(agent)).to.throw(
-        Error,
-        /^Shim must be initialized with .*? module name/
-      )
-    })
+  t.test('should require an agent parameter', (t) => {
+    t.throws(() => new ConglomerateShim(), /^Shim must be initialized with .*? agent/)
+    t.end()
+  })
+  t.test('should require a module name parameter', (t) => {
+    t.throws(() => new ConglomerateShim(agent), /^Shim must be initialized with .*? module name/)
+    t.end()
   })
 
-  describe('module type properties', () => {
-    it('should exist for each shim type', () => {
-      expect(shim).to.have.property('GENERIC', 'generic')
-      expect(shim).to.have.property('DATASTORE', 'datastore')
-      expect(shim).to.have.property('MESSAGE', 'message')
-      expect(shim).to.have.property('PROMISE', 'promise')
-      expect(shim).to.have.property('TRANSACTION', 'transaction')
-      expect(shim).to.have.property('WEB_FRAMEWORK', 'web-framework')
-    })
+  t.test('should exist for each shim type', (t) => {
+    t.ok(shim.GENERIC, 'generic')
+    t.ok(shim.DATASTORE, 'datastore')
+    t.ok(shim.MESSAGE, 'message')
+    t.ok(shim.PROMISE, 'promise')
+    t.ok(shim.TRANSACTION, 'transaction')
+    t.ok(shim.WEB_FRAMEWORK, 'web-framework')
+    t.end()
   })
 
-  describe('#makeSpecializedShim', () => {
-    it('should construct a new shim', () => {
-      expect(shim.makeSpecializedShim(shim.GENERIC, 'foobar'))
-        .to.be.an.instanceOf(Shim)
-        .and.not.equal(shim)
-    })
+  t.test('should construct a new shim', (t) => {
+    const specialShim = shim.makeSpecializedShim(shim.GENERIC, 'foobar')
+    t.ok(specialShim instanceof Shim)
+    t.not(specialShim, shim)
+    t.end()
+  })
 
-    describe('new shim', () => {
-      it('should be an instance of the correct class', () => {
-        expect(shim.makeSpecializedShim(shim.GENERIC, 'foobar')).to.be.an.instanceOf(Shim)
-        expect(shim.makeSpecializedShim(shim.DATASTORE, 'foobar')).to.be.an.instanceOf(
-          DatastoreShim
-        )
-        expect(shim.makeSpecializedShim(shim.MESSAGE, 'foobar')).to.be.an.instanceOf(MessageShim)
-        expect(shim.makeSpecializedShim(shim.PROMISE, 'foobar')).to.be.an.instanceOf(PromiseShim)
-        expect(shim.makeSpecializedShim(shim.TRANSACTION, 'foobar')).to.be.an.instanceOf(
-          TransactionShim
-        )
-        expect(shim.makeSpecializedShim(shim.WEB_FRAMEWORK, 'foobar')).to.be.an.instanceOf(
-          WebFrameworkShim
-        )
-      })
-    })
+  t.test('should be an instance of the correct class', (t) => {
+    t.ok(shim.makeSpecializedShim(shim.GENERIC, 'foobar') instanceof Shim)
+    t.ok(shim.makeSpecializedShim(shim.DATASTORE, 'foobar') instanceof DatastoreShim)
+    t.ok(shim.makeSpecializedShim(shim.MESSAGE, 'foobar') instanceof MessageShim)
+    t.ok(shim.makeSpecializedShim(shim.PROMISE, 'foobar') instanceof PromiseShim)
+    t.ok(shim.makeSpecializedShim(shim.TRANSACTION, 'foobar') instanceof TransactionShim)
+    t.ok(shim.makeSpecializedShim(shim.WEB_FRAMEWORK, 'foobar') instanceof WebFrameworkShim)
+    t.end()
   })
 })

--- a/test/unit/shim/datastore-shim.test.js
+++ b/test/unit/shim/datastore-shim.test.js
@@ -5,24 +5,20 @@
 
 'use strict'
 
-// TODO: convert to normal tap style.
-// Below allows use of mocha DSL with tap runner.
-require('tap').mochaGlobals()
+const { test } = require('tap')
+const getMetricHostName = require('../../lib/metrics_helper').getMetricHostName
+const helper = require('../../lib/agent_helper')
+const Shim = require('../../../lib/shim/shim')
+const DatastoreShim = require('../../../lib/shim/datastore-shim')
+const ParsedStatement = require('../../../lib/db/parsed-statement')
 
-var chai = require('chai')
-var expect = chai.expect
-var getMetricHostName = require('../../lib/metrics_helper').getMetricHostName
-var helper = require('../../lib/agent_helper')
-var Shim = require('../../../lib/shim/shim')
-var DatastoreShim = require('../../../lib/shim/datastore-shim')
-var ParsedStatement = require('../../../lib/db/parsed-statement')
+test('DatastoreShim', function (t) {
+  t.autoend()
+  let agent = null
+  let shim = null
+  let wrappable = null
 
-describe('DatastoreShim', function () {
-  var agent = null
-  var shim = null
-  var wrappable = null
-
-  beforeEach(function () {
+  function beforeEach() {
     agent = helper.loadMockedAgent()
     shim = new DatastoreShim(agent, 'test-cassandra', null, DatastoreShim.CASSANDRA)
     wrappable = {
@@ -44,173 +40,213 @@ describe('DatastoreShim', function () {
         return segment
       }
     }
-  })
+  }
 
-  afterEach(function () {
+  function afterEach() {
     helper.unloadAgent(agent)
     agent = null
     shim = null
-  })
+  }
 
-  it('should inherit from Shim', function () {
-    expect(shim).to.be.an.instanceof(DatastoreShim).and.an.instanceof(Shim)
-  })
+  t.test('constructor', (t) => {
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
 
-  describe('constructor', function () {
-    it('should require the `agent` parameter', function () {
-      expect(function () {
-        return new DatastoreShim()
-      }).to.throw(Error, /^Shim must be initialized with .*? agent/)
+    t.test('should inherit from Shim', function (t) {
+      t.ok(shim instanceof DatastoreShim)
+      t.ok(shim instanceof Shim)
+      t.end()
     })
 
-    it('should require the `moduleName` parameter', function () {
-      expect(function () {
-        return new DatastoreShim(agent)
-      }).to.throw(Error, /^Shim must be initialized with .*? module name/)
+    t.test('should require the `agent` parameter', function (t) {
+      t.throws(() => new DatastoreShim(), /^Shim must be initialized with .*? agent/)
+      t.end()
     })
 
-    it('should take an optional `datastore`', function () {
+    t.test('should require the `moduleName` parameter', function (t) {
+      t.throws(() => new DatastoreShim(agent), /^Shim must be initialized with .*? module name/)
+      t.end()
+    })
+
+    t.test('should take an optional `datastore`', function (t) {
       // Test without datastore
-      var _shim = null
-      expect(function () {
+      let _shim = null
+      t.doesNotThrow(function () {
         _shim = new DatastoreShim(agent, 'test-cassandra')
-      }).to.not.throw()
-      expect(_shim).to.not.have.property('_metrics')
+      })
+      t.notOk(_shim._metrics)
 
       // Use one provided for all tests to check constructed with datastore
-      expect(shim).to.have.property('_metrics')
+      t.ok(shim._metrics)
+      t.end()
     })
   })
 
-  describe('well-known datastores', function () {
-    it('should be enumerated on the class and prototype', function () {
-      var datastores = [
-        'CASSANDRA',
-        'DYNAMODB',
-        'MEMCACHED',
-        'MONGODB',
-        'MYSQL',
-        'NEPTUNE',
-        'REDIS',
-        'POSTGRES'
-      ]
-      datastores.forEach(function (ds) {
-        expect(DatastoreShim).to.have.property(ds)
-        expect(shim).to.have.property(ds)
+  t.test('well-known datastores', (t) => {
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    const datastores = [
+      'CASSANDRA',
+      'DYNAMODB',
+      'MEMCACHED',
+      'MONGODB',
+      'MYSQL',
+      'NEPTUNE',
+      'REDIS',
+      'POSTGRES'
+    ]
+    datastores.forEach((ds) => {
+      t.test(`should have property ${ds}`, (t) => {
+        t.ok(DatastoreShim[ds])
+        t.ok(shim[ds])
+        t.end()
       })
     })
   })
 
-  describe('#logger', function () {
-    it('should be a non-writable property', function () {
-      expect(function () {
+  t.test('#logger', (t) => {
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    t.test('logger should be a non-writable property', function (t) {
+      t.throws(function () {
         shim.logger = 'foobar'
-      }).to.throw()
+      })
 
-      expect(shim).to.have.property('logger').that.is.not.equal('foobar')
+      t.ok(shim.logger)
+      t.not(shim.logger, 'foobar')
+      t.end()
     })
 
-    it('should be a logger to use with the shim', function () {
-      expect(shim.logger).to.have.property('trace').that.is.an.instanceof(Function)
-      expect(shim.logger).to.have.property('debug').that.is.an.instanceof(Function)
-      expect(shim.logger).to.have.property('info').that.is.an.instanceof(Function)
-      expect(shim.logger).to.have.property('warn').that.is.an.instanceof(Function)
-      expect(shim.logger).to.have.property('error').that.is.an.instanceof(Function)
-    })
-  })
-
-  describe('#setDatastore', function () {
-    var shim = null
-
-    beforeEach(function () {
-      // Use a shim without a datastore set for these tests.
-      shim = new DatastoreShim(agent, 'test-cassandra')
-    })
-
-    it('should accept the id of a well-known datastore', function () {
-      expect(function () {
-        shim.setDatastore(shim.CASSANDRA)
-      }).to.not.throw()
-
-      expect(shim).to.have.property('_metrics').that.has.property('PREFIX', 'Cassandra')
-    })
-
-    it('should create custom metric names if the `datastoreId` is a string', function () {
-      expect(function () {
-        shim.setDatastore('Fake Datastore')
-      }).to.not.throw()
-
-      expect(shim).to.have.property('_metrics').that.has.property('PREFIX', 'Fake Datastore')
-    })
-
-    it("should update the shim's logger", function () {
-      var original = shim.logger
-      shim.setDatastore(shim.CASSANDRA)
-      expect(shim.logger).to.not.equal(original)
-      expect(shim.logger).to.have.property('extra').that.has.property('datastore', 'Cassandra')
+    const logLevels = ['trace', 'debug', 'info', 'warn', 'error']
+    logLevels.forEach((level) => {
+      t.test(`logger should have ${level} as a function`, (t) => {
+        t.ok(shim.logger[level] instanceof Function, 'should be function')
+        t.end()
+      })
     })
   })
 
-  describe('#setParser', function () {
-    var shim = null
+  t.test('#setDatastore', (t) => {
+    t.autoend()
+    let dsAgent = null
+    let dsShim = null
 
-    beforeEach(function () {
+    t.beforeEach(function () {
+      dsAgent = helper.loadMockedAgent()
+      dsShim = new DatastoreShim(dsAgent, 'test-cassandra')
+    })
+
+    t.afterEach(function () {
+      dsShim = null
+      dsAgent = helper.unloadAgent(dsAgent)
+    })
+
+    t.test('should accept the id of a well-known datastore', function (t) {
+      t.doesNotThrow(function () {
+        dsShim.setDatastore(dsShim.CASSANDRA)
+      })
+
+      t.ok(dsShim._metrics.PREFIX, 'Cassandra')
+      t.end()
+    })
+
+    t.test('should create custom metric names if the `datastoreId` is a string', function (t) {
+      const dsShim = new DatastoreShim(dsAgent, 'test-cassandra')
+      t.doesNotThrow(function () {
+        dsShim.setDatastore('Fake Datastore')
+      })
+
+      t.ok(dsShim._metrics.PREFIX, 'Fake Datastore')
+      t.end()
+    })
+
+    t.test("should update the dsShim's logger", function (t) {
+      const dsShim = new DatastoreShim(dsAgent, 'test-cassandra')
+      const original = dsShim.logger
+      dsShim.setDatastore(dsShim.CASSANDRA)
+      t.not(dsShim.logger, original)
+      t.ok(dsShim.logger.extra.datastore, 'Cassandra')
+      t.end()
+    })
+  })
+
+  t.test('#setParser', (t) => {
+    t.autoend()
+    let agent = null
+    let shim = null
+
+    t.beforeEach(function () {
+      agent = helper.loadMockedAgent()
       // Use a shim without a parser set for these tests.
       shim = new DatastoreShim(agent, 'test')
       shim._metrics = { PREFIX: '' }
     })
 
-    it('should default to an SQL parser', function () {
-      shim.agent.config.transaction_tracer.record_sql = 'raw'
-      var query = 'SELECT 1 FROM test'
-      var parsed = shim.parseQuery(query)
-      expect(parsed.operation).to.equal('select')
-      expect(parsed.collection).to.equal('test')
-      expect(parsed.raw).to.equal(query)
+    t.afterEach(function () {
+      shim = null
+      agent = helper.unloadAgent(agent)
     })
 
-    it('should allow for the parser to be set', function () {
-      var testValue = false
+    t.test('should default to an SQL parser', function (t) {
+      shim.agent.config.transaction_tracer.record_sql = 'raw'
+      const query = 'SELECT 1 FROM test'
+      const parsed = shim.parseQuery(query)
+      t.equal(parsed.operation, 'select')
+      t.equal(parsed.collection, 'test')
+      t.equal(parsed.raw, query)
+      t.end()
+    })
+
+    t.test('should allow for the parser to be set', function (t) {
+      let testValue = false
       shim.setParser(function fakeParser(query) {
-        expect(query).to.equal('foobar')
+        t.equal(query, 'foobar')
         testValue = true
         return {
           operation: 'test'
         }
       })
       shim.parseQuery('foobar')
-      expect(testValue).to.be.true
+      t.ok(testValue)
+      t.end()
     })
 
-    it('should have constants to set the query parser with', function () {
+    t.test('should have constants to set the query parser with', function (t) {
       shim.agent.config.transaction_tracer.record_sql = 'raw'
       shim.setParser(shim.SQL_PARSER)
-      var query = 'SELECT 1 FROM test'
-      var parsed = shim.parseQuery(query)
-      expect(parsed.operation).to.equal('select')
-      expect(parsed.collection).to.equal('test')
-      expect(parsed.raw).to.equal(query)
+      const query = 'SELECT 1 FROM test'
+      const parsed = shim.parseQuery(query)
+      t.equal(parsed.operation, 'select')
+      t.equal(parsed.collection, 'test')
+      t.equal(parsed.raw, query)
+      t.end()
     })
 
-    it('should not set parser to a new parser with invalid string', function () {
-      var testValue = false
+    t.test('should not set parser to a new parser with invalid string', function (t) {
+      let testValue = false
       shim.setParser(function fakeParser(query) {
-        expect(query).to.equal('SELECT 1 FROM test')
+        t.equal(query, 'SELECT 1 FROM test')
         testValue = true
         return {
           operation: 'test'
         }
       })
       shim.setParser('bad string')
-      var query = 'SELECT 1 FROM test'
+      const query = 'SELECT 1 FROM test'
       shim.parseQuery(query)
-      expect(testValue).to.be.true
+      t.ok(testValue)
+      t.end()
     })
 
-    it('should not set parser to a new parser with an object', function () {
-      var testValue = false
+    t.test('should not set parser to a new parser with an object', function (t) {
+      let testValue = false
       shim.setParser(function fakeParser(query) {
-        expect(query).to.equal('SELECT 1 FROM test')
+        t.equal(query, 'SELECT 1 FROM test')
         testValue = true
         return {
           operation: 'test'
@@ -221,657 +257,699 @@ describe('DatastoreShim', function () {
           throw new Error('get me outta here')
         }
       })
-      var query = 'SELECT 1 FROM test'
+      const query = 'SELECT 1 FROM test'
       shim.parseQuery(query)
-      expect(testValue).to.be.true
+      t.ok(testValue)
+      t.end()
     })
   })
 
-  describe('#recordOperation', function () {
-    it('should not wrap non-function objects', function () {
-      var wrapped = shim.recordOperation(wrappable)
-      expect(wrapped).to.equal(wrappable)
-      expect(shim.isWrapped(wrapped)).to.be.false
+  t.test('#recordOperation', (t) => {
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    t.test('should not wrap non-function objects', function (t) {
+      const wrapped = shim.recordOperation(wrappable)
+      t.equal(wrapped, wrappable)
+      t.not(shim.isWrapped(wrapped))
+      t.end()
     })
 
-    describe('with no properties', function () {
-      it('should wrap the first parameter if no properties are given', function () {
-        var wrapped = shim.recordOperation(wrappable.bar, {})
-        expect(wrapped).to.not.equal(wrappable.bar)
-        expect(shim.isWrapped(wrapped)).to.be.true
-        expect(shim.unwrap(wrapped)).to.equal(wrappable.bar)
-      })
+    t.test('should wrap the first parameter if no properties are given', function (t) {
+      const wrapped = shim.recordOperation(wrappable.bar, {})
+      t.not(wrapped, wrappable.bar)
+      t.ok(shim.isWrapped(wrapped))
+      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.end()
+    })
 
-      it('should wrap the first parameter if `null` is given for properties', function () {
-        var wrapped = shim.recordOperation(wrappable.bar, null, {})
-        expect(wrapped).to.not.equal(wrappable.bar)
-        expect(shim.isWrapped(wrapped)).to.be.true
-        expect(shim.unwrap(wrapped)).to.equal(wrappable.bar)
+    t.test('should wrap the first parameter if `null` is given for properties', function (t) {
+      const wrapped = shim.recordOperation(wrappable.bar, null, {})
+      t.not(wrapped, wrappable.bar)
+      t.ok(shim.isWrapped(wrapped))
+      t.ok(shim.isWrapped(wrapped))
+      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.end()
+    })
+
+    t.test('should replace wrapped properties on the original object', function (t) {
+      const original = wrappable.bar
+      shim.recordOperation(wrappable, 'bar', {})
+      t.not(wrappable.bar, original)
+      t.ok(shim.isWrapped(wrappable.bar))
+      t.equal(shim.unwrap(wrappable.bar), original)
+      t.end()
+    })
+
+    t.test('should not mark unwrapped properties as wrapped', function (t) {
+      shim.recordOperation(wrappable, 'name', {})
+      t.not(shim.isWrapped(wrappable.name))
+      t.end()
+    })
+
+    t.test(
+      'should create a datastore operation segment but no metric when `record` is false',
+      function (t) {
+        shim.recordOperation(wrappable, 'getActiveSegment', { record: false })
+
+        helper.runInTransaction(agent, function (tx) {
+          const startingSegment = agent.tracer.getSegment()
+          const segment = wrappable.getActiveSegment()
+          t.not(segment, startingSegment)
+          t.equal(segment.transaction, tx)
+          t.equal(segment.name, 'getActiveSegment')
+          t.equal(agent.tracer.getSegment(), startingSegment)
+          t.end()
+        })
+      }
+    )
+
+    t.test('should create a datastore operation metric when `record` is true', function (t) {
+      shim.recordOperation(wrappable, 'getActiveSegment', { record: true })
+
+      helper.runInTransaction(agent, function (tx) {
+        const startingSegment = agent.tracer.getSegment()
+        const segment = wrappable.getActiveSegment()
+        t.not(segment, startingSegment)
+        t.equal(segment.transaction, tx)
+        t.equal(segment.name, 'Datastore/operation/Cassandra/getActiveSegment')
+        t.equal(agent.tracer.getSegment(), startingSegment)
+        t.end()
       })
     })
 
-    describe('with properties', function () {
-      it('should replace wrapped properties on the original object', function () {
-        var original = wrappable.bar
-        shim.recordOperation(wrappable, 'bar', {})
-        expect(wrappable.bar).to.not.equal(original)
-        expect(shim.isWrapped(wrappable.bar)).to.be.true
-        expect(shim.unwrap(wrappable.bar)).to.equal(original)
-      })
+    t.test('should create a datastore operation metric when `record` is defaulted', function (t) {
+      shim.recordOperation(wrappable, 'getActiveSegment')
 
-      it('should not mark unwrapped properties as wrapped', function () {
-        shim.recordOperation(wrappable, 'name', {})
-        expect(shim.isWrapped(wrappable.name)).to.be.false
+      helper.runInTransaction(agent, function (tx) {
+        const startingSegment = agent.tracer.getSegment()
+        const segment = wrappable.getActiveSegment()
+        t.not(segment, startingSegment)
+        t.equal(segment.transaction, tx)
+        t.equal(segment.name, 'Datastore/operation/Cassandra/getActiveSegment')
+        t.equal(agent.tracer.getSegment(), startingSegment)
+        t.end()
       })
     })
 
-    describe('wrapper', function () {
-      describe('when `record` is false', function () {
-        it('should create a datastore operation segment but no metric', function () {
-          shim.recordOperation(wrappable, 'getActiveSegment', { record: false })
+    t.test('should create a child segment when opaque is false', (t) => {
+      shim.recordOperation(wrappable, 'withNested', () => {
+        return { name: 'test', opaque: false }
+      })
+      helper.runInTransaction(agent, (tx) => {
+        const startingSegment = agent.tracer.getSegment()
+        const segment = wrappable.withNested()
+        t.not(segment, startingSegment)
+        t.equal(segment.transaction, tx)
+        t.equal(segment.name, 'Datastore/operation/Cassandra/test')
+        t.equal(segment.children.length, 1)
+        const [childSegment] = segment.children
+        t.equal(childSegment.name, 'ChildSegment')
+        t.end()
+      })
+    })
 
-          helper.runInTransaction(agent, function (tx) {
-            var startingSegment = agent.tracer.getSegment()
-            var segment = wrappable.getActiveSegment()
-            expect(segment).to.not.equal(startingSegment)
-            expect(segment.transaction).to.equal(tx)
-            expect(segment.name).to.equal('getActiveSegment')
-            expect(agent.tracer.getSegment()).to.equal(startingSegment)
-          })
-        })
+    t.test('should not create a child segment when opaque is true', (t) => {
+      shim.recordOperation(wrappable, 'withNested', () => {
+        return { name: 'test', opaque: true }
+      })
+      helper.runInTransaction(agent, (tx) => {
+        const startingSegment = agent.tracer.getSegment()
+        const segment = wrappable.withNested()
+        t.not(segment, startingSegment)
+        t.equal(segment.transaction, tx)
+        t.equal(segment.name, 'Datastore/operation/Cassandra/test')
+        t.equal(segment.children.length, 0)
+        t.end()
+      })
+    })
+
+    t.test('should execute the wrapped function', function (t) {
+      let executed = false
+      const toWrap = function () {
+        executed = true
+      }
+      const wrapped = shim.recordOperation(toWrap, {})
+
+      helper.runInTransaction(agent, function () {
+        t.not(executed)
+        wrapped()
+        t.ok(executed)
+        t.end()
+      })
+    })
+
+    t.test('should invoke the spec in the context of the wrapped function', function (t) {
+      const original = wrappable.bar
+      let executed = false
+      shim.recordOperation(wrappable, 'bar', function (_, fn, name, args) {
+        executed = true
+        t.equal(fn, original)
+        t.equal(name, 'bar')
+        t.equal(this, wrappable)
+        t.same(args, ['a', 'b', 'c'])
+        return {}
       })
 
-      describe('when `record` is true', function () {
-        it('should create a datastore operation metric', function () {
-          shim.recordOperation(wrappable, 'getActiveSegment')
-
-          helper.runInTransaction(agent, function (tx) {
-            var startingSegment = agent.tracer.getSegment()
-            var segment = wrappable.getActiveSegment()
-            expect(segment).to.not.equal(startingSegment)
-            expect(segment.transaction).to.equal(tx)
-            expect(segment.name).to.equal('Datastore/operation/Cassandra/getActiveSegment')
-            expect(agent.tracer.getSegment()).to.equal(startingSegment)
-          })
-        })
+      helper.runInTransaction(agent, function () {
+        wrappable.bar('a', 'b', 'c')
+        t.ok(executed)
+        t.end()
       })
+    })
 
-      describe('when `record` is defaulted', function () {
-        it('should create a datastore operation metric', function () {
-          shim.recordOperation(wrappable, 'getActiveSegment')
+    t.test('should bind the callback if there is one', function (t) {
+      const cb = function () {}
+      const toWrap = function (wrappedCB) {
+        t.not(wrappedCB, cb)
+        t.ok(shim.isWrapped(wrappedCB))
+        t.equal(shim.unwrap(wrappedCB), cb)
 
-          helper.runInTransaction(agent, function (tx) {
-            var startingSegment = agent.tracer.getSegment()
-            var segment = wrappable.getActiveSegment()
-            expect(segment).to.not.equal(startingSegment)
-            expect(segment.transaction).to.equal(tx)
-            expect(segment.name).to.equal('Datastore/operation/Cassandra/getActiveSegment')
-            expect(agent.tracer.getSegment()).to.equal(startingSegment)
-          })
+        t.doesNotThrow(function () {
+          wrappedCB()
         })
-      })
+        t.end()
+      }
 
-      describe('when opaque false', () => {
-        it('should create a child segment', () => {
-          shim.recordOperation(wrappable, 'withNested', () => {
-            return { name: 'test', opaque: false }
-          })
-          helper.runInTransaction(agent, (tx) => {
-            const startingSegment = agent.tracer.getSegment()
-            const segment = wrappable.withNested()
-            expect(segment).to.not.equal(startingSegment)
-            expect(segment.transaction).to.equal(tx)
-            expect(segment.name).to.equal('Datastore/operation/Cassandra/test')
-            expect(segment.children).to.have.lengthOf(1)
-            const childSegment = segment.children[0]
-            expect(childSegment.name).to.equal('ChildSegment')
-          })
-        })
-      })
+      const wrapped = shim.recordOperation(toWrap, { callback: shim.LAST })
 
-      describe('when opaque true', () => {
-        it('should not create a child segment', () => {
-          shim.recordOperation(wrappable, 'withNested', () => {
-            return { name: 'test', opaque: true }
-          })
-          helper.runInTransaction(agent, (tx) => {
-            const startingSegment = agent.tracer.getSegment()
-            const segment = wrappable.withNested()
-            expect(segment).to.not.equal(startingSegment)
-            expect(segment.name).to.equal('Datastore/operation/Cassandra/test')
-            expect(segment.transaction).to.equal(tx)
-            expect(segment.children).to.have.lengthOf(0)
-          })
-        })
+      helper.runInTransaction(agent, function () {
+        wrapped(cb)
       })
+    })
+  })
 
-      it('should execute the wrapped function', function () {
-        var executed = false
-        var toWrap = function () {
-          executed = true
+  t.test('with `parameters`', function (t) {
+    t.autoend()
+    let localhost = null
+    t.beforeEach(function () {
+      beforeEach()
+      localhost = getMetricHostName(agent, 'localhost')
+      shim.recordOperation(wrappable, 'getActiveSegment', function (s, fn, n, args) {
+        return { parameters: args[0] }
+      })
+    })
+    t.afterEach(afterEach)
+
+    function run(parameters, cb) {
+      helper.runInTransaction(agent, function () {
+        const segment = wrappable.getActiveSegment(parameters)
+        cb(segment)
+      })
+    }
+
+    t.test('should set datatastore attributes accordingly', function (t) {
+      run(
+        {
+          host: 'localhost',
+          port_path_or_id: 1234,
+          database_name: 'foobar'
+        },
+        function (segment) {
+          t.ok(segment.attributes)
+          const attributes = segment.getAttributes()
+          t.equal(attributes.host, localhost)
+          t.equal(attributes.port_path_or_id, '1234')
+          t.equal(attributes.database_name, 'foobar')
+          t.end()
         }
-        var wrapped = shim.recordOperation(toWrap, {})
-
-        helper.runInTransaction(agent, function () {
-          expect(executed).to.be.false
-          wrapped()
-          expect(executed).to.be.true
-        })
-      })
-
-      it('should invoke the spec in the context of the wrapped function', function () {
-        var original = wrappable.bar
-        var executed = false
-        shim.recordOperation(wrappable, 'bar', function (_, fn, name, args) {
-          executed = true
-          expect(fn).to.equal(original)
-          expect(name).to.equal('bar')
-          expect(this).to.equal(wrappable)
-          expect(args).to.deep.equal(['a', 'b', 'c'])
-
-          return {}
-        })
-
-        helper.runInTransaction(agent, function () {
-          wrappable.bar('a', 'b', 'c')
-          expect(executed).to.be.true
-        })
-      })
-
-      it('should bind the callback if there is one', function () {
-        var cb = function () {}
-        var toWrap = function (wrappedCB) {
-          expect(wrappedCB).to.not.equal(cb)
-          expect(shim.isWrapped(wrappedCB)).to.be.true
-          expect(shim.unwrap(wrappedCB)).to.equal(cb)
-
-          expect(function () {
-            wrappedCB()
-          }).to.not.throw()
-        }
-
-        var wrapped = shim.recordOperation(toWrap, { callback: shim.LAST })
-
-        helper.runInTransaction(agent, function () {
-          wrapped(cb)
-        })
-      })
-
-      describe('with `parameters`', function () {
-        var localhost = null
-        beforeEach(function () {
-          localhost = getMetricHostName(agent, 'localhost')
-          shim.recordOperation(wrappable, 'getActiveSegment', function (s, fn, n, args) {
-            return { parameters: args[0] }
-          })
-        })
-
-        function run(parameters, cb) {
-          helper.runInTransaction(agent, function () {
-            var segment = wrappable.getActiveSegment(parameters)
-            cb(segment)
-          })
-        }
-
-        it('should normalize the values of datastore instance attributes', function () {
-          run(
-            {
-              host: 'localhost',
-              port_path_or_id: 1234,
-              database_name: 'foobar'
-            },
-            function (segment) {
-              expect(segment).to.have.property('attributes')
-              const attributes = segment.getAttributes()
-              expect(attributes).to.have.property('host', localhost)
-              expect(attributes).to.have.property('port_path_or_id', '1234')
-              expect(attributes).to.have.property('database_name', 'foobar')
-            }
-          )
-
-          run(
-            {
-              host: 'some_other_host',
-              port_path_or_id: null,
-              database_name: null
-            },
-            function (segment) {
-              expect(segment).to.have.property('attributes')
-              const attributes = segment.getAttributes()
-              expect(attributes).to.have.property('host', 'some_other_host')
-              expect(attributes).to.have.property('port_path_or_id', 'unknown')
-              expect(attributes).to.have.property('database_name', 'unknown')
-            }
-          )
-        })
-
-        it('should remove `database_name` if disabled', function () {
-          agent.config.datastore_tracer.database_name_reporting.enabled = false
-          run(
-            {
-              host: 'localhost',
-              port_path_or_id: 1234,
-              database_name: 'foobar'
-            },
-            function (segment) {
-              expect(segment).to.have.property('attributes')
-              const attributes = segment.getAttributes()
-              expect(attributes).to.have.property('host', localhost)
-              expect(attributes).to.have.property('port_path_or_id', '1234')
-              expect(attributes).to.not.have.property('database_name')
-            }
-          )
-        })
-
-        it('should remove `host` and `port_path_or_id` if disabled', function () {
-          agent.config.datastore_tracer.instance_reporting.enabled = false
-          run(
-            {
-              host: 'localhost',
-              port_path_or_id: 1234,
-              database_name: 'foobar'
-            },
-            function (segment) {
-              expect(segment).to.have.property('attributes')
-              const attributes = segment.getAttributes()
-              expect(attributes).to.not.have.property('host')
-              expect(attributes).to.not.have.property('port_path_or_id')
-              expect(attributes).to.have.property('database_name', 'foobar')
-            }
-          )
-        })
-      })
+      )
     })
 
-    describe('recorder', function () {
-      beforeEach(function (done) {
-        shim.recordOperation(wrappable, 'getActiveSegment', function () {
-          return {
-            name: 'op',
-            parameters: {
-              host: 'some_host',
-              port_path_or_id: 1234,
-              database_name: 'foobar'
-            }
+    t.test('should default undefined attributes to `unknown`', function (t) {
+      run(
+        {
+          host: 'some_other_host',
+          port_path_or_id: null,
+          database_name: null
+        },
+        function (segment) {
+          t.ok(segment.attributes)
+          const attributes = segment.getAttributes()
+          t.equal(attributes.host, 'some_other_host')
+          t.equal(attributes.port_path_or_id, 'unknown')
+          t.equal(attributes.database_name, 'unknown')
+          t.end()
+        }
+      )
+    })
+
+    t.test('should remove `database_name` if disabled', function (t) {
+      agent.config.datastore_tracer.database_name_reporting.enabled = false
+      run(
+        {
+          host: 'localhost',
+          port_path_or_id: 1234,
+          database_name: 'foobar'
+        },
+        function (segment) {
+          t.ok(segment.attributes)
+          const attributes = segment.getAttributes()
+          t.equal(attributes.host, localhost)
+          t.equal(attributes.port_path_or_id, '1234')
+          t.notOk(attributes.database_name)
+          t.end()
+        }
+      )
+    })
+
+    t.test('should remove `host` and `port_path_or_id` if disabled', function (t) {
+      agent.config.datastore_tracer.instance_reporting.enabled = false
+      run(
+        {
+          host: 'localhost',
+          port_path_or_id: 1234,
+          database_name: 'foobar'
+        },
+        function (segment) {
+          t.ok(segment.attributes)
+          const attributes = segment.getAttributes()
+          t.notOk(attributes.host)
+          t.notOk(attributes.port_path_or_id)
+          t.equal(attributes.database_name, 'foobar')
+          t.end()
+        }
+      )
+    })
+  })
+
+  t.test('recorder', function (t) {
+    t.autoend()
+    t.beforeEach(function () {
+      beforeEach()
+      shim.recordOperation(wrappable, 'getActiveSegment', function () {
+        return {
+          name: 'op',
+          parameters: {
+            host: 'some_host',
+            port_path_or_id: 1234,
+            database_name: 'foobar'
           }
-        })
+        }
+      })
+
+      return new Promise((resolve) => {
         helper.runInTransaction(agent, function (tx) {
           wrappable.getActiveSegment()
           tx.end()
-          done()
+          resolve()
         })
       })
+    })
 
-      it('should create datastore metrics', function () {
-        var metrics = getMetrics(agent).unscoped
-        expect(metrics).to.have.property('Datastore/all')
-        expect(metrics).to.have.property('Datastore/allWeb')
-        expect(metrics).to.have.property('Datastore/Cassandra/all')
-        expect(metrics).to.have.property('Datastore/Cassandra/allWeb')
-        expect(metrics).to.have.property('Datastore/operation/Cassandra/op')
-        expect(metrics).to.have.property('Datastore/instance/Cassandra/some_host/1234')
-      })
+    t.afterEach(afterEach)
+
+    t.test('should create unscoped datastore metrics', function (t) {
+      const { unscoped: metrics } = helper.getMetrics(agent)
+      t.ok(metrics['Datastore/all'])
+      t.ok(metrics['Datastore/allWeb'])
+      t.ok(metrics['Datastore/Cassandra/all'])
+      t.ok(metrics['Datastore/Cassandra/allWeb'])
+      t.ok(metrics['Datastore/operation/Cassandra/op'])
+      t.ok(metrics['Datastore/instance/Cassandra/some_host/1234'])
+      t.end()
     })
   })
 
-  describe('#recordQuery', function () {
-    it('should not wrap non-function objects', function () {
-      var wrapped = shim.recordQuery(wrappable)
-      expect(wrapped).to.equal(wrappable)
-      expect(shim.isWrapped(wrapped)).to.be.false
+  t.test('#recordQuery', function (t) {
+    const query = 'SELECT property FROM my_table'
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    t.test('should not wrap non-function objects', function (t) {
+      const wrapped = shim.recordQuery(wrappable)
+      t.equal(wrapped, wrappable)
+      t.notOk(shim.isWrapped(wrapped))
+      t.end()
     })
 
-    describe('with no properties', function () {
-      it('should wrap the first parameter if no properties are given', function () {
-        var wrapped = shim.recordQuery(wrappable.bar, {})
-        expect(wrapped).to.not.equal(wrappable.bar)
-        expect(shim.isWrapped(wrapped)).to.be.true
-        expect(shim.unwrap(wrapped)).to.equal(wrappable.bar)
-      })
-
-      it('should wrap the first parameter if `null` is given for properties', function () {
-        var wrapped = shim.recordQuery(wrappable.bar, null, {})
-        expect(wrapped).to.not.equal(wrappable.bar)
-        expect(shim.isWrapped(wrapped)).to.be.true
-        expect(shim.unwrap(wrapped)).to.equal(wrappable.bar)
-      })
+    t.test('should wrap the first parameter if no properties are given', function (t) {
+      const wrapped = shim.recordQuery(wrappable.bar, {})
+      t.not(wrapped, wrappable.bar)
+      t.ok(shim.isWrapped(wrapped))
+      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.end()
     })
 
-    describe('with properties', function () {
-      it('should replace wrapped properties on the original object', function () {
-        var original = wrappable.bar
-        shim.recordQuery(wrappable, 'bar', {})
-        expect(wrappable.bar).to.not.equal(original)
-        expect(shim.isWrapped(wrappable.bar)).to.be.true
-        expect(shim.unwrap(wrappable.bar)).to.equal(original)
-      })
-
-      it('should not mark unwrapped properties as wrapped', function () {
-        shim.recordQuery(wrappable, 'name', {})
-        expect(shim.isWrapped(wrappable.name)).to.be.false
-      })
+    t.test('should wrap the first parameter if `null` is given for properties', function (t) {
+      const wrapped = shim.recordQuery(wrappable.bar, null, {})
+      t.not(wrapped, wrappable.bar)
+      t.ok(shim.isWrapped(wrapped))
+      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.end()
     })
 
-    describe('wrapper', function () {
-      var query = null
+    t.test('should replace wrapped properties on the original object', function (t) {
+      const original = wrappable.bar
+      shim.recordQuery(wrappable, 'bar', {})
+      t.not(wrappable.bar, original)
+      t.ok(shim.isWrapped(wrappable.bar))
+      t.equal(shim.unwrap(wrappable.bar), original)
+      t.end()
+    })
 
-      beforeEach(function () {
-        query = 'SELECT property FROM my_table'
-      })
+    t.test('should not mark unwrapped properties as wrapped', function (t) {
+      shim.recordQuery(wrappable, 'name', {})
+      t.notOk(shim.isWrapped(wrappable.name))
+      t.end()
+    })
 
-      describe('when `record` is false', function () {
-        it('should create a datastore query segment but no metric', function () {
-          shim.recordQuery(wrappable, 'getActiveSegment', {
-            query: shim.FIRST,
-            record: false
-          })
-
-          helper.runInTransaction(agent, function (tx) {
-            var startingSegment = agent.tracer.getSegment()
-            var segment = wrappable.getActiveSegment(query)
-            expect(segment).to.not.equal(startingSegment)
-            expect(segment.transaction).to.equal(tx)
-            expect(segment.name).to.equal('getActiveSegment')
-            expect(agent.tracer.getSegment()).to.equal(startingSegment)
-          })
-        })
-      })
-
-      describe('when `record` is true', function () {
-        it('should create a datastore query metric', function () {
-          shim.recordQuery(wrappable, 'getActiveSegment', { query: shim.FIRST })
-
-          helper.runInTransaction(agent, function (tx) {
-            var startingSegment = agent.tracer.getSegment()
-            var segment = wrappable.getActiveSegment(query)
-            expect(segment).to.not.equal(startingSegment)
-            expect(segment.transaction).to.equal(tx)
-            expect(segment.name).to.equal('Datastore/statement/Cassandra/my_table/select')
-            expect(agent.tracer.getSegment()).to.equal(startingSegment)
-          })
-        })
-      })
-
-      describe('when `record` is defaulted', function () {
-        it('should create a datastore query metric', function () {
-          shim.recordQuery(wrappable, 'getActiveSegment', { query: shim.FIRST })
-
-          helper.runInTransaction(agent, function (tx) {
-            var startingSegment = agent.tracer.getSegment()
-            var segment = wrappable.getActiveSegment(query)
-            expect(segment).to.not.equal(startingSegment)
-            expect(segment.transaction).to.equal(tx)
-            expect(segment.name).to.equal('Datastore/statement/Cassandra/my_table/select')
-            expect(agent.tracer.getSegment()).to.equal(startingSegment)
-          })
-        })
-      })
-
-      it('should execute the wrapped function', function () {
-        var executed = false
-        var toWrap = function () {
-          executed = true
-        }
-        var wrapped = shim.recordQuery(toWrap, {})
-
-        helper.runInTransaction(agent, function () {
-          expect(executed).to.be.false
-          wrapped()
-          expect(executed).to.be.true
-        })
-      })
-
-      it('should allow after handlers to be specified', function () {
-        var executed = false
-        var toWrap = function () {}
-        var wrapped = shim.recordQuery(toWrap, {
-          query: function () {
-            return 'test'
-          },
-          after: function () {
-            executed = true
-          }
-        })
-
-        helper.runInTransaction(agent, function () {
-          expect(executed).to.be.false
-          wrapped()
-          expect(executed).to.be.true
-        })
-      })
-
-      it('should bind the callback if there is one', function () {
-        var cb = function () {}
-        var toWrap = function (_query, wrappedCB) {
-          expect(wrappedCB).to.not.equal(cb)
-          expect(shim.isWrapped(wrappedCB)).to.be.true
-          expect(shim.unwrap(wrappedCB)).to.equal(cb)
-
-          expect(function () {
-            wrappedCB()
-          }).to.not.throw()
-        }
-
-        var wrapped = shim.recordQuery(toWrap, {
+    t.test(
+      'should create a datastore query segment but no metric when `record` is false',
+      function (t) {
+        shim.recordQuery(wrappable, 'getActiveSegment', {
           query: shim.FIRST,
-          callback: shim.LAST
+          record: false
         })
-
-        helper.runInTransaction(agent, function () {
-          wrapped(query, cb)
-        })
-      })
-
-      it('should bind the row callback if there is one', function () {
-        var cb = function () {}
-        var toWrap = function (_query, wrappedCB) {
-          expect(wrappedCB).to.not.equal(cb)
-          expect(shim.isWrapped(wrappedCB)).to.be.true
-          expect(shim.unwrap(wrappedCB)).to.equal(cb)
-
-          expect(function () {
-            wrappedCB()
-          }).to.not.throw()
-        }
-
-        var wrapped = shim.recordQuery(toWrap, {
-          query: shim.FIRST,
-          rowCallback: shim.LAST
-        })
-
-        helper.runInTransaction(agent, function () {
-          wrapped(query, cb)
-        })
-      })
-    })
-  })
-
-  describe('#recordBatchQuery', function () {
-    it('should not wrap non-function objects', function () {
-      var wrapped = shim.recordBatchQuery(wrappable)
-      expect(wrapped).to.equal(wrappable)
-      expect(shim.isWrapped(wrapped)).to.be.false
-    })
-
-    describe('with no properties', function () {
-      it('should wrap the first parameter if no properties are given', function () {
-        var wrapped = shim.recordBatchQuery(wrappable.bar, {})
-        expect(wrapped).to.not.equal(wrappable.bar)
-        expect(shim.isWrapped(wrapped)).to.be.true
-        expect(shim.unwrap(wrapped)).to.equal(wrappable.bar)
-      })
-
-      it('should wrap the first parameter if `null` is given for properties', function () {
-        var wrapped = shim.recordBatchQuery(wrappable.bar, null, {})
-        expect(wrapped).to.not.equal(wrappable.bar)
-        expect(shim.isWrapped(wrapped)).to.be.true
-        expect(shim.unwrap(wrapped)).to.equal(wrappable.bar)
-      })
-    })
-
-    describe('with properties', function () {
-      it('should replace wrapped properties on the original object', function () {
-        var original = wrappable.bar
-        shim.recordBatchQuery(wrappable, 'bar', {})
-        expect(wrappable.bar).to.not.equal(original)
-        expect(shim.isWrapped(wrappable.bar)).to.be.true
-        expect(shim.unwrap(wrappable.bar)).to.equal(original)
-      })
-
-      it('should not mark unwrapped properties as wrapped', function () {
-        shim.recordBatchQuery(wrappable, 'name', {})
-        expect(shim.isWrapped(wrappable.name)).to.be.false
-      })
-    })
-
-    describe('wrapper', function () {
-      var query = null
-
-      beforeEach(function () {
-        query = 'SELECT property FROM my_table'
-      })
-
-      it('should create a datastore batch query metric', function () {
-        shim.recordBatchQuery(wrappable, 'getActiveSegment', { query: shim.FIRST })
 
         helper.runInTransaction(agent, function (tx) {
-          var startingSegment = agent.tracer.getSegment()
-          var segment = wrappable.getActiveSegment(query)
-          expect(segment).to.not.equal(startingSegment)
-          expect(segment.transaction).to.equal(tx)
-          expect(segment.name).to.equal('Datastore/statement/Cassandra/my_table/select/batch')
-          expect(agent.tracer.getSegment()).to.equal(startingSegment)
+          const startingSegment = agent.tracer.getSegment()
+          const segment = wrappable.getActiveSegment(query)
+          t.not(segment, startingSegment)
+          t.equal(segment.transaction, tx)
+          t.equal(segment.name, 'getActiveSegment')
+          t.equal(agent.tracer.getSegment(), startingSegment)
+          t.end()
         })
-      })
+      }
+    )
 
-      it('should execute the wrapped function', function () {
-        var executed = false
-        var toWrap = function () {
+    t.test('should create a datastore query metric when `record` is true', function (t) {
+      shim.recordQuery(wrappable, 'getActiveSegment', { query: shim.FIRST, record: true })
+
+      helper.runInTransaction(agent, function (tx) {
+        const startingSegment = agent.tracer.getSegment()
+        const segment = wrappable.getActiveSegment(query)
+        t.not(segment, startingSegment)
+        t.equal(segment.transaction, tx)
+        t.equal(segment.name, 'Datastore/statement/Cassandra/my_table/select')
+        t.equal(agent.tracer.getSegment(), startingSegment)
+        t.end()
+      })
+    })
+
+    t.test('should create a datastore query metric when `record` is defaulted', function (t) {
+      shim.recordQuery(wrappable, 'getActiveSegment', { query: shim.FIRST })
+
+      helper.runInTransaction(agent, function (tx) {
+        const startingSegment = agent.tracer.getSegment()
+        const segment = wrappable.getActiveSegment(query)
+        t.not(segment, startingSegment)
+        t.equal(segment.transaction, tx)
+        t.equal(segment.name, 'Datastore/statement/Cassandra/my_table/select')
+        t.equal(agent.tracer.getSegment(), startingSegment)
+        t.end()
+      })
+    })
+
+    t.test('should execute the wrapped function', function (t) {
+      let executed = false
+      const toWrap = function () {
+        executed = true
+      }
+      const wrapped = shim.recordQuery(toWrap, {})
+
+      helper.runInTransaction(agent, function () {
+        t.notOk(executed)
+        wrapped()
+        t.ok(executed)
+        t.end()
+      })
+    })
+
+    t.test('should allow after handlers to be specified', function (t) {
+      let executed = false
+      const toWrap = function () {}
+      const wrapped = shim.recordQuery(toWrap, {
+        query: function () {
+          return 'test'
+        },
+        after: function () {
           executed = true
         }
-        var wrapped = shim.recordBatchQuery(toWrap, {})
+      })
 
-        expect(executed).to.be.false
+      helper.runInTransaction(agent, function () {
+        t.notOk(executed)
         wrapped()
-        expect(executed).to.be.true
+        t.ok(executed)
+        t.end()
+      })
+    })
+
+    t.test('should bind the callback if there is one', function (t) {
+      let cb = function () {}
+
+      const toWrap = function (_query, wrappedCB) {
+        t.not(wrappedCB, cb)
+        t.ok(shim.isWrapped(wrappedCB))
+        t.equal(shim.unwrap(wrappedCB), cb)
+
+        t.doesNotThrow(function () {
+          wrappedCB()
+        })
+        t.end()
+      }
+
+      const wrapped = shim.recordQuery(toWrap, {
+        query: shim.FIRST,
+        callback: shim.LAST
+      })
+
+      helper.runInTransaction(agent, function () {
+        wrapped(query, cb)
+      })
+    })
+
+    t.test('should bind the row callback if there is one', function (t) {
+      const cb = function () {}
+      const toWrap = function (_query, wrappedCB) {
+        t.not(wrappedCB, cb)
+        t.ok(shim.isWrapped(wrappedCB))
+        t.equal(shim.unwrap(wrappedCB), cb)
+
+        t.doesNotThrow(function () {
+          wrappedCB()
+        })
+        t.end()
+      }
+
+      const wrapped = shim.recordQuery(toWrap, {
+        query: shim.FIRST,
+        rowCallback: shim.LAST
+      })
+
+      helper.runInTransaction(agent, function () {
+        wrapped(query, cb)
       })
     })
   })
 
-  describe('#parseQuery', function () {
-    it('should parse a query string into a ParsedStatement', function () {
-      var statement = shim.parseQuery('SELECT * FROM table')
-      expect(statement).to.be.an.instanceof(ParsedStatement)
+  t.test('#recordBatchQuery', function (t) {
+    const query = 'SELECT property FROM my_table'
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    t.test('should not wrap non-function objects', function (t) {
+      const wrapped = shim.recordBatchQuery(wrappable)
+      t.equal(wrapped, wrappable)
+      t.notOk(shim.isWrapped(wrapped))
+      t.end()
     })
 
-    it('should strip enclosing special characters from collection', function () {
-      expect(shim.parseQuery('select * from [table]').collection).to.equal('table')
-      expect(shim.parseQuery('select * from {table}').collection).to.equal('table')
-      expect(shim.parseQuery("select * from 'table'").collection).to.equal('table')
-      expect(shim.parseQuery('select * from "table"').collection).to.equal('table')
-      expect(shim.parseQuery('select * from `table`').collection).to.equal('table')
+    t.test('should wrap the first parameter if no properties are given', function (t) {
+      const wrapped = shim.recordBatchQuery(wrappable.bar, {})
+      t.not(wrapped, wrappable.bar)
+      t.ok(shim.isWrapped(wrapped))
+      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.end()
+    })
+
+    t.test('should wrap the first parameter if `null` is given for properties', function (t) {
+      const wrapped = shim.recordBatchQuery(wrappable.bar, null, {})
+      t.not(wrapped, wrappable.bar)
+      t.ok(shim.isWrapped(wrapped))
+      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.end()
+    })
+
+    t.test('should replace wrapped properties on the original object', function (t) {
+      const original = wrappable.bar
+      shim.recordBatchQuery(wrappable, 'bar', {})
+      t.not(wrappable.bar, original)
+      t.ok(shim.isWrapped(wrappable.bar))
+      t.equal(shim.unwrap(wrappable.bar), original)
+      t.end()
+    })
+
+    t.test('should not mark unwrapped properties as wrapped', function (t) {
+      shim.recordBatchQuery(wrappable, 'name', {})
+      t.notOk(shim.isWrapped(wrappable.name))
+      t.end()
+    })
+
+    t.test('should create a datastore batch query metric', function (t) {
+      shim.recordBatchQuery(wrappable, 'getActiveSegment', { query: shim.FIRST })
+
+      helper.runInTransaction(agent, function (tx) {
+        const startingSegment = agent.tracer.getSegment()
+        const segment = wrappable.getActiveSegment(query)
+        t.not(segment, startingSegment)
+        t.equal(segment.transaction, tx)
+        t.equal(segment.name, 'Datastore/statement/Cassandra/my_table/select/batch')
+        t.equal(agent.tracer.getSegment(), startingSegment)
+        t.end()
+      })
+    })
+
+    t.test('should execute the wrapped function', function (t) {
+      let executed = false
+      const toWrap = function () {
+        executed = true
+      }
+      const wrapped = shim.recordBatchQuery(toWrap, {})
+      t.notOk(executed)
+      wrapped()
+      t.ok(executed)
+      t.end()
     })
   })
 
-  describe('#bindRowCallbackSegment', function () {
-    it('should wrap the identified argument', function () {
-      var args = [1, 2, wrappable.bar]
+  t.test('#parseQuery', function (t) {
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    t.test('should parse a query string into a ParsedStatement', function (t) {
+      const statement = shim.parseQuery('SELECT * FROM table')
+      t.ok(statement instanceof ParsedStatement)
+      t.end()
+    })
+
+    t.test('should strip enclosing special characters from collection', function (t) {
+      t.equal(shim.parseQuery('select * from [table]').collection, 'table')
+      t.equal(shim.parseQuery('select * from {table}').collection, 'table')
+      t.equal(shim.parseQuery("select * from 'table'").collection, 'table')
+      t.equal(shim.parseQuery('select * from "table"').collection, 'table')
+      t.equal(shim.parseQuery('select * from `table`').collection, 'table')
+      t.end()
+    })
+  })
+
+  t.test('#bindRowCallbackSegment', function (t) {
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    t.test('should wrap the identified argument', function (t) {
+      const args = [1, 2, wrappable.bar]
       shim.bindRowCallbackSegment(args, shim.LAST)
 
-      expect(args[2]).to.not.equal(wrappable.bar)
-      expect(shim.isWrapped(args[2])).to.be.true
-      expect(shim.unwrap(args[2])).to.equal(wrappable.bar)
+      t.not(args[2], wrappable.bar)
+      t.ok(shim.isWrapped(args[2]))
+      t.equal(shim.unwrap(args[2]), wrappable.bar)
+      t.end()
     })
 
-    it('should not wrap if the index is invalid', function () {
-      var args = [1, 2, wrappable.bar]
+    t.test('should not wrap if the index is invalid', function (t) {
+      const args = [1, 2, wrappable.bar]
 
-      expect(function () {
+      t.doesNotThrow(function () {
         shim.bindRowCallbackSegment(args, 50)
-      }).to.not.throw()
+      })
 
-      expect(args[2]).to.equal(wrappable.bar)
-      expect(shim.isWrapped(args[2])).to.be.false
+      t.equal(args[2], wrappable.bar)
+      t.notOk(shim.isWrapped(args[2]))
+      t.end()
     })
 
-    it('should not wrap the argument if it is not a function', function () {
-      var args = [1, 2, wrappable.bar]
+    t.test('should not wrap the argument if it is not a function', function (t) {
+      const args = [1, 2, wrappable.bar]
 
-      expect(function () {
+      t.doesNotThrow(function () {
         shim.bindRowCallbackSegment(args, 1)
-      }).to.not.throw()
+      })
 
-      expect(args[1]).to.equal(2)
-      expect(shim.isWrapped(args[1])).to.be.false
-      expect(args[2]).to.equal(wrappable.bar)
-      expect(shim.isWrapped(args[2])).to.be.false
+      t.equal(args[1], 2)
+      t.notOk(shim.isWrapped(args[1]))
+      t.equal(args[2], wrappable.bar)
+      t.notOk(shim.isWrapped(args[2]))
+      t.end()
     })
 
-    it('should create a new segment on the first call', function () {
+    t.test('should create a new segment on the first call', function (t) {
       helper.runInTransaction(agent, function () {
-        var args = [1, 2, wrappable.getActiveSegment]
+        const args = [1, 2, wrappable.getActiveSegment]
         shim.bindRowCallbackSegment(args, shim.LAST)
 
         // Check the segment
-        var segment = shim.getSegment()
-        var cbSegment = args[2]()
-        expect(cbSegment).to.not.equal(segment)
-        expect(segment.children).to.contain(cbSegment)
+        const segment = shim.getSegment()
+        const cbSegment = args[2]()
+        t.not(cbSegment, segment)
+        t.not(segment.children.includes(cbSegment))
+        t.end()
       })
     })
 
-    it('should not create a new segment for calls after the first', function () {
+    t.test('should not create a new segment for calls after the first', function (t) {
       helper.runInTransaction(agent, function () {
-        var args = [1, 2, wrappable.getActiveSegment]
+        const args = [1, 2, wrappable.getActiveSegment]
         shim.bindRowCallbackSegment(args, shim.LAST)
 
         // Check the segment from the first call.
-        var segment = shim.getSegment()
-        var cbSegment = args[2]()
-        expect(cbSegment).to.not.equal(segment)
-        expect(segment.children).to.contain(cbSegment)
-        expect(segment.children).to.have.length(1)
+        const segment = shim.getSegment()
+        const cbSegment = args[2]()
+        t.not(cbSegment, segment)
+        t.ok(segment.children.includes(cbSegment))
+        t.equal(segment.children.length, 1)
 
         // Call it a second time and see if we have the same segment.
-        var cbSegment2 = args[2]()
-        expect(cbSegment2).to.equal(cbSegment)
-        expect(segment.children).to.have.length(1)
+        const cbSegment2 = args[2]()
+        t.equal(cbSegment2, cbSegment)
+        t.equal(segment.children.length, 1)
+        t.end()
       })
     })
 
-    it('should name the segment based on number of calls', function () {
+    t.test('should name the segment based on number of calls', function (t) {
       helper.runInTransaction(agent, function () {
-        var args = [1, 2, wrappable.getActiveSegment]
+        const args = [1, 2, wrappable.getActiveSegment]
         shim.bindRowCallbackSegment(args, shim.LAST)
 
         // Check the segment from the first call.
-        var cbSegment = args[2]()
-        expect(cbSegment)
-          .to.have.property('name')
-          .match(/^Callback: getActiveSegment/)
-
-        expect(cbSegment.getAttributes()).to.have.property('count', 1)
+        const cbSegment = args[2]()
+        t.match(cbSegment.name, /^Callback: getActiveSegment/)
+        t.equal(cbSegment.getAttributes().count, 1)
 
         // Call it a second time and see if the name changed.
         args[2]()
-        expect(cbSegment.getAttributes()).to.have.property('count', 2)
+        t.equal(cbSegment.getAttributes().count, 2)
 
         // And a third time, why not?
         args[2]()
-        expect(cbSegment.getAttributes()).to.have.property('count', 3)
+        t.equal(cbSegment.getAttributes().count, 3)
+        t.end()
       })
     })
   })
 
-  describe('#captureInstanceAttributes', function () {
-    it('should not crash outside of a transaction', function () {
-      expect(function () {
+  t.test('#captureInstanceAttributes', function (t) {
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    t.test('should not crash outside of a transaction', function (t) {
+      t.doesNotThrow(function () {
         shim.captureInstanceAttributes('foo', 123, 'bar')
-      }).to.not.throw()
+      })
+      t.end()
     })
 
-    it('should not add parameters to segments it did not create', function () {
-      var bound = agent.tracer.wrapFunction(
+    t.test('should not add parameters to segments it did not create', function (t) {
+      const bound = agent.tracer.wrapFunction(
         'foo',
         null,
         function (host, port, db) {
@@ -884,68 +962,76 @@ describe('DatastoreShim', function () {
       )
 
       helper.runInTransaction(agent, function () {
-        var segment = bound('foobar', 123, 'bar')
-        expect(segment).to.have.property('attributes')
+        const segment = bound('foobar', 123, 'bar')
+        t.ok(segment.attributes)
         const attributes = segment.getAttributes()
-        expect(attributes).to.not.have.property('host')
-        expect(attributes).to.not.have.property('port_path_or_id')
-        expect(attributes).to.not.have.property('database_name')
+        t.notOk(attributes.host)
+        t.notOk(attributes.port_path_or_id)
+        t.notOk(attributes.database_name)
+        t.end()
       })
     })
 
-    it('should add normalized attributes to its own segments', function () {
-      var wrapped = shim.recordOperation(function (host, port, db) {
+    t.test('should add normalized attributes to its own segments', function (t) {
+      const wrapped = shim.recordOperation(function (host, port, db) {
         shim.captureInstanceAttributes(host, port, db)
         return shim.getSegment()
       })
 
       helper.runInTransaction(agent, function () {
-        var segment = wrapped('foobar', 123, 'bar')
-        expect(segment).to.have.property('attributes')
+        const segment = wrapped('foobar', 123, 'bar')
+        t.ok(segment.attributes)
         const attributes = segment.getAttributes()
-        expect(attributes).to.have.property('host', 'foobar')
-        expect(attributes).to.have.property('port_path_or_id', '123')
-        expect(attributes).to.have.property('database_name', 'bar')
+        t.equal(attributes.host, 'foobar')
+        t.equal(attributes.port_path_or_id, '123')
+        t.equal(attributes.database_name, 'bar')
+        t.end()
       })
     })
   })
 
-  describe('#getDatabaseNameFromUseQuery', () => {
-    it('should match single statement use expressions', () => {
-      expect(shim.getDatabaseNameFromUseQuery('use test_db;')).to.equal('test_db')
-      expect(shim.getDatabaseNameFromUseQuery('USE INIT')).to.equal('INIT')
+  t.test('#getDatabaseNameFromUseQuery', (t) => {
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    t.test('should match single statement use expressions', (t) => {
+      t.equal(shim.getDatabaseNameFromUseQuery('use test_db;'), 'test_db')
+      t.equal(shim.getDatabaseNameFromUseQuery('USE INIT'), 'INIT')
+      t.end()
     })
 
-    it('should not be sensitive to ; omission', () => {
-      expect(shim.getDatabaseNameFromUseQuery('use test_db')).to.equal('test_db')
+    t.test('should not be sensitive to ; omission', (t) => {
+      t.equal(shim.getDatabaseNameFromUseQuery('use test_db'), 'test_db')
+      t.end()
     })
 
-    it('should not be sensitive to extra ;', () => {
-      expect(shim.getDatabaseNameFromUseQuery('use test_db;;;;;;')).to.equal('test_db')
+    t.test('should not be sensitive to extra ;', (t) => {
+      t.equal(shim.getDatabaseNameFromUseQuery('use test_db;;;;;;'), 'test_db')
+      t.end()
     })
 
-    it('should not be sensitive to extra white space', () => {
-      expect(shim.getDatabaseNameFromUseQuery('            use test_db;')).to.equal('test_db')
-      expect(shim.getDatabaseNameFromUseQuery('use             test_db;')).to.equal('test_db')
-      expect(shim.getDatabaseNameFromUseQuery('use test_db            ;')).to.equal('test_db')
-      expect(shim.getDatabaseNameFromUseQuery('use test_db;            ')).to.equal('test_db')
+    t.test('should not be sensitive to extra white space', (t) => {
+      t.equal(shim.getDatabaseNameFromUseQuery('            use test_db;'), 'test_db')
+      t.equal(shim.getDatabaseNameFromUseQuery('use             test_db;'), 'test_db')
+      t.equal(shim.getDatabaseNameFromUseQuery('use test_db            ;'), 'test_db')
+      t.equal(shim.getDatabaseNameFromUseQuery('use test_db;            '), 'test_db')
+      t.end()
     })
 
-    it('should match backtick expressions', () => {
-      expect(shim.getDatabaseNameFromUseQuery('use `test_db`;')).to.equal('`test_db`')
-      expect(shim.getDatabaseNameFromUseQuery('use `☃☃☃☃☃☃`;')).to.equal('`☃☃☃☃☃☃`')
+    t.test('should match backtick expressions', (t) => {
+      t.equal(shim.getDatabaseNameFromUseQuery('use `test_db`;'), '`test_db`')
+      t.equal(shim.getDatabaseNameFromUseQuery('use `☃☃☃☃☃☃`;'), '`☃☃☃☃☃☃`')
+      t.end()
     })
 
-    it('should not match malformed use expressions', () => {
-      expect(shim.getDatabaseNameFromUseQuery('use cxvozicjvzocixjv`oasidfjaosdfij`;')).to.be.null
-      expect(shim.getDatabaseNameFromUseQuery('use `oasidfjaosdfij`123;')).to.be.null
-      expect(shim.getDatabaseNameFromUseQuery('use `oasidfjaosdfij` 123;')).to.be.null
-      expect(shim.getDatabaseNameFromUseQuery('use \u0001;')).to.be.null
-      expect(shim.getDatabaseNameFromUseQuery('use oasidfjaosdfij 123;')).to.be.null
+    t.test('should not match malformed use expressions', (t) => {
+      t.equal(shim.getDatabaseNameFromUseQuery('use cxvozicjvzocixjv`oasidfjaosdfij`;'), null)
+      t.equal(shim.getDatabaseNameFromUseQuery('use `oasidfjaosdfij`123;'), null)
+      t.equal(shim.getDatabaseNameFromUseQuery('use `oasidfjaosdfij` 123;'), null)
+      t.equal(shim.getDatabaseNameFromUseQuery('use \u0001;'), null)
+      t.equal(shim.getDatabaseNameFromUseQuery('use oasidfjaosdfij 123;'), null)
+      t.end()
     })
   })
 })
-
-function getMetrics(agent) {
-  return agent.metrics._metrics
-}

--- a/test/unit/shim/datastore-shim.test.js
+++ b/test/unit/shim/datastore-shim.test.js
@@ -156,7 +156,6 @@ test('DatastoreShim', function (t) {
     })
 
     t.test('should create custom metric names if the `datastoreId` is a string', function (t) {
-      const dsShim = new DatastoreShim(dsAgent, 'test-cassandra')
       t.doesNotThrow(function () {
         dsShim.setDatastore('Fake Datastore')
       })
@@ -166,7 +165,6 @@ test('DatastoreShim', function (t) {
     })
 
     t.test("should update the dsShim's logger", function (t) {
-      const dsShim = new DatastoreShim(dsAgent, 'test-cassandra')
       const original = dsShim.logger
       dsShim.setDatastore(dsShim.CASSANDRA)
       t.not(dsShim.logger, original)
@@ -177,25 +175,25 @@ test('DatastoreShim', function (t) {
 
   t.test('#setParser', (t) => {
     t.autoend()
-    let agent = null
-    let shim = null
+    let parserAgent = null
+    let parserShim = null
 
     t.beforeEach(function () {
-      agent = helper.loadMockedAgent()
-      // Use a shim without a parser set for these tests.
-      shim = new DatastoreShim(agent, 'test')
-      shim._metrics = { PREFIX: '' }
+      parserAgent = helper.loadMockedAgent()
+      // Use a parserShim without a parser set for these tests.
+      parserShim = new DatastoreShim(parserAgent, 'test')
+      parserShim._metrics = { PREFIX: '' }
     })
 
     t.afterEach(function () {
-      shim = null
-      agent = helper.unloadAgent(agent)
+      parserShim = null
+      parserAgent = helper.unloadAgent(parserAgent)
     })
 
     t.test('should default to an SQL parser', function (t) {
-      shim.agent.config.transaction_tracer.record_sql = 'raw'
+      parserShim.agent.config.transaction_tracer.record_sql = 'raw'
       const query = 'SELECT 1 FROM test'
-      const parsed = shim.parseQuery(query)
+      const parsed = parserShim.parseQuery(query)
       t.equal(parsed.operation, 'select')
       t.equal(parsed.collection, 'test')
       t.equal(parsed.raw, query)
@@ -204,23 +202,23 @@ test('DatastoreShim', function (t) {
 
     t.test('should allow for the parser to be set', function (t) {
       let testValue = false
-      shim.setParser(function fakeParser(query) {
+      parserShim.setParser(function fakeParser(query) {
         t.equal(query, 'foobar')
         testValue = true
         return {
           operation: 'test'
         }
       })
-      shim.parseQuery('foobar')
+      parserShim.parseQuery('foobar')
       t.ok(testValue)
       t.end()
     })
 
     t.test('should have constants to set the query parser with', function (t) {
-      shim.agent.config.transaction_tracer.record_sql = 'raw'
-      shim.setParser(shim.SQL_PARSER)
+      parserShim.agent.config.transaction_tracer.record_sql = 'raw'
+      parserShim.setParser(parserShim.SQL_PARSER)
       const query = 'SELECT 1 FROM test'
-      const parsed = shim.parseQuery(query)
+      const parsed = parserShim.parseQuery(query)
       t.equal(parsed.operation, 'select')
       t.equal(parsed.collection, 'test')
       t.equal(parsed.raw, query)
@@ -229,41 +227,40 @@ test('DatastoreShim', function (t) {
 
     t.test('should not set parser to a new parser with invalid string', function (t) {
       let testValue = false
-      shim.setParser(function fakeParser(query) {
+      parserShim.setParser(function fakeParser(query) {
         t.equal(query, 'SELECT 1 FROM test')
         testValue = true
         return {
           operation: 'test'
         }
       })
-      shim.setParser('bad string')
+      parserShim.setParser('bad string')
       const query = 'SELECT 1 FROM test'
-      shim.parseQuery(query)
+      parserShim.parseQuery(query)
       t.ok(testValue)
       t.end()
     })
 
     t.test('should not set parser to a new parser with an object', function (t) {
       let testValue = false
-      shim.setParser(function fakeParser(query) {
+      parserShim.setParser(function fakeParser(query) {
         t.equal(query, 'SELECT 1 FROM test')
         testValue = true
         return {
           operation: 'test'
         }
       })
-      shim.setParser({
+      parserShim.setParser({
         parser: function shouldNotBeCalled() {
           throw new Error('get me outta here')
         }
       })
       const query = 'SELECT 1 FROM test'
-      shim.parseQuery(query)
+      parserShim.parseQuery(query)
       t.ok(testValue)
       t.end()
     })
   })
-
   t.test('#recordOperation', (t) => {
     t.autoend()
     t.beforeEach(beforeEach)

--- a/test/unit/shim/message-shim.test.js
+++ b/test/unit/shim/message-shim.test.js
@@ -4,14 +4,16 @@
  */
 
 'use strict'
-const { test } = require('tap')
+const tap = require('tap')
 const API = require('../../../api')
 var DESTINATIONS = require('../../../lib/config/attribute-filter').DESTINATIONS
 const hashes = require('../../../lib/util/hashes')
 const helper = require('../../lib/agent_helper')
 const MessageShim = require('../../../lib/shim/message-shim')
 
-test('MessageShim', function (t) {
+tap.Test.prototype.addAssert('isNonWritable', 1, helper.isNonWritable)
+
+tap.test('MessageShim', function (t) {
   t.autoend()
   let agent = null
   let shim = null
@@ -100,8 +102,8 @@ test('MessageShim', function (t) {
 
     t.test('should be enumerated on the class and prototype', function (t) {
       messageLibs.forEach(function (lib) {
-        helper.testNonWritable({ t, obj: MessageShim, key: lib })
-        helper.testNonWritable({ t, obj: shim, key: lib })
+        t.isNonWritable({ obj: MessageShim, key: lib })
+        t.isNonWritable({ obj: shim, key: lib })
       })
       t.end()
     })
@@ -115,8 +117,8 @@ test('MessageShim', function (t) {
 
     t.test('should be enumerated on the class and prototype', function (t) {
       messageLibs.forEach(function (lib) {
-        helper.testNonWritable({ t, obj: MessageShim, key: lib })
-        helper.testNonWritable({ t, obj: shim, key: lib })
+        t.isNonWritable({ obj: MessageShim, key: lib })
+        t.isNonWritable({ obj: shim, key: lib })
       })
       t.end()
     })

--- a/test/unit/shim/message-shim.test.js
+++ b/test/unit/shim/message-shim.test.js
@@ -4,28 +4,22 @@
  */
 
 'use strict'
-
-// TODO: convert to normal tap style.
-// Below allows use of mocha DSL with tap runner.
-require('tap').mochaGlobals()
-
-var API = require('../../../api')
-var chai = require('chai')
+const { test } = require('tap')
+const API = require('../../../api')
 var DESTINATIONS = require('../../../lib/config/attribute-filter').DESTINATIONS
-var expect = chai.expect
-var hashes = require('../../../lib/util/hashes')
-var helper = require('../../lib/agent_helper')
-var MessageShim = require('../../../lib/shim/message-shim')
-var Promise = require('bluebird')
+const hashes = require('../../../lib/util/hashes')
+const helper = require('../../lib/agent_helper')
+const MessageShim = require('../../../lib/shim/message-shim')
 
-describe('MessageShim', function () {
-  var agent = null
-  var shim = null
-  var wrappable = null
-  var interval = null
-  var tasks = []
+test('MessageShim', function (t) {
+  t.autoend()
+  let agent = null
+  let shim = null
+  let wrappable = null
+  let interval = null
+  let tasks = []
 
-  before(function () {
+  t.before(function () {
     interval = setInterval(function () {
       if (tasks.length) {
         tasks.pop()()
@@ -33,11 +27,11 @@ describe('MessageShim', function () {
     }, 10)
   })
 
-  after(function () {
+  t.teardown(function () {
     clearInterval(interval)
   })
 
-  beforeEach(function () {
+  function beforeEach() {
     agent = helper.instrumentMockedAgent({
       span_events: {
         attributes: { enabled: true, include: ['message.parameters.*'] }
@@ -70,1114 +64,1118 @@ describe('MessageShim', function () {
     agent.config.trusted_account_ids = [9876, 6789]
     agent.config._fromServer(params, 'encoding_key')
     agent.config._fromServer(params, 'cross_process_id')
-  })
+  }
 
-  afterEach(function () {
+  function afterEach() {
     helper.unloadAgent(agent)
     agent = null
     shim = null
-  })
+  }
 
-  describe('constructor', function () {
-    it('should require an agent parameter', function () {
-      expect(function () {
+  t.test('constructor', function (t) {
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    t.test('should require an agent parameter', function (t) {
+      t.throws(function () {
         return new MessageShim()
-      }).to.throw(Error, /^Shim must be initialized with .*? agent/)
+      }, /^Shim must be initialized with .*? agent/)
+      t.end()
     })
 
-    it('should require a module name parameter', function () {
-      expect(function () {
+    t.test('should require a module name parameter', function (t) {
+      t.throws(function () {
         return new MessageShim(agent)
-      }).to.throw(Error, /^Shim must be initialized with .*? module name/)
+      }, /^Shim must be initialized with .*? module name/)
+      t.end()
     })
   })
 
-  describe('well-known message libraries', function () {
-    var messageLibs = ['RABBITMQ']
+  t.test('well-known message libraries', function (t) {
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+    const messageLibs = ['RABBITMQ']
 
-    it('should be enumerated on the class and prototype', function () {
+    t.test('should be enumerated on the class and prototype', function (t) {
       messageLibs.forEach(function (lib) {
-        testNonWritable(MessageShim, lib)
-        testNonWritable(shim, lib)
+        helper.testNonWritable({ t, obj: MessageShim, key: lib })
+        helper.testNonWritable({ t, obj: shim, key: lib })
       })
+      t.end()
     })
   })
 
-  describe('well-known destination types', function () {
-    var messageLibs = ['EXCHANGE', 'QUEUE', 'TOPIC']
+  t.test('well-known destination types', function (t) {
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+    const messageLibs = ['EXCHANGE', 'QUEUE', 'TOPIC']
 
-    it('should be enumerated on the class and prototype', function () {
+    t.test('should be enumerated on the class and prototype', function (t) {
       messageLibs.forEach(function (lib) {
-        testNonWritable(MessageShim, lib)
-        testNonWritable(shim, lib)
+        helper.testNonWritable({ t, obj: MessageShim, key: lib })
+        helper.testNonWritable({ t, obj: shim, key: lib })
       })
+      t.end()
     })
   })
 
-  describe('#setLibrary', function () {
-    it('should create broker metric names', function () {
-      var s = new MessageShim(agent, 'test')
-      expect(s._metrics).to.not.exist
+  t.test('#setLibrary', function (t) {
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    t.test('should create broker metric names', function (t) {
+      const s = new MessageShim(agent, 'test')
+      t.notOk(s._metrics)
       s.setLibrary('foobar')
-      expect(s._metrics).to.have.property('PREFIX', 'MessageBroker/')
-      expect(s._metrics).to.have.property('LIBRARY', 'foobar')
+      t.equal(s._metrics.PREFIX, 'MessageBroker/')
+      t.equal(s._metrics.LIBRARY, 'foobar')
+      t.end()
     })
 
-    it("should update the shim's logger", function () {
-      var s = new MessageShim(agent, 'test')
-      var logger = s.logger
+    t.test("should update the shim's logger", function (t) {
+      const s = new MessageShim(agent, 'test')
+      const { logger } = s
       s.setLibrary('foobar')
-      expect(s.logger).to.not.equal(logger)
+      t.not(s.logger, logger)
+      t.end()
     })
   })
 
-  describe('#recordProduce', function () {
-    it('should not wrap non-function objects', function () {
-      var wrapped = shim.recordProduce(wrappable, function () {})
-      expect(wrapped).to.equal(wrappable)
-      expect(shim.isWrapped(wrapped)).to.be.false
+  t.test('#recordProduce', function (t) {
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    t.test('should not wrap non-function objects', function (t) {
+      const wrapped = shim.recordProduce(wrappable, function () {})
+      t.equal(wrapped, wrappable)
+      t.notOk(shim.isWrapped(wrapped))
+      t.end()
     })
 
-    describe('with no properties', function () {
-      it('should wrap the first parameter if no properties are given', function () {
-        var wrapped = shim.recordProduce(wrappable.bar, function () {})
-        expect(wrapped).to.not.equal(wrappable.bar)
-        expect(shim.isWrapped(wrapped)).to.be.true
-        expect(shim.unwrap(wrapped)).to.equal(wrappable.bar)
+    t.test('should wrap the first parameter if no properties are given', function (t) {
+      const wrapped = shim.recordProduce(wrappable.bar, function () {})
+      t.not(wrapped, wrappable.bar)
+      t.ok(shim.isWrapped(wrapped))
+      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.end()
+    })
+
+    t.test('should wrap the first parameter if `null` is given for properties', function (t) {
+      const wrapped = shim.recordProduce(wrappable.bar, null, function () {})
+      t.not(wrapped, wrappable.bar)
+      t.ok(shim.isWrapped(wrapped))
+      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.end()
+    })
+
+    t.test('should replace wrapped properties on the original object', function (t) {
+      const original = wrappable.bar
+      shim.recordProduce(wrappable, 'bar', function () {})
+      t.not(wrappable.bar, original)
+      t.ok(shim.isWrapped(wrappable.bar))
+      t.equal(shim.unwrap(wrappable.bar), original)
+      t.end()
+    })
+
+    t.test('should not mark unwrapped properties as wrapped', function (t) {
+      shim.recordProduce(wrappable, 'name', function () {})
+      t.not(shim.isWrapped(wrappable.name))
+      t.end()
+    })
+
+    t.test('should create a produce segment', function (t) {
+      shim.recordProduce(wrappable, 'getActiveSegment', function () {
+        return { destinationName: 'foobar' }
       })
 
-      it('should wrap the first parameter if `null` is given for properties', function () {
-        var wrapped = shim.recordProduce(wrappable.bar, null, function () {})
-        expect(wrapped).to.not.equal(wrappable.bar)
-        expect(shim.isWrapped(wrapped)).to.be.true
-        expect(shim.unwrap(wrapped)).to.equal(wrappable.bar)
+      helper.runInTransaction(agent, function (tx) {
+        const startingSegment = agent.tracer.getSegment()
+        const segment = wrappable.getActiveSegment()
+        t.not(segment, startingSegment)
+        t.equal(segment.transaction, tx)
+        t.equal(segment.name, 'MessageBroker/RabbitMQ/Exchange/Produce/Named/foobar')
+        t.equal(agent.tracer.getSegment(), startingSegment)
+        t.end()
       })
     })
 
-    describe('with properties', function () {
-      it('should replace wrapped properties on the original object', function () {
-        var original = wrappable.bar
-        shim.recordProduce(wrappable, 'bar', function () {})
-        expect(wrappable.bar).to.not.equal(original)
-        expect(shim.isWrapped(wrappable.bar)).to.be.true
-        expect(shim.unwrap(wrappable.bar)).to.equal(original)
+    t.test('should add parameters to segment', function (t) {
+      shim.recordProduce(wrappable, 'getActiveSegment', function () {
+        return {
+          routingKey: 'foo.bar',
+          parameters: { a: 'a', b: 'b' }
+        }
       })
 
-      it('should not mark unwrapped properties as wrapped', function () {
-        shim.recordProduce(wrappable, 'name', function () {})
-        expect(shim.isWrapped(wrappable.name)).to.be.false
+      helper.runInTransaction(agent, function () {
+        const segment = wrappable.getActiveSegment()
+        const attributes = segment.getAttributes()
+        t.equal(attributes.routing_key, 'foo.bar')
+        t.equal(attributes.a, 'a')
+        t.equal(attributes.b, 'b')
+        t.end()
       })
     })
 
-    describe('wrapper', function () {
-      it('should create a produce segment', function () {
-        shim.recordProduce(wrappable, 'getActiveSegment', function () {
-          return { destinationName: 'foobar' }
-        })
-
-        helper.runInTransaction(agent, function (tx) {
-          var startingSegment = agent.tracer.getSegment()
-          var segment = wrappable.getActiveSegment()
-          expect(segment).to.not.equal(startingSegment)
-          expect(segment.transaction).to.equal(tx)
-          expect(segment.name).to.equal('MessageBroker/RabbitMQ/Exchange/Produce/Named/foobar')
-
-          expect(agent.tracer.getSegment()).to.equal(startingSegment)
-        })
-      })
-
-      it('should add parameters to segment', function () {
-        shim.recordProduce(wrappable, 'getActiveSegment', function () {
-          return {
-            routingKey: 'foo.bar',
-            parameters: { a: 'a', b: 'b' }
+    t.test('should not add parameters when disabled', function (t) {
+      agent.config.message_tracer.segment_parameters.enabled = false
+      shim.recordProduce(wrappable, 'getActiveSegment', function () {
+        return {
+          parameters: {
+            a: 'a',
+            b: 'b'
           }
-        })
-
-        helper.runInTransaction(agent, function () {
-          var segment = wrappable.getActiveSegment()
-          const attributes = segment.getAttributes()
-          expect(attributes).to.have.property('routing_key', 'foo.bar')
-          expect(attributes).to.have.property('a', 'a')
-          expect(attributes).to.have.property('b', 'b')
-        })
-      })
-
-      it('should not add parameters when disabled', function () {
-        agent.config.message_tracer.segment_parameters.enabled = false
-        shim.recordProduce(wrappable, 'getActiveSegment', function () {
-          return {
-            parameters: {
-              a: 'a',
-              b: 'b'
-            }
-          }
-        })
-
-        helper.runInTransaction(agent, function () {
-          var segment = wrappable.getActiveSegment()
-          const attributes = segment.getAttributes()
-          expect(attributes).to.not.have.property('a')
-          expect(attributes).to.not.have.property('b')
-        })
-      })
-
-      it('should execute the wrapped function', function () {
-        var executed = false
-        var toWrap = function () {
-          executed = true
         }
-        var wrapped = shim.recordProduce(toWrap, function () {})
-
-        helper.runInTransaction(agent, function () {
-          expect(executed).to.be.false
-          wrapped()
-          expect(executed).to.be.true
-        })
       })
 
-      it('should invoke the spec in the context of the wrapped function', function () {
-        var original = wrappable.bar
-        var executed = false
-        shim.recordProduce(wrappable, 'bar', function (_, fn, name, args) {
-          executed = true
-          expect(fn).to.equal(original)
-          expect(name).to.equal('bar')
-          expect(this).to.equal(wrappable)
-          expect(args).to.deep.equal(['a', 'b', 'c'])
+      helper.runInTransaction(agent, function () {
+        const segment = wrappable.getActiveSegment()
+        const attributes = segment.getAttributes()
+        t.notOk(attributes.a)
+        t.notOk(attributes.b)
+        t.end()
+      })
+    })
 
-          return { destinationName: 'foobar' }
-        })
+    t.test('should execute the wrapped function', function (t) {
+      let executed = false
+      const toWrap = function () {
+        executed = true
+      }
+      const wrapped = shim.recordProduce(toWrap, function () {})
 
-        helper.runInTransaction(agent, function () {
-          wrappable.bar('a', 'b', 'c')
-          expect(executed).to.be.true
-        })
+      helper.runInTransaction(agent, function () {
+        t.notOk(executed)
+        wrapped()
+        t.ok(executed)
+        t.end()
+      })
+    })
+
+    t.test('should invoke the spec in the context of the wrapped function', function (t) {
+      const original = wrappable.bar
+      let executed = false
+      shim.recordProduce(wrappable, 'bar', function (_, fn, name, args) {
+        executed = true
+        t.equal(fn, original)
+        t.equal(name, 'bar')
+        t.equal(this, wrappable)
+        t.same(args, ['a', 'b', 'c'])
+
+        return { destinationName: 'foobar' }
       })
 
-      it('should bind the callback if there is one', function () {
-        var cb = function () {}
-        var toWrap = function (wrappedCB) {
-          expect(wrappedCB).to.not.equal(cb)
-          expect(shim.isWrapped(wrappedCB)).to.be.true
-          expect(shim.unwrap(wrappedCB)).to.equal(cb)
+      helper.runInTransaction(agent, function () {
+        wrappable.bar('a', 'b', 'c')
+        t.ok(executed)
+        t.end()
+      })
+    })
 
-          expect(function () {
-            wrappedCB()
-          }).to.not.throw()
-        }
+    t.test('should bind the callback if there is one', function (t) {
+      const cb = function () {}
+      const toWrap = function (wrappedCB) {
+        t.not(wrappedCB, cb)
+        t.ok(shim.isWrapped(wrappedCB))
+        t.equal(shim.unwrap(wrappedCB), cb)
 
-        var wrapped = shim.recordProduce(toWrap, function () {
-          return { callback: shim.LAST }
+        t.doesNotThrow(function () {
+          wrappedCB()
         })
+        t.end()
+      }
 
-        helper.runInTransaction(agent, function () {
-          wrapped(cb)
-        })
+      const wrapped = shim.recordProduce(toWrap, function () {
+        return { callback: shim.LAST }
       })
 
-      it('should link the promise if one is returned', function () {
-        var DELAY = 25
-        var segment = null
-        var val = {}
-        var toWrap = function () {
-          segment = shim.getSegment()
-          return new Promise(function (res) {
-            setTimeout(res, DELAY, val)
-          })
-        }
+      helper.runInTransaction(agent, function () {
+        wrapped(cb)
+      })
+    })
 
-        var wrapped = shim.recordProduce(toWrap, function () {
-          return { promise: true }
+    t.test('should link the promise if one is returned', function (t) {
+      const DELAY = 25
+      let segment = null
+      const val = {}
+      const toWrap = function () {
+        segment = shim.getSegment()
+        return new Promise(function (res) {
+          setTimeout(res, DELAY, val)
         })
+      }
 
-        return helper.runInTransaction(agent, function () {
-          return wrapped().then(function (v) {
-            expect(v).to.equal(val)
-            expect(segment.getDurationInMillis()).to.be.above(DELAY)
-          })
-        })
+      const wrapped = shim.recordProduce(toWrap, function () {
+        return { promise: true }
       })
 
-      describe('when opaque false', () => {
-        it('should create a child segment', function () {
-          shim.recordProduce(wrappable, 'withNested', function () {
-            return { destinationName: 'foobar' }
-          })
-
-          helper.runInTransaction(agent, (tx) => {
-            const segment = wrappable.withNested()
-            expect(segment.transaction).to.equal(tx)
-            expect(segment.name).to.equal('MessageBroker/RabbitMQ/Exchange/Produce/Named/foobar')
-
-            expect(segment.children).to.have.lengthOf(1)
-            const childSegment = segment.children[0]
-            expect(childSegment.name).to.equal('ChildSegment')
-          })
-        })
-      })
-
-      describe('when opaque true', () => {
-        it('should not create a child segment', function () {
-          shim.recordProduce(wrappable, 'withNested', function () {
-            return { destinationName: 'foobar', opaque: true }
-          })
-
-          helper.runInTransaction(agent, (tx) => {
-            const segment = wrappable.withNested()
-            expect(segment.transaction).to.equal(tx)
-            expect(segment.name).to.equal('MessageBroker/RabbitMQ/Exchange/Produce/Named/foobar')
-
-            expect(segment.children).to.have.lengthOf(0)
-          })
-        })
-      })
-
-      describe('when headers are provided', function () {
-        it('should insert CAT request headers', function () {
-          var headers = {}
-          shim.recordProduce(wrappable, 'getActiveSegment', function () {
-            return { headers: headers }
-          })
-
-          helper.runInTransaction(agent, function () {
-            wrappable.getActiveSegment()
-            expect(headers).to.have.property('NewRelicID')
-            expect(headers).to.have.property('NewRelicTransaction')
-          })
+      return helper.runInTransaction(agent, function () {
+        return wrapped().then(function (v) {
+          t.equal(v, val)
+          t.ok(segment.getDurationInMillis() > DELAY)
         })
       })
     })
 
-    describe('recorder', function () {
-      var transaction = null
-
-      beforeEach(function (done) {
-        shim.recordProduce(wrappable, 'getActiveSegment', function () {
-          return { destinationName: 'my-queue' }
-        })
-
-        helper.runInTransaction(agent, function (tx) {
-          transaction = tx
-          wrappable.getActiveSegment()
-          tx.end()
-          done()
-        })
+    t.test('should create a child segment when `opaque` is false', function (t) {
+      shim.recordProduce(wrappable, 'withNested', function () {
+        return { destinationName: 'foobar', opaque: false }
       })
 
-      it('should create message broker metrics', function () {
-        var unscoped = getMetrics(agent).unscoped
-        var scoped = transaction.metrics.unscoped
-        expect(unscoped).to.have.property('MessageBroker/RabbitMQ/Exchange/Produce/Named/my-queue')
-        expect(scoped).to.have.property('MessageBroker/RabbitMQ/Exchange/Produce/Named/my-queue')
+      helper.runInTransaction(agent, (tx) => {
+        const segment = wrappable.withNested()
+        t.equal(segment.transaction, tx)
+        t.equal(segment.name, 'MessageBroker/RabbitMQ/Exchange/Produce/Named/foobar')
+
+        t.equal(segment.children.length, 1)
+        const [childSegment] = segment.children
+        t.equal(childSegment.name, 'ChildSegment')
+        t.end()
+      })
+    })
+
+    t.test('should not create a child segment when `opaque` is true', function (t) {
+      shim.recordProduce(wrappable, 'withNested', function () {
+        return { destinationName: 'foobar', opaque: true }
+      })
+
+      helper.runInTransaction(agent, (tx) => {
+        const segment = wrappable.withNested()
+        t.equal(segment.transaction, tx)
+        t.equal(segment.name, 'MessageBroker/RabbitMQ/Exchange/Produce/Named/foobar')
+
+        t.equal(segment.children.length, 0)
+        t.end()
+      })
+    })
+
+    t.test('should insert CAT request headers', function (t) {
+      const headers = {}
+      shim.recordProduce(wrappable, 'getActiveSegment', function () {
+        return { headers: headers }
+      })
+
+      helper.runInTransaction(agent, function () {
+        wrappable.getActiveSegment()
+        t.ok(headers.NewRelicID)
+        t.ok(headers.NewRelicTransaction)
+        t.end()
+      })
+    })
+
+    t.test('should create message broker metrics', function (t) {
+      let transaction = null
+
+      shim.recordProduce(wrappable, 'getActiveSegment', function () {
+        return { destinationName: 'my-queue' }
+      })
+
+      helper.runInTransaction(agent, function (tx) {
+        transaction = tx
+        wrappable.getActiveSegment()
+        tx.end()
+        const { unscoped } = helper.getMetrics(agent)
+        const scoped = transaction.metrics.unscoped
+        t.ok(unscoped['MessageBroker/RabbitMQ/Exchange/Produce/Named/my-queue'])
+        t.ok(scoped['MessageBroker/RabbitMQ/Exchange/Produce/Named/my-queue'])
+        t.end()
       })
     })
   })
 
-  describe('#recordConsume', function () {
-    it('should not wrap non-function objects', function () {
-      var wrapped = shim.recordConsume(wrappable, function () {})
-      expect(wrapped).to.equal(wrappable)
-      expect(shim.isWrapped(wrapped)).to.be.false
+  t.test('#recordConsume', function (t) {
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    t.test('should not wrap non-function objects', function (t) {
+      const wrapped = shim.recordConsume(wrappable, function () {})
+      t.equal(wrapped, wrappable)
+      t.notOk(shim.isWrapped(wrapped))
+      t.end()
     })
 
-    describe('with no properties', function () {
-      it('should wrap the first parameter if no properties are given', function () {
-        var wrapped = shim.recordConsume(wrappable.bar, function () {})
-        expect(wrapped).to.not.equal(wrappable.bar)
-        expect(shim.isWrapped(wrapped)).to.be.true
-        expect(shim.unwrap(wrapped)).to.equal(wrappable.bar)
+    t.test('should wrap the first parameter if no properties are given', function (t) {
+      const wrapped = shim.recordConsume(wrappable.bar, function () {})
+      t.not(wrapped, wrappable.bar)
+      t.ok(shim.isWrapped(wrapped))
+      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.end()
+    })
+
+    t.test('should wrap the first parameter if `null` is given for properties', function (t) {
+      const wrapped = shim.recordConsume(wrappable.bar, null, function () {})
+      t.not(wrapped, wrappable.bar)
+      t.ok(shim.isWrapped(wrapped))
+      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.end()
+    })
+
+    t.test('should replace wrapped properties on the original object', function (t) {
+      const original = wrappable.bar
+      shim.recordConsume(wrappable, 'bar', function () {})
+      t.not(wrappable.bar, original)
+      t.ok(shim.isWrapped(wrappable.bar))
+      t.equal(shim.unwrap(wrappable.bar), original)
+      t.end()
+    })
+
+    t.test('should not mark unwrapped properties as wrapped', function (t) {
+      shim.recordConsume(wrappable, 'name', function () {})
+      t.notOk(shim.isWrapped(wrappable.name))
+      t.end()
+    })
+
+    t.test('should create a consume segment', function (t) {
+      shim.recordConsume(wrappable, 'getActiveSegment', function () {
+        return { destinationName: 'foobar' }
       })
 
-      it('should wrap the first parameter if `null` is given for properties', function () {
-        var wrapped = shim.recordConsume(wrappable.bar, null, function () {})
-        expect(wrapped).to.not.equal(wrappable.bar)
-        expect(shim.isWrapped(wrapped)).to.be.true
-        expect(shim.unwrap(wrapped)).to.equal(wrappable.bar)
+      helper.runInTransaction(agent, function (tx) {
+        const startingSegment = agent.tracer.getSegment()
+        const segment = wrappable.getActiveSegment()
+        t.not(segment, startingSegment)
+        t.equal(segment.transaction, tx)
+        t.equal(segment.name, 'MessageBroker/RabbitMQ/Exchange/Consume/Named/foobar')
+        t.equal(agent.tracer.getSegment(), startingSegment)
+        t.end()
       })
     })
 
-    describe('with properties', function () {
-      it('should replace wrapped properties on the original object', function () {
-        var original = wrappable.bar
-        shim.recordConsume(wrappable, 'bar', function () {})
-        expect(wrappable.bar).to.not.equal(original)
-        expect(shim.isWrapped(wrappable.bar)).to.be.true
-        expect(shim.unwrap(wrappable.bar)).to.equal(original)
+    t.test('should bind the callback if there is one', function (t) {
+      const cb = function () {}
+      const toWrap = function (wrappedCB) {
+        t.not(wrappedCB, cb)
+        t.ok(shim.isWrapped(wrappedCB))
+        t.equal(shim.unwrap(wrappedCB), cb)
+
+        t.doesNotThrow(function () {
+          wrappedCB()
+        })
+        t.end()
+      }
+
+      const wrapped = shim.recordConsume(toWrap, function () {
+        return { callback: shim.LAST }
       })
 
-      it('should not mark unwrapped properties as wrapped', function () {
-        shim.recordConsume(wrappable, 'name', function () {})
-        expect(shim.isWrapped(wrappable.name)).to.be.false
+      helper.runInTransaction(agent, function () {
+        wrapped(cb)
       })
     })
 
-    describe('wrapper', function () {
-      beforeEach(function () {
-        var params = {
-          encoding_key: 'this is an encoding key',
-          cross_process_id: '1234#4321'
+    t.test('should add parameters to segment', function (t) {
+      function wrapMe(q, cb) {
+        cb()
+        return shim.getSegment()
+      }
+
+      const wrapped = shim.recordConsume(wrapMe, {
+        destinationName: shim.FIRST,
+        callback: shim.LAST,
+        messageHandler: function () {
+          return { parameters: { a: 'a', b: 'b' } }
         }
-        agent.config.trusted_account_ids = [9876, 6789]
-        agent.config._fromServer(params, 'encoding_key')
-        agent.config._fromServer(params, 'cross_process_id')
       })
 
-      it('should create a consume segment', function () {
-        shim.recordConsume(wrappable, 'getActiveSegment', function () {
-          return { destinationName: 'foobar' }
-        })
+      helper.runInTransaction(agent, function () {
+        const segment = wrapped('foo', function () {})
+        const attributes = segment.getAttributes()
+        t.equal(attributes.a, 'a')
+        t.equal(attributes.b, 'b')
+        t.end()
+      })
+    })
 
-        helper.runInTransaction(agent, function (tx) {
-          var startingSegment = agent.tracer.getSegment()
-          var segment = wrappable.getActiveSegment()
-          expect(segment).to.not.equal(startingSegment)
-          expect(segment.transaction).to.equal(tx)
-          expect(segment.name).to.equal('MessageBroker/RabbitMQ/Exchange/Consume/Named/foobar')
-          expect(agent.tracer.getSegment()).to.equal(startingSegment)
-        })
+    t.test('should not add parameters when disabled', function (t) {
+      agent.config.message_tracer.segment_parameters.enabled = false
+      function wrapMe(q, cb) {
+        cb()
+        return shim.getSegment()
+      }
+
+      const wrapped = shim.recordConsume(wrapMe, {
+        destinationName: shim.FIRST,
+        callback: shim.LAST,
+        messageHandler: function () {
+          return { parameters: { a: 'a', b: 'b' } }
+        }
       })
 
-      it('should bind the callback if there is one', function () {
-        const cb = function () {}
-        const toWrap = function (wrappedCB) {
-          expect(wrappedCB).to.not.equal(cb)
-          expect(shim.isWrapped(wrappedCB)).to.be.true
-          expect(shim.unwrap(wrappedCB)).to.equal(cb)
+      helper.runInTransaction(agent, function () {
+        const segment = wrapped('foo', function () {})
+        const attributes = segment.getAttributes()
+        t.notOk(attributes.a)
+        t.notOk(attributes.b)
+        t.end()
+      })
+    })
 
-          expect(function () {
-            wrappedCB()
-          }).to.not.throw()
-        }
-
-        const wrapped = shim.recordConsume(toWrap, function () {
-          return { callback: shim.LAST }
-        })
-
-        helper.runInTransaction(agent, function () {
-          wrapped(cb)
-        })
+    t.test('should be able to get destinationName from arguments', function (t) {
+      shim.recordConsume(wrappable, 'getActiveSegment', {
+        destinationName: shim.FIRST,
+        destinationType: shim.EXCHANGE
       })
 
-      it('should add parameters to segment', function () {
-        function wrapMe(q, cb) {
-          cb()
-          return shim.getSegment()
+      helper.runInTransaction(agent, function (tx) {
+        const startingSegment = agent.tracer.getSegment()
+        const segment = wrappable.getActiveSegment('fizzbang')
+        t.not(segment, startingSegment)
+        t.equal(segment.transaction, tx)
+        t.equal(segment.name, 'MessageBroker/RabbitMQ/Exchange/Consume/Named/fizzbang')
+        t.equal(agent.tracer.getSegment(), startingSegment)
+        t.end()
+      })
+    })
+
+    t.test('should handle promise-based APIs', function (t) {
+      const msg = {}
+      let segment = null
+
+      function wrapMe() {
+        segment = shim.getSegment()
+        return new Promise((resolve) => resolve(msg))
+      }
+
+      const wrapped = shim.recordConsume(wrapMe, {
+        destinationName: shim.FIRST,
+        promise: true,
+        messageHandler: function (shim, fn, name, message) {
+          t.equal(message, msg)
+          return { parameters: { a: 'a', b: 'b' } }
         }
+      })
 
-        var wrapped = shim.recordConsume(wrapMe, {
-          destinationName: shim.FIRST,
-          callback: shim.LAST,
-          messageHandler: function () {
-            return { parameters: { a: 'a', b: 'b' } }
-          }
-        })
-
-        helper.runInTransaction(agent, function () {
-          var segment = wrapped('foo', function () {})
+      return helper.runInTransaction(agent, function () {
+        return wrapped('foo', function () {}).then(function (message) {
+          t.equal(message, msg)
           const attributes = segment.getAttributes()
-          expect(attributes).to.have.property('a', 'a')
-          expect(attributes).to.have.property('b', 'b')
-        })
-      })
-
-      it('should not add parameters when disabled', function () {
-        agent.config.message_tracer.segment_parameters.enabled = false
-        function wrapMe(q, cb) {
-          cb()
-          return shim.getSegment()
-        }
-
-        var wrapped = shim.recordConsume(wrapMe, {
-          destinationName: shim.FIRST,
-          callback: shim.LAST,
-          messageHandler: function () {
-            return { parameters: { a: 'a', b: 'b' } }
-          }
-        })
-
-        helper.runInTransaction(agent, function () {
-          var segment = wrapped('foo', function () {})
-          const attributes = segment.getAttributes()
-          expect(attributes).to.not.have.property('a')
-          expect(attributes).to.not.have.property('b')
-        })
-      })
-
-      it('should be able to get destinationName from arguments', function () {
-        shim.recordConsume(wrappable, 'getActiveSegment', {
-          destinationName: shim.FIRST,
-          destinationType: shim.EXCHANGE
-        })
-
-        helper.runInTransaction(agent, function (tx) {
-          var startingSegment = agent.tracer.getSegment()
-          var segment = wrappable.getActiveSegment('fizzbang')
-          expect(segment).to.not.equal(startingSegment)
-          expect(segment.transaction).to.equal(tx)
-          expect(segment.name).to.equal('MessageBroker/RabbitMQ/Exchange/Consume/Named/fizzbang')
-          expect(agent.tracer.getSegment()).to.equal(startingSegment)
-        })
-      })
-
-      it('should handle promise-based APIs', function () {
-        var msg = {}
-        var segment = null
-
-        function wrapMe() {
-          segment = shim.getSegment()
-          return Promise.resolve(msg)
-        }
-
-        var wrapped = shim.recordConsume(wrapMe, {
-          destinationName: shim.FIRST,
-          promise: true,
-          messageHandler: function (shim, fn, name, message) {
-            expect(message).to.equal(msg)
-            return { parameters: { a: 'a', b: 'b' } }
-          }
-        })
-
-        return helper.runInTransaction(agent, function () {
-          return wrapped('foo', function () {}).then(function (message) {
-            expect(message).to.equal(msg)
-            const attributes = segment.getAttributes()
-            expect(attributes).to.have.property('a', 'a')
-            expect(attributes).to.have.property('b', 'b')
-          })
-        })
-      })
-
-      it('should execute the wrapped function', function () {
-        var executed = false
-        var toWrap = function () {
-          executed = true
-        }
-        var wrapped = shim.recordConsume(toWrap, function () {
-          return { destinationName: 'foo' }
-        })
-
-        helper.runInTransaction(agent, function () {
-          expect(executed).to.be.false
-          wrapped()
-          expect(executed).to.be.true
-        })
-      })
-
-      it('should invoke the spec in the context of the wrapped function', function () {
-        var original = wrappable.bar
-        var executed = false
-        shim.recordConsume(wrappable, 'bar', function (_, fn, name, args) {
-          executed = true
-          expect(fn).to.equal(original)
-          expect(name).to.equal('bar')
-          expect(this).to.equal(wrappable)
-          expect(args).to.deep.equal(['a', 'b', 'c'])
-
-          return { destinationName: 'foobar' }
-        })
-
-        helper.runInTransaction(agent, function () {
-          wrappable.bar('a', 'b', 'c')
-          expect(executed).to.be.true
+          t.equal(attributes.a, 'a')
+          t.equal(attributes.b, 'b')
         })
       })
     })
 
-    describe('when opaque false', () => {
-      it('should create a child segment', function () {
-        shim.recordConsume(wrappable, 'withNested', function () {
-          return { destinationName: 'foobar' }
-        })
+    t.test('should execute the wrapped function', function (t) {
+      let executed = false
+      const toWrap = function () {
+        executed = true
+      }
+      const wrapped = shim.recordConsume(toWrap, function () {
+        return { destinationName: 'foo' }
+      })
 
-        helper.runInTransaction(agent, function (tx) {
-          const segment = wrappable.withNested()
-          expect(segment.transaction).to.equal(tx)
-          expect(segment.name).to.equal('MessageBroker/RabbitMQ/Exchange/Consume/Named/foobar')
-
-          expect(segment.children).to.have.lengthOf(1)
-          const childSegment = segment.children[0]
-          expect(childSegment.name).to.equal('ChildSegment')
-        })
+      helper.runInTransaction(agent, function () {
+        t.notOk(executed)
+        wrapped()
+        t.ok(executed)
+        t.end()
       })
     })
 
-    describe('when opaque true', () => {
-      it('should not create a child segment', function () {
-        shim.recordConsume(wrappable, 'withNested', function () {
-          return { destinationName: 'foobar', opaque: true }
-        })
+    t.test('should invoke the spec in the context of the wrapped function', function (t) {
+      const original = wrappable.bar
+      let executed = false
+      shim.recordConsume(wrappable, 'bar', function (_, fn, name, args) {
+        executed = true
+        t.equal(fn, original)
+        t.equal(name, 'bar')
+        t.equal(this, wrappable)
+        t.same(args, ['a', 'b', 'c'])
 
-        helper.runInTransaction(agent, function (tx) {
-          const segment = wrappable.withNested()
-          expect(segment.transaction).to.equal(tx)
-          expect(segment.name).to.equal('MessageBroker/RabbitMQ/Exchange/Consume/Named/foobar')
+        return { destinationName: 'foobar' }
+      })
 
-          expect(segment.children).to.have.lengthOf(0)
-        })
+      helper.runInTransaction(agent, function () {
+        wrappable.bar('a', 'b', 'c')
+        t.ok(executed)
+        t.end()
       })
     })
 
-    describe('recorder', function () {
-      it('should create message broker metrics', function (done) {
-        shim.recordConsume(wrappable, 'getActiveSegment', function () {
-          return { destinationName: 'foobar' }
-        })
+    t.test('should create a child segment when `opaque` is false', function (t) {
+      shim.recordConsume(wrappable, 'withNested', function () {
+        return { destinationName: 'foobar', opaque: false }
+      })
 
-        helper.runInTransaction(agent, function (tx) {
-          wrappable.getActiveSegment()
-          tx.finalizeName('test-transaction')
-          setImmediate(tx.end.bind(tx))
-        })
+      helper.runInTransaction(agent, function (tx) {
+        const segment = wrappable.withNested()
+        t.equal(segment.transaction, tx)
+        t.equal(segment.name, 'MessageBroker/RabbitMQ/Exchange/Consume/Named/foobar')
 
-        agent.on('transactionFinished', function () {
-          var metrics = getMetrics(agent)
-          expect(metrics.unscoped).to.have.property(
+        t.equal(segment.children.length, 1)
+        const [childSegment] = segment.children
+        t.equal(childSegment.name, 'ChildSegment')
+        t.end()
+      })
+    })
+
+    t.test('should not create a child segment when `opaque` is true', function (t) {
+      shim.recordConsume(wrappable, 'withNested', function () {
+        return { destinationName: 'foobar', opaque: true }
+      })
+
+      helper.runInTransaction(agent, function (tx) {
+        const segment = wrappable.withNested()
+        t.equal(segment.transaction, tx)
+        t.equal(segment.name, 'MessageBroker/RabbitMQ/Exchange/Consume/Named/foobar')
+        t.equal(segment.children.length, 0)
+        t.end()
+      })
+    })
+
+    t.test('should create message broker metrics', function (t) {
+      shim.recordConsume(wrappable, 'getActiveSegment', function () {
+        return { destinationName: 'foobar' }
+      })
+
+      helper.runInTransaction(agent, function (tx) {
+        wrappable.getActiveSegment()
+        tx.finalizeName('test-transaction')
+        setImmediate(tx.end.bind(tx))
+      })
+
+      agent.on('transactionFinished', function () {
+        const metrics = helper.getMetrics(agent)
+        t.ok(metrics.unscoped['MessageBroker/RabbitMQ/Exchange/Consume/Named/foobar'])
+        t.ok(
+          metrics.scoped['WebTransaction/test-transaction'][
             'MessageBroker/RabbitMQ/Exchange/Consume/Named/foobar'
-          )
-          expect(metrics.scoped)
-            .property('WebTransaction/test-transaction')
-            .to.have.property('MessageBroker/RabbitMQ/Exchange/Consume/Named/foobar')
-          done()
-        })
+          ]
+        )
+        t.end()
       })
     })
   })
 
-  describe('#recordPurgeQueue', function () {
-    it('should not wrap non-function objects', function () {
-      var wrapped = shim.recordPurgeQueue(wrappable, {})
-      expect(wrapped).to.equal(wrappable)
-      expect(shim.isWrapped(wrapped)).to.be.false
+  t.test('#recordPurgeQueue', function (t) {
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    t.test('should not wrap non-function objects', function (t) {
+      const wrapped = shim.recordPurgeQueue(wrappable, {})
+      t.equal(wrapped, wrappable)
+      t.notOk(shim.isWrapped(wrapped))
+      t.end()
     })
 
-    describe('with no properties', function () {
-      it('should wrap the first parameter if no properties are given', function () {
-        var wrapped = shim.recordPurgeQueue(wrappable.bar, {})
-        expect(wrapped).to.not.equal(wrappable.bar)
-        expect(shim.isWrapped(wrapped)).to.be.true
-        expect(shim.unwrap(wrapped)).to.equal(wrappable.bar)
-      })
-
-      it('should wrap the first parameter if `null` is given for properties', function () {
-        var wrapped = shim.recordPurgeQueue(wrappable.bar, null, {})
-        expect(wrapped).to.not.equal(wrappable.bar)
-        expect(shim.isWrapped(wrapped)).to.be.true
-        expect(shim.unwrap(wrapped)).to.equal(wrappable.bar)
-      })
+    t.test('should wrap the first parameter if no properties are given', function (t) {
+      const wrapped = shim.recordPurgeQueue(wrappable.bar, {})
+      t.not(wrapped, wrappable.bar)
+      t.ok(shim.isWrapped(wrapped))
+      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.end()
     })
 
-    describe('with properties', function () {
-      it('should replace wrapped properties on the original object', function () {
-        var original = wrappable.bar
-        shim.recordPurgeQueue(wrappable, 'bar', {})
-        expect(wrappable.bar).to.not.equal(original)
-        expect(shim.isWrapped(wrappable.bar)).to.be.true
-        expect(shim.unwrap(wrappable.bar)).to.equal(original)
-      })
-
-      it('should not mark unwrapped properties as wrapped', function () {
-        shim.recordPurgeQueue(wrappable, 'name', {})
-        expect(shim.isWrapped(wrappable.name)).to.be.false
-      })
+    t.test('should wrap the first parameter if `null` is given for properties', function (t) {
+      const wrapped = shim.recordPurgeQueue(wrappable.bar, null, {})
+      t.not(wrapped, wrappable.bar)
+      t.ok(shim.isWrapped(wrapped))
+      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.end()
     })
 
-    describe('wrapper', function () {
-      it('should create a purge segment and metric', function () {
-        shim.recordPurgeQueue(wrappable, 'getActiveSegment', { queue: shim.FIRST })
+    t.test('should replace wrapped properties on the original object', function (t) {
+      const original = wrappable.bar
+      shim.recordPurgeQueue(wrappable, 'bar', {})
+      t.not(wrappable.bar, original)
+      t.ok(shim.isWrapped(wrappable.bar))
+      t.equal(shim.unwrap(wrappable.bar), original)
+      t.end()
+    })
 
-        helper.runInTransaction(agent, function (tx) {
-          var startingSegment = agent.tracer.getSegment()
-          var segment = wrappable.getActiveSegment('foobar')
-          expect(segment).to.not.equal(startingSegment)
-          expect(segment.transaction).to.equal(tx)
-          expect(segment.name).to.equal('MessageBroker/RabbitMQ/Queue/Purge/Named/foobar')
-          expect(agent.tracer.getSegment()).to.equal(startingSegment)
-        })
-      })
+    t.test('should not mark unwrapped properties as wrapped', function (t) {
+      shim.recordPurgeQueue(wrappable, 'name', {})
+      t.notOk(shim.isWrapped(wrappable.name))
+      t.end()
+    })
 
-      it('should call the spec if it is not static', function () {
-        var called = false
+    t.test('should create a purge segment and metric', function (t) {
+      shim.recordPurgeQueue(wrappable, 'getActiveSegment', { queue: shim.FIRST })
 
-        shim.recordPurgeQueue(wrappable, 'getActiveSegment', function () {
-          called = true
-          return { queue: shim.FIRST }
-        })
-
-        helper.runInTransaction(agent, function () {
-          expect(called).to.be.false
-          wrappable.getActiveSegment('foobar')
-          expect(called).to.be.true
-        })
-      })
-
-      it('should execute the wrapped function', function () {
-        var executed = false
-        var toWrap = function () {
-          executed = true
-        }
-        var wrapped = shim.recordPurgeQueue(toWrap, {})
-
-        helper.runInTransaction(agent, function () {
-          expect(executed).to.be.false
-          wrapped()
-          expect(executed).to.be.true
-        })
-      })
-
-      it('should bind the callback if there is one', function () {
-        var cb = function () {}
-        var toWrap = function (wrappedCB) {
-          expect(wrappedCB).to.not.equal(cb)
-          expect(shim.isWrapped(wrappedCB)).to.be.true
-          expect(shim.unwrap(wrappedCB)).to.equal(cb)
-
-          expect(function () {
-            wrappedCB()
-          }).to.not.throw()
-        }
-
-        var wrapped = shim.recordPurgeQueue(toWrap, { callback: shim.LAST })
-
-        helper.runInTransaction(agent, function () {
-          wrapped(cb)
-        })
-      })
-
-      it('should link the promise if one is returned', function () {
-        var DELAY = 25
-        var segment = null
-        var val = {}
-        var toWrap = function () {
-          segment = shim.getSegment()
-          return new Promise(function (res) {
-            setTimeout(res, DELAY, val)
-          })
-        }
-
-        var wrapped = shim.recordPurgeQueue(toWrap, { promise: true })
-
-        return helper.runInTransaction(agent, function () {
-          return wrapped().then(function (v) {
-            expect(v).to.equal(val)
-            expect(segment.getDurationInMillis()).to.be.above(DELAY - 1)
-          })
-        })
+      helper.runInTransaction(agent, function (tx) {
+        const startingSegment = agent.tracer.getSegment()
+        const segment = wrappable.getActiveSegment('foobar')
+        t.not(segment, startingSegment)
+        t.equal(segment.transaction, tx)
+        t.equal(segment.name, 'MessageBroker/RabbitMQ/Queue/Purge/Named/foobar')
+        t.equal(agent.tracer.getSegment(), startingSegment)
+        t.end()
       })
     })
 
-    describe('recorder', function () {
-      var transaction = null
+    t.test('should call the spec if it is not static', function (t) {
+      let called = false
 
-      beforeEach(function (done) {
-        shim.recordPurgeQueue(wrappable, 'getActiveSegment', { queue: shim.FIRST })
-
-        helper.runInTransaction(agent, function (tx) {
-          transaction = tx
-          wrappable.getActiveSegment('my-queue')
-          tx.end()
-          done()
-        })
+      shim.recordPurgeQueue(wrappable, 'getActiveSegment', function () {
+        called = true
+        return { queue: shim.FIRST }
       })
 
-      it('should create message broker metrics', function () {
-        var unscoped = getMetrics(agent).unscoped
-        var scoped = transaction.metrics.unscoped
-        expect(unscoped).to.have.property('MessageBroker/RabbitMQ/Queue/Purge/Named/my-queue')
-        expect(scoped).to.have.property('MessageBroker/RabbitMQ/Queue/Purge/Named/my-queue')
+      helper.runInTransaction(agent, function () {
+        t.notOk(called)
+        wrappable.getActiveSegment('foobar')
+        t.ok(called)
+        t.end()
+      })
+    })
+
+    t.test('should execute the wrapped function', function (t) {
+      let executed = false
+      const toWrap = function () {
+        executed = true
+      }
+      const wrapped = shim.recordPurgeQueue(toWrap, {})
+
+      helper.runInTransaction(agent, function () {
+        t.notOk(executed)
+        wrapped()
+        t.ok(executed)
+        t.end()
+      })
+    })
+
+    t.test('should bind the callback if there is one', function (t) {
+      const cb = function () {}
+      const toWrap = function (wrappedCB) {
+        t.not(wrappedCB, cb)
+        t.ok(shim.isWrapped(wrappedCB))
+        t.equal(shim.unwrap(wrappedCB), cb)
+
+        t.doesNotThrow(function () {
+          wrappedCB()
+        })
+        t.end()
+      }
+
+      const wrapped = shim.recordPurgeQueue(toWrap, { callback: shim.LAST })
+
+      helper.runInTransaction(agent, function () {
+        wrapped(cb)
+      })
+    })
+
+    t.test('should link the promise if one is returned', function (t) {
+      const DELAY = 25
+      const val = {}
+      let segment = null
+      const toWrap = function () {
+        segment = shim.getSegment()
+        return new Promise(function (res) {
+          setTimeout(res, DELAY, val)
+        })
+      }
+
+      const wrapped = shim.recordPurgeQueue(toWrap, { promise: true })
+
+      return helper.runInTransaction(agent, function () {
+        return wrapped().then(function (v) {
+          t.equal(v, val)
+          t.ok(segment.getDurationInMillis() > DELAY - 1)
+        })
+      })
+    })
+
+    t.test('should create message broker metrics', function (t) {
+      let transaction = null
+      shim.recordPurgeQueue(wrappable, 'getActiveSegment', { queue: shim.FIRST })
+
+      helper.runInTransaction(agent, function (tx) {
+        transaction = tx
+        wrappable.getActiveSegment('my-queue')
+        tx.end()
+        const { unscoped } = helper.getMetrics(agent)
+        const scoped = transaction.metrics.unscoped
+        t.ok(unscoped['MessageBroker/RabbitMQ/Queue/Purge/Named/my-queue'])
+        t.ok(scoped['MessageBroker/RabbitMQ/Queue/Purge/Named/my-queue'])
+        t.end()
       })
     })
   })
 
-  describe('#recordSubscribedConsume', function () {
-    it('should not wrap non-function objects', function () {
-      var wrapped = shim.recordSubscribedConsume(wrappable, {
+  t.test('#recordSubscribedConsume', function (t) {
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    t.test('should not wrap non-function objects', function (t) {
+      const wrapped = shim.recordSubscribedConsume(wrappable, {
         consumer: shim.FIRST,
         messageHandler: function () {}
       })
-      expect(wrapped).to.equal(wrappable)
-      expect(shim.isWrapped(wrapped)).to.be.false
+      t.equal(wrapped, wrappable)
+      t.notOk(shim.isWrapped(wrapped))
+      t.end()
     })
 
-    describe('with no properties', function () {
-      it('should wrap the first parameter if no properties are given', function () {
-        var wrapped = shim.recordSubscribedConsume(wrappable.bar, {
-          consumer: shim.FIRST,
-          messageHandler: function () {},
-          wrapper: function () {}
-        })
-        expect(wrapped).to.not.equal(wrappable.bar)
-        expect(shim.isWrapped(wrapped)).to.be.true
-        expect(shim.unwrap(wrapped)).to.equal(wrappable.bar)
+    t.test('should wrap the first parameter if no properties are given', function (t) {
+      const wrapped = shim.recordSubscribedConsume(wrappable.bar, {
+        consumer: shim.FIRST,
+        messageHandler: function () {},
+        wrapper: function () {}
       })
-
-      it('should wrap the first parameter if `null` is given for properties', function () {
-        var wrapped = shim.recordSubscribedConsume(wrappable.bar, null, {
-          consumer: shim.FIRST,
-          messageHandler: function () {},
-          wrapper: function () {}
-        })
-        expect(wrapped).to.not.equal(wrappable.bar)
-        expect(shim.isWrapped(wrapped)).to.be.true
-        expect(shim.unwrap(wrapped)).to.equal(wrappable.bar)
-      })
+      t.not(wrapped, wrappable.bar)
+      t.ok(shim.isWrapped(wrapped))
+      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.end()
     })
 
-    describe('with properties', function () {
-      it('should replace wrapped properties on the original object', function () {
-        var original = wrappable.bar
-        shim.recordSubscribedConsume(wrappable, 'bar', {
-          consumer: shim.FIRST,
-          messageHandler: function () {},
-          wrapper: function () {}
-        })
-        expect(wrappable.bar).to.not.equal(original)
-        expect(shim.isWrapped(wrappable.bar)).to.be.true
-        expect(shim.unwrap(wrappable.bar)).to.equal(original)
+    t.test('should wrap the first parameter if `null` is given for properties', function (t) {
+      const wrapped = shim.recordSubscribedConsume(wrappable.bar, null, {
+        consumer: shim.FIRST,
+        messageHandler: function () {},
+        wrapper: function () {}
       })
-
-      it('should not mark unwrapped properties as wrapped', function () {
-        shim.recordSubscribedConsume(wrappable, 'name', {
-          consumer: shim.FIRST,
-          messageHandler: function () {},
-          wrapper: function () {}
-        })
-        expect(shim.isWrapped(wrappable.name)).to.be.false
-      })
+      t.not(wrapped, wrappable.bar)
+      t.ok(shim.isWrapped(wrapped))
+      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.end()
     })
 
-    describe('wrapper', function () {
-      var subscriber = null
-      var messageHandler = null
-      var wrapped = null
-      var subscriberCalled = false
-      var handlerCalled = false
-      var message = null
+    t.test('should replace wrapped properties on the original object', function (t) {
+      const original = wrappable.bar
+      shim.recordSubscribedConsume(wrappable, 'bar', {
+        consumer: shim.FIRST,
+        messageHandler: function () {},
+        wrapper: function () {}
+      })
+      t.not(wrappable.bar, original)
+      t.ok(shim.isWrapped(wrappable.bar))
+      t.equal(shim.unwrap(wrappable.bar), original)
+      t.end()
+    })
 
-      beforeEach(function () {
-        message = {}
-        subscriber = function consumeSubscriber(queue, consumer, cb) {
-          subscriberCalled = true
-          if (cb) {
-            setImmediate(cb)
-          }
-          if (consumer) {
-            setImmediate(consumer, message)
-          }
-          return shim.getSegment()
+    t.test('should not mark unwrapped properties as wrapped', function (t) {
+      shim.recordSubscribedConsume(wrappable, 'name', {
+        consumer: shim.FIRST,
+        messageHandler: function () {},
+        wrapper: function () {}
+      })
+      t.not(shim.isWrapped(wrappable.name))
+      t.end()
+    })
+  })
+
+  t.test('#recordSubscribedConsume wrapper', function (t) {
+    let message = null
+    let messageHandler = null
+    let subscriber = null
+    let wrapped = null
+    let handlerCalled = false
+    let subscriberCalled = false
+
+    t.autoend()
+
+    t.beforeEach(function () {
+      beforeEach()
+
+      message = {}
+      subscriber = function consumeSubscriber(queue, consumer, cb) {
+        subscriberCalled = true
+        if (cb) {
+          setImmediate(cb)
         }
+        if (consumer) {
+          setImmediate(consumer, message)
+        }
+        return shim.getSegment()
+      }
 
-        wrapped = shim.recordSubscribedConsume(subscriber, {
-          name: 'Channel#subscribe',
-          queue: shim.FIRST,
-          consumer: shim.SECOND,
-          callback: shim.LAST,
-          messageHandler: function (shim) {
-            handlerCalled = true
-            if (messageHandler) {
-              return messageHandler.apply(this, arguments)
-            }
-            return {
-              destinationName: 'exchange.foo',
-              destinationType: shim.EXCHANGE,
-              routingKey: 'routing.key',
-              properties: {
-                queue_name: 'amq.randomQueueName'
-              },
-              parameters: { a: 'a', b: 'b' }
-            }
+      wrapped = shim.recordSubscribedConsume(subscriber, {
+        name: 'Channel#subscribe',
+        queue: shim.FIRST,
+        consumer: shim.SECOND,
+        callback: shim.LAST,
+        messageHandler: function (shim) {
+          handlerCalled = true
+          if (messageHandler) {
+            return messageHandler.apply(this, arguments)
           }
-        })
+          return {
+            destinationName: 'exchange.foo',
+            destinationType: shim.EXCHANGE,
+            routingKey: 'routing.key',
+            properties: {
+              queue_name: 'amq.randomQueueName'
+            },
+            parameters: { a: 'a', b: 'b' }
+          }
+        }
+      })
+    })
+
+    t.afterEach(function () {
+      afterEach()
+      message = null
+      subscriber = null
+      wrapped = null
+      messageHandler = null
+      subscriberCalled = false
+      handlerCalled = false
+    })
+
+    t.test('should start a new transaction in the consumer', function (t) {
+      const parent = wrapped('my.queue', function consumer() {
+        const segment = shim.getSegment()
+        t.not(segment.name, 'Callback: consumer')
+        t.equal(segment.transaction.type, 'message')
+        t.end()
       })
 
-      afterEach(function () {
-        message = null
-        subscriber = null
-        wrapped = null
-        messageHandler = null
-        subscriberCalled = false
-        handlerCalled = false
+      t.notOk(parent)
+    })
+
+    t.test('should end the transaction immediately if not handled', function (t) {
+      wrapped('my.queue', function consumer() {
+        const tx = shim.getSegment().transaction
+        t.ok(tx.isActive())
+        setTimeout(function () {
+          t.notOk(tx.isActive())
+          t.end()
+        }, 5)
       })
+    })
 
-      it('should start a new transaction in the consumer', function (done) {
-        var parent = wrapped('my.queue', function consumer() {
-          var segment = shim.getSegment()
-          expect(segment).to.exist.and.have.property('name').not.equal('Callback: consumer')
+    t.test('should end the transaction based on a promise', function (t) {
+      messageHandler = function () {
+        return { promise: true }
+      }
 
-          expect(segment).to.have.nested.property('transaction.type', 'message')
-          done()
-        })
-        expect(parent).to.not.exist
-      })
+      wrapped('my.queue', function consumer() {
+        const tx = shim.getSegment().transaction
+        t.ok(tx.isActive())
 
-      it('should end the transaction immediately if not handled', function (done) {
-        wrapped('my.queue', function consumer() {
-          var tx = shim.getSegment().transaction
-          expect(tx.isActive()).to.be.true
+        return new Promise(function (resolve) {
+          t.ok(tx.isActive())
+          setImmediate(resolve)
+        }).then(function () {
+          t.ok(tx.isActive())
           setTimeout(function () {
-            expect(tx.isActive()).to.be.false
-            done()
+            t.notOk(tx.isActive())
+            t.end()
           }, 5)
         })
       })
+    })
 
-      it('should end the transaction based on a promise', function (done) {
-        messageHandler = function () {
-          return { promise: true }
-        }
+    t.test('should end the transaction when the handle says to', function (t) {
+      const api = new API(agent)
 
-        wrapped('my.queue', function consumer() {
-          var tx = shim.getSegment().transaction
-          expect(tx.isActive()).to.be.true
+      wrapped('my.queue', function consumer() {
+        const tx = shim.getSegment().transaction
+        const handle = api.getTransaction()
 
-          return new Promise(function (resolve) {
-            expect(tx.isActive()).to.be.true
-            setImmediate(resolve)
-          }).then(function () {
-            expect(tx.isActive()).to.be.true
-            setTimeout(function () {
-              expect(tx.isActive()).to.be.false
-              done()
-            }, 5)
-          })
-        })
-      })
-
-      it('should end the transaction when the handle says to', function (done) {
-        var api = new API(agent)
-
-        wrapped('my.queue', function consumer() {
-          var tx = shim.getSegment().transaction
-          var handle = api.getTransaction()
-
-          expect(tx.isActive()).to.be.true
+        t.ok(tx.isActive())
+        setTimeout(function () {
+          t.ok(tx.isActive())
+          handle.end()
           setTimeout(function () {
-            expect(tx.isActive()).to.be.true
-            handle.end()
-            setTimeout(function () {
-              expect(tx.isActive()).to.be.false
-              done()
-            }, 5)
+            t.notOk(tx.isActive())
+            t.end()
           }, 5)
-        })
+        }, 5)
+      })
+    })
+
+    t.test('should call spec.messageHandler before consumer is invoked', function (t) {
+      wrapped('my.queue', function consumer() {
+        t.ok(handlerCalled)
+        t.end()
       })
 
-      it('should call spec.messageHandler before consumer is invoked', function (done) {
-        wrapped('my.queue', function consumer() {
-          expect(handlerCalled).to.be.true
-          done()
-        })
-        expect(handlerCalled).to.be.false
+      t.notOk(handlerCalled)
+    })
+
+    t.test('should add agent attributes (e.g. routing key)', function (t) {
+      wrapped('my.queue', function consumer() {
+        const segment = shim.getSegment()
+        const tx = segment.transaction
+        const traceParams = tx.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
+
+        t.equal(traceParams['message.routingKey'], 'routing.key')
+        t.equal(traceParams['message.queueName'], 'my.queue')
+        t.end()
+      })
+    })
+
+    t.test('should add agent attributes (e.g. routing key) to Spans', function (t) {
+      wrapped('my.queue', function consumer() {
+        const segment = shim.getSegment()
+        const spanParams = segment.attributes.get(DESTINATIONS.SPAN_EVENT)
+
+        t.equal(spanParams['message.routingKey'], 'routing.key')
+        t.equal(spanParams['message.queueName'], 'my.queue')
+        t.end()
+      })
+    })
+
+    t.test('should add message.paremeters.* attributes to Spans', function (t) {
+      wrapped('my.queue', function consumer() {
+        const segment = shim.getSegment()
+        const spanParams = segment.attributes.get(DESTINATIONS.SPAN_EVENT)
+
+        t.equal(spanParams['message.parameters.a'], 'a')
+        t.equal(spanParams['message.parameters.b'], 'b')
+        t.end()
+      })
+    })
+
+    t.test('should create message transaction metrics', function (t) {
+      const metricNames = [
+        'OtherTransaction/Message/RabbitMQ/Exchange/Named/exchange.foo',
+        'OtherTransactionTotalTime/Message/RabbitMQ/Exchange/Named/exchange.foo',
+        'OtherTransaction/Message/all',
+        'OtherTransaction/all',
+        'OtherTransactionTotalTime'
+      ]
+
+      wrapped('my.queue', function consumer() {
+        setTimeout(function () {
+          const metrics = helper.getMetrics(agent)
+          metricNames.forEach(function (name) {
+            t.equal(metrics.unscoped[name].callCount, 1)
+          })
+          t.end()
+        }, 15) // Let tx end from instrumentation
+      })
+    })
+
+    t.test('should be able to get destinationName from arguments', function (t) {
+      const metricNames = [
+        'OtherTransaction/Message/RabbitMQ/Exchange/Named/my.exchange',
+        'OtherTransactionTotalTime/Message/RabbitMQ/Exchange/Named/my.exchange'
+      ]
+
+      const func = shim.recordSubscribedConsume(subscriber, {
+        name: 'Channel#subscribe',
+        destinationName: shim.FIRST,
+        destinationType: shim.EXCHANGE,
+        consumer: shim.SECOND,
+        callback: shim.LAST,
+        messageHandler: function () {
+          return {}
+        }
       })
 
-      it('should add agent attributes (e.g. routing key)', function (done) {
-        wrapped('my.queue', function consumer() {
-          const segment = shim.getSegment()
-          const tx = segment.transaction
-          const traceParams = tx.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
-
-          expect(traceParams).to.have.property('message.routingKey', 'routing.key')
-          expect(traceParams).to.have.property('message.queueName', 'my.queue')
-          done()
-        })
+      func('my.exchange', function consumer() {
+        setTimeout(function () {
+          const metrics = helper.getMetrics(agent)
+          metricNames.forEach(function (name) {
+            t.equal(metrics.unscoped[name].callCount, 1)
+          })
+          t.end()
+        }, 15) // Let tx end from instrumentation
       })
+    })
 
-      it('should add agent attributes (e.g. routing key) to Spans', function (done) {
-        wrapped('my.queue', function consumer() {
-          const segment = shim.getSegment()
-          const spanParams = segment.attributes.get(DESTINATIONS.SPAN_EVENT)
+    t.test('should handle a missing destination name as temp', function (t) {
+      const metricNames = [
+        'OtherTransaction/Message/RabbitMQ/Exchange/Temp',
+        'OtherTransactionTotalTime/Message/RabbitMQ/Exchange/Temp'
+      ]
 
-          expect(spanParams).to.have.property('message.routingKey', 'routing.key')
-          expect(spanParams).to.have.property('message.queueName', 'my.queue')
-          done()
-        })
+      messageHandler = function () {
+        return {
+          destinationName: null,
+          destinationType: shim.EXCHANGE
+        }
+      }
+
+      wrapped('my.queue', function consumer() {
+        setTimeout(function () {
+          const metrics = helper.getMetrics(agent)
+          metricNames.forEach(function (name) {
+            t.equal(metrics.unscoped[name].callCount, 1)
+          })
+          t.end()
+        }, 15) // Let tx end from instrumentation
       })
+    })
 
-      it('should add message.paremeters.* attributes to Spans', function (done) {
-        wrapped('my.queue', function consumer() {
-          const segment = shim.getSegment()
-          const spanParams = segment.attributes.get(DESTINATIONS.SPAN_EVENT)
+    t.test('should extract CAT headers from the message', function (t) {
+      const params = {
+        encoding_key: 'this is an encoding key',
+        cross_process_id: '1234#4321'
+      }
+      agent.config.trusted_account_ids = [9876, 6789]
+      agent.config._fromServer(params, 'encoding_key')
+      agent.config._fromServer(params, 'cross_process_id')
 
-          expect(spanParams).to.have.property('message.parameters.a', 'a')
-          expect(spanParams).to.have.property('message.parameters.b', 'b')
-          done()
-        })
-      })
+      const idHeader = hashes.obfuscateNameUsingKey('9876#id', agent.config.encoding_key)
+      let txHeader = JSON.stringify(['trans id', false, 'trip id', 'path hash'])
+      txHeader = hashes.obfuscateNameUsingKey(txHeader, agent.config.encoding_key)
 
-      it('should create message transaction metrics', function (done) {
-        var metricNames = [
-          'OtherTransaction/Message/RabbitMQ/Exchange/Named/exchange.foo',
-          'OtherTransactionTotalTime/Message/RabbitMQ/Exchange/Named/exchange.foo',
-          'OtherTransaction/Message/all',
-          'OtherTransaction/all',
-          'OtherTransactionTotalTime'
-        ]
-
-        wrapped('my.queue', function consumer() {
-          setTimeout(function () {
-            var metrics = getMetrics(agent)
-            metricNames.forEach(function (name) {
-              expect(metrics.unscoped).property(name).to.have.property('callCount', 1)
-            })
-            done()
-          }, 15) // Let tx end from instrumentation
-        })
-      })
-
-      it('should be able to get destinationName from arguments', function (done) {
-        var metricNames = [
-          'OtherTransaction/Message/RabbitMQ/Exchange/Named/my.exchange',
-          'OtherTransactionTotalTime/Message/RabbitMQ/Exchange/Named/my.exchange'
-        ]
-
-        var func = shim.recordSubscribedConsume(subscriber, {
-          name: 'Channel#subscribe',
-          destinationName: shim.FIRST,
-          destinationType: shim.EXCHANGE,
-          consumer: shim.SECOND,
-          callback: shim.LAST,
-          messageHandler: function () {
-            return {}
-          }
-        })
-
-        func('my.exchange', function consumer() {
-          setTimeout(function () {
-            var metrics = getMetrics(agent)
-            metricNames.forEach(function (name) {
-              expect(metrics.unscoped).property(name).to.have.property('callCount', 1)
-            })
-            done()
-          }, 15) // Let tx end from instrumentation
-        })
-      })
-
-      it('should handle a missing destination name as temp', function (done) {
-        var metricNames = [
-          'OtherTransaction/Message/RabbitMQ/Exchange/Temp',
-          'OtherTransactionTotalTime/Message/RabbitMQ/Exchange/Temp'
-        ]
-
-        messageHandler = function () {
-          return {
-            destinationName: null,
-            destinationType: shim.EXCHANGE
-          }
+      messageHandler = function () {
+        var catHeaders = {
+          NewRelicID: idHeader,
+          NewRelicTransaction: txHeader
         }
 
-        wrapped('my.queue', function consumer() {
-          setTimeout(function () {
-            var metrics = getMetrics(agent)
-            metricNames.forEach(function (name) {
-              expect(metrics.unscoped).property(name).to.have.property('callCount', 1)
-            })
-            done()
-          }, 15) // Let tx end from instrumentation
-        })
-      })
-
-      it('should extract CAT headers from the message', function (done) {
-        var params = {
-          encoding_key: 'this is an encoding key',
-          cross_process_id: '1234#4321'
+        return {
+          destinationName: 'foo',
+          destingationType: shim.EXCHANGE,
+          headers: catHeaders
         }
-        agent.config.trusted_account_ids = [9876, 6789]
-        agent.config._fromServer(params, 'encoding_key')
-        agent.config._fromServer(params, 'cross_process_id')
+      }
 
-        var idHeader = hashes.obfuscateNameUsingKey('9876#id', agent.config.encoding_key)
-        var txHeader = JSON.stringify(['trans id', false, 'trip id', 'path hash'])
-        txHeader = hashes.obfuscateNameUsingKey(txHeader, agent.config.encoding_key)
+      wrapped('my.queue', function consumer() {
+        const tx = shim.getSegment().transaction
 
-        messageHandler = function () {
-          var catHeaders = {
-            NewRelicID: idHeader,
-            NewRelicTransaction: txHeader
-          }
-
-          return {
-            destinationName: 'foo',
-            destingationType: shim.EXCHANGE,
-            headers: catHeaders
-          }
-        }
-
-        wrapped('my.queue', function consumer() {
-          var tx = shim.getSegment().transaction
-
-          expect(tx).to.have.property('incomingCatId', '9876#id')
-          expect(tx).to.have.property('referringTransactionGuid', 'trans id')
-          expect(tx).to.have.property('tripId', 'trip id')
-          expect(tx).to.have.property('referringPathHash', 'path hash')
-          expect(tx).to.have.property('invalidIncomingExternalTransaction', false)
-
-          done()
-        })
+        t.equal(tx.incomingCatId, '9876#id')
+        t.equal(tx.referringTransactionGuid, 'trans id')
+        t.equal(tx.tripId, 'trip id')
+        t.equal(tx.referringPathHash, 'path hash')
+        t.equal(tx.invalidIncomingExternalTransaction, false)
+        t.end()
       })
+    })
 
-      it('should invoke the consumer with the correct arguments', function (done) {
-        wrapped('my.queue', function consumer(msg) {
-          expect(msg).to.equal(message)
-          done()
-        })
+    t.test('should invoke the consumer with the correct arguments', function (t) {
+      wrapped('my.queue', function consumer(msg) {
+        t.equal(msg, message)
+        t.end()
       })
+    })
 
-      describe('when invoked in a transaction', function () {
-        it('should create a subscribe segment', function () {
-          helper.runInTransaction(agent, function () {
-            expect(subscriberCalled).to.be.false
-            var segment = wrapped('my.queue')
-            expect(subscriberCalled).to.be.true
-            expect(segment).to.have.property('name', 'Channel#subscribe')
-          })
-        })
+    t.test('should create a subscribe segment', function (t) {
+      helper.runInTransaction(agent, function () {
+        t.notOk(subscriberCalled)
+        const segment = wrapped('my.queue')
+        t.ok(subscriberCalled)
+        t.equal(segment.name, 'Channel#subscribe')
+        t.end()
+      })
+    })
 
-        it('should bind the subscribe callback', function (done) {
-          helper.runInTransaction(agent, function () {
-            var parent = wrapped('my.queue', null, function subCb() {
-              var segment = shim.getSegment()
-              expect(segment).to.have.property('name', 'Callback: subCb')
-              expect(parent).property('children').to.deep.equal([segment])
-              done()
-            })
-            expect(parent).to.exist
-          })
+    t.test('should bind the subscribe callback', function (t) {
+      helper.runInTransaction(agent, function () {
+        const parent = wrapped('my.queue', null, function subCb() {
+          const segment = shim.getSegment()
+          t.equal(segment.name, 'Callback: subCb')
+          t.same(parent.children, [segment])
+          t.end()
         })
+        t.ok(parent)
+      })
+    })
 
-        it('should still start a new transaction in the consumer', function (done) {
-          helper.runInTransaction(agent, function () {
-            var parent = wrapped('my.queue', function consumer() {
-              var segment = shim.getSegment()
-              expect(segment).property('name').to.not.equal('Callback: consumer')
-              expect(segment)
-                .property('transaction')
-                .property('id')
-                .to.not.equal(parent.transaction.id)
-              done()
-            })
-            expect(parent).to.exist
-          })
+    t.test('should still start a new transaction in the consumer', function (t) {
+      helper.runInTransaction(agent, function () {
+        const parent = wrapped('my.queue', function consumer() {
+          const segment = shim.getSegment()
+          t.not(segment.name, 'Callback: consumer')
+          t.ok(segment.transaction.id)
+          t.not(segment.transaction.id, parent.transaction.id)
+          t.end()
         })
+        t.ok(parent)
       })
     })
   })
 })
-
-function testNonWritable(obj, key, value) {
-  expect(function () {
-    obj[key] = 'testNonWritable test value'
-  }).to.throw(
-    TypeError,
-    new RegExp("(read only property '" + key + "'|Cannot set property " + key + ')')
-  )
-
-  if (value) {
-    expect(obj).to.have.property(key, value)
-  } else {
-    expect(obj).to.have.property(key).that.is.not.equal('testNonWritable test value')
-  }
-}
-
-function getMetrics(agent) {
-  return agent.metrics._metrics
-}

--- a/test/unit/shim/promise-shim.js
+++ b/test/unit/shim/promise-shim.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const helper = require('../../lib/agent_helper')
+
+module.exports = () => {
+  const TestPromise = function (executor) {
+    this.executorCaller(executor)
+  }
+
+  TestPromise.resolve = function (val) {
+    const p = Object.create(TestPromise.prototype)
+    p.resolver(val)
+    return p
+  }
+
+  TestPromise.reject = function (val) {
+    const p = Object.create(TestPromise.prototype)
+    p.rejector(val)
+    return p
+  }
+
+  TestPromise.promisify = function (shim, func) {
+    return function () {
+      const args = shim.argsToArray.apply(shim, arguments)
+      const p = Object.create(TestPromise.prototype)
+      args.push((err, res) => {
+        if (err) {
+          p.rejector(err)
+        } else {
+          p.resolver(res)
+        }
+      })
+      func.apply(this, args)
+      return p
+    }
+  }
+
+  TestPromise.prototype.executorCaller = function (executor) {
+    try {
+      executor(this.resolver.bind(this), this.rejector.bind(this))
+    } catch (err) {
+      this.rejector(err)
+    }
+  }
+
+  TestPromise.prototype.resolver = function (resolution) {
+    this.resolution = resolution
+    helper.runOutOfContext(() => {
+      if (this._next._thenned) {
+        this._next._thenned(resolution)
+      }
+    })
+  }
+
+  TestPromise.prototype.rejector = function (rejection) {
+    this.rejection = rejection
+    helper.runOutOfContext(() => {
+      if (this._next._caught) {
+        this._next._caught(rejection)
+      }
+    })
+  }
+
+  TestPromise.prototype.then = function (res, rej) {
+    this.res = res
+    this.rej = rej
+
+    this._next = Object.create(TestPromise.prototype)
+    this._next._thenned = res
+    this._next._caught = rej
+
+    return this._next
+  }
+
+  TestPromise.prototype.catch = function (ErrorClass, rej) {
+    this.ErrorClass = ErrorClass
+    this.rej = rej
+
+    this._next = Object.create(TestPromise.prototype)
+    this._next._caught = rej || ErrorClass
+
+    return this._next
+  }
+
+  TestPromise.Promise = TestPromise
+  return TestPromise
+}

--- a/test/unit/shim/promise-shim.test.js
+++ b/test/unit/shim/promise-shim.test.js
@@ -22,12 +22,12 @@ tap.test('PromiseShim', (t) => {
 
   // ensure the test does not exist before all pending
   // runOutOfContext tasks are executed
-  helper.interval.ref()
+  helper.outOfContextQueueInterval.ref()
 
   // unref the runOutOfContext interval
   // so other tests can run unencumbered
   t.teardown(() => {
-    helper.interval.unref()
+    helper.outOfContextQueueInterval.unref()
   })
 
   let agent = null


### PR DESCRIPTION
tests to use tap

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Migrated `conglomerate-shim`, `datastore-shim`, `message-shim`, and `promise-shim` to use tap

## Details
Big thanks to @michaelgoin for digging into the promise-shim issue when migrating to tap.  
