### PR TITLE
convert high-security.test.js to use tap syntax

### DIFF
--- a/test/unit/high-security.test.js
+++ b/test/unit/high-security.test.js
@@ -36,24 +36,23 @@ function getPath(obj, path) {
 }
 
 tap.Test.prototype.addAssert('check', 3, function (key, before, after) {
-  var fromFile = { high_security: true }
+  const fromFile = { high_security: true }
   setPath(fromFile, key, before)
 
-  var config = new Config(fromFile)
+  const config = new Config(fromFile)
   return this.same(getPath(config, key), after)
 })
 
 tap.Test.prototype.addAssert('checkServer', 4, function (config, key, expected, server) {
   setPath(config, key, expected)
-  var fromServer = { high_security: true }
+  const fromServer = { high_security: true }
   fromServer[key] = server
 
   this.same(getPath(config, key), expected)
   this.same(fromServer[key], server)
 
   config.onConnect(fromServer)
-  this.same(getPath(config, key), expected)
-  return this.pass()
+  return this.same(getPath(config, key), expected)
 })
 
 tap.test('high security mode', function (t) {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

- Transitioned high-security.test.js to use tap instead of mocha syntax.

## Links

## Details
