### PR TITLE
added code to properly bind promises in recordConsume

### DIFF
--- a/lib/shim/message-shim.js
+++ b/lib/shim/message-shim.js
@@ -62,20 +62,16 @@ const DESTINATION_TYPES = {
 /**
  * Constructs a shim specialized for instrumenting message brokers.
  *
- * @constructor
- * @extends TransactionShim
+ * @class
+ * @augments TransactionShim
  * @classdesc
  *  Used for instrumenting message broker client libraries.
- *
  * @param {Agent} agent
  *  The agent this shim will use.
- *
  * @param {string} moduleName
  *  The name of the module being instrumented.
- *
  * @param {string} resolvedName
  *  The full path to the loaded module.
- *
  * @see Shim
  * @see TransactionShim
  */
@@ -112,115 +108,86 @@ MessageShim.prototype.recordSubscribedConsume = recordSubscribedConsume
 
 /**
  * @callback MessageFunction
- *
  * @summary
  *  Used for determining information about a message either being produced or
  *  consumed.
- *
  * @param {MessageShim} shim
  *  The shim this function was handed to.
- *
  * @param {Function} func
  *  The produce method or message consumer.
- *
  * @param {string} name
  *  The name of the producer or consumer.
- *
  * @param {Array.<*>} args
  *  The arguments being passed into the produce method or consumer.
- *
- * @return {MessageSpec} The specification for the message being produced or
+ * @returns {MessageSpec} The specification for the message being produced or
  *  consumed.
- *
  * @see MessageShim#recordProduce
  * @see MessageShim#recordConsume
  */
 
 /**
  * @callback MessageHandlerFunction
- *
  * @summary
  *  A function that is used to extract properties from a consumed message. This
  *  method is handed the results of a consume call. If the consume used a
  *  callback, then this method will receive the arguments to the callback. If
  *  the consume used a promise, then this method will receive the resolved
  *  value.
- *
  * @param {MessageShim} shim
  *  The shim this function was handed to.
- *
  * @param {Function} func
  *  The produce method or message consumer.
- *
  * @param {string} name
  *  The name of the producer or consumer.
- *
  * @param {Array|*} args
  *  Either the arguments for the consumer callback function or the result of
  *  the resolved consume promise, depending on the mode of the instrumented
  *  method.
- *
- * @return {MessageSpec} The extracted properties of the consumed message.
- *
+ * @returns {MessageSpec} The extracted properties of the consumed message.
  * @see MessageShim#recordConsume
  */
 
 /**
  * @callback MessageConsumerWrapperFunction
- *
  * @summary
  *  Function that is used to wrap message consumer functions. Used along side
  *  the MessageShim#recordSubscribedConsume API method.
- *
  * @param {MessageShim} shim
  *  The shim this function was handed to.
- *
  * @param {Function} consumer
  *  The message consumer to wrap.
- *
  * @param {string} name
  *  The name of the consumer method.
- *
  * @param {string} queue
  *  The name of the queue this consumer is being subscribed to.
- *
- * @return {Function} The consumer method, possibly wrapped.
- *
+ * @returns {Function} The consumer method, possibly wrapped.
  * @see MessageShim#recordSubscribedConsume
  * @see MessageShim#recordConsume
  */
 
 /**
  * @interface MessageSpec
- * @extends RecorderSpec
- *
+ * @augments RecorderSpec
  * @description
  *  The specification for a message being produced or consumed.
- *
  * @property {string} destinationName
  *  The name of the exchange or queue the message is being produced to or
  *  consumed from.
- *
  * @property {MessageShim.DESTINATION_TYPES} [destinationType=null]
  *  The type of the destination. Defaults to `shim.EXCHANGE`.
- *
- * @property {Object} [headers=null]
+ * @property {object} [headers=null]
  *  A reference to the message headers. On produce, more headers will be added
  *  to this object which should be sent along with the message. On consume,
  *  cross-application headers will be read from this object.
- *
  * @property {string} [routingKey=null]
  *  The routing key for the message. If provided on consume, the routing key
  *  will be added to the transaction attributes as `message.routingKey`.
- *
  * @property {string} [queue=null]
  *  The name of the queue the message was consumed from. If provided on
  *  consume, the queue name will be added to the transaction attributes as
  *  `message.queueName`.
- *
  * @property {string} [parameters.correlation_id]
  *  In AMQP, this should be the correlation Id of the message, if it has one.
- *
  * @property {string} [parameters.reply_to]
  *  In AMQP, this should be the name of the queue to reply to, if the message
  *  has one.
@@ -238,23 +205,19 @@ MessageShim.prototype.recordSubscribedConsume = recordSubscribedConsume
 
 /**
  * @interface MessageSubscribeSpec
- * @extends MessageSpec
- *
+ * @augments MessageSpec
  * @description
  *  Specification for message subscriber methods. That is, methods which
  *  register a consumer to start receiving messages.
- *
  * @property {number} consumer
  *  The index of the consumer in the method's arguments. Note that if the
  *  consumer and callback indexes point to the same argument, the argument will
  *  be wrapped as a consumer.
- *
  * @property {MessageHandlerFunction} messageHandler
  *  A function to extract message properties from a consumed message.
  *  This method is only used in the consume case to pull data from the
  *  retrieved message. Its return value is combined with the `MessageSubscribeSpec`
  *  to fully describe the consumed message.
- *
  * @see MessageSpec
  * @see MessageConsumerWrapperFunction
  * @see MessageShim#recordSubscribedConsume
@@ -269,11 +232,9 @@ MessageShim.prototype.recordSubscribedConsume = recordSubscribedConsume
  * passed, metric names will be generated using that.
  *
  * @memberof MessageShim.prototype
- *
  * @param {MessageShim.LIBRARY_NAMES|string} library
  *  The name of the message broker library. Use one of the well-known constants
  *  listed in {@link MessageShim.LIBRARY_NAMES} if available for the library.
- *
  * @see MessageShim.LIBRARY_NAMES
  */
 function setLibrary(library) {
@@ -305,20 +266,15 @@ function setLibrary(library) {
  * `PRODUCE` metric.
  *
  * @memberof MessageShim.prototype
- *
- * @param {Object|Function} nodule
+ * @param {object | Function} nodule
  *  The source for the properties to wrap, or a single function to wrap.
- *
  * @param {string|Array.<string>} [properties]
  *  One or more properties to wrap. If omitted, the `nodule` parameter is
  *  assumed to be the function to wrap.
- *
  * @param {MessageFunction} recordNamer
  *  A function which specifies details of the message.
- *
- * @return {Object|Function} The first parameter to this function, after
+ * @returns {object | Function} The first parameter to this function, after
  *  wrapping it or its properties.
- *
  * @see Shim#wrap
  * @see Shim#record
  * @see MessageSpec
@@ -374,21 +330,16 @@ function recordProduce(nodule, properties, recordNamer) {
  * consumers see {@link MessageShim#recordSubscribedConsume}
  *
  * @memberof MessageShim.prototype
- *
- * @param {Object|Function} nodule
+ * @param {object | Function} nodule
  *  The source for the properties to wrap, or a single function to wrap.
- *
  * @param {string|Array.<string>} [properties]
  *  One or more properties to wrap. If omitted, the `nodule` parameter is
  *  assumed to be the function to wrap.
- *
  * @param {MessageSpec|MessageFunction} spec
  *  The spec for the method or a function which returns the details of the
  *  method.
- *
- * @return {Object|Function} The first parameter to this function, after
+ * @returns {object | Function} The first parameter to this function, after
  *  wrapping it or its properties.
- *
  * @see Shim#wrap
  * @see Shim#record
  * @see MessageShim#recordSubscribedConsume
@@ -489,6 +440,7 @@ function recordConsume(nodule, properties, spec) {
 
       // Intercept the promise to handle the result.
       if (resHandler && ret && msgDesc.promise && shim.isPromise(ret)) {
+        ret = shim.bindPromise(ret, segment)
         ret = ret.then(function interceptValue(res) {
           const msgProps = resHandler.call(this, shim, fn, fnName, res)
           if (getParams && msgProps && msgProps.parameters) {
@@ -510,23 +462,17 @@ function recordConsume(nodule, properties, spec) {
  * - `recordPurgeQueue(func, spec)`
  *
  * @memberof MessageShim.prototype
- *
- * @param {Object|Function} nodule
+ * @param {object | Function} nodule
  *  The source for the properties to wrap, or a single function to wrap.
- *
  * @param {string|Array.<string>} [properties]
  *  One or more properties to wrap. If omitted, the `nodule` parameter is
  *  assumed to be the function to wrap.
- *
  * @param {RecorderSpec} spec
  *  The specification for this queue purge method's interface.
- *
  * @param {string} spec.queue
  *  The name of the queue being purged.
- *
- * @return {Object|Function} The first parameter to this function, after
+ * @returns {object | Function} The first parameter to this function, after
  *  wrapping it or its properties.
- *
  * @see Shim#wrap
  * @see Shim#record
  * @see RecorderSpec
@@ -598,20 +544,15 @@ function recordPurgeQueue(nodule, properties, spec) {
  * `spec.wrapper` method even if no transaction is active.
  *
  * @memberof MessageShim.prototype
- *
- * @param {Object|Function} nodule
+ * @param {object | Function} nodule
  *  The source for the properties to wrap, or a single function to wrap.
- *
  * @param {string|Array.<string>} [properties]
  *  One or more properties to wrap. If omitted, the `nodule` parameter is
  *  assumed to be the function to wrap.
- *
  * @param {MessageSubscribeSpec} spec
  *  The specification for this subscription method's interface.
- *
- * @return {Object|Function} The first parameter to this function, after
+ * @returns {object | Function} The first parameter to this function, after
  *  wrapping it or its properties.
- *
  * @see Shim#wrap
  * @see Shim#record
  * @see MessageShim#recordConsume
@@ -702,6 +643,10 @@ function recordSubscribedConsume(nodule, properties, spec) {
     }
   })
 
+  /**
+   * @param queue
+   * @param destinationName
+   */
   function makeWrapConsumer(queue, destinationName) {
     const msgDescDefaults = copy.shallow(spec)
     if (destNameIsArg && destinationName != null) {
@@ -810,6 +755,9 @@ function recordSubscribedConsume(nodule, properties, spec) {
 
           return ret
 
+          /**
+           *
+           */
           function endTransaction() {
             tx.finalizeName(null) // Use existing partial name.
             tx.end()
@@ -830,12 +778,10 @@ function recordSubscribedConsume(nodule, properties, spec) {
  * Constructs a message segment name from the given message descriptor.
  *
  * @private
- *
  * @param {MessageShim} shim    - The shim the segment will be constructed by.
  * @param {MessageSpec} msgDesc - The message descriptor.
  * @param {string}      action  - Produce or consume?
- *
- * @return {string} The generated name of the message segment.
+ * @returns {string} The generated name of the message segment.
  */
 function _nameMessageSegment(shim, msgDesc, action) {
   let name =
@@ -855,6 +801,10 @@ function _nameMessageSegment(shim, msgDesc, action) {
   return name
 }
 
+/**
+ * @param shim
+ * @param msgDesc
+ */
 function _nameMessageTransaction(shim, msgDesc) {
   let name = shim._metrics.LIBRARY + '/' + (msgDesc.destinationType || shim.EXCHANGE) + '/'
 

--- a/lib/shim/message-shim.js
+++ b/lib/shim/message-shim.js
@@ -440,10 +440,11 @@ function recordConsume(nodule, properties, spec) {
       // Call the method in the context of our segment.
       let ret = shim.applySegment(fn, segment, true, this, args)
 
-      if (ret && shim.isPromise(ret)) {
+      if (ret && msgDesc.promise && shim.isPromise(ret)) {
         ret = shim.bindPromise(ret, segment)
+
         // Intercept the promise to handle the result.
-        if (resHandler && msgDesc.promise) {
+        if (resHandler) {
           ret = ret.then(function interceptValue(res) {
             const msgProps = resHandler.call(this, shim, fn, fnName, res)
             if (getParams && msgProps && msgProps.parameters) {

--- a/lib/shim/message-shim.js
+++ b/lib/shim/message-shim.js
@@ -191,12 +191,10 @@ MessageShim.prototype.recordSubscribedConsume = recordSubscribedConsume
  * @property {string} [parameters.reply_to]
  *  In AMQP, this should be the name of the queue to reply to, if the message
  *  has one.
- *
  * @property {MessageHandlerFunction} [messageHandler]
  *  An optional function to extract message properties from a consumed message.
  *  This method is only used in the consume case to pull data from the
  *  retrieved message.
- *
  * @see RecorderSpec
  * @see MessageShim#recordProduce
  * @see MessageShim#recordConsume
@@ -362,6 +360,10 @@ function recordConsume(nodule, properties, spec) {
     spec = this.setDefaults(spec, DEFAULT_SPEC)
   }
 
+  // This is using wrap instead of record because the spec allows for a messageHandler
+  // which is being used to handle the result of the callback or promise of the
+  // original wrapped consume function.
+  // TODO: https://github.com/newrelic/node-newrelic/issues/981
   return this.wrap(nodule, properties, function wrapConsume(shim, fn, fnName) {
     if (!shim.isFunction(fn)) {
       shim.logger.debug('Not wrapping %s (%s) as consume', fn, fnName)
@@ -438,16 +440,18 @@ function recordConsume(nodule, properties, spec) {
       // Call the method in the context of our segment.
       let ret = shim.applySegment(fn, segment, true, this, args)
 
-      // Intercept the promise to handle the result.
-      if (resHandler && ret && msgDesc.promise && shim.isPromise(ret)) {
+      if (ret && shim.isPromise(ret)) {
         ret = shim.bindPromise(ret, segment)
-        ret = ret.then(function interceptValue(res) {
-          const msgProps = resHandler.call(this, shim, fn, fnName, res)
-          if (getParams && msgProps && msgProps.parameters) {
-            shim.copySegmentParameters(segment, msgProps.parameters)
-          }
-          return res
-        })
+        // Intercept the promise to handle the result.
+        if (resHandler && msgDesc.promise) {
+          ret = ret.then(function interceptValue(res) {
+            const msgProps = resHandler.call(this, shim, fn, fnName, res)
+            if (getParams && msgProps && msgProps.parameters) {
+              shim.copySegmentParameters(segment, msgProps.parameters)
+            }
+            return res
+          })
+        }
       }
 
       return ret

--- a/test/unit/shim/message-shim.test.js
+++ b/test/unit/shim/message-shim.test.js
@@ -544,10 +544,15 @@ tap.test('MessageShim', function (t) {
     t.test('should handle promise-based APIs', function (t) {
       const msg = {}
       let segment = null
+      const DELAY = 25
 
       function wrapMe() {
         segment = shim.getSegment()
-        return new Promise((resolve) => resolve(msg))
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(msg)
+          }, DELAY)
+        })
       }
 
       const wrapped = shim.recordConsume(wrapMe, {
@@ -561,6 +566,8 @@ tap.test('MessageShim', function (t) {
 
       return helper.runInTransaction(agent, function () {
         return wrapped('foo', function () {}).then(function (message) {
+          const duration = segment.getDurationInMillis()
+          t.ok(duration > DELAY - 1, 'segment duration should be at least 100 ms')
           t.equal(message, msg)
           const attributes = segment.getAttributes()
           t.equal(attributes.a, 'a')
@@ -972,6 +979,27 @@ tap.test('MessageShim', function (t) {
             t.notOk(tx.isActive())
             t.end()
           }, 5)
+        })
+      })
+    })
+
+    t.test('should properly time promise based consumers', function (t) {
+      messageHandler = function () {
+        return { promise: true }
+      }
+
+      let segment
+      const DELAY = 25
+      wrapped('my.queue', function consumer() {
+        return new Promise((resolve) => {
+          segment = shim.getSegment()
+          setTimeout(resolve, DELAY)
+        }).then(function () {
+          setImmediate(() => {
+            const duration = segment.getDurationInMillis()
+            t.ok(duration > DELAY - 1, 'promised based consumers should be timed properly')
+            t.end()
+          })
         })
       })
     })

--- a/test/unit/shim/message-shim.test.js
+++ b/test/unit/shim/message-shim.test.js
@@ -591,7 +591,8 @@ tap.test('MessageShim', function (t) {
       }
 
       const wrapped = shim.recordConsume(wrapMe, {
-        destinationName: shim.FIRST
+        destinationName: shim.FIRST,
+        promise: true
       })
 
       return helper.runInTransaction(agent, function () {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed issue where `recordConsume` was not binding consumer if it was a promise

## Links
Closes #977 

## Details
It looks like it cannot use the simple `shim.record` method as the spec contains different keys to handle in the consumer.  I also added a test to `recordConsume` which was failling before fix. 
