### PR TITLE
change span_events.max_samples_stored default 1000 -> 2000

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -802,7 +802,7 @@ exports.config = () => ({
      *
      * @env NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED
      */
-    max_samples_stored: 1000
+    max_samples_stored: 2000
   },
 
   /**

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -240,7 +240,7 @@ tap.test('with default properties', (t) => {
   })
 
   t.test('should default span event max_samples_stored', (t) => {
-    t.equal(configuration.span_events.max_samples_stored, 1000)
+    t.equal(configuration.span_events.max_samples_stored, 2000)
     t.end()
   })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

- Changed default for `span_events.max_samples_stored` from 1000 to 2000.

## Links

- Closes https://github.com/newrelic/node-newrelic/issues/883

## Details
