### PR TITLE
Fastify prototype

### DIFF
--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -63,13 +63,14 @@ const setupRouteHandler = (shim, fastify) => {
   })
 
   // wraps all request lifecyle events aside from onRoute middleware
-  // this can properly time, nesting is weird atm(I want this to be like express
-  // but currently looks more like koa where it's nested)
   shim.wrap(fastify, 'addHook', function wrapAddHook(shim, fn) {
     return function wrappedAddHook() {
       const args = shim.argsToArray.apply(shim, arguments)
       if (REQUEST_HOOKS.includes(args[0])) {
         const middlewareFunction = args[1]
+        // TODO: figure out a way to include the life cyle name in the span name
+        // So would like to see
+        // Nodejs/Middleware/Fastify/<lifecyle name>/<fn name>
         const newMiddlewareFunction = shim.recordMiddleware(
           middlewareFunction,
           buildMiddlewareSpecForMiddlewareFunction(shim)

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -39,22 +39,22 @@ const setupRouteHandler = (shim, fastify) => {
     return function wrappedDecorate() {
       const args = shim.argsToArray.apply(shim, arguments)
       if (args[0] === 'use') {
-        args[1] = shim.wrap(args[1], function wrapFastifyUse(shim, fn) {
+        args[1] = shim.wrap(args[1], function wrapFastifyUse(shim, mwFn) {
           return function wrappedFastifyUser() {
-            const args = shim.argsToArray.apply(shim, arguments)
+            const mwArgs = shim.argsToArray.apply(shim, arguments)
             // The way fastify registers middleware it does it at instance level
             // and then propagates to every route. check to see if function is already wrapped to avoid double recording
-            if (!shim.isWrapped(args[0])) {
-              const middlewareFunction = args[0]
+            if (!shim.isWrapped(mwArgs[0])) {
+              const middlewareFunction = mwArgs[0]
               const newMiddlewareFunction = shim.recordMiddleware(
                 middlewareFunction,
                 buildMiddlewareSpecForMiddlewareFunction(shim, 'onRequest')
               )
               // replace original function with our function
-              args[0] = newMiddlewareFunction
+              mwArgs[0] = newMiddlewareFunction
             }
 
-            return fn.apply(this, args)
+            return mwFn.apply(this, mwArgs)
           }
         })
       }
@@ -103,7 +103,6 @@ const setupRouteHandler = (shim, fastify) => {
 const setupMiddlewareHandlers = (shim, fastify) => {
   shim.wrap(fastify, 'use', function wrapFastifyUse(shim, fn) {
     return function wrappedFastifyUser() {
-      debugger
       const args = shim.argsToArray.apply(shim, arguments)
       const middlewareFunction = args[0]
       const newMiddlewareFunction = shim.recordMiddleware(
@@ -140,7 +139,6 @@ module.exports = function initialize(agent, fastify, moduleName, shim) {
 
       setupRouteHandler(shim, fastifyForWrapping)
 
-      debugger
       // Don't wrap use() in fastify v3+
       if (!isv3Plus) {
         setupMiddlewareHandlers(shim, fastifyForWrapping)

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -7,8 +7,17 @@
 const semver = require('semver')
 const {
   buildMiddlewareSpecForRouteHandler,
-  buildMiddlewareSpecForMiddlewareFunction,
+  buildMiddlewareSpecForMiddlewareFunction
 } = require('./fastify/spec-builders')
+const REQUEST_HOOKS = [
+  'onRequest',
+  'preParsing',
+  'preValidation',
+  'preHandler',
+  'preSerialization',
+  'onSend',
+  'onResponse'
+]
 /**
  * Sets up fastify route handler
  *
@@ -22,6 +31,10 @@ const {
  * maintain code
  */
 const setupRouteHandler = (shim, fastify) => {
+  // this is waiting for decorate to be called with use
+  // both middie and fastify-express use this so you can add
+  // traditional middleware to fastify
+
   shim.wrap(fastify, 'decorate', function wrapDecorate(shim, fn) {
     return function wrappedDecorate() {
       const args = shim.argsToArray.apply(shim, arguments)
@@ -48,10 +61,14 @@ const setupRouteHandler = (shim, fastify) => {
       return fn.apply(this, args)
     }
   })
+
+  // wraps all request lifecyle events aside from onRoute middleware
+  // this can properly time, nesting is weird atm(I want this to be like express
+  // but currently looks more like koa where it's nested)
   shim.wrap(fastify, 'addHook', function wrapAddHook(shim, fn) {
     return function wrappedAddHook() {
       const args = shim.argsToArray.apply(shim, arguments)
-      if (args[0] === 'onRequest') {
+      if (REQUEST_HOOKS.includes(args[0])) {
         const middlewareFunction = args[1]
         const newMiddlewareFunction = shim.recordMiddleware(
           middlewareFunction,
@@ -75,6 +92,7 @@ const setupRouteHandler = (shim, fastify) => {
      * i.e. dont be confused by the call to recordMiddlware -- we don't
      * have a recordRouteHandler, everything goes through recordMiddleware
      */
+    // TODO: check .path in cases where routing has placeholders
     const newRouteHandler = shim.recordMiddleware(
       routeOptions.handler,
       buildMiddlewareSpecForRouteHandler(shim, routeOptions.path)
@@ -84,6 +102,7 @@ const setupRouteHandler = (shim, fastify) => {
   })
 }
 
+// TODO: this is no longer used and can be removed based on hooks above
 const setupMiddlewareHandlers = (shim, fastify) => {
   shim.wrap(fastify, 'use', function wrapFastifyUse(shim, fn) {
     return function wrappedFastifyUser() {

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -8,7 +8,6 @@ const semver = require('semver')
 const {
   buildMiddlewareSpecForRouteHandler,
   buildMiddlewareSpecForMiddlewareFunction,
-  buildMiddlewareSpecForDecoratedMiddlewareFunction
 } = require('./fastify/spec-builders')
 /**
  * Sets up fastify route handler
@@ -36,7 +35,7 @@ const setupRouteHandler = (shim, fastify) => {
               const middlewareFunction = args[0]
               const newMiddlewareFunction = shim.recordMiddleware(
                 middlewareFunction,
-                buildMiddlewareSpecForDecoratedMiddlewareFunction(shim)
+                buildMiddlewareSpecForMiddlewareFunction(shim)
               )
               // replace original function with our function
               args[0] = newMiddlewareFunction

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -48,7 +48,7 @@ const setupRouteHandler = (shim, fastify) => {
               const middlewareFunction = args[0]
               const newMiddlewareFunction = shim.recordMiddleware(
                 middlewareFunction,
-                buildMiddlewareSpecForMiddlewareFunction(shim)
+                buildMiddlewareSpecForMiddlewareFunction(shim, 'onRequest')
               )
               // replace original function with our function
               args[0] = newMiddlewareFunction
@@ -68,12 +68,9 @@ const setupRouteHandler = (shim, fastify) => {
       const args = shim.argsToArray.apply(shim, arguments)
       if (REQUEST_HOOKS.includes(args[0])) {
         const middlewareFunction = args[1]
-        // TODO: figure out a way to include the life cyle name in the span name
-        // So would like to see
-        // Nodejs/Middleware/Fastify/<lifecyle name>/<fn name>
         const newMiddlewareFunction = shim.recordMiddleware(
           middlewareFunction,
-          buildMiddlewareSpecForMiddlewareFunction(shim)
+          buildMiddlewareSpecForMiddlewareFunction(shim, args[0])
         )
 
         args[1] = newMiddlewareFunction

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -107,7 +107,7 @@ const setupMiddlewareHandlers = (shim, fastify) => {
       const middlewareFunction = args[0]
       const newMiddlewareFunction = shim.recordMiddleware(
         middlewareFunction,
-        buildMiddlewareSpecForMiddlewareFunction(shim)
+        buildMiddlewareSpecForMiddlewareFunction(shim, 'onRequest')
       )
       // replace original function with our function
       args[0] = newMiddlewareFunction

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -7,7 +7,8 @@
 const semver = require('semver')
 const {
   buildMiddlewareSpecForRouteHandler,
-  buildMiddlewareSpecForMiddlewareFunction
+  buildMiddlewareSpecForMiddlewareFunction,
+  buildMiddlewareSpecForDecoratedMiddlewareFunction
 } = require('./fastify/spec-builders')
 /**
  * Sets up fastify route handler
@@ -22,6 +23,48 @@ const {
  * maintain code
  */
 const setupRouteHandler = (shim, fastify) => {
+  shim.wrap(fastify, 'decorate', function wrapDecorate(shim, fn) {
+    return function wrappedDecorate() {
+      const args = shim.argsToArray.apply(shim, arguments)
+      if (args[0] === 'use') {
+        args[1] = shim.wrap(args[1], function wrapFastifyUse(shim, fn) {
+          return function wrappedFastifyUser() {
+            const args = shim.argsToArray.apply(shim, arguments)
+            // The way fastify registers middleware it does it at instance level
+            // and then propagates to every route. check to see if function is already wrapped to avoid double recording
+            if (!shim.isWrapped(args[0])) {
+              const middlewareFunction = args[0]
+              const newMiddlewareFunction = shim.recordMiddleware(
+                middlewareFunction,
+                buildMiddlewareSpecForDecoratedMiddlewareFunction(shim)
+              )
+              // replace original function with our function
+              args[0] = newMiddlewareFunction
+            }
+
+            return fn.apply(this, args)
+          }
+        })
+      }
+      return fn.apply(this, args)
+    }
+  })
+  shim.wrap(fastify, 'addHook', function wrapAddHook(shim, fn) {
+    return function wrappedAddHook() {
+      const args = shim.argsToArray.apply(shim, arguments)
+      if (args[0] === 'onRequest') {
+        const middlewareFunction = args[1]
+        const newMiddlewareFunction = shim.recordMiddleware(
+          middlewareFunction,
+          buildMiddlewareSpecForMiddlewareFunction(shim)
+        )
+
+        args[1] = newMiddlewareFunction
+      }
+      return fn.apply(this, args)
+    }
+  })
+
   fastify.addHook('onRoute', (routeOptions) => {
     if (!routeOptions.handler) {
       return

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -100,10 +100,10 @@ const setupRouteHandler = (shim, fastify) => {
   })
 }
 
-// TODO: this is no longer used and can be removed based on hooks above
 const setupMiddlewareHandlers = (shim, fastify) => {
   shim.wrap(fastify, 'use', function wrapFastifyUse(shim, fn) {
     return function wrappedFastifyUser() {
+      debugger
       const args = shim.argsToArray.apply(shim, arguments)
       const middlewareFunction = args[0]
       const newMiddlewareFunction = shim.recordMiddleware(
@@ -140,6 +140,7 @@ module.exports = function initialize(agent, fastify, moduleName, shim) {
 
       setupRouteHandler(shim, fastifyForWrapping)
 
+      debugger
       // Don't wrap use() in fastify v3+
       if (!isv3Plus) {
         setupMiddlewareHandlers(shim, fastifyForWrapping)

--- a/lib/instrumentation/fastify/spec-builders.js
+++ b/lib/instrumentation/fastify/spec-builders.js
@@ -17,6 +17,10 @@ const getParamsFromFastifyRequest = (shim, fn, fnName, args) => {
   return req && req.params
 }
 
+const getFastifyRequest = (shim, fn, fnName, args) => {
+  return args[0]
+}
+
 /**
  * Builds the recordMiddleware Spec for the route handler
  *
@@ -105,7 +109,25 @@ function buildMiddlewareSpecForMiddlewareFunction() {
   }
 }
 
+function buildMiddlewareSpecForDecoratedMiddlewareFunction() {
+  return {
+    req: getFastifyRequest,
+
+    next: function wrapNext(shim, fn, fnName, args, bindSegment) {
+      const next = args[2]
+      if (!shim.isFunction(next)) {
+        return
+      }
+      const isFinal = false
+      bindSegment(next, null, isFinal)
+    },
+
+    params: getParamsFromFastifyRequest
+  }
+}
+
 module.exports = {
   buildMiddlewareSpecForRouteHandler,
+  buildMiddlewareSpecForDecoratedMiddlewareFunction,
   buildMiddlewareSpecForMiddlewareFunction
 }

--- a/lib/instrumentation/fastify/spec-builders.js
+++ b/lib/instrumentation/fastify/spec-builders.js
@@ -6,7 +6,7 @@
 'use strict'
 
 const getRequestFromFastify = (shim, fn, fnName, args) => {
-  const [ request ] = args
+  const [request] = args
   // sometimes request is Fastify request
   // so we need to extract the IncomingMessage
   if (request && request.raw) {
@@ -93,11 +93,11 @@ function buildMiddlewareSpecForRouteHandler(shim, path) {
   }
 }
 
-function buildMiddlewareSpecForMiddlewareFunction() {
+function buildMiddlewareSpecForMiddlewareFunction(shim) {
   return {
     req: getRequestFromFastify,
 
-    next: function wrapNext(shim, fn, fnName, args, bindSegment) {
+    /* next: function wrapNext(shim, fn, fnName, args, bindSegment) {
       const next = args[2]
       if (!shim.isFunction(next)) {
         return
@@ -105,7 +105,9 @@ function buildMiddlewareSpecForMiddlewareFunction() {
       const isFinal = false
       debugger
       bindSegment(next, null, isFinal)
-    },
+    },*/
+    next: shim.LAST,
+    promise: true,
 
     params: getParamsFromFastifyRequest
   }

--- a/lib/instrumentation/fastify/spec-builders.js
+++ b/lib/instrumentation/fastify/spec-builders.js
@@ -33,6 +33,7 @@ const getParamsFromFastifyRequest = (shim, fn, fnName, args) => {
  */
 function buildMiddlewareSpecForRouteHandler(shim, path) {
   return {
+    segmentPrefix: 'onRoute',
     /**
      * The path to use for transaction naming
      */
@@ -93,22 +94,12 @@ function buildMiddlewareSpecForRouteHandler(shim, path) {
   }
 }
 
-function buildMiddlewareSpecForMiddlewareFunction(shim) {
+function buildMiddlewareSpecForMiddlewareFunction(shim, prefix) {
   return {
     req: getRequestFromFastify,
-
-    /* next: function wrapNext(shim, fn, fnName, args, bindSegment) {
-      const next = args[2]
-      if (!shim.isFunction(next)) {
-        return
-      }
-      const isFinal = false
-      debugger
-      bindSegment(next, null, isFinal)
-    },*/
     next: shim.LAST,
     type: shim.MIDDLEWARE,
-
+    segmentPrefix: prefix,
     params: getParamsFromFastifyRequest
   }
 }

--- a/lib/instrumentation/fastify/spec-builders.js
+++ b/lib/instrumentation/fastify/spec-builders.js
@@ -107,7 +107,7 @@ function buildMiddlewareSpecForMiddlewareFunction(shim) {
       bindSegment(next, null, isFinal)
     },*/
     next: shim.LAST,
-    promise: true,
+    type: shim.MIDDLEWARE,
 
     params: getParamsFromFastifyRequest
   }

--- a/lib/instrumentation/fastify/spec-builders.js
+++ b/lib/instrumentation/fastify/spec-builders.js
@@ -5,20 +5,21 @@
 
 'use strict'
 
-const getRawRequestFromFastifyRequest = (shim, fn, fnName, args) => {
-  const request = args[0]
+const getRequestFromFastify = (shim, fn, fnName, args) => {
+  const [ request ] = args
+  // sometimes request is Fastify request
+  // so we need to extract the IncomingMessage
   if (request && request.raw) {
     return request.raw
   }
+
+  // not a Fastify request, use the IncomingMessage
+  return request
 }
 
 const getParamsFromFastifyRequest = (shim, fn, fnName, args) => {
   const req = args[0]
   return req && req.params
-}
-
-const getFastifyRequest = (shim, fn, fnName, args) => {
-  return args[0]
 }
 
 /**
@@ -50,7 +51,7 @@ function buildMiddlewareSpecForRouteHandler(shim, path) {
      * @param {any} fnName the handler function's name
      * @param {any} args the arguments passed to the handler function
      */
-    req: getRawRequestFromFastifyRequest,
+    req: getRequestFromFastify,
     /**
      * A function where we can wrap next, reply send, etc. methods
      *
@@ -94,7 +95,7 @@ function buildMiddlewareSpecForRouteHandler(shim, path) {
 
 function buildMiddlewareSpecForMiddlewareFunction() {
   return {
-    req: getRawRequestFromFastifyRequest,
+    req: getRequestFromFastify,
 
     next: function wrapNext(shim, fn, fnName, args, bindSegment) {
       const next = args[2]
@@ -102,23 +103,7 @@ function buildMiddlewareSpecForMiddlewareFunction() {
         return
       }
       const isFinal = false
-      bindSegment(next, null, isFinal)
-    },
-
-    params: getParamsFromFastifyRequest
-  }
-}
-
-function buildMiddlewareSpecForDecoratedMiddlewareFunction() {
-  return {
-    req: getFastifyRequest,
-
-    next: function wrapNext(shim, fn, fnName, args, bindSegment) {
-      const next = args[2]
-      if (!shim.isFunction(next)) {
-        return
-      }
-      const isFinal = false
+      debugger
       bindSegment(next, null, isFinal)
     },
 
@@ -128,6 +113,5 @@ function buildMiddlewareSpecForDecoratedMiddlewareFunction() {
 
 module.exports = {
   buildMiddlewareSpecForRouteHandler,
-  buildMiddlewareSpecForDecoratedMiddlewareFunction,
   buildMiddlewareSpecForMiddlewareFunction
 }

--- a/lib/shim/specs/index.js
+++ b/lib/shim/specs/index.js
@@ -77,6 +77,7 @@ function MiddlewareSpec(spec) {
   this.route = hasOwnProperty(spec, 'route') ? spec.route : null
   this.params = hasOwnProperty(spec, 'params') ? spec.params : _defaultGetParams
   this.appendPath = hasOwnProperty(spec, 'appendPath') ? spec.appendPath : true
+  this.segmentPrefix = hasOwnProperty(spec, 'segmentPrefix') ? spec.segmentPrefix : null
 }
 util.inherits(MiddlewareSpec, RecorderSpec)
 

--- a/lib/shim/webframework-shim.js
+++ b/lib/shim/webframework-shim.js
@@ -791,7 +791,13 @@ function _recordMiddleware(shim, middleware, spec) {
   }
 
   const typeDetails = MIDDLEWARE_TYPE_DETAILS[spec.type]
-  const name = spec.name || shim.getName(shim.getOriginal(middleware))
+  let name = spec.name || shim.getName(shim.getOriginal(middleware))
+
+  // mostly used in fastify to add the lifecyle name to before the function
+  // to provide more context to user about when function was executed
+  if (spec.segmentPrefix) {
+    name = `${spec.segmentPrefix}/${name}`
+  }
   let metricName = shim._metrics.PREFIX + typeDetails.name
   if (typeDetails.record) {
     metricName = shim._metrics.MIDDLEWARE + metricName + name


### PR DESCRIPTION
## Details
This prototyped additional instrumentation to support more use cases in fastify. It also fixed a few issues with the existing.  I explored the options of making a fastify plugin or fully leveraging `fastify.addHook` but the challenge is there isn't a hook point to track every middleware hop so we have to do traditional instrumentation at the moment.  Also the `fastify.use` scenarios rely on `middie` or `fastify-express` which itself are middleware that execute their middleware within itself so we'd either have to PR the middleware libraries to emit some events along with fastify to emit when it goes between each middleware. Adding events to fastify core could be done all middleware are executed within this [hookRunner](https://github.com/fastify/fastify/blob/main/lib/hooks.js#L164) but it would require more work with the fastify group and would take longer to implement.  I see this perhaps as a v3 of our instrumentation.


This instrumentation now will show all middleware executed in any request lifecycle and also capture middleware registered via middie or fastify-express.  I also added a new key to the spec called `segmentPrefix`(I suck at naming) but the gist is it will provide the lifecycle name in the span event for better context to the user.

## Before
[Nr One Link](https://staging-one.newrelic.com/launcher/nr1-core.explorer/?platform[filters]=Iihkb21haW4gPSAnQVBNJyBBTkQgdHlwZSA9ICdBUFBMSUNBVElPTicpIg==&platform[timeRange][duration]=1800000&platform[$isFallbackTimeRange]=true&pane=eyJuZXJkbGV0SWQiOiJkaXN0cmlidXRlZC10cmFjaW5nLmRpc3RyaWJ1dGVkLXRyYWNlLWxpc3QiLCJlbnRpdHlHdWlkIjoiTVRrd2ZFRlFUWHhCVUZCTVNVTkJWRWxQVG53eU1qZ3dPVGM1TXciLCJzb3J0QnkiOiJUUkFDRV9DT1VOVCJ9&cards[0]=eyJuZXJkbGV0SWQiOiJkaXN0cmlidXRlZC10cmFjaW5nLmhvbWUiLCJpc1RyYWNlR3JvdXBzTGlzdE1vZGUiOnRydWUsInRyYWNlR3JvdXBSb290RW50aXR5R3VpZCI6Ik1Ua3dmRUZRVFh4QlVGQk1TVU5CVkVsUFRud3lNamd3T1RjNU13IiwidHJhY2VHcm91cFJvb3RTcGFuTmFtZSI6IldlYlRyYW5zYWN0aW9uL1dlYkZyYW1ld29ya1VyaS9GYXN0aWZ5L0dFVC8vc3FsSW5qZWN0aW9uL3F1ZXJ5L3NlcXVlbGl6ZVByb3RvdHlwZVF1ZXJ5L3Vuc2FmZSIsInF1ZXJ5Ijp7Im9wZXJhdG9yIjoiQU5EIiwiaW5kZXhRdWVyeSI6eyJjb25kaXRpb25UeXBlIjoiSU5ERVgiLCJvcGVyYXRvciI6IkFORCIsImNvbmRpdGlvblNldHMiOlt7ImNvbmRpdGlvblR5cGUiOiJJTkRFWCIsImNvbmRpdGlvbnMiOlt7ImF0dHIiOiJlbnRpdHlHdWlkcyIsIm9wZXJhdG9yIjoiTElLRSIsInZhbHVlIjoiJU1Ua3dmRUZRVFh4QlVGQk1TVU5CVkVsUFRud3lNamd3T1RjNU13JSIsImlkIjoiOCJ9XSwib3BlcmF0b3IiOiJPUiIsImlkIjoiNyJ9LHsiY29uZGl0aW9uVHlwZSI6IklOREVYIiwib3BlcmF0b3IiOiJBTkQiLCJjb25kaXRpb25zIjpbeyJhdHRyIjoicm9vdC5lbnRpdHkuZ3VpZCIsIm9wZXJhdG9yIjoiRVEiLCJ2YWx1ZSI6Ik1Ua3dmRUZRVFh4QlVGQk1TVU5CVkVsUFRud3lNamd3T1RjNU13In0seyJhdHRyIjoicm9vdC5zcGFuLm5hbWUiLCJvcGVyYXRvciI6IkhBU0giLCJ2YWx1ZSI6IjUyNTQ0NzgyNCJ9XX1dLCJpZCI6IjYifSwic3BhblF1ZXJ5Ijp7Im9wZXJhdG9yIjoiQU5EIiwiY29uZGl0aW9uU2V0cyI6W10sImlkIjoiOSJ9LCJpZCI6IjUifSwiZW50aXR5R3VpZCI6Ik1Ua3dmRUZRVFh4QlVGQk1TVU5CVkVsUFRud3lNamd3T1RjNU13In0=&cards[1]=eyJuZXJkbGV0SWQiOiJkaXN0cmlidXRlZC10cmFjaW5nLmRldGFpbCIsInRyYWNlSWQiOiI1NzkyMjY4ZGQ2ZDI2NGI3ZTc0NTIzY2VjOTg4YWQxZCIsInN0YXJ0VGltZU1zIjoxNjMyNDI2ODIzOTczLCJhY2NvdW50SWQiOjE5MCwicm9vdEVudGl0eUd1aWQiOiJNVGt3ZkVGUVRYeEJVRkJNU1VOQlZFbFBUbnd5TWpnd09UYzVNdyIsImVudGl0eUd1aWQiOiJNVGt3ZkVGUVRYeEJVRkJNU1VOQlZFbFBUbnd5TWpnd09UYzVNdyJ9&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwic2VsZWN0ZWROZXJkbGV0Ijp7Im5lcmRsZXRJZCI6ImRpc3RyaWJ1dGVkLXRyYWNpbmcuZGlzdHJpYnV0ZWQtdHJhY2UtbGlzdCJ9LCJlbnRpdHlHdWlkIjoiTVRrd2ZFRlFUWHhCVUZCTVNVTkJWRWxQVG53eU1qZ3dPVGM1TXcifQ==&state=58dbd1ca-b572-525e-0ae3-3effdbad471c)

<img width="1460" alt="screenshot 2021-09-23 at 3 57 05 PM" src="https://user-images.githubusercontent.com/1874937/134575296-6bd0970e-08e1-4157-9541-859642386891.png">

## After 

[NR One Link](https://staging.onenr.io/0znQxpJA7QV)

<img width="1718" alt="screenshot 2021-09-21 at 4 32 58 PM" src="https://user-images.githubusercontent.com/1874937/134243427-9d46ad24-7299-4823-a0b0-f83eb4f656fc.png">

## Next Steps
I see the following tickets:

 * https://github.com/newrelic/node-newrelic/issues/924
 * https://github.com/newrelic/node-newrelic/issues/925 
 * https://github.com/newrelic/node-newrelic/issues/926
 * https://github.com/newrelic/node-newrelic/issues/927
 * https://github.com/newrelic/node-newrelic/issues/928
 * https://github.com/newrelic/node-newrelic/issues/929
 * https://github.com/newrelic/node-newrelic/issues/930

