### PR TITLE
fixed tests that broke when running on Node.js v16.9.0

### DIFF
--- a/test/integration/instrumentation/http.tap.js
+++ b/test/integration/instrumentation/http.tap.js
@@ -107,33 +107,33 @@ test('built-in http instrumentation should handle internal & external requests',
         return t.end()
       }
 
-      t.equals(response.statusCode, 200, 'should successfully fetch the page')
-      t.equals(fetchedBody, PAGE, "page shouldn't change")
+      t.equal(response.statusCode, 200, 'should successfully fetch the page')
+      t.equal(fetchedBody, PAGE, "page shouldn't change")
 
       var scope = 'WebTransaction/NormalizedUri/*'
       var stats = agent.metrics.getOrCreateMetric(scope)
 
-      t.equals(transaction.type, 'web', 'should be a web transaction')
-      t.equals(transaction.name, scope, 'should set transaction name')
-      t.equals(
+      t.equal(transaction.type, 'web', 'should be a web transaction')
+      t.equal(transaction.name, scope, 'should set transaction name')
+      t.equal(
         transaction.name,
         transaction.baseSegment.name,
         'baseSegment name should match transaction name'
       )
 
-      t.equals(stats.callCount, 2, 'should record unscoped path stats after a normal request')
+      t.equal(stats.callCount, 2, 'should record unscoped path stats after a normal request')
 
       var isDispatcher = agent.environment.get('Dispatcher').indexOf('http') > -1
       t.ok(isDispatcher, 'should indicate that the http dispatcher is in play')
 
       stats = agent.metrics.getOrCreateMetric('HttpDispatcher')
-      t.equals(stats.callCount, 2, 'should have accounted for all the internal http requests')
+      t.equal(stats.callCount, 2, 'should have accounted for all the internal http requests')
 
       stats = agent.metrics.getOrCreateMetric('External/localhost:8321/http', scope)
-      t.equals(stats.callCount, 1, 'should record outbound HTTP requests in metrics')
+      t.equal(stats.callCount, 1, 'should record outbound HTTP requests in metrics')
 
       stats = transaction.metrics.getOrCreateMetric('External/localhost:8321/http', scope)
-      t.equals(
+      t.equal(
         stats.callCount,
         1,
         'should associate outbound HTTP requests with the inbound transaction'
@@ -230,11 +230,13 @@ test('built-in http instrumentation should not swallow errors', function (t) {
       var second = errors[1]
       t.ok(first, 'should have the first error')
 
-      t.equal(
-        first[2],
+      // In v16.9 of Node.js the response error message
+      // changed
+      const expectedError = [
         "Cannot read property 'dieshere' of undefined",
-        'should get the expected error'
-      )
+        "Cannot read properties of undefined (reading 'dieshere')"
+      ]
+      t.ok(expectedError.includes(first[2]), 'should get the expected error')
 
       if (t.ok(second, 'should have the second error')) {
         t.equal(second[2], 'HttpError 501', 'should get the expected error')
@@ -273,11 +275,7 @@ test('built-in http instrumentation making outbound requests', function (t) {
             return t.end()
           }
 
-          t.deepEqual(
-            JSON.parse(body),
-            { status: 'ok' },
-            'request with ' + type + ' defined succeeded'
-          )
+          t.same(JSON.parse(body), { status: 'ok' }, 'request with ' + type + ' defined succeeded')
           next()
         })
         res.pipe(sink)

--- a/test/versioned/express/render.tap.js
+++ b/test/versioned/express/render.tap.js
@@ -130,7 +130,7 @@ function runTests(conf) {
             'got correct content type'
           )
 
-          t.deepEqual(JSON.parse(body), { yep: true }, 'Express correctly serves.')
+          t.same(JSON.parse(body), { yep: true }, 'Express correctly serves.')
 
           var stats
 
@@ -253,7 +253,18 @@ function runTests(conf) {
           var first = errors[0]
           t.ok(first, 'have the first error')
 
-          t.equal(first[2], "Cannot read property 'ohno' of undefined", 'got the expected error')
+          // The error msg changed in v16.9
+          // change assertion to check for an include of
+          // diff msgs
+          const expectedError = [
+            "Cannot read property 'ohno' of undefined",
+            "Cannot read properties of undefined (reading 'ohno')"
+          ]
+          t.ok(
+            expectedError.includes(first[2]),
+            "Cannot read property 'ohno' of undefined",
+            'got the expected error'
+          )
 
           t.end()
         })
@@ -277,7 +288,7 @@ function runTests(conf) {
           t.ok(isFramework, 'should indicate that express is a framework')
 
           t.notOk(agent.getTransaction(), "transaction shouldn't be visible from request")
-          t.equals(body, BODY, 'response and original page text match')
+          t.equal(body, BODY, 'response and original page text match')
 
           var stats = agent.metrics.getMetric('WebTransaction/Expressjs/GET//test')
           t.ok(stats, 'Statistics should have been found for request.')
@@ -304,7 +315,7 @@ function runTests(conf) {
           t.error(error, 'should not fail making request')
 
           t.notOk(agent.getTransaction(), "transaction shouldn't be visible from request")
-          t.equals(body, BODY, 'response and original page text match')
+          t.equal(body, BODY, 'response and original page text match')
 
           var stats = agent.metrics.getMetric('WebTransaction/Expressjs/GET//test')
           t.ok(stats, 'Statistics should have been found for request.')
@@ -590,7 +601,7 @@ function runTests(conf) {
     server.listen(0, TEST_HOST, function () {
       var port = server.address().port
       request.get(TEST_URL + port + TEST_PATH, function (err, response, body) {
-        t.equals(body, 'bar', 'should not fail with a proxy layer')
+        t.equal(body, 'bar', 'should not fail with a proxy layer')
         t.end()
       })
     })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Changed assertions for 2 http error msg tests to work with all versions of Node.js

## Details
In Node.js v16.9.0 2 tests broke because the error message in a http response changed from:

```
"Cannot read property '<prop name>' of undefined",
```

to
```
"Cannot read properties of undefined (reading '<prop name>')"
```

This appears to have been a v8 changed that was address in Node.js core here https://github.com/nodejs/node/commit/f43c292520c
