### PR TITLE
Prototype of undici diagnostic channel events to get feature parity

### DIFF
--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const recordExternal = require('../metrics/recorders/http_external')
+const hashes = require('../util/hashes')
+const logger = require('../logger').child({ component: 'undici' })
+const NAMES = require('../metrics/names')
+const SHIM_SYMBOLS = require('../shim/constants').SYMBOLS
+
+const NEWRELIC_ID_HEADER = 'x-newrelic-id'
+const NEWRELIC_TRANSACTION_HEADER = 'x-newrelic-transaction'
+const NEWRELIC_SYNTHETICS_HEADER = 'x-newrelic-synthetics'
+const diagnosticsChannel = require('diagnostics_channel')
+const SEGMENT = Symbol('__NR_segment')
+const PARSED_URL = Symbol('__NR_parsedUrl')
+
+/**
+ * Subscribes to undici diagnostic channel events
+ *  `undici:request:create` - happens right before request is made
+ *  `undici:request:headers` - happens when response headers are returned from server
+ *  `undici:request:trailer` - happens right before response ends
+ *  `undici:request:error` - happens when request errors
+ *
+ * @param {Agent} agent
+ */
+module.exports = function addUndiciChannels(agent, undici, modName, shim) {
+  diagnosticsChannel.channel('undici:request:create').subscribe(({ request }) => {
+    const url = new URL(`${request.origin}${request.path}`)
+    request[PARSED_URL] = url
+
+    const name = NAMES.EXTERNAL.PREFIX + url.host + url.pathname
+    const parent = agent.tracer.getSegment()
+    if (parent && parent.opaque) {
+      logger.trace(
+        'Not capturing data for outbound request (%s) because parent segment opaque (%s)',
+        name,
+        parent.name
+      )
+
+      return
+    }
+
+    const segment = agent.tracer.createSegment(name, recordExternal(url.host, 'undici'), parent)
+    segment.start()
+    shim.setActiveSegment(segment)
+    const transaction = segment.transaction
+    const outboundHeaders = Object.create(null)
+    if (agent.config.encoding_key && transaction.syntheticsHeader) {
+      outboundHeaders[NEWRELIC_SYNTHETICS_HEADER] = transaction.syntheticsHeader
+    }
+
+    // TODO: abstract header logic shared with TransactionShim#insertCATRequestHeaders
+    if (agent.config.distributed_tracing.enabled) {
+      if (request.headers && request.headers[SHIM_SYMBOLS.DISABLE_DT]) {
+        logger.trace('Distributed tracing disabled by instrumentation.')
+      } else {
+        transaction.insertDistributedTraceHeaders(outboundHeaders)
+      }
+    } else if (agent.config.cross_application_tracer.enabled) {
+      if (agent.config.encoding_key) {
+        _addCATHeaders(agent, transaction, outboundHeaders)
+      } else {
+        logger.trace('No encoding key found, not adding CAT headers')
+      }
+    } else {
+      logger.trace('CAT disabled, not adding headers!')
+    }
+
+    // eslint-disable-next-line guard-for-in
+    for (const key in outboundHeaders) {
+      request.addHeader(key, outboundHeaders[key])
+    }
+
+    // TODO: Need https://github.com/nodejs/undici/issues/863
+    segment.addAttribute('url', `${request.origin}${url.pathname}`)
+
+    url.searchParams.forEach((value, key) => {
+      segment.addSpanAttribute(`request.parameters.${key}`, value)
+    })
+    segment.addAttribute('procedure', request.method || 'GET')
+    request[SEGMENT] = segment
+  })
+
+  diagnosticsChannel.channel('undici:request:headers').subscribe(({ request, response }) => {
+    const activeSegment = request[SEGMENT]
+    if (activeSegment) {
+      activeSegment.addSpanAttribute('http.statusCode', response.statusCode)
+      activeSegment.addSpanAttribute('http.statusText', response.statusText)
+      // If CAT is enabled, grab those headers!
+      if (
+        agent.config.cross_application_tracer.enabled &&
+        !agent.config.distributed_tracing.enabled
+      ) {
+        pullCatHeaders(
+          agent.config,
+          activeSegment,
+          request.origin,
+          response.headers['x-newrelic-app-data']
+        )
+      }
+    }
+  })
+
+  diagnosticsChannel.channel('undici:request:trailers').subscribe(({ request }) => {
+    const activeSegment = request[SEGMENT]
+    if (activeSegment) {
+      activeSegment.end()
+    }
+  })
+
+  diagnosticsChannel.channel('undici:request:error').subscribe(({ request, error }) => {
+    const activeSegment = request[SEGMENT]
+    if (activeSegment) {
+      activeSegment.end()
+      // TODO: this is not IncomingMessage so has no listener count
+      handleError(
+        activeSegment,
+        {
+          listenerCount() {
+            return 0
+          }
+        },
+        error
+      )
+    }
+  })
+}
+
+/**
+ * Notices the given error if there is no listener for the `error` event on the
+ * request object.
+ *
+ * @param {TraceSegment} segment
+ * @param {http.ClientRequest} req
+ * @param {Error} error
+ *
+ * @return {bool} True if the error will be collected by New Relic.
+ */
+function handleError(segment, req, error) {
+  if (req.listenerCount('error') > 0) {
+    logger.trace(error, 'Not capturing outbound error because user has already handled it.')
+    return false
+  }
+
+  logger.trace(error, 'Captured outbound error on behalf of the user.')
+  const tx = segment.transaction
+  tx.agent.errors.add(tx, error)
+  return true
+}
+
+function pullCatHeaders(config, segment, host, obfAppData) {
+  if (!config.encoding_key) {
+    logger.trace('config.encoding_key is not set - not parsing response CAT headers')
+    return
+  }
+
+  if (!config.trusted_account_ids) {
+    logger.trace('config.trusted_account_ids is not set - not parsing response CAT headers')
+    return
+  }
+
+  // is our downstream request CAT-aware?
+  if (!obfAppData) {
+    logger.trace('Got no CAT app data in response header x-newrelic-app-data')
+  } else {
+    let appData = null
+    try {
+      appData = JSON.parse(hashes.deobfuscateNameUsingKey(obfAppData, config.encoding_key))
+    } catch (e) {
+      logger.warn('Got an unparsable CAT header x-newrelic-app-data: %s', obfAppData)
+      return
+    }
+    // Make sure it is a trusted account
+    if (appData.length && typeof appData[0] === 'string') {
+      let accountId = appData[0].split('#')[0]
+      accountId = parseInt(accountId, 10)
+      if (config.trusted_account_ids.indexOf(accountId) === -1) {
+        logger.trace('Response from untrusted CAT header account id: %s', accountId)
+      } else {
+        segment.catId = appData[0]
+        segment.catTransaction = appData[1]
+        segment.name =
+          NAMES.EXTERNAL.TRANSACTION + host + '/' + segment.catId + '/' + segment.catTransaction
+        if (appData.length >= 6) {
+          segment.addAttribute('transaction_guid', appData[5])
+        }
+        logger.trace('Got inbound response CAT headers in transaction %s', segment.transaction.id)
+      }
+    }
+  }
+}
+
+function _addCATHeaders(agent, tx, outboundHeaders) {
+  if (agent.config.obfuscatedId) {
+    outboundHeaders[NEWRELIC_ID_HEADER] = agent.config.obfuscatedId
+  }
+
+  const pathHash = hashes.calculatePathHash(
+    agent.config.applications()[0],
+    tx.getFullName() || '',
+    tx.referringPathHash
+  )
+  tx.pushPathHash(pathHash)
+
+  try {
+    let txData = JSON.stringify([tx.id, false, tx.tripId || tx.id, pathHash])
+    txData = hashes.obfuscateNameUsingKey(txData, agent.config.encoding_key)
+    outboundHeaders[NEWRELIC_TRANSACTION_HEADER] = txData
+
+    logger.trace('Added outbound request CAT headers in transaction %s', tx.id)
+  } catch (err) {
+    logger.trace(err, 'Failed to create CAT payload')
+  }
+}

