### PR TITLE
added logic to add error when unhandledRejection occurs during lambda handler

### DIFF
--- a/lib/serverless/aws-lambda.js
+++ b/lib/serverless/aws-lambda.js
@@ -82,8 +82,14 @@ class AwsLambda {
       // NOTE: This may be converted to holding onto a single ender function if only
       // one invocation is executing at a time.
       shim.wrap(process, 'emit', function wrapEmit(shim, emit) {
-        return function wrappedEmit(ev) {
-          if (ev === 'beforeExit') {
+        return function wrappedEmit(ev, error) {
+          // need to add error as uncaughtException to be used
+          // later to add to transaction errors
+          if (ev === 'unhandledRejection') {
+            uncaughtException = error
+          }
+
+          if (['beforeExit', 'unhandledRejection'].includes(ev)) {
             transactionEnders.forEach((ender) => {
               ender()
             })


### PR DESCRIPTION

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed issue where unhandled promise rejections were not getting logged as errors in a lambda execution

## Links
Closes #970 

## Details
I manually built our newrelic layer with this version of node agent and re-ran my lambda that was not logging errors and it works 🎉 .  

<img width="1418" alt="screenshot 2021-11-09 at 10 45 19 AM" src="https://user-images.githubusercontent.com/1874937/140956600-ef07ede4-3783-422a-a3f6-ec4638354508.png">

[Permalink](https://onenr.io/0e1wZYODAQ6)

