### PR TITLE
Adds fastify v3 middleware mounting and fixes mount location naming

### DIFF
--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -4,11 +4,13 @@
  */
 
 'use strict'
+
 const semver = require('semver')
 const {
   buildMiddlewareSpecForRouteHandler,
   buildMiddlewareSpecForMiddlewareFunction
 } = require('./fastify/spec-builders')
+
 /**
  * Sets up fastify route handler
  *
@@ -42,30 +44,11 @@ const setupRouteHandler = (shim, fastify) => {
   })
 }
 
-const setupMiddlewareHandlers = (shim, fastify) => {
-  shim.wrap(fastify, 'use', function wrapFastifyUse(shim, fn) {
-    return function wrappedFastifyUser() {
-      const args = shim.argsToArray.apply(shim, arguments)
-      const [middlewareFunction] = args
-      // prefixing the segment name for middleware execution
-      // with the Fastify lifecycle hook
-      const name = `onRequest/${shim.getName(middlewareFunction)}`
-      const newMiddlewareFunction = shim.recordMiddleware(
-        middlewareFunction,
-        buildMiddlewareSpecForMiddlewareFunction(shim, name)
-      )
-      // replace original function with our function
-      args[0] = newMiddlewareFunction
-
-      return fn.apply(this, args)
-    }
-  })
-}
-
 module.exports = function initialize(agent, fastify, moduleName, shim) {
   if (!agent.config.feature_flag.fastify_instrumentation) {
     return
   }
+
   shim.setFramework(shim.FASTIFY)
 
   const fastifyVersion = shim.require('./package.json').version
@@ -76,18 +59,12 @@ module.exports = function initialize(agent, fastify, moduleName, shim) {
    */
   const wrappedExport = shim.wrapExport(fastify, function wrapFastifyModule(shim, fn) {
     return function wrappedFastifyModule() {
-      // normalize arguments
-      const args = shim.argsToArray.apply(shim, arguments)
-
       // call original function get get fastify object (which is singleton-ish)
-      const fastifyForWrapping = fn.apply(this, args)
+      const fastifyForWrapping = fn.apply(this, arguments)
 
       setupRouteHandler(shim, fastifyForWrapping)
 
-      // Don't wrap use() in fastify v3+
-      if (!isv3Plus) {
-        setupMiddlewareHandlers(shim, fastifyForWrapping)
-      }
+      setupMiddlewareHandlers(shim, fastifyForWrapping, isv3Plus)
 
       return fastifyForWrapping
     }
@@ -96,6 +73,49 @@ module.exports = function initialize(agent, fastify, moduleName, shim) {
   if (isv3Plus) {
     setupExports(fastify, wrappedExport)
   }
+}
+
+function setupMiddlewareHandlers(shim, fastify, isv3Plus) {
+  const mounterSpec = {
+    route: shim.FIRST,
+    wrapper: wrapMiddleware
+  }
+
+  if (isv3Plus) {
+    // Fastify v3+ does not ship with traditional Node.js middleware mounting.
+    // This style is accomplished leveraging decorators. Both middie (which was built-in in v2)
+    // and fastify-express mount a 'use' function for mounting middleware.
+    shim.wrap(fastify, 'decorate', function wrapDecorate(shim, fn) {
+      return function wrappedDecorate() {
+        const name = arguments[0]
+        if (name !== 'use') {
+          return fn.apply(this, arguments)
+        }
+
+        const args = shim.argsToArray.apply(shim, arguments)
+        args[1] = shim.wrapMiddlewareMounter(args[1], mounterSpec)
+
+        return fn.apply(this, args)
+      }
+    })
+  } else {
+    shim.wrapMiddlewareMounter(fastify, 'use', mounterSpec)
+  }
+}
+
+function wrapMiddleware(shim, middleware, name, route) {
+  if (shim.isWrapped(middleware)) {
+    return middleware
+  }
+
+  // prefixing the segment name for middleware execution
+  // with the Fastify lifecycle hook
+  const segmentName = `onRequest/${name}`
+  const spec = buildMiddlewareSpecForMiddlewareFunction(shim, segmentName, route)
+
+  const newMiddlewareFunction = shim.recordMiddleware(middleware, spec)
+
+  return newMiddlewareFunction
 }
 
 /**

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -27,10 +27,10 @@ const setupRouteHandler = (shim, fastify) => {
       return
     }
     /**
-     * recordMiddlware handler call
+     * recordMiddleware handler call
      *
      * The WebFramework shim treats the main route handler like any other
-     * i.e. dont be confused by the call to recordMiddlware -- we don't
+     * i.e. dont be confused by the call to recordMiddleware -- we don't
      * have a recordRouteHandler, everything goes through recordMiddleware
      */
     const newRouteHandler = shim.recordMiddleware(

--- a/lib/instrumentation/fastify/spec-builders.js
+++ b/lib/instrumentation/fastify/spec-builders.js
@@ -45,7 +45,7 @@ const getParamsFromFastifyRequest = (shim, fn, fnName, args) => {
  * Builds the recordMiddleware Spec for the route handler
  *
  * A spec is basically a specification -- or a list
- * of insrtuctions to the recordMiddleware function
+ * of instructions to the recordMiddleware function
  * that provide it with the information it needs to
  * do its job.  You could also think of it as a
  * mini-DSL
@@ -97,9 +97,10 @@ function buildMiddlewareSpecForRouteHandler(shim, path) {
  * @param {string} name metric name for middleware being executed
  * @returns {Object} spec for Fastify middleware
  */
-function buildMiddlewareSpecForMiddlewareFunction(shim, name) {
+function buildMiddlewareSpecForMiddlewareFunction(shim, name, route) {
   return {
     name,
+    route,
     next: shim.LAST,
     params: getParamsFromFastifyRequest,
     req: getRequestFromFastify,

--- a/test/versioned/fastify/fastify-2-naming.tap.js
+++ b/test/versioned/fastify/fastify-2-naming.tap.js
@@ -18,6 +18,15 @@ const loadMiddleware = async (fastify) => {
   }
 
   fastify.use(testMiddleware)
+
+  function pathMountedMiddleware(req, res, next) {
+    next()
+  }
+
+  fastify.use('/async-return', pathMountedMiddleware)
+  fastify.use('/async-reply-send', pathMountedMiddleware)
+  fastify.use('/sync-reply-send', pathMountedMiddleware)
+  fastify.use('/plugin-registered', pathMountedMiddleware)
 }
 
 /**
@@ -74,6 +83,7 @@ const testUri = (uri, agent, test, port) => {
       `WebTransaction/WebFrameworkUri/Fastify/GET/${uri}`,
       [
         'Nodejs/Middleware/Fastify/onRequest/testMiddleware',
+        `Nodejs/Middleware/Fastify/onRequest/pathMountedMiddleware/${uri}`,
         `Nodejs/Middleware/Fastify/<anonymous>/${uri}`
       ]
     ])

--- a/test/versioned/fastify/fastify-3-naming.tap.js
+++ b/test/versioned/fastify/fastify-3-naming.tap.js
@@ -20,6 +20,15 @@ const loadMiddleware = async (fastify) => {
   await fastify.register(require('middie'))
 
   fastify.use(testMiddleware)
+
+  function pathMountedMiddleware(req, res, next) {
+    next()
+  }
+
+  fastify.use('/async-return', pathMountedMiddleware)
+  fastify.use('/async-reply-send', pathMountedMiddleware)
+  fastify.use('/sync-reply-send', pathMountedMiddleware)
+  fastify.use('/plugin-registered', pathMountedMiddleware)
 }
 
 /**
@@ -73,7 +82,11 @@ const testUri = (uri, agent, test, port) => {
     )
     metrics.assertSegments(transaction.trace.root, [
       `WebTransaction/WebFrameworkUri/Fastify/GET/${uri}`,
-      [`Nodejs/Middleware/Fastify/<anonymous>/${uri}`]
+      [
+        'Nodejs/Middleware/Fastify/onRequest/testMiddleware',
+        `Nodejs/Middleware/Fastify/onRequest/pathMountedMiddleware/${uri}`,
+        `Nodejs/Middleware/Fastify/<anonymous>/${uri}`
+      ]
     ])
   })
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Added middleware mounting for fastify v3.

* Fixed capturing of mount point for middleware naming.

## Links

* Closes: https://github.com/newrelic/node-newrelic/issues/927

## Details

Note: the inclusion of the hook that fires the middleware 'onRequest' does result in awkward UI formatting with the old UI which does auto formatting.

Without it, you would see something like `Middleware: pathMountedMiddleware /async-return`. With it, you see: `Middleware: onRequest pathMountedMiddleware//async-return`.

The newer UI doesn't do any formatting currently so has no impact.
