### PR TITLE
transition priority-queue.test.js from mocha to tap

### DIFF
--- a/test/unit/priority-queue.test.js
+++ b/test/unit/priority-queue.test.js
@@ -5,19 +5,17 @@
 
 'use strict'
 
-// TODO: convert to normal tap style.
-// Below allows use of mocha DSL with tap runner.
-require('tap').mochaGlobals()
+const tap = require('tap')
+const PriorityQueue = require('../../lib/priority-queue')
 
-var chai = require('chai')
-var expect = chai.expect
-var PriorityQueue = require('../../lib/priority-queue')
+tap.test('PriorityQueue', function (t) {
+  t.autoend()
+  let queue = null
 
-describe('PriorityQueue', function () {
-  var queue = null
+  t.test('#add', function (t) {
+    t.autoend()
 
-  describe('#add', function () {
-    it('structures the data as a min heap', function () {
+    t.test('structures the data as a min heap', function (t) {
       queue = new PriorityQueue()
 
       queue.add('left grandchild', 10)
@@ -25,14 +23,11 @@ describe('PriorityQueue', function () {
       queue.add('right child', 5)
       queue.add('left child', 8)
 
-      expect(queue.toArray()).to.deep.equal([
-        'parent',
-        'left child',
-        'right child',
-        'left grandchild'
-      ])
+      t.same(queue.toArray(), ['parent', 'left child', 'right child', 'left grandchild'])
+      t.end()
     })
-    it('replaces lowest priority item if limit is met', function () {
+
+    t.test('replaces lowest priority item if limit is met', function (t) {
       queue = new PriorityQueue(4)
 
       queue.add('left grandchild', 10)
@@ -40,32 +35,26 @@ describe('PriorityQueue', function () {
       queue.add('right child', 5)
       queue.add('left child', 8)
 
-      expect(queue.toArray()).to.deep.equal([
-        'parent',
-        'left child',
-        'right child',
-        'left grandchild'
-      ])
+      t.same(queue.toArray(), ['parent', 'left child', 'right child', 'left grandchild'])
 
       queue.add('new parent', 2)
 
-      expect(queue.toArray()).to.deep.equal([
-        'new parent',
-        'right child',
-        'left grandchild',
-        'left child'
-      ])
+      t.same(queue.toArray(), ['new parent', 'right child', 'left grandchild', 'left child'])
+      t.end()
     })
 
-    it('does not insert events in the case the limit is 0', function () {
+    t.test('does not insert events in the case the limit is 0', function (t) {
       queue = new PriorityQueue(0)
-      expect(queue.add('test', 1)).to.be.false
-      expect(queue.length).to.equal(0)
+      t.equal(queue.add('test', 1), false)
+      t.equal(queue.length, 0)
+      t.end()
     })
   })
 
-  describe('#merge', function () {
-    it('merges two sources and maintains the limit', function () {
+  t.test('#merge', function (t) {
+    t.autoend()
+
+    t.test('merges two sources and maintains the limit', function (t) {
       var queueLimit = 4
       var queue1 = new PriorityQueue(queueLimit)
       var queue2 = new PriorityQueue(queueLimit)
@@ -76,27 +65,31 @@ describe('PriorityQueue', function () {
       }
 
       queue1.merge(queue2)
-      expect(queue1.length).to.equal(queueLimit)
+      t.equal(queue1.length, queueLimit)
+      t.end()
     })
   })
 
-  describe('#setLimit', function () {
-    it('resets the limit property and slices the data if necessary', function () {
+  t.test('#setLimit', function (t) {
+    t.autoend()
+
+    t.test('resets the limit property and slices the data if necessary', function (t) {
       queue = new PriorityQueue(5)
 
-      expect(queue.limit).to.equal(5)
+      t.equal(queue.limit, 5)
       queue.setLimit(10)
-      expect(queue.limit).to.equal(10)
+      t.equal(queue.limit, 10)
 
       for (var i = 0; i < 6; i++) {
         queue.add(i, i)
       }
 
-      expect(queue.length).to.equal(6)
-      expect(queue.toArray()).to.deep.equal([0, 5, 4, 3, 2, 1])
+      t.equal(queue.length, 6)
+      t.same(queue.toArray(), [0, 5, 4, 3, 2, 1])
       queue.setLimit(5)
-      expect(queue.toArray()).to.deep.equal([1, 2, 3, 4, 5])
-      expect(queue.length).to.equal(5)
+      t.same(queue.toArray(), [1, 2, 3, 4, 5])
+      t.equal(queue.length, 5)
+      t.end()
     })
   })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

- Transitioned priority-queue.test.js to use tap rather than Mocha globals.

## Links

## Details
