### PR TITLE
Centralized CAT logic into util/cat

### DIFF
--- a/lib/instrumentation/core/http-outbound.js
+++ b/lib/instrumentation/core/http-outbound.js
@@ -6,8 +6,8 @@
 'use strict'
 
 const recordExternal = require('../../metrics/recorders/http_external')
+const cat = require('../../util/cat')
 const urltils = require('../../util/urltils')
-const hashes = require('../../util/hashes')
 const logger = require('../../logger').child({ component: 'outbound' })
 const shimmer = require('../../shimmer')
 const url = require('url')
@@ -20,8 +20,6 @@ const DEFAULT_HOST = 'localhost'
 const DEFAULT_PORT = 80
 const DEFAULT_SSL_PORT = 443
 
-const NEWRELIC_ID_HEADER = 'x-newrelic-id'
-const NEWRELIC_TRANSACTION_HEADER = 'x-newrelic-transaction'
 const NEWRELIC_SYNTHETICS_HEADER = 'x-newrelic-synthetics'
 
 /**
@@ -96,11 +94,7 @@ module.exports = function instrumentOutbound(agent, opts, makeRequest) {
         transaction.insertDistributedTraceHeaders(outboundHeaders)
       }
     } else if (agent.config.cross_application_tracer.enabled) {
-      if (agent.config.encoding_key) {
-        _addCATHeaders(agent, transaction, outboundHeaders)
-      } else {
-        logger.trace('No encoding key found, not adding CAT headers')
-      }
+      cat.addCatHeaders(agent.config, transaction, outboundHeaders)
     } else {
       logger.trace('CAT disabled, not adding headers!')
     }
@@ -196,7 +190,9 @@ function handleResponse(segment, hostname, req, res) {
   // If CAT is enabled, grab those headers!
   const agent = segment.transaction.agent
   if (agent.config.cross_application_tracer.enabled && !agent.config.distributed_tracing.enabled) {
-    pullCatHeaders(agent.config, segment, hostname, res.headers['x-newrelic-app-data'])
+    const { appData } = cat.extractCatHeaders(res.headers)
+    cat.pullCatHeaders(agent.config, segment, appData)
+    segment.name = `${NAMES.EXTERNAL.TRANSACTION}${hostname}/${segment.catId}/${segment.catTransaction}`
   }
 
   // Again a custom emit wrapper because we want to watch for the `end` event.
@@ -212,48 +208,6 @@ function handleResponse(segment, hostname, req, res) {
   _makeNonEnumerable(res, 'emit')
 }
 
-function pullCatHeaders(config, segment, host, obfAppData) {
-  if (!config.encoding_key) {
-    logger.trace('config.encoding_key is not set - not parsing response CAT headers')
-    return
-  }
-
-  if (!config.trusted_account_ids) {
-    logger.trace('config.trusted_account_ids is not set - not parsing response CAT headers')
-    return
-  }
-
-  // is our downstream request CAT-aware?
-  if (!obfAppData) {
-    logger.trace('Got no CAT app data in response header x-newrelic-app-data')
-  } else {
-    let appData = null
-    try {
-      appData = JSON.parse(hashes.deobfuscateNameUsingKey(obfAppData, config.encoding_key))
-    } catch (e) {
-      logger.warn('Got an unparsable CAT header x-newrelic-app-data: %s', obfAppData)
-      return
-    }
-    // Make sure it is a trusted account
-    if (appData.length && typeof appData[0] === 'string') {
-      let accountId = appData[0].split('#')[0]
-      accountId = parseInt(accountId, 10)
-      if (config.trusted_account_ids.indexOf(accountId) === -1) {
-        logger.trace('Response from untrusted CAT header account id: %s', accountId)
-      } else {
-        segment.catId = appData[0]
-        segment.catTransaction = appData[1]
-        segment.name =
-          NAMES.EXTERNAL.TRANSACTION + host + '/' + segment.catId + '/' + segment.catTransaction
-        if (appData.length >= 6) {
-          segment.addAttribute('transaction_guid', appData[5])
-        }
-        logger.trace('Got inbound response CAT headers in transaction %s', segment.transaction.id)
-      }
-    }
-  }
-}
-
 function _makeNonEnumerable(obj, prop) {
   try {
     const desc = Object.getOwnPropertyDescriptor(obj, prop)
@@ -261,28 +215,5 @@ function _makeNonEnumerable(obj, prop) {
     Object.defineProperty(obj, prop, desc)
   } catch (e) {
     logger.debug(e, 'Failed to make %s non enumerable.', prop)
-  }
-}
-
-function _addCATHeaders(agent, tx, outboundHeaders) {
-  if (agent.config.obfuscatedId) {
-    outboundHeaders[NEWRELIC_ID_HEADER] = agent.config.obfuscatedId
-  }
-
-  const pathHash = hashes.calculatePathHash(
-    agent.config.applications()[0],
-    tx.getFullName() || '',
-    tx.referringPathHash
-  )
-  tx.pushPathHash(pathHash)
-
-  try {
-    let txData = JSON.stringify([tx.id, false, tx.tripId || tx.id, pathHash])
-    txData = hashes.obfuscateNameUsingKey(txData, agent.config.encoding_key)
-    outboundHeaders[NEWRELIC_TRANSACTION_HEADER] = txData
-
-    logger.trace('Added outbound request CAT headers in transaction %s', tx.id)
-  } catch (err) {
-    logger.trace(err, 'Failed to create CAT payload')
   }
 }

--- a/lib/instrumentation/core/http-outbound.js
+++ b/lib/instrumentation/core/http-outbound.js
@@ -191,8 +191,8 @@ function handleResponse(segment, hostname, req, res) {
   const agent = segment.transaction.agent
   if (agent.config.cross_application_tracer.enabled && !agent.config.distributed_tracing.enabled) {
     const { appData } = cat.extractCatHeaders(res.headers)
-    cat.pullCatHeaders(agent.config, segment, appData)
-    segment.name = `${NAMES.EXTERNAL.TRANSACTION}${hostname}/${segment.catId}/${segment.catTransaction}`
+    const decodedAppData = cat.parseAppData(agent.config, appData)
+    cat.assignCatToSegment(decodedAppData, segment, hostname)
   }
 
   // Again a custom emit wrapper because we want to watch for the `end` event.

--- a/lib/instrumentation/core/http.js
+++ b/lib/instrumentation/core/http.js
@@ -139,7 +139,13 @@ function wrapEmitWithTransaction(agent, emit, isHTTPS) {
       // Node http headers are automatically lowercase
       transaction.acceptDistributedTraceHeaders(transport, request.headers)
     } else if (agent.config.cross_application_tracer.enabled) {
-      cat.handleCatHeaders(request.headers, agent.config.encoding_key, transaction)
+      const { id, transactionId } = cat.extractCatHeaders(request.headers)
+      const { externalId, externalTransaction } = cat.parseCatData(
+        id,
+        transactionId,
+        agent.config.encoding_key
+      )
+      cat.assignCatToTransaction(externalId, externalTransaction, transaction)
     }
 
     function instrumentedFinish() {

--- a/lib/instrumentation/core/http.js
+++ b/lib/instrumentation/core/http.js
@@ -26,9 +26,6 @@ const DESTS = require('../../config/attribute-filter').DESTINATIONS
  *
  */
 const NR_CONNECTION_PROP = '__NR__connection'
