### PR TITLE
Undici fixes for parallel requests

### DIFF
--- a/lib/feature_flags.js
+++ b/lib/feature_flags.js
@@ -15,6 +15,7 @@ exports.prerelease = {
   promise_segments: false,
   reverse_naming_rules: false,
   undici_instrumentation: false,
+  undici_async_tracking: true,
   unresolved_promise_cleanup: true
 }
 

--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -14,6 +14,8 @@ const SYMBOLS = {
   SEGMENT: Symbol('__NR_segment'),
   PARENT_SEGMENT: Symbol('__NR_parent_segment')
 }
+const { executionAsyncId } = require('async_hooks')
+const segmentMap = new Map()
 
 let diagnosticsChannel = null
 try {
@@ -32,6 +34,34 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
   }
 
   /**
+   * Retrieves the current segment in transaction(parent in our context) from local Map
+   * of from `shim.getSegment()` then adds to local Map by executionAsyncId for future
+   * undici requests within same async context.
+   *
+   * It was found that when running concurrent undici requests
+   * within a transaction that the parent segment would get out of sync
+   * depending on the async context of the transaction.  By using
+   * `async_hooks.executionAsyncId` it is more reliable.
+   *
+   * Note: However, if you have concurrent undici requests in a transaction
+   * and the request to the transaction is using a keep alive there is a chance the
+   * executionAsyncId may be incorrect because of share connections.  To revert to a more
+   * naive tracking of parent set `config.feature_flag.undici_async_tracking: false` and
+   * it will just call `shim.getSegment()`
+   */
+  function getParentSegment() {
+    if (agent.config.feature_flag.undici_async_tracking) {
+      const id = executionAsyncId()
+      if (!segmentMap.has(id)) {
+        const parent = shim.getSegment()
+        segmentMap.set(id, parent)
+      }
+      return segmentMap.get(id)
+    }
+    return shim.getSegment()
+  }
+
+  /**
    * This event occurs after the Undici Request is created
    * We will check current segment for opaque and also attach
    * relevant headers to outgoing http request
@@ -40,7 +70,7 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
    * @param {Object} params.request undici request object
    */
   diagnosticsChannel.channel('undici:request:create').subscribe(({ request }) => {
-    const parent = shim.getSegment()
+    const parent = getParentSegment()
     request[SYMBOLS.PARENT_SEGMENT] = parent
     if (!parent || (parent && parent.opaque)) {
       logger.trace(
@@ -104,20 +134,18 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
     const url = new URL(urlString)
 
     const name = NAMES.EXTERNAL.PREFIX + url.host + url.pathname
-    const segment = shim.createSegment(
-      name,
-      recordExternal(url.host, 'undici'),
-      request[SYMBOLS.PARENT_SEGMENT]
-    )
-    segment.start()
-    shim.setActiveSegment(segment)
-    segment.addAttribute('url', `${url.protocol}//${url.host}${url.pathname}`)
+    const segment = shim.createSegment(name, recordExternal(url.host, 'undici'), parentSegment)
+    if (segment) {
+      segment.start()
+      shim.setActiveSegment(segment)
+      segment.addAttribute('url', `${url.protocol}//${url.host}${url.pathname}`)
 
-    url.searchParams.forEach((value, key) => {
-      segment.addSpanAttribute(`request.parameters.${key}`, value)
-    })
-    segment.addAttribute('procedure', request.method || 'GET')
-    request[SYMBOLS.SEGMENT] = segment
+      url.searchParams.forEach((value, key) => {
+        segment.addSpanAttribute(`request.parameters.${key}`, value)
+      })
+      segment.addAttribute('procedure', request.method || 'GET')
+      request[SYMBOLS.SEGMENT] = segment
+    }
   })
 
   /**

--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -76,7 +76,7 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
       logger.trace(
         'Not capturing data for outbound request (%s) because parent segment opaque (%s)',
         request.path,
-        parent.name
+        parent && parent.name
       )
 
       return

--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -14,8 +14,7 @@ const SYMBOLS = {
   SEGMENT: Symbol('__NR_segment'),
   PARENT_SEGMENT: Symbol('__NR_parent_segment')
 }
-const { executionAsyncId } = require('async_hooks')
-const segmentMap = new Map()
+const { executionAsyncResource } = require('async_hooks')
 
 let diagnosticsChannel = null
 try {
@@ -34,29 +33,30 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
   }
 
   /**
-   * Retrieves the current segment in transaction(parent in our context) from local Map
-   * of from `shim.getSegment()` then adds to local Map by executionAsyncId for future
+   * Retrieves the current segment in transaction(parent in our context) from executionAsyncResource
+   * or from `shim.getSegment()` then adds to the executionAsyncResource for future
    * undici requests within same async context.
    *
    * It was found that when running concurrent undici requests
    * within a transaction that the parent segment would get out of sync
    * depending on the async context of the transaction.  By using
-   * `async_hooks.executionAsyncId` it is more reliable.
+   * `async_hooks.executionResource` it is more reliable.
    *
    * Note: However, if you have concurrent undici requests in a transaction
    * and the request to the transaction is using a keep alive there is a chance the
-   * executionAsyncId may be incorrect because of share connections.  To revert to a more
+   * executionAsyncResource may be incorrect because of shared connections.  To revert to a more
    * naive tracking of parent set `config.feature_flag.undici_async_tracking: false` and
    * it will just call `shim.getSegment()`
    */
   function getParentSegment() {
     if (agent.config.feature_flag.undici_async_tracking) {
-      const id = executionAsyncId()
-      if (!segmentMap.has(id)) {
+      const resource = executionAsyncResource()
+
+      if (!resource[SYMBOLS.PARENT_SEGMENT]) {
         const parent = shim.getSegment()
-        segmentMap.set(id, parent)
+        resource[SYMBOLS.PARENT_SEGMENT] = parent
       }
-      return segmentMap.get(id)
+      return resource[SYMBOLS.PARENT_SEGMENT]
     }
     return shim.getSegment()
   }

--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -203,46 +203,6 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
   })
 
   /**
-   * This event occurs before creating connection to socket.
-   * We will create and start a segment for the `undici.Client.connect`
-   *
-   * @param {Object} params
-   * @param {Function} params.connector function to connect to socket
-   */
-  diagnosticsChannel.channel('undici:client:beforeConnect').subscribe(({ connector }) => {
-    const parent = shim.getSegment()
-    const segment = shim.createSegment('undici.Client.connect')
-    connector[SYMBOLS.SEGMENT] = segment
-    connector[SYMBOLS.PARENT_SEGMENT] = parent
-    segment.start()
-    shim.setActiveSegment(segment)
-  })
-
-  /**
-   * This event occurs when the socket connection has been made.
-   * We will end the segment for the `undici.Client.connect` and restores parent
-   * to before connect
-   *
-   * @param {Object} params
-   * @param {Function} params.connector function to connect to socket
-   */
-  diagnosticsChannel.channel('undici:client:connected').subscribe(({ connector }) => {
-    endAndRestoreSegment(connector)
-  })
-
-  /**
-   * This event occurs when connection to socket fails.
-   * We will end segment for the `undici.Client.connect` and restore parent
-   * to before connect. It will also attach the error to the transaction
-   *
-   * @param {Object} params
-   * @param {Function} params.connector function to connect to socket
-   */
-  diagnosticsChannel.channel('undici:client:connectError').subscribe(({ connector, error }) => {
-    endAndRestoreSegment(connector, error)
-  })
-
-  /**
    * Gets the active and parent from given ctx(request, client connector)
    * and ends active and restores parent to active.  If an error exists
    * it will add the error to the transaction

--- a/test/unit/feature_flag.test.js
+++ b/test/unit/feature_flag.test.js
@@ -38,7 +38,8 @@ const used = [
   'certificate_bundle',
   'new_promise_tracking',
   'unresolved_promise_cleanup',
-  'undici_instrumentation'
+  'undici_instrumentation',
+  'undici_async_tracking'
 ]
 
 describe('feature flags', function () {

--- a/test/unit/instrumentation/undici.test.js
+++ b/test/unit/instrumentation/undici.test.js
@@ -78,6 +78,16 @@ tap.test('undici instrumentation', { skip: shouldSkip }, function (t) {
     t.autoend()
     t.afterEach(afterEach)
 
+    t.test('should log trace if request is not in an active transaction', function (t) {
+      channels.create.publish({ request: { path: '/foo' } })
+      t.same(loggerMock.trace.args[0], [
+        'Not capturing data for outbound request (%s) because parent segment opaque (%s)',
+        '/foo',
+        undefined
+      ])
+      t.end()
+    })
+
     t.test('should not add headers when segment is opaque', function (t) {
       helper.runInTransaction(agent, function (tx) {
         const segment = tx.trace.add('parent')

--- a/test/unit/instrumentation/undici.test.js
+++ b/test/unit/instrumentation/undici.test.js
@@ -147,7 +147,7 @@ tap.test('undici instrumentation', { skip: shouldSkip }, function (t) {
     })
 
     t.test(
-      'should get the parent segment from Map when executionAsyncId is the same',
+      'should get the parent segment executionAsyncResource when it already exists',
       function (t) {
         helper.runInTransaction(agent, function (tx) {
           const addHeader = sandbox.stub()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed an issue with undici instrumentation where the parent segment wasn't always correct.  
 * Fixed an issue where undici instrumentation would crash if transaction got ended before undici external segment was added
 * Removed instrumentation for undici connections as it did not provide any additional context from what we already have with the net module and socket connections

## Details
I added a new feature flag `undici_async_tracking` that defaults to true.  This relies on async hooks' executionAsyncId to get the proper async context for storing the current active segment before an undici request is made.  

**Note**: This poses issues if requests to an app are made with keep alive and you have multiple undici requests being made in paralell.  If this is a use case of yours, set `feature_flag: { undici_async_tracking: false }`