--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -16,7 +16,7 @@ const NEWRELIC_TRANSACTION_HEADER = 'x-newrelic-transaction'
 const NEWRELIC_SYNTHETICS_HEADER = 'x-newrelic-synthetics'
 const diagnosticsChannel = require('diagnostics_channel')
 const SEGMENT = Symbol('__NR_segment')
-const PARSED_URL = Symbol('__NR_parsedUrl')
+const PARENT_SEGMENT = Symbol('__NR_parent_segment')
 
 /**
  * Subscribes to undici diagnostic channel events
@@ -30,7 +30,6 @@ const PARSED_URL = Symbol('__NR_parsedUrl')
 module.exports = function addUndiciChannels(agent, undici, modName, shim) {
   diagnosticsChannel.channel('undici:request:create').subscribe(({ request }) => {
     const url = new URL(`${request.origin}${request.path}`)
-    request[PARSED_URL] = url
 
     const name = NAMES.EXTERNAL.PREFIX + url.host + url.pathname
     const parent = agent.tracer.getSegment()
@@ -83,6 +82,7 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
     })
     segment.addAttribute('procedure', request.method || 'GET')
     request[SEGMENT] = segment
+    request[PARENT_SEGMENT] = parent
   })
 
   diagnosticsChannel.channel('undici:request:headers').subscribe(({ request, response }) => {
@@ -107,13 +107,18 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
 
   diagnosticsChannel.channel('undici:request:trailers').subscribe(({ request }) => {
     const activeSegment = request[SEGMENT]
+    const parentSegment = request[PARENT_SEGMENT]
     if (activeSegment) {
       activeSegment.end()
+      if (parentSegment) {
+        shim.setActiveSegment(parentSegment)
+      }
     }
   })
 
   diagnosticsChannel.channel('undici:request:error').subscribe(({ request, error }) => {
     const activeSegment = request[SEGMENT]
+    const parentSegment = request[PARENT_SEGMENT]
     if (activeSegment) {
       activeSegment.end()
       // TODO: this is not IncomingMessage so has no listener count
@@ -126,6 +131,9 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
         },
         error
       )
+      if (parentSegment) {
+        shim.setActiveSegment(activeSegment.parent)
+      }
     }
   })
 }

--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -17,6 +17,7 @@ const NEWRELIC_SYNTHETICS_HEADER = 'x-newrelic-synthetics'
 const diagnosticsChannel = require('diagnostics_channel')
 const SEGMENT = Symbol('__NR_segment')
 const PARENT_SEGMENT = Symbol('__NR_parent_segment')
+const { TLSSocket } = require('tls')
 
 /**
  * Subscribes to undici diagnostic channel events
@@ -29,24 +30,19 @@ const PARENT_SEGMENT = Symbol('__NR_parent_segment')
  */
 module.exports = function addUndiciChannels(agent, undici, modName, shim) {
   diagnosticsChannel.channel('undici:request:create').subscribe(({ request }) => {
-    const url = new URL(`${request.origin}${request.path}`)
-
-    const name = NAMES.EXTERNAL.PREFIX + url.host + url.pathname
     const parent = agent.tracer.getSegment()
+    request[PARENT_SEGMENT] = parent
     if (parent && parent.opaque) {
       logger.trace(
         'Not capturing data for outbound request (%s) because parent segment opaque (%s)',
-        name,
+        request.path,
         parent.name
       )
 
       return
     }
 
-    const segment = agent.tracer.createSegment(name, recordExternal(url.host, 'undici'), parent)
-    segment.start()
-    shim.setActiveSegment(segment)
-    const transaction = segment.transaction
+    const transaction = parent.transaction
     const outboundHeaders = Object.create(null)
     if (agent.config.encoding_key && transaction.syntheticsHeader) {
       outboundHeaders[NEWRELIC_SYNTHETICS_HEADER] = transaction.syntheticsHeader
@@ -73,16 +69,42 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
     for (const key in outboundHeaders) {
       request.addHeader(key, outboundHeaders[key])
     }
+  })
 
-    // TODO: Need https://github.com/nodejs/undici/issues/863
-    segment.addAttribute('url', `${request.origin}${url.pathname}`)
+  diagnosticsChannel.channel('undici:client:sendHeaders').subscribe(({ request, socket }) => {
+    const parentSegment = request[PARENT_SEGMENT]
+    if (parentSegment && parentSegment.opaque) {
+      return
+    }
+
+    const port = socket.remotePort
+    const isHttps = socket instanceof TLSSocket
+    let urlString
+    if (isHttps) {
+      urlString = `https://${socket.servername}`
+      urlString += port === 443 ? request.path : `:${port}${request.path}`
+    } else {
+      urlString = `http://${socket._host}`
+      urlString += port === 80 ? request.path : `:${port}${request.path}`
+    }
+
+    const url = new URL(urlString)
+
+    const name = NAMES.EXTERNAL.PREFIX + url.host + url.pathname
+    const segment = agent.tracer.createSegment(
+      name,
+      recordExternal(url.host, 'undici'),
+      request[PARENT_SEGMENT]
+    )
+    segment.start()
+    shim.setActiveSegment(segment)
+    segment.addAttribute('url', `${url.protocol}//${url.host}${url.pathname}`)
 
     url.searchParams.forEach((value, key) => {
       segment.addSpanAttribute(`request.parameters.${key}`, value)
     })
     segment.addAttribute('procedure', request.method || 'GET')
     request[SEGMENT] = segment
-    request[PARENT_SEGMENT] = parent
   })
 
   diagnosticsChannel.channel('undici:request:headers').subscribe(({ request, response }) => {
@@ -132,7 +154,49 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
         error
       )
       if (parentSegment) {
-        shim.setActiveSegment(activeSegment.parent)
+        shim.setActiveSegment(parentSegment)
+      }
+    }
+  })
+
+  // TODO: no object to apply context to
+  diagnosticsChannel.channel('undici:client:beforeConnect').subscribe(({ client }) => {
+    const parent = agent.tracer.getSegment()
+    const segment = agent.tracer.createSegment('undici.Client.connect')
+    client[SEGMENT] = segment
+    client[PARENT_SEGMENT] = parent
+    segment.start()
+    shim.setActiveSegment(segment)
+  })
+
+  diagnosticsChannel.channel('undici:client:connected').subscribe(({ client }) => {
+    const segment = client[SEGMENT]
+    const parent = client[PARENT_SEGMENT]
+    if (segment) {
+      segment.end()
+      if (parent) {
+        shim.setActiveSegment(parent)
+      }
+    }
+  })
+
+  diagnosticsChannel.channel('undici:client:connectError').subscribe(({ client, error }) => {
+    const activeSegment = client[SEGMENT]
+    const parentSegment = client[PARENT_SEGMENT]
+    if (activeSegment) {
+      activeSegment.end()
+      // TODO: this is not IncomingMessage so has no listener count
+      handleError(
+        activeSegment,
+        {
+          listenerCount() {
+            return 0
+          }
+        },
+        error
+      )
+      if (parentSegment) {
+        shim.setActiveSegment(parentSegment)
       }
     }
   })

