### PR TITLE
support cassandra-driver >4

### DIFF
--- a/lib/instrumentation/cassandra-driver.js
+++ b/lib/instrumentation/cassandra-driver.js
@@ -9,7 +9,11 @@ module.exports = function initialize(agent, cassandra, moduleName, shim) {
   const proto = cassandra.Client.prototype
   shim.setDatastore(shim.CASSANDRA)
   shim.recordOperation(proto, ['connect', 'shutdown'], { callback: shim.LAST })
-  shim.recordQuery(proto, '_innerExecute', { query: shim.FIRST, callback: shim.LAST })
+  if (proto._innerExecute) {
+    shim.recordQuery(proto, '_innerExecute', { query: shim.FIRST, callback: shim.LAST })
+  } else {
+    shim.recordQuery(proto, '_execute', { query: shim.FIRST, callback: shim.LAST })
+  }
   shim.recordBatchQuery(proto, 'batch', {
     query: findBatchQueryArg,
     callback: shim.LAST

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "newrelic",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.2.11",
@@ -26,7 +26,7 @@
         "newrelic-naming-rules": "bin/test-naming-rules.js"
       },
       "devDependencies": {
-        "@newrelic/eslint-config": "0.0.3",
+        "@newrelic/eslint-config": "^0.0.3",
         "@newrelic/newrelic-oss-cli": "^0.1.2",
         "@newrelic/proxy": "^2.0.0",
         "@newrelic/test-utilities": "^6.0.0",

--- a/test/versioned/cassandra-driver/package.json
+++ b/test/versioned/cassandra-driver/package.json
@@ -8,7 +8,7 @@
         "node": ">=12"
       },
       "dependencies": {
-        "cassandra-driver": ">=3.4.0 <4"
+        "cassandra-driver": ">=3.4.0 <5"
       },
       "files": [
         "query.tap.js"

--- a/test/versioned/cassandra-driver/package.json
+++ b/test/versioned/cassandra-driver/package.json
@@ -8,7 +8,7 @@
         "node": ">=12"
       },
       "dependencies": {
-        "cassandra-driver": ">=3.4.0 <5"
+        "cassandra-driver": ">=3.4.0"
       },
       "files": [
         "query.tap.js"

--- a/test/versioned/cassandra-driver/query.tap.js
+++ b/test/versioned/cassandra-driver/query.tap.js
@@ -117,18 +117,18 @@ test('Cassandra instrumentation', { timeout: 5000 }, function testInstrumentatio
             }
 
             t.ok(agent.getTransaction(), 'transaction should still still be visible')
-            t.equals(value.rows[0][COL], colValArr[0], 'Cassandra client should still work')
+            t.equal(value.rows[0][COL], colValArr[0], 'Cassandra client should still work')
 
             const trace = transaction.trace
             t.ok(trace, 'trace should exist')
             t.ok(trace.root, 'root element should exist')
 
-            t.equals(trace.root.children.length, 1, 'there should be only one child of the root')
+            t.equal(trace.root.children.length, 1, 'there should be only one child of the root')
 
             const setSegment = trace.root.children[0]
             t.ok(setSegment, 'trace segment for insert should exist')
             if (setSegment) {
-              t.equals(
+              t.equal(
                 setSegment.name,
                 'Datastore/statement/Cassandra/test.testFamily/insert/batch',
                 'should register the executeBatch'
@@ -142,7 +142,7 @@ test('Cassandra instrumentation', { timeout: 5000 }, function testInstrumentatio
               const getSegment = setSegment.children[childIndex].children[0]
               t.ok(getSegment, 'trace segment for select should exist')
               if (getSegment) {
-                t.equals(
+                t.equal(
                   getSegment.name,
                   'Datastore/statement/Cassandra/test.testFamily/select',
                   'should register the execute'

--- a/test/versioned/cassandra-driver/query.tap.js
+++ b/test/versioned/cassandra-driver/query.tap.js
@@ -22,7 +22,8 @@ const COL = 'test_column'
 const client = new cassandra.Client({
   contactPoints: [params.cassandra_host],
   protocolOptions: params.cassandra_port,
-  keyspace: KS
+  keyspace: KS,
+  localDataCenter: 'datacenter1'
 })
 
 /**
@@ -36,7 +37,8 @@ const client = new cassandra.Client({
 function cassSetup(runTest) {
   const setupClient = new cassandra.Client({
     contactPoints: [params.cassandra_host],
-    protocolOptions: params.cassandra_port
+    protocolOptions: params.cassandra_port,
+    localDataCenter: 'datacenter1'
   })
 
   const ksDrop = 'DROP KEYSPACE IF EXISTS ' + KS + ';'


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

- Support Cassandra driver v4.0.0 and above.

## Links

- Closes https://github.com/newrelic/node-newrelic/issues/909

## Details

This PR adds support for Cassandra v4. In v4.4.0, the private method `_innerExecute` was replaced with `_execute`. Because our tests were pinned to test only *up to but not including* v4, we only detected this failure once it was [reported to us](https://github.com/newrelic/node-newrelic/issues/564). This PR creates query hooks on `_execute` if `_innerExecute` does not exist. As well, the test suite has been updated
