### PR TITLE
added prefix to MiddlewareSpec, added assertion of segment naming as …

### DIFF
--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -49,7 +49,7 @@ const setupMiddlewareHandlers = (shim, fastify) => {
       const middlewareFunction = args[0]
       const newMiddlewareFunction = shim.recordMiddleware(
         middlewareFunction,
-        buildMiddlewareSpecForMiddlewareFunction(shim)
+        buildMiddlewareSpecForMiddlewareFunction(shim, 'onRequest')
       )
       // replace original function with our function
       args[0] = newMiddlewareFunction

--- a/lib/instrumentation/fastify/spec-builders.js
+++ b/lib/instrumentation/fastify/spec-builders.js
@@ -6,10 +6,17 @@
 'use strict'
 
 const getRawRequestFromFastifyRequest = (shim, fn, fnName, args) => {
-  const request = args[0]
+  const [request] = args
+
+  // sometimes request is Fastify request
+  // so we need to extract the IncomingMessage
+  // from .raw property
   if (request && request.raw) {
     return request.raw
   }
+
+  // not a Fastify request, use the IncomingMessage
+  return request
 }
 
 const getParamsFromFastifyRequest = (shim, fn, fnName, args) => {
@@ -88,8 +95,15 @@ function buildMiddlewareSpecForRouteHandler(shim, path) {
   }
 }
 
-function buildMiddlewareSpecForMiddlewareFunction() {
+/**
+ * Defines the Spec for the middleware handler
+ *
+ * @param {WebFrameworkShim} shim
+ * @param {string} mwPrefix defines the lifecycle in which the middleware occurs
+ */
+function buildMiddlewareSpecForMiddlewareFunction(shim, mwPrefix) {
   return {
+    prefix: mwPrefix,
     req: getRawRequestFromFastifyRequest,
 
     next: function wrapNext(shim, fn, fnName, args, bindSegment) {

--- a/lib/shim/specs/index.js
+++ b/lib/shim/specs/index.js
@@ -77,6 +77,7 @@ function MiddlewareSpec(spec) {
   this.route = hasOwnProperty(spec, 'route') ? spec.route : null
   this.params = hasOwnProperty(spec, 'params') ? spec.params : _defaultGetParams
   this.appendPath = hasOwnProperty(spec, 'appendPath') ? spec.appendPath : true
+  this.prefix = hasOwnProperty(spec, 'prefix') ? spec.prefix : null
 }
 util.inherits(MiddlewareSpec, RecorderSpec)
 

--- a/lib/shim/webframework-shim.js
+++ b/lib/shim/webframework-shim.js
@@ -791,7 +791,14 @@ function _recordMiddleware(shim, middleware, spec) {
   }
 
   const typeDetails = MIDDLEWARE_TYPE_DETAILS[spec.type]
-  const name = spec.name || shim.getName(shim.getOriginal(middleware))
+  let name = spec.name || shim.getName(shim.getOriginal(middleware))
+
+  // used to further qualify a metric name.  This was added for Fastify
+  // as middleware execute for a given lifecycle hook point.  This provides
+  // more context to the user as to when the middleware was executed
+  if (spec.prefix) {
+    name = `${spec.prefix}/${name}`
+  }
   let metricName = shim._metrics.PREFIX + typeDetails.name
   if (typeDetails.record) {
     metricName = shim._metrics.MIDDLEWARE + metricName + name

--- a/test/unit/shim/webframework-shim.test.js
+++ b/test/unit/shim/webframework-shim.test.js
@@ -565,6 +565,24 @@ test('WebFrameworkShim', function (t) {
       t.end()
     })
 
+    t.test('should prepend spec.prefix to a metric name when present', function (t) {
+      const wrapped = shim.recordMiddleware(wrappable.getActiveSegment, {
+        prefix: 'unitTestPrefix',
+        type: shim.MIDDLEWARE,
+        route: '/unit-test-route'
+      })
+      helper.runInTransaction(agent, function (tx) {
+        txInfo.transaction = tx
+        const segment = wrapped(req)
+
+        t.equal(
+          segment.name,
+          'Nodejs/Middleware/Restify/unitTestPrefix/getActiveSegment//unit-test-route'
+        )
+        t.end()
+      })
+    })
+
     t.test('should reinstate its own context', function (t) {
       testType(shim.MIDDLEWARE, 'Nodejs/Middleware/Restify/getActiveSegment')
 

--- a/test/versioned/fastify/fastify-2-naming.tap.js
+++ b/test/versioned/fastify/fastify-2-naming.tap.js
@@ -8,6 +8,7 @@
 const tap = require('tap')
 const requestClient = require('request')
 const helper = require('../../lib/agent_helper')
+const metrics = require('../../lib/metrics_helper')
 
 let callCount = 0
 const loadMiddleware = async (fastify) => {
@@ -63,16 +64,26 @@ let testCount = 0
 const testUri = (uri, agent, test, port) => {
   agent.on('transactionFinished', (transaction) => {
     testCount++
-    test.equals(
+    test.equal(
       `WebFrameworkUri/Fastify/GET/${uri}`,
       transaction.getName(),
       `transaction name matched for ${uri}`
     )
+
+    // FIXME: https://github.com/newrelic/node-newrelic/issues/926
+    // The middleware segments should be siblings not children
+    metrics.assertSegments(transaction.trace.root, [
+      `WebTransaction/WebFrameworkUri/Fastify/GET/${uri}`,
+      [
+        'Nodejs/Middleware/Fastify/onRequest/testMiddleware',
+        [`Nodejs/Middleware/Fastify/<anonymous>/${uri}`]
+      ]
+    ])
   })
 
   requestClient.get(`http://127.0.0.1:${port}${uri}`, function (error, response, body) {
     const result = (body = JSON.parse(body))
-    test.equals(result.called, uri, `${uri} url did not error`)
+    test.equal(result.called, uri, `${uri} url did not error`)
   })
 }
 
@@ -114,5 +125,5 @@ tap.test('Test Transaction Naming', (test) => {
     })
   }
 
-  test.equals(testCount, callCount, 'middleware was called')
+  test.equal(testCount, callCount, 'middleware was called')
 })


### PR DESCRIPTION
…it currently stands

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added `prefix` as an option to `MiddlewareSpec` to further qualify a metric name

## Links
Closes #924 

## Details
I tried to keep this scope very narrow but had to fix some of the things called out in #926 to write some versioned tests to assert the prefix was getting added to Fastify middleware.  I also commented on the naming tests in both versions 2 and 3 because the assertions will need to change when other bugs are fixed
