### PR TITLE
Fix opaque timer issue

### DIFF
--- a/lib/instrumentation/core/timers.js
+++ b/lib/instrumentation/core/timers.js
@@ -85,9 +85,9 @@ function initialize(agent, timers, moduleName, shim) {
 }
 
 function makeWrappedPromisifyCompatible(shim, timers) {
-  const originalSetTimout = shim.getOriginal(timers.setTimeout)
-  Object.getOwnPropertySymbols(originalSetTimout).forEach((symbol) => {
-    timers.setTimeout[symbol] = originalSetTimout[symbol]
+  const originalSetTimeout = shim.getOriginal(timers.setTimeout)
+  Object.getOwnPropertySymbols(originalSetTimeout).forEach((symbol) => {
+    timers.setTimeout[symbol] = originalSetTimeout[symbol]
   })
 
   const originalSetInterval = shim.getOriginal(timers.setInterval)

--- a/lib/instrumentation/core/timers.js
+++ b/lib/instrumentation/core/timers.js
@@ -70,7 +70,7 @@ function initialize(agent, timers, moduleName, shim) {
     return function wrappedClearTimeout(timer) {
       if (timer && timer._onTimeout) {
         const segment = timer._onTimeout.__NR_segment
-        if (segment) {
+        if (segment && !segment.opaque) {
           segment.ignore = true
         }
       }

--- a/test/integration/core/timers.tap.js
+++ b/test/integration/core/timers.tap.js
@@ -110,7 +110,7 @@ tap.test('setImmediate', function testSetImmediate(t) {
 tap.test('setInterval', function testSetInterval(t) {
   const agent = setupAgent(t)
   helper.runInTransaction(agent, function transactionWrapper() {
-    const interval = timers.setInterval(function anonymous() {
+    const interval = timers.setInterval(() => {
       clearInterval(interval)
       verifySegments(t, agent, 'timers.setInterval')
     }, 10)
@@ -140,7 +140,7 @@ tap.test('global setImmediate', function testSetImmediate(t) {
 tap.test('global setInterval', function testSetInterval(t) {
   const agent = setupAgent(t)
   helper.runInTransaction(agent, function transactionWrapper() {
-    const interval = setInterval(function anonymous() {
+    const interval = setInterval(() => {
       clearInterval(interval)
       verifySegments(t, agent, 'timers.setInterval')
     }, 10)
@@ -185,66 +185,49 @@ tap.test('nextTick with extra args', function testNextTick(t) {
   }
 })
 
-tap.test('clearTimeout', function testNextTick(t) {
+tap.test('clearImmediate', (t) => {
   const agent = setupAgent(t)
-  const timer = setTimeout(fail)
-
-  clearTimeout(timer)
-
-  helper.runInTransaction(agent, function transactionWrapper(transaction) {
-    process.nextTick(function callback() {
-      const timer2 = setTimeout(fail)
-      t.notOk(transaction.trace.root.children[0].ignore)
-      clearTimeout(timer2)
-      t.ok(transaction.trace.root.children[0].ignore)
-      setTimeout(t.end.bind(t))
-    })
-  })
-
-  function fail() {
-    t.fail()
-  }
-})
-
-tap.test('clearImmediate', function testNextTick(t) {
-  const agent = setupAgent(t)
-  const timer = setImmediate(fail)
+  const timer = setImmediate(t.fail)
 
   clearImmediate(timer)
 
   helper.runInTransaction(agent, function transactionWrapper(transaction) {
     process.nextTick(function callback() {
-      const timer2 = setImmediate(fail)
+      const timer2 = setImmediate(t.fail)
       t.notOk(transaction.trace.root.children[0])
       clearImmediate(timer2)
       setImmediate(t.end.bind(t))
     })
   })
-
-  function fail() {
-    t.fail()
-  }
 })
 
-tap.test('clearTimeout', function testNextTick(t) {
-  const agent = setupAgent(t)
-  const timer = setTimeout(fail)
+tap.test('clearTimeout should function outside of transaction context', (t) => {
+  setupAgent(t)
+
+  const timer = setTimeout(t.fail)
 
   clearTimeout(timer)
 
+  setImmediate(t.end)
+})
+
+tap.test('clearTimeout should ignore segment created for timer', (t) => {
+  const agent = setupAgent(t)
+
   helper.runInTransaction(agent, function transactionWrapper(transaction) {
     process.nextTick(function callback() {
-      const timer2 = setTimeout(fail)
-      t.notOk(transaction.trace.root.children[0].ignore)
-      clearTimeout(timer2)
-      t.ok(transaction.trace.root.children[0].ignore)
-      setTimeout(t.end.bind(t))
+      const timer = setTimeout(t.fail)
+
+      const timerSegment = transaction.trace.root.children[0]
+      t.equal(timerSegment.name, 'timers.setTimeout')
+      t.equal(timerSegment.ignore, false)
+
+      clearTimeout(timer)
+      t.equal(timerSegment.ignore, true)
+
+      setTimeout(t.end)
     })
   })
-
-  function fail() {
-    t.fail()
-  }
 })
 
 function setupAgent(t) {

--- a/test/integration/core/timers.tap.js
+++ b/test/integration/core/timers.tap.js
@@ -230,6 +230,56 @@ tap.test('clearTimeout should ignore segment created for timer', (t) => {
   })
 })
 
+tap.test('clearTimeout should not ignore parent segment when opaque', (t) => {
+  const expectedParentName = 'opaque segment'
+
+  const agent = setupAgent(t)
+
+  helper.runInTransaction(agent, function transactionWrapper(transaction) {
+    process.nextTick(function callback() {
+      helper.runInSegment(agent, expectedParentName, (segment) => {
+        segment.opaque = true
+
+        const timer = setTimeout(t.fail)
+
+        const parentSegment = transaction.trace.root.children[0]
+        t.equal(parentSegment.name, expectedParentName)
+        t.equal(parentSegment.ignore, false)
+
+        clearTimeout(timer)
+        t.equal(parentSegment.ignore, false)
+
+        setTimeout(t.end)
+      })
+    })
+  })
+})
+
+tap.test('clearTimeout should not ignore parent segment when internal', (t) => {
+  const expectedParentName = 'internal segment'
+
+  const agent = setupAgent(t)
+
+  helper.runInTransaction(agent, function transactionWrapper(transaction) {
+    process.nextTick(function callback() {
+      helper.runInSegment(agent, expectedParentName, (segment) => {
+        segment.internal = true
+
+        const timer = setTimeout(t.fail)
+
+        const parentSegment = transaction.trace.root.children[0]
+        t.equal(parentSegment.name, expectedParentName)
+        t.equal(parentSegment.ignore, false)
+
+        clearTimeout(timer)
+        t.equal(parentSegment.ignore, false)
+
+        setTimeout(t.end)
+      })
+    })
+  })
+})
+
 function setupAgent(t) {
   const agent = helper.instrumentMockedAgent()
   t.teardown(function tearDown() {

--- a/test/lib/agent_helper.js
+++ b/test/lib/agent_helper.js
@@ -231,6 +231,12 @@ const helper = (module.exports = {
     })
   },
 
+  runInSegment: (agent, name, callback) => {
+    const tracer = agent.tracer
+
+    return tracer.addSegment(name, null, null, null, callback)
+  },
+
   /**
    * Stub to bootstrap a memcached instance
    *

--- a/test/versioned/mongodb/collection-common.js
+++ b/test/versioned/mongodb/collection-common.js
@@ -84,7 +84,7 @@ function collectionTest(name, run) {
             const segment = agent.tracer.getSegment()
             let current = transaction.trace.root
 
-            // this logic is just for the collection.aggrate v4+
+            // this logic is just for the collection.aggregate v4+
             // aggregate no longer returns a callback with cursor
             // it just returns a cursor. so the segments on the
             // transaction are not nested but both on the trace
@@ -100,6 +100,7 @@ function collectionTest(name, run) {
                 t.equal(child.name, expectedSegment, `child should be named ${expectedSegment}`)
                 if (common.MONGO_SEGMENT_RE.test(child.name)) {
                   checkSegmentParams(t, child)
+                  t.equal(child.ignore, false, 'should not ignore segment')
                 }
 
                 t.equal(child.children.length, 0, 'should have no more children')
@@ -111,6 +112,7 @@ function collectionTest(name, run) {
                 t.equal(current.name, segments[i], 'child should be named ' + segments[i])
                 if (common.MONGO_SEGMENT_RE.test(current.name)) {
                   checkSegmentParams(t, current)
+                  t.equal(current.ignore, false, 'should not ignore segment')
                 }
               }
 
@@ -318,7 +320,7 @@ function collectionTest(name, run) {
             const segment = agent.tracer.getSegment()
             let current = transaction.trace.root
 
-            // this logic is just for the collection.aggrate v4+
+            // this logic is just for the collection.aggregate v4+
             // aggregate no longer returns a callback with cursor
             // it just returns a cursor. so the segments on the
             // transaction are not nested but both on the trace
@@ -334,6 +336,7 @@ function collectionTest(name, run) {
                 t.equal(child.name, expectedSegment, `child should be named ${expectedSegment}`)
                 if (common.MONGO_SEGMENT_RE.test(child.name)) {
                   checkSegmentParams(t, child)
+                  t.equal(child.ignore, false, 'should not ignore segment')
                 }
 
                 t.equal(child.children.length, 0, 'should have no more children')
@@ -345,6 +348,7 @@ function collectionTest(name, run) {
                 t.equal(current.name, segments[i], 'child should be named ' + segments[i])
                 if (common.MONGO_SEGMENT_RE.test(current.name)) {
                   checkSegmentParams(t, current)
+                  t.equal(current.ignore, false, 'should not ignore segment')
                 }
               }
 

--- a/test/versioned/mongodb/cursor.tap.js
+++ b/test/versioned/mongodb/cursor.tap.js
@@ -31,7 +31,7 @@ common.test('explain', function explainTest(t, collection, verify) {
     if (data.hasOwnProperty('cursor')) {
       t.equal(data.cursor, 'BasicCursor', 'should have correct response')
     } else {
-      t.ok(data.hasOwnProperty('queryPlanner'), 'should have correct reponse')
+      t.ok(data.hasOwnProperty('queryPlanner'), 'should have correct response')
     }
     verify(
       null,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Fixes issue with `clearTimeout` that could result in dropping parent segments or spans.

  This bug resulted in some MongoDB calls being dropped from Transaction Traces and Distributed Traces (spans): https://github.com/newrelic/node-newrelic/issues/922.

## Links

* Fixes: https://github.com/newrelic/node-newrelic/issues/922

## Details

I looked at the pre-shim code and it had the same issue. I think ideally we could avoid doing work when the parent is opaque for the timers but we currently have to based on the existing context propagation mechanisms. If we successfully switch to newer context mechanisms, perhaps we can have a more obvious means of detecting we are not in this context. We could potentially use another mechanism for identifying it is in fact a timer span.

For now, I went with matching against "opaque" which is the case that results in this so there's at least an obvious cause/effect check.

Internal also has the case to trigger this but it seems, at least on the segment creation side, we check for botht he child being flagged internal and the parent as to when it won't create the child segment. Timers are not 'internal' so seem to create children. I added a test case to catch if this behavior ever changes.
