### PR TITLE
Adds a hook prior to module load for doing early-instrumentation

### DIFF
--- a/api.js
+++ b/api.js
@@ -55,7 +55,8 @@ const CUSTOM_EVENT_TYPE_REGEX = /^[a-zA-Z0-9:_ ]+$/
  * You do not need to directly instantiate this class, as an instance of this is
  * the return from `require('newrelic')`.
  *
- * @constructor
+ * @param agent
+ * @class
  */
 function API(agent) {
   this.agent = agent
@@ -139,6 +140,7 @@ API.prototype.getTransaction = function getTransaction() {
  *   utilization.full_hostname. If utilization.full_hostname is null or empty,
  *   this will be the hostname specified in the connect request as host.
  *
+ * @param omitSupportability
  * @returns {LinkingMetadata} The linking object with the data above
  */
 API.prototype.getLinkingMetadata = function getLinkingMetadata(omitSupportability) {
@@ -186,7 +188,6 @@ API.prototype.getLinkingMetadata = function getLinkingMetadata(omitSupportabilit
  *
  * @param {string} name The string you would like to report to New Relic
  *                      as the dispatcher.
- *
  * @param {string} [version] The dispatcher version you would like to
  *                           report to New Relic
  */
@@ -414,7 +415,6 @@ API.prototype.addCustomSpanAttribute = function addCustomSpanAttribute(key, valu
  *
  * @param {Error} error
  *  The error to be traced.
- *
  * @param {object} [customAttributes]
  *  Optional. Any custom attributes to be displayed in the New Relic UI.
  */
@@ -526,7 +526,7 @@ API.prototype.addIgnoringRule = function addIgnoringRule(pattern) {
  * Do *not* reuse the headers between users, or even between requests.
  *
  * @param {string} [options.nonce] - Nonce to inject into `<script>` header.
- *
+ * @param options
  * @returns {string} The `<script>` header to be injected.
  */
 API.prototype.getBrowserTimingHeader = function getBrowserTimingHeader(options) {
@@ -545,7 +545,7 @@ API.prototype.getBrowserTimingHeader = function getBrowserTimingHeader(options) 
    *
    * @param {number} num          - Error code from `RUM_ISSUES`.
    * @param {bool} [quite=false]  - Be quiet about this failure.
-   *
+   * @param quiet
    * @see RUM_ISSUES
    */
   function _gracefail(num, quiet) {
@@ -687,9 +687,9 @@ API.prototype.getBrowserTimingHeader = function getBrowserTimingHeader(options) 
 
 /**
  * @callback startSegmentCallback
- * @param {function} cb
+ * @param {Function} cb
  *   The function to time with the created segment.
- * @return {Promise=} Returns a promise if cb returns a promise.
+ * @returns {Promise=} Returns a promise if cb returns a promise.
  */
 
 /**
@@ -701,23 +701,18 @@ API.prototype.getBrowserTimingHeader = function getBrowserTimingHeader(options) 
  *    // The returned promise here will signify the end of the segment.
  *    return myAsyncTask().then(myNextTask)
  *  })
- *
  * @param {string} name
  *  The name to give the new segment. This will also be the name of the metric.
- *
  * @param {bool} record
  *  Indicates if the segment should be recorded as a metric. Metrics will show
  *  up on the transaction breakdown table and server breakdown graph. Segments
  *  just show up in transaction traces.
- *
  * @param {startSegmentCallback} handler
  *  The function to track as a segment.
- *
- * @param {function} [callback]
+ * @param {Function} [callback]
  *  An optional callback for the handler. This will indicate the end of the
  *  timing if provided.
- *
- * @return {*} Returns the result of calling `handler`.
+ * @returns {*} Returns the result of calling `handler`.
  */
 API.prototype.startSegment = function startSegment(name, record, handler, callback) {
   this.agent.metrics
@@ -775,11 +770,9 @@ API.prototype.startSegment = function startSegment(name, record, handler, callba
  *     transaction.end()
  *   }, 100)
  * })
- *
  * @param {string} url
  *  The URL of the transaction.  It is used to name and group related transactions in APM,
  *  so it should be a generic name and not iclude any variable parameters.
- *
  * @param {Function}  handle
  *  Function that represents the transaction work.
  */
@@ -862,20 +855,16 @@ API.prototype.startBackgroundTransaction = startBackgroundTransaction
  *     transaction.end()
  *   }, 100)
  * })
- *
  * @param {string} name
  *  The name of the transaction. It is used to name and group related
  *  transactions in APM, so it should be a generic name and not iclude any
  *  variable parameters.
- *
  * @param {string} [group]
  *  Optional, used for grouping background transactions in APM. For more
  *  information see:
  *  https://docs.newrelic.com/docs/apm/applications-menu/monitoring/transactions-page#txn-type-dropdown
- *
  * @param {Function} handle
  *  Function that represents the background work.
- *
  * @memberOf API#
  */
 function startBackgroundTransaction(name, group, handle) {
@@ -972,9 +961,9 @@ API.prototype.endTransaction = function endTransaction() {
  * Record a custom metric, usually associated with a particular duration.
  * The `name` must be a string following standard metric naming rules. The `value` will
  * usually be a number, but it can also be an object.
- *   * When `value` is a numeric value, it should represent the magnitude of a measurement
+ *   When `value` is a numeric value, it should represent the magnitude of a measurement
  *     associated with an event; for example, the duration for a particular method call.
- *   * When `value` is an object, it must contain count, total, min, max, and sumOfSquares
+ *   When `value` is an object, it must contain count, total, min, max, and sumOfSquares
  *     keys, all with number values. This form is useful to aggregate metrics on your own
  *     and report them periodically; for example, from a setInterval. These values will
  *     be aggregated with any previously collected values for the same metric. The names
@@ -1151,18 +1140,15 @@ API.prototype.recordCustomEvent = function recordCustomEvent(eventType, attribut
  *  - `newrelic.instrument(moduleName, onRequire [,onError])`
  *  - `newrelic.instrument(options)`
  *
- * @param {object} options
- *  The options for this custom instrumentation.
- *
- * @param {string} options.moduleName
- *  The module name given to require to load the module
- *
- * @param {function}  options.onRequire
- *  The function to call when the module is required
- *
- * @param {function} [options.onError]
- *  If provided, should `onRequire` throw an error, the error will be passed to
+ * @param {object} options The options for this custom instrumentation.
+ * @param {string} options.moduleName The module name given to require to load the module
+ * @param {Function}  options.onResolved The function to call when prior to module load after the filepath has been resolved
+ * @param {Function}  options.onRequire The function to call when the module has been loaded
+ * @param {Function} [options.onError] If provided, should `onRequire` throw an error, the error will be passed to
  *  this function.
+ * @param moduleName
+ * @param onRequire
+ * @param onError
  */
 API.prototype.instrument = function instrument(moduleName, onRequire, onError) {
   const metric = this.agent.metrics.getOrCreateMetric(NAMES.SUPPORTABILITY.API + '/instrument')
@@ -1187,18 +1173,15 @@ API.prototype.instrument = function instrument(moduleName, onRequire, onError) {
  * - `newrelic.instrumentConglomerate(moduleName, onRequire [, onError])`
  * - `newrelic.isntrumentConglomerate(options)`
  *
- * @param {object} options
- *  The options for this custom instrumentation.
- *
- * @param {string} options.moduleName
- *  The module name given to require to load the module
- *
- * @param {function} options.onRequire
- *  The function to call when the module is required
- *
- * @param {function} [options.onError]
- *  If provided, should `onRequire` throw an error, the error will be passed to
+ * @param {object} options The options for this custom instrumentation.
+ * @param {string} options.moduleName The module name given to require to load the module
+ * @param {Function}  options.onResolved The function to call when prior to module load after the filepath has been resolved
+ * @param {Function}  options.onRequire The function to call when the module has been loaded
+ * @param {Function} [options.onError] If provided, should `onRequire` throw an error, the error will be passed to
  *  this function.
+ * @param moduleName
+ * @param onRequire
+ * @param onError
  */
 API.prototype.instrumentConglomerate = function instrumentConglomerate(
   moduleName,
@@ -1224,18 +1207,15 @@ API.prototype.instrumentConglomerate = function instrumentConglomerate(
  *  - `newrelic.instrumentDatastore(moduleName, onRequire [,onError])`
  *  - `newrelic.instrumentDatastore(options)`
  *
- * @param {object} options
- *  The options for this custom instrumentation.
- *
- * @param {string} options.moduleName
- *  The module name given to require to load the module
- *
- * @param {function} options.onRequire
- *  The function to call when the module is required
- *
- * @param {function} [options.onError]
- *  If provided, should `onRequire` throw an error, the error will be passed to
+ * @param {object} options The options for this custom instrumentation.
+ * @param {string} options.moduleName The module name given to require to load the module
+ * @param {Function}  options.onResolved The function to call when prior to module load after the filepath has been resolved
+ * @param {Function}  options.onRequire The function to call when the module has been loaded
+ * @param {Function} [options.onError] If provided, should `onRequire` throw an error, the error will be passed to
  *  this function.
+ * @param moduleName
+ * @param onRequire
+ * @param onError
  */
 API.prototype.instrumentDatastore = function instrumentDatastore(moduleName, onRequire, onError) {
   const metric = this.agent.metrics.getOrCreateMetric(
@@ -1257,6 +1237,80 @@ API.prototype.instrumentDatastore = function instrumentDatastore(moduleName, onR
 }
 
 /**
+ * Registers an instrumentation function.
+ *
+ *  - `newrelic.instrumentWebframework(moduleName, onRequire [,onError])`
+ *  - `newrelic.instrumentWebframework(options)`
+ *
+ * @param {object} options The options for this custom instrumentation.
+ * @param {string} options.moduleName The module name given to require to load the module
+ * @param {Function}  options.onResolved The function to call when prior to module load after the filepath has been resolved
+ * @param {Function}  options.onRequire The function to call when the module has been loaded
+ * @param {Function} [options.onError] If provided, should `onRequire` throw an error, the error will be passed to
+ *  this function.
+ * @param moduleName
+ * @param onRequire
+ * @param onError
+ */
+API.prototype.instrumentWebframework = function instrumentWebframework(
+  moduleName,
+  onRequire,
+  onError
+) {
+  const metric = this.agent.metrics.getOrCreateMetric(
+    NAMES.SUPPORTABILITY.API + '/instrumentWebframework'
+  )
+  metric.incrementCallCount()
+
+  let opts = moduleName
+  if (typeof opts === 'string') {
+    opts = {
+      moduleName: moduleName,
+      onRequire: onRequire,
+      onError: onError
+    }
+  }
+
+  opts.type = MODULE_TYPE.WEB_FRAMEWORK
+  shimmer.registerInstrumentation(opts)
+}
+
+/**
+ * Registers an instrumentation function for instrumenting message brokers.
+ *
+ *  - `newrelic.instrumentMessages(moduleName, onRequire [,onError])`
+ *  - `newrelic.instrumentMessages(options)`
+ *
+ * @param {object} options The options for this custom instrumentation.
+ * @param {string} options.moduleName The module name given to require to load the module
+ * @param {Function}  options.onResolved The function to call when prior to module load after the filepath has been resolved
+ * @param {Function}  options.onRequire The function to call when the module has been loaded
+ * @param {Function} [options.onError] If provided, should `onRequire` throw an error, the error will be passed to
+ *  this function.
+ * @param moduleName
+ * @param onRequire
+ * @param onError
+ */
+API.prototype.instrumentMessages = function instrumentMessages(moduleName, onRequire, onError) {
+  const metric = this.agent.metrics.getOrCreateMetric(
+    NAMES.SUPPORTABILITY.API + '/instrumentMessages'
+  )
+  metric.incrementCallCount()
+
+  let opts = moduleName
+  if (typeof opts === 'string') {
+    opts = {
+      moduleName: moduleName,
+      onRequire: onRequire,
+      onError: onError
+    }
+  }
+
+  opts.type = MODULE_TYPE.MESSAGE
+  shimmer.registerInstrumentation(opts)
+}
+
+/**
  * Applies an instrumentation to an already loaded module.
  *
  *    // oh no, express was loaded before newrelic
@@ -1270,7 +1324,6 @@ API.prototype.instrumentDatastore = function instrumentDatastore(moduleName, onR
  * @param {string} moduleName
  *  The module's name/identifier.  Will be normalized
  *  into an instrumentation key.
- *
  * @param {object} module
  *  The actual module object or function we're instrumenting
  */
@@ -1305,88 +1358,8 @@ API.prototype.instrumentLoadedModule = function instrumentLoadedModule(moduleNam
 
     return true
   } catch (error) {
-    logger.error('instrumentLoadedModule encountered an error, module not instrumentend: %s', error)
+    logger.error('instrumentLoadedModule encountered an error, module not instrumented: %s', error)
   }
-}
-
-/**
- * Registers an instrumentation function.
- *
- *  - `newrelic.instrumentWebframework(moduleName, onRequire [,onError])`
- *  - `newrelic.instrumentWebframework(options)`
- *
- * @param {object} options
- *  The options for this custom instrumentation.
- *
- * @param {string} options.moduleName
- *  The module name given to require to load the module
- *
- * @param {function}  options.onRequire
- *  The function to call when the module is required
- *
- * @param {function} [options.onError]
- *  If provided, should `onRequire` throw an error, the error will be passed to
- *  this function.
- */
-API.prototype.instrumentWebframework = function instrumentWebframework(
-  moduleName,
-  onRequire,
-  onError
-) {
-  const metric = this.agent.metrics.getOrCreateMetric(
-    NAMES.SUPPORTABILITY.API + '/instrumentWebframework'
-  )
-  metric.incrementCallCount()
-
-  let opts = moduleName
-  if (typeof opts === 'string') {
-    opts = {
-      moduleName: moduleName,
-      onRequire: onRequire,
-      onError: onError
-    }
-  }
-
-  opts.type = MODULE_TYPE.WEB_FRAMEWORK
-  shimmer.registerInstrumentation(opts)
-}
-
-/**
- * Registers an instrumentation function for instrumenting message brokers.
- *
- *  - `newrelic.instrumentMessages(moduleName, onRequire [,onError])`
- *  - `newrelic.instrumentMessages(options)`
- *
- * @param {object} options
- *  The options for this custom instrumentation.
- *
- * @param {string} options.moduleName
- *  The module name given to require to load the module
- *
- * @param {function}  options.onRequire
- *  The function to call when the module is required
- *
- * @param {function} [options.onError]
- *  If provided, should `onRequire` throw an error, the error will be passed to
- *  this function.
- */
-API.prototype.instrumentMessages = function instrumentMessages(moduleName, onRequire, onError) {
-  const metric = this.agent.metrics.getOrCreateMetric(
-    NAMES.SUPPORTABILITY.API + '/instrumentMessages'
-  )
-  metric.incrementCallCount()
-
-  let opts = moduleName
-  if (typeof opts === 'string') {
-    opts = {
-      moduleName: moduleName,
-      onRequire: onRequire,
-      onError: onError
-    }
-  }
-
-  opts.type = MODULE_TYPE.MESSAGE
-  shimmer.registerInstrumentation(opts)
 }
 
 /**
@@ -1424,19 +1397,16 @@ API.prototype.getTraceMetadata = function getTraceMetadata() {
  *
  * @param {object} [options]
  *  Object with shut down options.
- *
  * @param {boolean} [options.collectPendingData=false]
  *  If true, the agent will send any pending data to the collector before
  *  shutting down.
- *
  * @param {number} [options.timeout=0]
  *  Time in milliseconds to wait before shutting down.
- *
  * @param {boolean} [options.waitForIdle=false]
  *  If true, the agent will not shut down until there are no active transactions.
- *
- * @param {function} [callback]
+ * @param {Function} [callback]
  *  Callback function that runs when agent stops.
+ * @param cb
  */
 API.prototype.shutdown = function shutdown(options, cb) {
   this.agent.metrics.getOrCreateMetric(`${NAMES.SUPPORTABILITY.API}/shutdown`).incrementCallCount()
@@ -1458,6 +1428,11 @@ API.prototype.shutdown = function shutdown(options, cb) {
   _doShutdown(this, options, callback)
 }
 
+/**
+ * @param api
+ * @param options
+ * @param callback
+ */
 function _doShutdown(api, options, callback) {
   const agent = api.agent
 
@@ -1473,6 +1448,9 @@ function _doShutdown(api, options, callback) {
     return
   }
 
+  /**
+   * @param error
+   */
   function afterHarvest(error) {
     if (error) {
       logger.error(error, 'An error occurred while running last harvest before shutdown.')
@@ -1506,6 +1484,10 @@ function _doShutdown(api, options, callback) {
   }
 }
 
+/**
+ * @param object
+ * @param maxLength
+ */
 function _checkKeyLength(object, maxLength) {
   const keys = Object.keys(object)
   let badKey = false
@@ -1534,6 +1516,10 @@ API.prototype.setLambdaHandler = function setLambdaHandler(handler) {
   return this.awsLambda.patchLambdaHandler(handler)
 }
 
+/**
+ * @param attributes
+ * @param name
+ */
 function _filterAttributes(attributes, name) {
   const filteredAttributes = Object.create(null)
   Object.keys(attributes).forEach((attributeKey) => {

--- a/api.js
+++ b/api.js
@@ -1142,7 +1142,7 @@ API.prototype.recordCustomEvent = function recordCustomEvent(eventType, attribut
  *
  * @param {object} options The options for this custom instrumentation.
  * @param {string} options.moduleName The module name given to require to load the module
- * @param {Function}  options.onResolved The function to call when prior to module load after the filepath has been resolved
+ * @param {Function}  options.onResolved The function to call prior to module load after the filepath has been resolved
  * @param {Function}  options.onRequire The function to call when the module has been loaded
  * @param {Function} [options.onError] If provided, should `onRequire` throw an error, the error will be passed to
  *  this function.
@@ -1175,7 +1175,7 @@ API.prototype.instrument = function instrument(moduleName, onRequire, onError) {
  *
  * @param {object} options The options for this custom instrumentation.
  * @param {string} options.moduleName The module name given to require to load the module
- * @param {Function}  options.onResolved The function to call when prior to module load after the filepath has been resolved
+ * @param {Function}  options.onResolved The function to call prior to module load after the filepath has been resolved
  * @param {Function}  options.onRequire The function to call when the module has been loaded
  * @param {Function} [options.onError] If provided, should `onRequire` throw an error, the error will be passed to
  *  this function.
@@ -1209,7 +1209,7 @@ API.prototype.instrumentConglomerate = function instrumentConglomerate(
  *
  * @param {object} options The options for this custom instrumentation.
  * @param {string} options.moduleName The module name given to require to load the module
- * @param {Function}  options.onResolved The function to call when prior to module load after the filepath has been resolved
+ * @param {Function}  options.onResolved The function to call prior to module load after the filepath has been resolved
  * @param {Function}  options.onRequire The function to call when the module has been loaded
  * @param {Function} [options.onError] If provided, should `onRequire` throw an error, the error will be passed to
  *  this function.
@@ -1244,7 +1244,7 @@ API.prototype.instrumentDatastore = function instrumentDatastore(moduleName, onR
  *
  * @param {object} options The options for this custom instrumentation.
  * @param {string} options.moduleName The module name given to require to load the module
- * @param {Function}  options.onResolved The function to call when prior to module load after the filepath has been resolved
+ * @param {Function}  options.onResolved The function to call prior to module load after the filepath has been resolved
  * @param {Function}  options.onRequire The function to call when the module has been loaded
  * @param {Function} [options.onError] If provided, should `onRequire` throw an error, the error will be passed to
  *  this function.
@@ -1283,7 +1283,7 @@ API.prototype.instrumentWebframework = function instrumentWebframework(
  *
  * @param {object} options The options for this custom instrumentation.
  * @param {string} options.moduleName The module name given to require to load the module
- * @param {Function}  options.onResolved The function to call when prior to module load after the filepath has been resolved
+ * @param {Function}  options.onResolved The function to call prior to module load after the filepath has been resolved
  * @param {Function}  options.onRequire The function to call when the module has been loaded
  * @param {Function} [options.onError] If provided, should `onRequire` throw an error, the error will be passed to
  *  this function.

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -90,9 +90,8 @@ const shimmer = (module.exports = {
   /**
    * Detects if the given function has already been wrapped.
    *
-   * @param {function} fn - The function to look for a wrapper on.
-   *
-   * @return {bool} True if `fn` exists and has an attached original, else false.
+   * @param {Function} fn - The function to look for a wrapper on.
+   * @returns {bool} True if `fn` exists and has an attached original, else false.
    */
   isWrapped: function isWrapped(fn) {
     return !!(fn && fn.__NR_original)
@@ -111,7 +110,7 @@ const shimmer = (module.exports = {
    *                            helpful than you'd think.
    * @param {string} methods One or more names of methods or functions to extract
    *                         and wrap.
-   * @param {function} wrapper A generator that, when called, returns a
+   * @param {Function} wrapper A generator that, when called, returns a
    *                           wrapped version of the original function.
    */
   wrapMethod: function wrapMethod(nodule, noduleName, methods, wrapper) {
@@ -177,8 +176,7 @@ const shimmer = (module.exports = {
    * @param {object}   noduleName Human-readable module / Class name. More
    *                              helpful than you'd think.
    * @param {string}   property   The property to replace with the accessor.
-   * @param {function} options    Optional getter and setter to use for the accessor.
-   *
+   * @param {Function} options    Optional getter and setter to use for the accessor.
    * @returns {object} The original value of the property.
    */
   wrapDeprecated: function wrapDeprecated(nodule, noduleName, property, options) {
@@ -275,6 +273,8 @@ const shimmer = (module.exports = {
   /**
    * Patch the module.load function so that we see modules loading and
    * have an opportunity to patch them with instrumentation.
+   *
+   * @param agent
    */
   patchModule: function patchModule(agent) {
     logger.trace('Wrapping module loader.')
@@ -306,6 +306,7 @@ const shimmer = (module.exports = {
      * their parent has already been loaded/cached by Node.
      * Provides a fall-back for unexpected cases that may occur.
      * Also provides flexibility for testing now that node 11+ caches these.
+     *
      * @param {*} request
      * @param {*} parent
      * @param {*} isMain
@@ -398,6 +399,10 @@ const shimmer = (module.exports = {
   },
 
   registerInstrumentation: function registerInstrumentation(opts) {
+    if (!hasValidRegisterOptions(opts)) {
+      return
+    }
+
     shimmer.registeredInstrumentations[opts.moduleName] = opts
   },
 
@@ -419,6 +424,9 @@ const shimmer = (module.exports = {
    * re-wrap them.
    *
    * Use this to re-apply any applicable instrumentation.
+   *
+   * @param agent
+   * @param modulePath
    */
   reinstrument: function reinstrument(agent, modulePath) {
     return _postLoad(agent, require(modulePath), modulePath)
@@ -428,6 +436,8 @@ const shimmer = (module.exports = {
    * Given a NodeJS module name, return the name/identifier of our
    * instrumentation.  These two things are usually, but not always,
    * the same.
+   *
+   * @param moduleName
    */
   getInstrumentationNameFromModuleName(moduleName) {
     let instrumentation
@@ -467,8 +477,13 @@ function applyDebugState(shim, nodule) {
  * All instrumentation files must export the same interface: a single
  * initialization function that takes the agent and the module to be
  * instrumented.
+ *
+ * @param agent
+ * @param nodule
+ * @param moduleName
+ * @param resolvedName
  */
-function instrument(agent, nodule, moduleName, resolvedName) {
+function instrumentPostLoad(agent, nodule, moduleName, resolvedName) {
   const instrumentation = shimmer.registeredInstrumentations[moduleName]
   if (
     properties.hasOwn(nodule, '__NR_instrumented') ||
@@ -536,11 +551,38 @@ function _firstPartyInstrumentation(agent, fileName, shim, nodule, moduleName) {
 function _postLoad(agent, nodule, name, resolvedName) {
   const instrumentation = shimmer.getInstrumentationNameFromModuleName(name)
 
+  const registeredInstrumentation = shimmer.registeredInstrumentations[instrumentation]
+  const hasPostLoadInstrumentation =
+    registeredInstrumentation && registeredInstrumentation.onRequire
+
   // Check if this is a known instrumentation and then run it.
-  if (shimmer.registeredInstrumentations[instrumentation]) {
+  if (hasPostLoadInstrumentation) {
     logger.trace('Instrumenting %s.', name)
-    return instrument(agent, nodule, instrumentation, resolvedName)
+    return instrumentPostLoad(agent, nodule, instrumentation, resolvedName)
   }
 
   return nodule
+}
+
+function hasValidRegisterOptions(opts) {
+  if (!opts) {
+    logger.warn('Instrumentation registration failed, no options provided')
+    return false
+  }
+
+  if (!opts.moduleName) {
+    logger.warn(`Instrumentation registration failed, 'moduleName' not provided`)
+    return false
+  }
+
+  if (!opts.onRequire) {
+    logger.warn(
+      'Instrumentation registration for %s failed, no require hooks provided.',
+      opts.moduleName
+    )
+
+    return false
+  }
+
+  return true
 }

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -571,11 +571,11 @@ function _onResolveFileName(agent, requiredNameOrPath, resolvedFilepath) {
   const instrumentation = shimmer.getInstrumentationNameFromModuleName(requiredNameOrPath)
 
   const registeredInstrumentation = shimmer.registeredInstrumentations[instrumentation]
-  const hasPostLoadInstrumentation =
+  const hasResolvedFileInstrumentation =
     registeredInstrumentation && registeredInstrumentation.onResolved
 
   // Check if this is a known instrumentation and then run it.
-  if (hasPostLoadInstrumentation) {
+  if (hasResolvedFileInstrumentation) {
     logger.trace('Instrumenting %s with onResolved hook.', requiredNameOrPath)
     _instrumentOnResolved(agent, instrumentation, resolvedFilepath)
   }

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -287,6 +287,9 @@ const shimmer = (module.exports = {
         // we can examine it after the load call has returned.
         const resolvedFilepath = resolve.apply(this, arguments)
         filepathMap[file] = resolvedFilepath
+
+        _onResolveFileName(agent, file, resolvedFilepath)
+
         return resolvedFilepath
       }
     })
@@ -557,11 +560,66 @@ function _postLoad(agent, nodule, name, resolvedName) {
 
   // Check if this is a known instrumentation and then run it.
   if (hasPostLoadInstrumentation) {
-    logger.trace('Instrumenting %s.', name)
+    logger.trace('Instrumenting %s with onRequire (module loaded) hook.', name)
     return instrumentPostLoad(agent, nodule, instrumentation, resolvedName)
   }
 
   return nodule
+}
+
+function _onResolveFileName(agent, requiredNameOrPath, resolvedFilepath) {
+  const instrumentation = shimmer.getInstrumentationNameFromModuleName(requiredNameOrPath)
+
+  const registeredInstrumentation = shimmer.registeredInstrumentations[instrumentation]
+  const hasPostLoadInstrumentation =
+    registeredInstrumentation && registeredInstrumentation.onResolved
+
+  // Check if this is a known instrumentation and then run it.
+  if (hasPostLoadInstrumentation) {
+    logger.trace('Instrumenting %s with onResolved hook.', requiredNameOrPath)
+    _instrumentOnResolved(agent, instrumentation, resolvedFilepath)
+  }
+}
+
+/**
+ * Invokes the onResolved handler with a shim instance.
+ *
+ * Given Node.js caches resolvedFilePaths in versions we support and we cache as well
+ * for the cases we force resolution, we should not run into the case of multiple
+ * invocations for the same module. As such, this function does not defend against multiple runs.
+ *
+ * @param agent
+ * @param moduleName
+ * @param resolvedFilepath
+ */
+function _instrumentOnResolved(agent, moduleName, resolvedFilepath) {
+  const instrumentation = shimmer.registeredInstrumentations[moduleName]
+
+  const shim = shims.createShimFromType(instrumentation.type, agent, moduleName, resolvedFilepath)
+
+  try {
+    instrumentation.onResolved(shim, moduleName, resolvedFilepath)
+  } catch (instrumentationError) {
+    if (instrumentation.onError) {
+      try {
+        instrumentation.onError(instrumentationError)
+      } catch (error) {
+        logger.warn(
+          error,
+          instrumentationError,
+          'OnResolved instrumentation for %s failed, then the onError handler threw an error',
+          moduleName
+        )
+      }
+    } else {
+      logger.warn(
+        instrumentationError,
+        'OnResolved instrumentation for %s failed. Please report this to the ' +
+          'maintainers of the custom instrumentation.',
+        moduleName
+      )
+    }
+  }
 }
 
 function hasValidRegisterOptions(opts) {
@@ -575,7 +633,7 @@ function hasValidRegisterOptions(opts) {
     return false
   }
 
-  if (!opts.onRequire) {
+  if (!opts.onRequire && !opts.onResolved) {
     logger.warn(
       'Instrumentation registration for %s failed, no require hooks provided.',
       opts.moduleName

--- a/test/integration/module-loading/module-loading.tap.js
+++ b/test/integration/module-loading/module-loading.tap.js
@@ -24,7 +24,8 @@ tap.test('Should properly track module paths to enable shim.require()', function
   })
 
   shimmer.registerInstrumentation({
-    moduleName: customPackagePath
+    moduleName: customPackagePath,
+    onRequire: () => {}
   })
 
   // As of node 11, this path is being cached, and will not hit our resolve hooks for
@@ -49,7 +50,8 @@ tap.test('shim.require() should play well with multiple test runs', (t) => {
   let agent = helper.instrumentMockedAgent()
 
   shimmer.registerInstrumentation({
-    moduleName: customPackagePath
+    moduleName: customPackagePath,
+    onRequire: () => {}
   })
 
   t.teardown(() => {

--- a/test/lib/agent_helper.js
+++ b/test/lib/agent_helper.js
@@ -158,6 +158,7 @@ const helper = (module.exports = {
     agent.emit('unload')
     shimmer.unpatchModule()
     shimmer.unwrapAll()
+    shimmer.registeredInstrumentations = Object.create(null)
     shimmer.debug = false
 
     // On all versions each agent will add an unhandledRejection handler. This

--- a/test/unit/shimmer.test.js
+++ b/test/unit/shimmer.test.js
@@ -619,7 +619,7 @@ tap.test('Should not crash on empty instrumentation registration', (t) => {
     helper.unloadAgent(agent)
   })
 
-  shimmer.registerInstrumentation()
+  t.doesNotThrow(shimmer.registerInstrumentation)
 
   t.end()
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Added `onResolved` instrumentation hook to apply instrumentation prior to module load.

  This hook fires after the module filepath has been resolved just prior to the module being loaded by the CommonJS module loader.

## Links

* Closes: https://github.com/newrelic/node-newrelic/issues/978

## Details

Flagging high-risk as if anything breaks in module loading everything breaks for a customer.

onResolved instrumentation accepts the following arguments: `(shim, moduleName, resolvedFilepath)`.

Due to both Node.js filepath caching (and our own) this instrumentation does not have special protections against multiple runs. If for some reason this changes in the future (or there is an unknown case where multiple runs could occur), I might recommend augmenting the onResolved handler itself since there's no module available to be able to check against for success/error already incurred.

Recommend we consider introducing an onLoaded hook to replace onRequire for clarity of when the handler will be invoked. Renaming onRequire woudl be a breaking change but we could migrate all of our stuff and eventually rip out. although, I might just leave in there for a while.

Not touching signature of `API.instrument*` methods. These have the ability to pass in options so figure will avoid lumping another param on at least while we are getting a real usage exercised for this. Lumping at the end eventually (if we do) will make the param order a little awkward but changing would be a breaking change. We could consider never updating as the current params are the golden path and the options object style is available for advanced usage. :shrug:

Also worth noting this implementation creates a shim instance per hook you provide. A potential enhancement would be able to allow a shim instance to be used for both hooks.