--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -153,19 +153,18 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
     }
   })
 
-  // TODO: no object to apply context to
-  diagnosticsChannel.channel('undici:client:beforeConnect').subscribe(({ client }) => {
+  diagnosticsChannel.channel('undici:client:beforeConnect').subscribe(({ connector }) => {
     const parent = agent.tracer.getSegment()
     const segment = agent.tracer.createSegment('undici.Client.connect')
-    client[SEGMENT] = segment
-    client[PARENT_SEGMENT] = parent
+    connector[SEGMENT] = segment
+    connector[PARENT_SEGMENT] = parent
     segment.start()
     shim.setActiveSegment(segment)
   })
 
-  diagnosticsChannel.channel('undici:client:connected').subscribe(({ client }) => {
-    const segment = client[SEGMENT]
-    const parent = client[PARENT_SEGMENT]
+  diagnosticsChannel.channel('undici:client:connected').subscribe(({ connector }) => {
+    const segment = connector[SEGMENT]
+    const parent = connector[PARENT_SEGMENT]
     if (segment) {
       segment.end()
       if (parent) {
@@ -174,9 +173,9 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
     }
   })
 
-  diagnosticsChannel.channel('undici:client:connectError').subscribe(({ client, error }) => {
-    const activeSegment = client[SEGMENT]
-    const parentSegment = client[PARENT_SEGMENT]
+  diagnosticsChannel.channel('undici:client:connectError').subscribe(({ connector, error }) => {
+    const activeSegment = connector[SEGMENT]
+    const parentSegment = connector[PARENT_SEGMENT]
     if (activeSegment) {
       activeSegment.end()
       // TODO: this is not IncomingMessage so has no listener count

--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -50,6 +50,7 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
 
     // TODO: abstract header logic shared with TransactionShim#insertCATRequestHeaders
     if (agent.config.distributed_tracing.enabled) {
+      // TODO: show can a request header be a symbol??
       if (request.headers && request.headers[SHIM_SYMBOLS.DISABLE_DT]) {
         logger.trace('Distributed tracing disabled by instrumentation.')
       } else {

--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -9,7 +9,6 @@ const recordExternal = require('../metrics/recorders/http_external')
 const hashes = require('../util/hashes')
 const logger = require('../logger').child({ component: 'undici' })
 const NAMES = require('../metrics/names')
-const SHIM_SYMBOLS = require('../shim/constants').SYMBOLS
 
 const NEWRELIC_ID_HEADER = 'x-newrelic-id'
 const NEWRELIC_TRANSACTION_HEADER = 'x-newrelic-transaction'
@@ -48,14 +47,8 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
       outboundHeaders[NEWRELIC_SYNTHETICS_HEADER] = transaction.syntheticsHeader
     }
 
-    // TODO: abstract header logic shared with TransactionShim#insertCATRequestHeaders
     if (agent.config.distributed_tracing.enabled) {
-      // TODO: show can a request header be a symbol??
-      if (request.headers && request.headers[SHIM_SYMBOLS.DISABLE_DT]) {
-        logger.trace('Distributed tracing disabled by instrumentation.')
-      } else {
-        transaction.insertDistributedTraceHeaders(outboundHeaders)
-      }
+      transaction.insertDistributedTraceHeaders(outboundHeaders)
     } else if (agent.config.cross_application_tracer.enabled) {
       if (agent.config.encoding_key) {
         _addCATHeaders(agent, transaction, outboundHeaders)

--- a/lib/instrumentations.js
+++ b/lib/instrumentations.js
@@ -31,6 +31,7 @@ module.exports = function instrumentations() {
     'redis': { type: MODULE_TYPE.DATASTORE },
     'restify': { type: MODULE_TYPE.WEB_FRAMEWORK },
     'superagent': { module: '@newrelic/superagent' },
+    'undici': { type: MODULE_TYPE.TRANSACTION },
     'oracle': { type: null },
     'vision': { type: MODULE_TYPE.WEB_FRAMEWORK },
     'when': { type: null }


### PR DESCRIPTION
This PR is to demonstrate feature parity between undici and http(outbound/client requests).  

## Gaps
During this work I identified two gaps. One is a must have the other I'm not so sure.
 * [undici request object missing some outgoing headers](https://github.com/nodejs/undici/issues/1032).  the net of this is that we lack the host header to drive segment naming.  Below is a patch of what I did to get this working
 * Undici lib doesn't emit events when connections are created so we cannot replicate [http.Agent.prototype.createConnection spans](https://github.com/newrelic/node-newrelic/blob/main/lib/instrumentation/core/http.js#L511)
 * This will only work in Node 16 as undici uses the `diagnostics_channel` module, but I think that will be ok
 * We are not sure when a release of Undici will include the diagnostic channel work
 
## Future work
 * abstract some of the reusable code between http-outbound and undici instrumentation
 * add proper tests for undici

## How to use
You can use this repo [undici-http-app](https://github.com/bizob2828/undici-http-app) and follow the README to get it up and running.  As you can see the spans for httpbin.org are identical and the traces are properly nested.

### [Http trace](https://staging.onenr.io/0PLREN9AMja)
 
<img width="1466" alt="screenshot 2021-09-14 at 12 07 02 PM" src="https://user-images.githubusercontent.com/1874937/133294573-f7fe89de-2d64-4bc2-ad41-36414fb9d594.png">

<img width="368" alt="screenshot 2021-09-14 at 12 10 10 PM" src="https://user-images.githubusercontent.com/1874937/133294611-c0c14ccf-e9d1-44e4-91d0-4367fb22fa89.png">

###  [Undici trace](https://staging.onenr.io/0dBj3v0BbRX)

<img width="1436" alt="screenshot 2021-09-14 at 12 08 14 PM" src="https://user-images.githubusercontent.com/1874937/133294602-46ab81b9-a07d-41ed-824a-b76e051447da.png">

<img width="343" alt="screenshot 2021-09-14 at 12 09 42 PM" src="https://user-images.githubusercontent.com/1874937/133294531-b9652033-b3d6-43ef-a6c2-2eaa052b54b5.png">




## Undici patch

```
  3 --- a/lib/core/request.js
  4 +++ b/lib/core/request.js
  5 @@ -28,6 +28,7 @@ try {
  6
  7  class Request {
  8    constructor ({
  9 +    origin,
 10      path,
 11      method,
 12      body,
 13 @@ -100,6 +101,7 @@ class Request {
 14      this.blocking = blocking == null ? false : blocking
 15
 16      this.host = null
 17 +    this.origin = origin
```