-const NEWRELIC_ID_HEADER = 'x-newrelic-id'
-const NEWRELIC_APP_DATA_HEADER = 'x-newrelic-app-data'
-const NEWRELIC_TRANSACTION_HEADER = 'x-newrelic-transaction'
 const NEWRELIC_SYNTHETICS_HEADER = 'x-newrelic-synthetics'
 const TRANSACTION_INFO_KEY = '__NR_transactionInfo'
 
@@ -142,15 +139,7 @@ function wrapEmitWithTransaction(agent, emit, isHTTPS) {
       // Node http headers are automatically lowercase
       transaction.acceptDistributedTraceHeaders(transport, request.headers)
     } else if (agent.config.cross_application_tracer.enabled) {
-      const incomingCatId = request.headers[NEWRELIC_ID_HEADER]
-      const obfTransaction = request.headers[NEWRELIC_TRANSACTION_HEADER]
-
-      if (agent.config.encoding_key) {
-        cat.handleCatHeaders(incomingCatId, obfTransaction, agent.config.encoding_key, transaction)
-        if (transaction.incomingCatId) {
-          logger.trace('Got inbound request CAT headers in transaction %s', transaction.id)
-        }
-      }
+      cat.handleCatHeaders(request.headers, agent.config.encoding_key, transaction)
     }
 
     function instrumentedFinish() {
@@ -307,13 +296,7 @@ function wrapWriteHead(agent, writeHead) {
       return writeHead.apply(this, arguments)
     }
 
-    let accountId = transaction.incomingCatId.split('#')[0]
-    accountId = parseInt(accountId, 10)
-    if (agent.config.trusted_account_ids.indexOf(accountId) === -1) {
-      logger.trace(
-        'Request from untrusted account id: %s - not adding response CAT headers',
-        accountId
-      )
+    if (!cat.isTrustedAccountId(transaction.incomingCatId, agent.config.trusted_account_ids)) {
       return writeHead.apply(this, arguments)
     }
 
@@ -347,33 +330,11 @@ function wrapWriteHead(agent, writeHead) {
     // actual duration.
     transaction.catResponseTime = transaction.timer.getDurationInMillis()
 
-    let appData = null
-    const txName = transaction.getFullName() || ''
-
-    try {
-      appData = JSON.stringify([
-        agent.config.cross_process_id, // cross_process_id
-        txName, // transaction name
-        transaction.queueTime / 1000, // queue time (s)
-        transaction.catResponseTime / 1000, // response time (s)
-        contentLength, // content length (if content-length header is also being sent)
-        transaction.id, // TransactionGuid
-        false // force a transaction trace to be recorded
-      ])
-    } catch (err) {
-      logger.trace(
-        err,
-        'Failed to serialize transaction: %s - not adding CAT response headers',
-        txName
-      )
-      return writeHead.apply(this, arguments)
+    const { key, data } = cat.encodeAppData(agent.config, transaction, contentLength)
+    if (key && data) {
+      this.setHeader(key, data)
+      logger.trace('Added outbound response CAT headers in transaction %s', transaction.id)
     }
-
-    const encKey = agent.config.encoding_key
-    const obfAppData = hashes.obfuscateNameUsingKey(appData, encKey)
-    this.setHeader(NEWRELIC_APP_DATA_HEADER, obfAppData)
-    logger.trace('Added outbound response CAT headers in transaction %s', transaction.id)
-
     return writeHead.apply(this, arguments)
   }
 }

--- a/lib/shim/transaction-shim.js
+++ b/lib/shim/transaction-shim.js
@@ -68,6 +68,7 @@ TransactionShim.prototype.pushTransactionName = pushTransactionName
 TransactionShim.prototype.popTransactionName = popTransactionName
 TransactionShim.prototype.setTransactionName = setTransactionName
 TransactionShim.prototype.handleCATHeaders = handleCATHeaders
+TransactionShim.prototype.insertCATReplyHeader = insertCATReplyHeader
 TransactionShim.prototype.insertCATRequestHeaders = insertCATRequestHeaders
 
 // -------------------------------------------------------------------------- //
@@ -263,9 +264,15 @@ function handleCATHeaders(headers, segment, transportType) {
 
   // Not DT so processing CAT.
   // TODO: Below will be removed when CAT removed.
-  cat.handleCatHeaders(headers, config.encoding_key, transaction)
-  const { appData } = cat.extractCatHeaders(headers)
-  cat.pullCatHeaders(config, currentSegment, appData)
+  const { appData, id, transactionId } = cat.extractCatHeaders(headers)
+  const { externalId, externalTransaction } = cat.parseCatData(
+    id,
+    transactionId,
+    config.encoding_key
+  )
+  cat.assignCatToTransaction(externalId, externalTransaction, transaction)
+  const decodedAppData = cat.parseAppData(config, appData)
+  cat.assignCatToSegment(decodedAppData, currentSegment)
   // TODO: Handle adding ExternalTransaction metrics for this segment.
 }
 
@@ -311,6 +318,66 @@ function insertCATRequestHeaders(headers, useAlternateHeaderNames) {
     tx.insertDistributedTraceHeaders(headers)
   } else {
     cat.addCatHeaders(this.agent.config, tx, headers, useAlternateHeaderNames)
+  }
+}
+
+/**
+ * Adds CAT headers for an outbound response.
+ *
+ * - `insertCATReplyHeaders(headers [, useAlternateHeaderNames])`
+ *
+ * @memberof TransactionShim.prototype
+ *
+ * @param {object} headers
+ *  The outbound response headers object to inject our CAT headers into.
+ *
+ * @param {bool} [useAlternateHeaderNames=false]
+ *  Indicates if HTTP-style headers should be used or alternate style. Some
+ *  transport protocols are more strict on the characters allowed in headers
+ *  and this option can be used to toggle use of pure-alpha header names.
+ */
+function insertCATReplyHeader(headers, useAlternateHeaderNames) {
+  // Is CAT enabled?
+  const config = this.agent.config
+  if (!config.cross_application_tracer.enabled) {
+    this.logger.trace('CAT disabled, not adding CAT reply header.')
+    return
+  } else if (config.distributed_tracing.enabled) {
+    this.logger.warn('Distributed tracing is enabled, not adding CAT reply header.')
+    return
+  } else if (!config.encoding_key) {
+    this.logger.warn('Missing encoding key, not adding CAT reply header!')
+    return
+  } else if (!headers) {
+    this.logger.debug('Missing headers object, not adding CAT reply header!')
+    return
+  }
+
+  // Are we in a transaction?
+  const segment = this.getSegment()
+  if (!segment || !segment.transaction.isActive()) {
+    this.logger.trace('Not adding CAT reply header, not in an active transaction.')
+    return
+  }
+  const tx = segment.transaction
+
+  // Hunt down the content length.
+  // NOTE: In AMQP, content-type and content-encoding are guaranteed fields, but
+  // there is no content-length field or header. For that, content length will
+  // always be -1.
+  let contentLength = -1
+  for (const key in headers) {
+    if (key.toLowerCase() === 'content-length') {
+      contentLength = headers[key]
+      break
+    }
+  }
+
+  const { key, data } = cat.encodeAppData(config, tx, contentLength, useAlternateHeaderNames)
+  // Add the header.
+  if (key && data) {
+    headers[key] = data
+    this.logger.trace('Added outbound response CAT headers for transaction %s', tx.id)
   }
 }
 

--- a/lib/shim/transaction-shim.js
+++ b/lib/shim/transaction-shim.js
@@ -6,30 +6,10 @@
 'use strict'
 
 const cat = require('../util/cat')
-const hashes = require('../util/hashes')
 const logger = require('../logger').child({ component: 'TransactionShim' })
 const Shim = require('./shim')
 const Transaction = require('../transaction')
 const util = require('util')
-
-const HTTP_CAT_ID_HEADER = 'X-NewRelic-Id'
-const MQ_CAT_ID_HEADER = 'NewRelicID'
-const MATCH_CAT_ID_HEADER = new RegExp(
-  '^(?:' + HTTP_CAT_ID_HEADER + '|' + MQ_CAT_ID_HEADER + ')$',
-  'i'
-)
-const HTTP_CAT_TRANSACTION_HEADER = 'X-NewRelic-Transaction'
-const MQ_CAT_TRANSACTION_HEADER = 'NewRelicTransaction'
-const MATCH_CAT_TRANSACTION_HEADER = new RegExp(
-  '^(?:' + HTTP_CAT_TRANSACTION_HEADER + '|' + MQ_CAT_TRANSACTION_HEADER + ')$',
-  'i'
-)
-const HTTP_CAT_APP_DATA_HEADER = 'X-NewRelic-App-Data'
-const MQ_CAT_APP_DATA_HEADER = 'NewRelicAppData'
-const MATCH_CAT_APP_DATA_HEADER = new RegExp(
-  '^(?:' + HTTP_CAT_APP_DATA_HEADER + '|' + MQ_CAT_APP_DATA_HEADER + ')$',
-  'i'
-)
 
 const TRANSACTION_TYPES_SET = Transaction.TYPES_SET
 
@@ -89,7 +69,6 @@ TransactionShim.prototype.popTransactionName = popTransactionName
 TransactionShim.prototype.setTransactionName = setTransactionName
 TransactionShim.prototype.handleCATHeaders = handleCATHeaders
 TransactionShim.prototype.insertCATRequestHeaders = insertCATRequestHeaders
-TransactionShim.prototype.insertCATReplyHeader = insertCATReplyHeader
 
 // -------------------------------------------------------------------------- //
 
@@ -284,44 +263,10 @@ function handleCATHeaders(headers, segment, transportType) {
 
   // Not DT so processing CAT.
   // TODO: Below will be removed when CAT removed.
-  if (!config.encoding_key) {
-    this.logger.warn('Missing encoding key, not extracting CAT headers!')
-    return
-  }
-
-  // Hunt down the CAT headers.
-  let catId = null
-  let transactionData = null
-  let appData = null
-  // eslint-disable-next-line guard-for-in
-  for (const key in headers) {
-    if (MATCH_CAT_ID_HEADER.test(key)) {
-      catId = headers[key]
-    } else if (MATCH_CAT_TRANSACTION_HEADER.test(key)) {
-      transactionData = headers[key]
-    } else if (MATCH_CAT_APP_DATA_HEADER.test(key)) {
-      appData = headers[key]
-    }
-    if (catId && transactionData && appData) {
-      break
-    }
-  }
-
-  if (catId && transactionData) {
-    cat.handleCatHeaders(catId, transactionData, config.encoding_key, transaction)
-    if (transaction.incomingCatId) {
-      this.logger.trace(
-        'Got inbound CAT headers in transaction %s from %s',
-        transaction.id,
-        transaction.incomingCatId
-      )
-    }
-  }
-
-  if (appData) {
-    _handleCATReplyHeader(this, currentSegment, appData)
-    // TODO: Handle adding ExternalTransaction metrics for this segment.
-  }
+  cat.handleCatHeaders(headers, config.encoding_key, transaction)
+  const { appData } = cat.extractCatHeaders(headers)
+  cat.pullCatHeaders(config, currentSegment, appData)
+  // TODO: Handle adding ExternalTransaction metrics for this segment.
 }
 
 /**
@@ -365,176 +310,8 @@ function insertCATRequestHeaders(headers, useAlternateHeaderNames) {
     // TODO: Official testing and support.
     tx.insertDistributedTraceHeaders(headers)
   } else {
-    if (!this.agent.config.encoding_key) {
-      this.logger.warn('Missing encoding key, not adding CAT headers!')
-      return
-    }
-
-    // Determine the names of the headers we'll add.
-    let transHeader = HTTP_CAT_TRANSACTION_HEADER
-    let idHeader = HTTP_CAT_ID_HEADER
-    if (useAlternateHeaderNames) {
-      idHeader = MQ_CAT_ID_HEADER
-      transHeader = MQ_CAT_TRANSACTION_HEADER
-    }
-
-    // Add in the application ID.
-    if (this.agent.config.obfuscatedId) {
-      headers[idHeader] = this.agent.config.obfuscatedId
-    }
-
-    // Generate an application path hash. This is essentially a snapshot of what
-    // the transaction would be named if it ended right now.
-    const pathHash = hashes.calculatePathHash(
-      this.agent.config.applications()[0],
-      tx.getFullName(),
-      tx.referringPathHash
-    )
-
-    tx.pushPathHash(pathHash)
-
-    try {
-      const catData = hashes.obfuscateNameUsingKey(
-        JSON.stringify([tx.id, false, tx.tripId || tx.id, pathHash]),
-        this.agent.config.encoding_key
-      )
-      if (catData) {
-        headers[transHeader] = catData
-        this.logger.trace('Added CAT headers for transaction %s', tx.id)
-      }
-    } catch (e) {
-      this.logger.warn({ error: e.stack }, 'Failed to serialize CAT header!')
-    }
+    cat.addCatHeaders(this.agent.config, tx, headers, useAlternateHeaderNames)
   }
-}
-
-/**
- * Adds CAT headers for an outbound response.
- *
- * - `insertCATReplyHeaders(headers [, useAlternateHeaderNames])`
- *
- * @memberof TransactionShim.prototype
- *
- * @param {object} headers
- *  The outbound response headers object to inject our CAT headers into.
- *
- * @param {bool} [useAlternateHeaderNames=false]
- *  Indicates if HTTP-style headers should be used or alternate style. Some
- *  transport protocols are more strict on the characters allowed in headers
- *  and this option can be used to toggle use of pure-alpha header names.
- */
-function insertCATReplyHeader(headers, useAlternateHeaderNames) {
-  // Is CAT enabled?
-  const config = this.agent.config
-  if (!config.cross_application_tracer.enabled) {
-    this.logger.trace('CAT disabled, not adding CAT reply header.')
-    return
-  } else if (config.distributed_tracing.enabled) {
-    this.logger.warn('Distributed tracing is enabled, not adding CAT reply header.')
-    return
-  } else if (!config.encoding_key) {
-    this.logger.warn('Missing encoding key, not adding CAT reply header!')
-    return
-  } else if (!headers) {
-    this.logger.debug('Missing headers object, not adding CAT reply header!')
-    return
-  }
-
-  // Are we in a transaction?
-  const segment = this.getSegment()
-  if (!segment || !segment.transaction.isActive()) {
-    this.logger.trace('Not adding CAT reply header, not in an active transaction.')
-    return
-  }
-  const tx = segment.transaction
-
-  // Hunt down the content length.
-  // NOTE: In AMQP, content-type and content-encoding are guaranteed fields, but
-  // there is no content-length field or header. For that, content length will
-  // always be -1.
-  let contentLength = -1
-  for (const key in headers) {
-    if (key.toLowerCase() === 'content-length') {
-      contentLength = headers[key]
-      break
-    }
-  }
-
-  // Compose the obfuscated app data value.
-  let appData = null
-  const txName = tx.getFullName()
-  try {
-    appData = hashes.obfuscateNameUsingKey(
-      JSON.stringify([
-        config.cross_process_id,
-        txName,
-        tx.queueTime / 1000,
-        tx.catResponseTime / 1000,
-        contentLength,
-        tx.id,
-        false
-      ]),
-      config.encoding_key
-    )
-  } catch (e) {
-    this.logger.warn({ error: e.stack }, 'Failed to serialize CAT data for %s', txName)
-  }
-
-  // Add the header.
-  headers[useAlternateHeaderNames ? MQ_CAT_APP_DATA_HEADER : HTTP_CAT_APP_DATA_HEADER] = appData
-  this.logger.trace('Added outbound response CAT headers for transaction %s', tx.id)
-}
-
-/**
- * Parses the given CAT response app-data and links the transaction to it.
- *
- * - `_handleCATReplyHeader(shim, segment, appData)`
- *
- * @private
- *
- * @param {TransactionShim} shim
- *  The shim to use in the process of extracting the app data.
- *
- * @param {!TraceSegment} segment
- *  The segment to attach the CAT data to.
- *
- * @param {string} appData
- *  The application data to parse and use.
- */
-function _handleCATReplyHeader(shim, segment, appData) {
-  // Attempt to parse the app data header.
-  const config = shim.agent.config
-  try {
-    appData = JSON.parse(hashes.deobfuscateNameUsingKey(appData, config.encoding_key))
-  } catch (e) {
-    shim.logger.warn('Unparsable CAT application data header: %s', appData)
-    return
-  }
-
-  // Make sure the app data is of the expected format and that we trust the
-  // origin application.
-  if (!appData.length || !shim.isString(appData[0])) {
-    shim.logger.trace('Unknown format for CAT application data header.')
-    return
-  }
-  const accountId = parseInt(appData[0].split('#')[0], 10)
-  const trustedIds = config.trusted_account_ids
-  if (trustedIds && trustedIds.indexOf(accountId) === -1) {
-    shim.logger.trace('CAT headers from untrusted application %s', accountId)
-    return
-  }
-
-  // It's good! Pull out the data we care about.
-  segment.catId = appData[0]
-  segment.catTransaction = appData[1]
-  if (appData.length >= 6) {
-    segment.addAttribute('transaction_guid', appData[5])
-  }
-  shim.logger.trace(
-    'Got inbound response CAT headers for transaction %s from %s',
-    segment.transaction.id,
-    appData[5]
-  )
 }
 
 /**

--- a/lib/util/cat.js
+++ b/lib/util/cat.js
@@ -5,51 +5,272 @@
 
 'use strict'
 
+const cat = module.exports
 const hashes = require('./hashes')
 const logger = require('../logger').child({ component: 'cat' })
 
-module.exports.handleCatHeaders = handleCatHeaders
-module.exports.parsedHeadersToTrans = parsedHeadersToTrans
+const HTTP_CAT_ID_HEADER = 'X-NewRelic-Id'
+const MQ_CAT_ID_HEADER = 'NewRelicID'
+const MATCH_CAT_ID_HEADER = new RegExp(
+  '^(?:' + HTTP_CAT_ID_HEADER + '|' + MQ_CAT_ID_HEADER + ')$',
+  'i'
+)
+const HTTP_CAT_TRANSACTION_HEADER = 'X-NewRelic-Transaction'
+const MQ_CAT_TRANSACTION_HEADER = 'NewRelicTransaction'
+const MATCH_CAT_TRANSACTION_HEADER = new RegExp(
+  '^(?:' + HTTP_CAT_TRANSACTION_HEADER + '|' + MQ_CAT_TRANSACTION_HEADER + ')$',
+  'i'
+)
+const HTTP_CAT_APP_DATA_HEADER = 'X-NewRelic-App-Data'
+const MQ_CAT_APP_DATA_HEADER = 'NewRelicAppData'
+const MATCH_CAT_APP_DATA_HEADER = new RegExp(
+  '^(?:' + HTTP_CAT_APP_DATA_HEADER + '|' + MQ_CAT_APP_DATA_HEADER + ')$',
+  'i'
+)
 
-function handleCatHeaders(incomingCatId, obfTransaction, encKey, transaction) {
+/**
+ * Parses and decodes the CAT headers from incoming request and adds information to the active
+ * transaction
+ *
+ * @param {Object} headers incoming headers
+ * @param {string} encKey config.encoding_key used to decode CAT headers
+ * @param {Transaction} tx
+ */
+cat.handleCatHeaders = function handleCatHeaders(headers, encKey, tx) {
+  if (!encKey) {
+    logger.warn('Missing encoding key, not extract CAT headers!')
+    return
+  }
+
+  const { id, transactionId } = cat.extractCatHeaders(headers)
+
   let parsedCatId = null
-  if (incomingCatId) {
-    parsedCatId = hashes.deobfuscateNameUsingKey(incomingCatId, encKey)
+  if (id) {
+    parsedCatId = hashes.deobfuscateNameUsingKey(id, encKey)
   }
 
   let externalTrans = null
-  if (obfTransaction) {
+  if (transactionId) {
     try {
-      externalTrans = JSON.parse(hashes.deobfuscateNameUsingKey(obfTransaction, encKey))
+      externalTrans = JSON.parse(hashes.deobfuscateNameUsingKey(transactionId, encKey))
     } catch (e) {
-      logger.trace('Got an unparsable CAT header x-newrelic-transaction: %s', obfTransaction)
+      logger.trace(`Got an unparsable CAT header ${HTTP_CAT_ID_HEADER} %s`, transactionId)
     }
   }
 
-  parsedHeadersToTrans(parsedCatId, externalTrans, transaction)
+  cat.parsedHeadersToTx(parsedCatId, externalTrans, tx)
+
+  if (tx.incomingCatId) {
+    logger.trace('Got inbound CAT headers in transaction %s from %s', tx.id, tx.incomingCatId)
+  }
 }
 
-function parsedHeadersToTrans(parsedCatId, externalTrans, transaction) {
+/**
+ * Checks if hash is string
+ *
+ * @param {*} hash
+ * @return {Boolean}
+ */
+function _isValidReferringHash(hash) {
+  return typeof hash === 'string'
+}
+
+/**
+ * Adds the appropriate keys to transaction based on the incoming parsed CAT data
+ *
+ * @param {string} parsedCatId decoded CAT id
+ * @param {Array} externalTrans CAT transaction
+ * @param {Transaction} tx active transaction
+ */
+cat.parsedHeadersToTx = function parsedHeadersToTx(parsedCatId, externalTrans, tx) {
   if (typeof parsedCatId === 'string') {
-    transaction.incomingCatId = parsedCatId
+    tx.incomingCatId = parsedCatId
   }
 
   if (Array.isArray(externalTrans)) {
-    transaction.referringTransactionGuid = externalTrans[0]
+    tx.referringTransactionGuid = externalTrans[0]
     if (typeof externalTrans[2] === 'string') {
-      transaction.tripId = externalTrans[2]
+      tx.tripId = externalTrans[2]
     } else if (externalTrans[2]) {
-      transaction.invalidIncomingExternalTransaction = true
+      tx.invalidIncomingExternalTransaction = true
     }
 
     if (_isValidReferringHash(externalTrans[3])) {
-      transaction.referringPathHash = externalTrans[3]
+      tx.referringPathHash = externalTrans[3]
     } else if (externalTrans[3]) {
-      transaction.invalidIncomingExternalTransaction = true
+      tx.invalidIncomingExternalTransaction = true
     }
   }
 }
 
-function _isValidReferringHash(hash) {
-  return typeof hash === 'string'
+/**
+ * Encodes the data to be set on the header CAT AppData header
+ * for incoming requests
+ *
+ * @param {Object} config agent config
+ * @param {Transaction} tx
+ * @param {string} contentLength
+ * @return {Object} { key, data} to add as header
+ */
+cat.encodeAppData = function encodeAppData(config, tx, contentLength) {
+  let appData = null
+  const txName = tx.getFullName() || ''
+
+  try {
+    appData = JSON.stringify([
+      config.cross_process_id, // cross_process_id
+      txName, // transaction name
+      tx.queueTime / 1000, // queue time (s)
+      tx.catResponseTime / 1000, // response time (s)
+      contentLength, // content length (if content-length header is also being sent)
+      tx.id, // TransactionGuid
+      false // force a transaction trace to be recorded
+    ])
+  } catch (err) {
+    logger.trace(
+      err,
+      'Failed to serialize transaction: %s - not adding CAT response headers',
+      txName
+    )
+    return
+  }
+
+  const encKey = config.encoding_key
+  const obfAppData = hashes.obfuscateNameUsingKey(appData, encKey)
+  return { key: HTTP_CAT_APP_DATA_HEADER, data: obfAppData }
+}
+
+/**
+ * Adds CAT headers to outbound request.
+ *
+ * @param {Object} config agent config
+ * @param {Transaction} tx
+ * @param {Object} headers object that contains headers the agent is adding to client request
+ */
+cat.addCatHeaders = function addCatHeaders(config, tx, headers, useMqHeaders) {
+  if (!config.encoding_key) {
+    logger.warn('Missing encoding key, not adding CAT headers!')
+    return
+  }
+
+  const idHeader = useMqHeaders ? MQ_CAT_ID_HEADER : HTTP_CAT_ID_HEADER
+  const txHeader = useMqHeaders ? MQ_CAT_TRANSACTION_HEADER : HTTP_CAT_TRANSACTION_HEADER
+
+  // Add in the application ID
+  if (config.obfuscatedId) {
+    headers[idHeader] = config.obfuscatedId
+  }
+
+  const txName = tx.getFullName() || ''
+
+  const pathHash = hashes.calculatePathHash(config.applications()[0], txName, tx.referringPathHash)
+  tx.pushPathHash(pathHash)
+
+  try {
+    const txData = hashes.obfuscateNameUsingKey(
+      JSON.stringify([tx.id, false, tx.tripId || tx.id, pathHash]),
+      config.encoding_key
+    )
+    headers[txHeader] = txData
+
+    logger.trace('Added outbound request CAT headers in transaction %s', tx.id)
+  } catch (err) {
+    logger.trace(err, 'Failed to create CAT payload')
+  }
+}
+
+/**
+ * Find the CAT id, transaction, app data headers
+ * from the headers of either HTTP or MQ request
+ *
+ * @param {Object} headers
+ * @return {Object} { id, transactionId, appData }
+ */
+cat.extractCatHeaders = function extractCatHeaders(headers) {
+  // Hunt down the CAT headers.
+  let id = null
+  let transactionId = null
+  let appData = null
+  // eslint-disable-next-line guard-for-in
+  for (const key in headers) {
+    if (MATCH_CAT_ID_HEADER.test(key)) {
+      id = headers[key]
+    } else if (MATCH_CAT_TRANSACTION_HEADER.test(key)) {
+      transactionId = headers[key]
+    } else if (MATCH_CAT_APP_DATA_HEADER.test(key)) {
+      appData = headers[key]
+    }
+    if (id && transactionId && appData) {
+      break
+    }
+  }
+
+  return { id, transactionId, appData }
+}
+
+/**
+ * Extracts the account Id from CAT data and verifies if it is
+ * a trusted account id
+ *
+ * @param {Object} CAT data
+ * @param {Array} trustedAccounts from config
+ * @return {Boolean}
+ */
+cat.isTrustedAccountId = function isTrustedAccountId(data, trustedAccounts) {
+  const accountId = parseInt(data.split('#')[0], 10)
+  const trusted = trustedAccounts.includes(accountId)
+  if (!trusted) {
+    logger.trace('Response from untrusted CAT header account id: %s', accountId)
+  }
+  return trusted
+}
+
+/**
+ * Decodes the CAT App Data header and extracts the downstream
+ * CAT id, transaction id and adds to the active segment
+ *
+ * @param {Object} config agent config
+ * @param {TraceSegment} segment to attach the CAT data to
+ * @param {string} obfAppData encoded app data to parse and use
+ *
+ */
+cat.pullCatHeaders = function pullCatHeaders(config, segment, obfAppData) {
+  if (!config.encoding_key) {
+    logger.trace('config.encoding_key is not set - not parsing response CAT headers')
+    return
+  }
+
+  if (!config.trusted_account_ids) {
+    logger.trace('config.trusted_account_ids is not set - not parsing response CAT headers')
+    return
+  }
+
+  let appData = null
+  try {
+    appData = JSON.parse(hashes.deobfuscateNameUsingKey(obfAppData, config.encoding_key))
+  } catch (e) {
+    logger.warn(`Got an unparsable CAT header ${HTTP_CAT_APP_DATA_HEADER}: %s`, obfAppData)
+    return
+  }
+
+  // Make sure it is a trusted account
+  if (!appData.length || typeof appData[0] !== 'string') {
+    logger.trace(`Unknown format for CAT header ${HTTP_CAT_APP_DATA_HEADER}.`)
+  }
+
+  if (!cat.isTrustedAccountId(appData[0], config.trusted_account_ids)) {
+    return
+  }
+
+  // It's good! Pull out the data we care about
+  segment.catId = appData[0]
+  segment.catTransaction = appData[1]
+  if (appData.length >= 6) {
+    segment.addAttribute('transaction_guid', appData[5])
+  }
+  logger.trace(
+    'Got inbound response CAT headers in transaction %s from %s',
+    segment.transaction.id,
+    appData[5]
+  )
 }

--- a/lib/util/cat.js
+++ b/lib/util/cat.js
@@ -8,6 +8,7 @@
 const cat = module.exports
 const hashes = require('./hashes')
 const logger = require('../logger').child({ component: 'cat' })
+const NAMES = require('../metrics/names')
 
 const HTTP_CAT_ID_HEADER = 'X-NewRelic-Id'
 const MQ_CAT_ID_HEADER = 'NewRelicID'
@@ -29,40 +30,34 @@ const MATCH_CAT_APP_DATA_HEADER = new RegExp(
 )
 
 /**
- * Parses and decodes the CAT headers from incoming request and adds information to the active
- * transaction
+ * Decodes the CAT id and transaction headers from incoming request
  *
  * @param {Object} headers incoming headers
  * @param {string} encKey config.encoding_key used to decode CAT headers
- * @param {Transaction} tx
+ * @param {Object} { externalId, externalTransaction }
  */
-cat.handleCatHeaders = function handleCatHeaders(headers, encKey, tx) {
+cat.parseCatData = function parseCatData(id, transactionId, encKey) {
   if (!encKey) {
     logger.warn('Missing encoding key, not extract CAT headers!')
-    return
+    return {}
   }
 
-  const { id, transactionId } = cat.extractCatHeaders(headers)
+  let externalId = null
 
-  let parsedCatId = null
   if (id) {
-    parsedCatId = hashes.deobfuscateNameUsingKey(id, encKey)
+    externalId = hashes.deobfuscateNameUsingKey(id, encKey)
   }
 
-  let externalTrans = null
+  let externalTransaction = null
   if (transactionId) {
     try {
-      externalTrans = JSON.parse(hashes.deobfuscateNameUsingKey(transactionId, encKey))
+      externalTransaction = JSON.parse(hashes.deobfuscateNameUsingKey(transactionId, encKey))
     } catch (e) {
       logger.trace(`Got an unparsable CAT header ${HTTP_CAT_ID_HEADER} %s`, transactionId)
     }
   }
 
-  cat.parsedHeadersToTx(parsedCatId, externalTrans, tx)
-
-  if (tx.incomingCatId) {
-    logger.trace('Got inbound CAT headers in transaction %s from %s', tx.id, tx.incomingCatId)
-  }
+  return { externalId, externalTransaction }
 }
 
 /**
@@ -78,102 +73,121 @@ function _isValidReferringHash(hash) {
 /**
  * Adds the appropriate keys to transaction based on the incoming parsed CAT data
  *
- * @param {string} parsedCatId decoded CAT id
- * @param {Array} externalTrans CAT transaction
- * @param {Transaction} tx active transaction
+ * @param {string} externalId decoded CAT id
+ * @param {Array} externalTransaction CAT transaction
+ * @param {Transaction} transaction active transaction
  */
-cat.parsedHeadersToTx = function parsedHeadersToTx(parsedCatId, externalTrans, tx) {
-  if (typeof parsedCatId === 'string') {
-    tx.incomingCatId = parsedCatId
+cat.assignCatToTransaction = function assignCatToTransaction(
+  externalId,
+  externalTransaction,
+  transaction
+) {
+  if (typeof externalId === 'string') {
+    transaction.incomingCatId = externalId
   }
 
-  if (Array.isArray(externalTrans)) {
-    tx.referringTransactionGuid = externalTrans[0]
-    if (typeof externalTrans[2] === 'string') {
-      tx.tripId = externalTrans[2]
-    } else if (externalTrans[2]) {
-      tx.invalidIncomingExternalTransaction = true
+  if (Array.isArray(externalTransaction)) {
+    transaction.referringTransactionGuid = externalTransaction[0]
+    if (typeof externalTransaction[2] === 'string') {
+      transaction.tripId = externalTransaction[2]
+    } else if (externalTransaction[2]) {
+      transaction.invalidIncomingExternalTransaction = true
     }
 
-    if (_isValidReferringHash(externalTrans[3])) {
-      tx.referringPathHash = externalTrans[3]
-    } else if (externalTrans[3]) {
-      tx.invalidIncomingExternalTransaction = true
+    if (_isValidReferringHash(externalTransaction[3])) {
+      transaction.referringPathHash = externalTransaction[3]
+    } else if (externalTransaction[3]) {
+      transaction.invalidIncomingExternalTransaction = true
     }
+  }
+
+  if (transaction.incomingCatId) {
+    logger.trace(
+      'Got inbound CAT headers in transaction %s from %s',
+      transaction.id,
+      transaction.incomingCatId
+    )
   }
 }
 
 /**
- * Encodes the data to be set on the header CAT AppData header
+ * Encodes the data to be set on the CAT app data header
  * for incoming requests
  *
  * @param {Object} config agent config
- * @param {Transaction} tx
+ * @param {Transaction} transaction
  * @param {string} contentLength
+ * @param {Boolean} useMqHeaders flag to return proper headers for MQ compliance
  * @return {Object} { key, data} to add as header
  */
-cat.encodeAppData = function encodeAppData(config, tx, contentLength) {
+cat.encodeAppData = function encodeAppData(config, transaction, contentLength, useMqHeaders) {
   let appData = null
-  const txName = tx.getFullName() || ''
+  const transactionName = transaction.getFullName() || ''
 
   try {
     appData = JSON.stringify([
       config.cross_process_id, // cross_process_id
-      txName, // transaction name
-      tx.queueTime / 1000, // queue time (s)
-      tx.catResponseTime / 1000, // response time (s)
+      transactionName, // transaction name
+      transaction.queueTime / 1000, // queue time (s)
+      transaction.catResponseTime / 1000, // response time (s)
       contentLength, // content length (if content-length header is also being sent)
-      tx.id, // TransactionGuid
+      transaction.id, // TransactionGuid
       false // force a transaction trace to be recorded
     ])
   } catch (err) {
     logger.trace(
       err,
       'Failed to serialize transaction: %s - not adding CAT response headers',
-      txName
+      transactionName
     )
     return
   }
 
   const encKey = config.encoding_key
   const obfAppData = hashes.obfuscateNameUsingKey(appData, encKey)
-  return { key: HTTP_CAT_APP_DATA_HEADER, data: obfAppData }
+  const key = useMqHeaders ? MQ_CAT_APP_DATA_HEADER : HTTP_CAT_APP_DATA_HEADER
+  return { key, data: obfAppData }
 }
 
 /**
  * Adds CAT headers to outbound request.
  *
  * @param {Object} config agent config
- * @param {Transaction} tx
+ * @param {Transaction} transaction
  * @param {Object} headers object that contains headers the agent is adding to client request
+ * @param {Boolean} useMqHeaders flag to return proper headers for MQ compliance
  */
-cat.addCatHeaders = function addCatHeaders(config, tx, headers, useMqHeaders) {
+cat.addCatHeaders = function addCatHeaders(config, transaction, headers, useMqHeaders) {
   if (!config.encoding_key) {
     logger.warn('Missing encoding key, not adding CAT headers!')
     return
   }
 
   const idHeader = useMqHeaders ? MQ_CAT_ID_HEADER : HTTP_CAT_ID_HEADER
-  const txHeader = useMqHeaders ? MQ_CAT_TRANSACTION_HEADER : HTTP_CAT_TRANSACTION_HEADER
+  const transactionHeader = useMqHeaders ? MQ_CAT_TRANSACTION_HEADER : HTTP_CAT_TRANSACTION_HEADER
 
   // Add in the application ID
   if (config.obfuscatedId) {
     headers[idHeader] = config.obfuscatedId
   }
 
-  const txName = tx.getFullName() || ''
+  const transactionName = transaction.getFullName() || ''
 
-  const pathHash = hashes.calculatePathHash(config.applications()[0], txName, tx.referringPathHash)
-  tx.pushPathHash(pathHash)
+  const pathHash = hashes.calculatePathHash(
+    config.applications()[0],
+    transactionName,
+    transaction.referringPathHash
+  )
+  transaction.pushPathHash(pathHash)
 
   try {
-    const txData = hashes.obfuscateNameUsingKey(
-      JSON.stringify([tx.id, false, tx.tripId || tx.id, pathHash]),
+    const transactionData = hashes.obfuscateNameUsingKey(
+      JSON.stringify([transaction.id, false, transaction.tripId || transaction.id, pathHash]),
       config.encoding_key
     )
-    headers[txHeader] = txData
+    headers[transactionHeader] = transactionData
 
-    logger.trace('Added outbound request CAT headers in transaction %s', tx.id)
+    logger.trace('Added outbound request CAT headers in transaction %s', transaction.id)
   } catch (err) {
     logger.trace(err, 'Failed to create CAT payload')
   }
@@ -227,14 +241,13 @@ cat.isTrustedAccountId = function isTrustedAccountId(data, trustedAccounts) {
 
 /**
  * Decodes the CAT App Data header and extracts the downstream
- * CAT id, transaction id and adds to the active segment
+ * CAT id, transaction id
  *
  * @param {Object} config agent config
- * @param {TraceSegment} segment to attach the CAT data to
  * @param {string} obfAppData encoded app data to parse and use
- *
+ * @param {Array} decoded app data header
  */
-cat.pullCatHeaders = function pullCatHeaders(config, segment, obfAppData) {
+cat.parseAppData = function parseAppData(config, obfAppData) {
   if (!config.encoding_key) {
     logger.trace('config.encoding_key is not set - not parsing response CAT headers')
     return
@@ -254,23 +267,42 @@ cat.pullCatHeaders = function pullCatHeaders(config, segment, obfAppData) {
   }
 
   // Make sure it is a trusted account
-  if (!appData.length || typeof appData[0] !== 'string') {
-    logger.trace(`Unknown format for CAT header ${HTTP_CAT_APP_DATA_HEADER}.`)
-  }
-
-  if (!cat.isTrustedAccountId(appData[0], config.trusted_account_ids)) {
+  if (!cat.isTrustedAccountId(appData && appData[0], config.trusted_account_ids)) {
     return
   }
 
-  // It's good! Pull out the data we care about
+  return appData
+}
+
+/**
+ * Assigns the CAT id, transaction to segment and adds `transaction_guid` when it exists.
+ * It also renames the segment name based on the newly decoded app data when host is present
+ *
+ * @param {Array} appData decodes CAT app data
+ * @param {TraceSegment} segment
+ * @param {string} [host] if host is present it will rename segment with app data and host
+ */
+cat.assignCatToSegment = function assignCatToSegment(appData, segment, host) {
+  if (!Array.isArray(appData) || typeof appData[0] !== 'string') {
+    logger.trace(`Unknown format for CAT header ${HTTP_CAT_APP_DATA_HEADER}.`)
+    return
+  }
+
   segment.catId = appData[0]
   segment.catTransaction = appData[1]
+
+  if (host) {
+    segment.name = `${NAMES.EXTERNAL.TRANSACTION}${host}/${segment.catId}/${segment.catTransaction}`
+  }
+
+  let transactionGuid
   if (appData.length >= 6) {
-    segment.addAttribute('transaction_guid', appData[5])
+    transactionGuid = appData[5]
+    segment.addAttribute('transaction_guid', transactionGuid)
   }
   logger.trace(
     'Got inbound response CAT headers in transaction %s from %s',
     segment.transaction.id,
-    appData[5]
+    transactionGuid
   )
 }

--- a/lib/util/cat.js
+++ b/lib/util/cat.js
@@ -61,16 +61,6 @@ cat.parseCatData = function parseCatData(id, transactionId, encKey) {
 }
 
 /**
- * Checks if hash is string
- *
- * @param {*} hash
- * @return {Boolean}
- */
-function _isValidReferringHash(hash) {
-  return typeof hash === 'string'
-}
-
-/**
  * Adds the appropriate keys to transaction based on the incoming parsed CAT data
  *
  * @param {string} externalId decoded CAT id
@@ -87,16 +77,18 @@ cat.assignCatToTransaction = function assignCatToTransaction(
   }
 
   if (Array.isArray(externalTransaction)) {
-    transaction.referringTransactionGuid = externalTransaction[0]
-    if (typeof externalTransaction[2] === 'string') {
-      transaction.tripId = externalTransaction[2]
-    } else if (externalTransaction[2]) {
+    const [referringGuid, , tripId, referringPathHash] = externalTransaction
+    transaction.referringTransactionGuid = referringGuid
+
+    if (typeof tripId === 'string') {
+      transaction.tripId = tripId
+    } else if (tripId) {
       transaction.invalidIncomingExternalTransaction = true
     }
 
-    if (_isValidReferringHash(externalTransaction[3])) {
-      transaction.referringPathHash = externalTransaction[3]
-    } else if (externalTransaction[3]) {
+    if (typeof referringPathHash === 'string') {
+      transaction.referringPathHash = referringPathHash
+    } else if (referringPathHash) {
       transaction.invalidIncomingExternalTransaction = true
     }
   }

--- a/test/unit/agent/intrinsics.test.js
+++ b/test/unit/agent/intrinsics.test.js
@@ -268,10 +268,10 @@ function getMockTransaction(agent, test, start, durationInSeconds, totalTimeInSe
 
   // CAT data
   if (test.inboundPayload) {
-    cat.parsedHeadersToTx(test.inboundPayload[0], test.inboundPayload, transaction)
+    cat.assignCatToTransaction(test.inboundPayload[0], test.inboundPayload, transaction)
   } else {
     // Simulate the headers being unparsable or not existing
-    cat.parsedHeadersToTx(null, null, transaction)
+    cat.assignCatToTransaction(null, null, transaction)
   }
 
   if (test.outboundRequests) {

--- a/test/unit/agent/intrinsics.test.js
+++ b/test/unit/agent/intrinsics.test.js
@@ -268,10 +268,10 @@ function getMockTransaction(agent, test, start, durationInSeconds, totalTimeInSe
 
   // CAT data
   if (test.inboundPayload) {
-    cat.parsedHeadersToTrans(test.inboundPayload[0], test.inboundPayload, transaction)
+    cat.parsedHeadersToTx(test.inboundPayload[0], test.inboundPayload, transaction)
   } else {
     // Simulate the headers being unparsable or not existing
-    cat.parsedHeadersToTrans(null, null, transaction)
+    cat.parsedHeadersToTx(null, null, transaction)
   }
 
   if (test.outboundRequests) {

--- a/test/unit/header-attributes.test.js
+++ b/test/unit/header-attributes.test.js
@@ -159,7 +159,7 @@ describe('header-attributes', () => {
         }
 
         helper.runInTransaction(agent, (transaction) => {
-          headerAttributes.collectRequestHeaders(headers, transaction, true)
+          headerAttributes.collectRequestHeaders(headers, transaction)
 
           const attributes = transaction.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
           expect(attributes).to.not.have.property('request.headers.x-filtered-out')

--- a/test/unit/header-attributes.test.js
+++ b/test/unit/header-attributes.test.js
@@ -159,7 +159,7 @@ describe('header-attributes', () => {
         }
 
         helper.runInTransaction(agent, (transaction) => {
-          headerAttributes.collectRequestHeaders(headers, transaction)
+          headerAttributes.collectRequestHeaders(headers, transaction, true)
 
           const attributes = transaction.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
           expect(attributes).to.not.have.property('request.headers.x-filtered-out')

--- a/test/unit/shim/transaction-shim.test.js
+++ b/test/unit/shim/transaction-shim.test.js
@@ -852,7 +852,7 @@ tap.test('TransactionShim', function (t) {
         shim.insertCATRequestHeaders(headers)
 
         t.equal(tx.pathHashes.length, 1)
-        t.equal(tx.pathHashes[0], '14cd4d06')
+        t.equal(tx.pathHashes[0], '0f9570a6')
         t.end()
       })
     })
@@ -909,104 +909,6 @@ tap.test('TransactionShim', function (t) {
 
           t.ok(Array.isArray(txInfo))
           t.equal(txInfo.length, 4)
-          t.end()
-        })
-      }
-    )
-  })
-
-  t.test('#insertCATReplyHeader', function (t) {
-    t.autoend()
-    t.beforeEach(() => {
-      beforeEach()
-      agent.config.cross_application_tracer.enabled = true
-      agent.config.distributed_tracing.enabled = false
-    })
-    t.afterEach(afterEach)
-
-    t.test('should not run if disabled', function (t) {
-      helper.runInTransaction(agent, function () {
-        agent.config.cross_application_tracer.enabled = false
-        const headers = {}
-
-        shim.insertCATReplyHeader(headers)
-
-        t.notOk(headers['X-NewRelic-App-Data'])
-        t.end()
-      })
-    })
-
-    t.test('should not run if the encoding key is missing', function (t) {
-      helper.runInTransaction(agent, function () {
-        delete agent.config.encoding_key
-        const headers = {}
-
-        shim.insertCATReplyHeader(headers)
-
-        t.notOk(headers['X-NewRelic-App-Data'])
-        t.end()
-      })
-    })
-
-    t.test('should fail gracefully when no headers are given', function (t) {
-      helper.runInTransaction(agent, function () {
-        t.doesNotThrow(function () {
-          shim.insertCATReplyHeader(null)
-        })
-        t.end()
-      })
-    })
-
-    t.test('should use X-Http-Style-Headers when useAlt is false - DT disabled', function (t) {
-      helper.runInTransaction(agent, function () {
-        const headers = {}
-        shim.insertCATReplyHeader(headers)
-
-        t.notOk(headers.NewRelicAppData)
-        t.match(headers['X-NewRelic-App-Data'], /^[a-zA-Z0-9/-]{60,80}={0,2}$/)
-        t.end()
-      })
-    })
-
-    t.test('should use MessageQueueStyleHeaders when useAlt is true - DT disabled', function (t) {
-      helper.runInTransaction(agent, function () {
-        const headers = {}
-        shim.insertCATReplyHeader(headers, true)
-
-        t.notOk(headers['X-NewRelic-App-Data'])
-        t.match(headers.NewRelicAppData, /^[a-zA-Z0-9/-]{60,80}={0,2}$/)
-        t.end()
-      })
-    })
-
-    t.test('should be an obfuscated value - DT disabled, app data header', function (t) {
-      helper.runInTransaction(agent, function () {
-        const headers = {}
-        shim.insertCATReplyHeader(headers)
-
-        t.match(headers['X-NewRelic-App-Data'], /^[a-zA-Z0-9/-]{60,80}={0,2}$/)
-        t.end()
-      })
-    })
-
-    t.test(
-      'should deobfuscate to CAT application data - DT disabled, app data header',
-      function (t) {
-        helper.runInTransaction(agent, function () {
-          const headers = {}
-          shim.insertCATReplyHeader(headers)
-
-          let appData = hashes.deobfuscateNameUsingKey(
-            headers['X-NewRelic-App-Data'],
-            agent.config.encoding_key
-          )
-
-          t.doesNotThrow(function () {
-            appData = JSON.parse(appData)
-          })
-
-          t.equal(appData.length, 7)
-          t.ok(Array.isArray(appData))
           t.end()
         })
       }

--- a/test/unit/shim/transaction-shim.test.js
+++ b/test/unit/shim/transaction-shim.test.js
@@ -914,4 +914,102 @@ tap.test('TransactionShim', function (t) {
       }
     )
   })
+
+  t.test('#insertCATReplyHeader', function (t) {
+    t.autoend()
+    t.beforeEach(() => {
+      beforeEach()
+      agent.config.cross_application_tracer.enabled = true
+      agent.config.distributed_tracing.enabled = false
+    })
+    t.afterEach(afterEach)
+
+    t.test('should not run if disabled', function (t) {
+      helper.runInTransaction(agent, function () {
+        agent.config.cross_application_tracer.enabled = false
+        const headers = {}
+
+        shim.insertCATReplyHeader(headers)
+
+        t.notOk(headers['X-NewRelic-App-Data'])
+        t.end()
+      })
+    })
+
+    t.test('should not run if the encoding key is missing', function (t) {
+      helper.runInTransaction(agent, function () {
+        delete agent.config.encoding_key
+        const headers = {}
+
+        shim.insertCATReplyHeader(headers)
+
+        t.notOk(headers['X-NewRelic-App-Data'])
+        t.end()
+      })
+    })
+
+    t.test('should fail gracefully when no headers are given', function (t) {
+      helper.runInTransaction(agent, function () {
+        t.doesNotThrow(function () {
+          shim.insertCATReplyHeader(null)
+        })
+        t.end()
+      })
+    })
+
+    t.test('should use X-Http-Style-Headers when useAlt is false - DT disabled', function (t) {
+      helper.runInTransaction(agent, function () {
+        const headers = {}
+        shim.insertCATReplyHeader(headers)
+
+        t.notOk(headers.NewRelicAppData)
+        t.match(headers['X-NewRelic-App-Data'], /^[a-zA-Z0-9/-]{60,80}={0,2}$/)
+        t.end()
+      })
+    })
+
+    t.test('should use MessageQueueStyleHeaders when useAlt is true - DT disabled', function (t) {
+      helper.runInTransaction(agent, function () {
+        const headers = {}
+        shim.insertCATReplyHeader(headers, true)
+
+        t.notOk(headers['X-NewRelic-App-Data'])
+        t.match(headers.NewRelicAppData, /^[a-zA-Z0-9/-]{60,80}={0,2}$/)
+        t.end()
+      })
+    })
+
+    t.test('should be an obfuscated value - DT disabled, app data header', function (t) {
+      helper.runInTransaction(agent, function () {
+        const headers = {}
+        shim.insertCATReplyHeader(headers)
+
+        t.match(headers['X-NewRelic-App-Data'], /^[a-zA-Z0-9/-]{60,80}={0,2}$/)
+        t.end()
+      })
+    })
+
+    t.test(
+      'should deobfuscate to CAT application data - DT disabled, app data header',
+      function (t) {
+        helper.runInTransaction(agent, function () {
+          const headers = {}
+          shim.insertCATReplyHeader(headers)
+
+          let appData = hashes.deobfuscateNameUsingKey(
+            headers['X-NewRelic-App-Data'],
+            agent.config.encoding_key
+          )
+
+          t.doesNotThrow(function () {
+            appData = JSON.parse(appData)
+          })
+
+          t.equal(appData.length, 7)
+          t.ok(Array.isArray(appData))
+          t.end()
+        })
+      }
+    )
+  })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Refactored `transaction-shim`, `http` and `http-outbound` to use centralized CAT methods in `util/cat`

## Links
Closes #913 

## Details
There is still code in transaction-shim and http-outbound that could be abstracted but I didn't want to go too far.  This code will also help seed an upcoming undici PR that you can see copied some of the code here #901. 