### PR TITLE
Removes tracer.segment

### DIFF
--- a/lib/transaction/tracer/index.js
+++ b/lib/transaction/tracer/index.js
@@ -45,16 +45,6 @@ Tracer.prototype.wrapFunctionFirst = wrapFunctionFirst
 Tracer.prototype.wrapSyncFunction = wrapSyncFunction
 Tracer.prototype.wrapCallback = wrapCallback
 
-Object.defineProperty(Tracer.prototype, 'segment', {
-  get: function segmentGetter() {
-    return this._contextManager.getContext()
-  },
-  set: function segmentSetter(segment) {
-    this._contextManager.setContext(segment)
-    return segment
-  }
-})
-
 function getTransaction() {
   const currentSegment = this._contextManager.getContext()
   if (currentSegment && currentSegment.transaction && currentSegment.transaction.isActive()) {
@@ -69,6 +59,7 @@ function getSegment() {
   return this._contextManager.getContext()
 }
 
+// TODO: Remove/replace external uses to tracer.getSpanContext()
 function getSpanContext() {
   const currentSegment = this.getSegment()
   return currentSegment && currentSegment.getSpanContext()

--- a/test/benchmark/shim/record.bench.js
+++ b/test/benchmark/shim/record.bench.js
@@ -10,6 +10,8 @@ const helper = require('../../lib/agent_helper')
 const Shim = require('../../../lib/shim/shim')
 
 const agent = helper.loadMockedAgent()
+const contextManager = helper.getContextManager()
+
 const shim = new Shim(agent, 'test-module', './')
 const suite = benchmark.createBenchmark({ name: 'Shim#record' })
 
@@ -38,7 +40,7 @@ const wrapped = shim.record(getTest(), 'func', function () {
 suite.add({
   name: 'wrapper - no transaction',
   fn: function () {
-    agent.tracer.segment = null
+    contextManager.setContext(null)
     wrapped.func(noop)
   }
 })
@@ -46,7 +48,7 @@ suite.add({
 suite.add({
   name: 'wrapper - in transaction',
   fn: function () {
-    agent.tracer.segment = transaction.trace.root
+    contextManager.setContext(transaction.trace.root)
     wrapped.func(noop)
   }
 })

--- a/test/benchmark/tracer/bindFunction.bench.js
+++ b/test/benchmark/tracer/bindFunction.bench.js
@@ -11,10 +11,11 @@ const shared = require('./shared')
 const s = shared.makeSuite()
 const suite = s.suite
 const tracer = s.agent.tracer
+const contextManager = helper.getContextManager()
 const tx = helper.runInTransaction(s.agent, function (_tx) {
   return _tx
 })
-tracer.segment = tx.root
+contextManager.setContext(tx.root)
 
 preOptBind()
 const bound = tracer.bindFunction(shared.getTest().func, tx.root, true)

--- a/test/benchmark/tracer/segments.bench.js
+++ b/test/benchmark/tracer/segments.bench.js
@@ -11,11 +11,13 @@ const shared = require('./shared')
 const s = shared.makeSuite('Tracer segments')
 const suite = s.suite
 const tracer = s.agent.tracer
+const contextManager = helper.getContextManager()
+
 const tx = helper.runInTransaction(s.agent, function (_tx) {
   return _tx
 })
 const bound = tracer.bindFunction(shared.getTest(), tx.root, true)
-tracer.segment = tx.root
+contextManager.setContext(tx.root)
 
 suite.add({
   name: 'tracer.getSegment',
@@ -27,7 +29,7 @@ suite.add({
 suite.add({
   name: 'tracer.createSegment',
   fn: function () {
-    tracer.segment = tracer.createSegment('test', null, null)
+    return tracer.createSegment('test', null, null)
   }
 })
 

--- a/test/benchmark/tracer/transaction.bench.js
+++ b/test/benchmark/tracer/transaction.bench.js
@@ -11,10 +11,13 @@ const shared = require('./shared')
 const s = shared.makeSuite('Tracer transactions')
 const suite = s.suite
 const tracer = s.agent.tracer
+
+const contextManager = helper.getContextManager()
 const tx = helper.runInTransaction(s.agent, function (_tx) {
   return _tx
 })
-tracer.segment = tx.root
+
+contextManager.setContext(tx.root)
 
 suite.add({
   name: 'tracer.getTransaction',

--- a/test/benchmark/tracer/utilities.bench.js
+++ b/test/benchmark/tracer/utilities.bench.js
@@ -11,10 +11,13 @@ const helper = require('../../lib/agent_helper')
 const s = shared.makeSuite('Tracer utilities')
 const suite = s.suite
 const tracer = s.agent.tracer
+const contextManager = helper.getContextManager()
+
 const tx = helper.runInTransaction(s.agent, function (_tx) {
   return _tx
 })
-tracer.segment = tx.root
+
+contextManager.setContext(tx.root)
 
 suite.add({
   name: 'tracer.slice',

--- a/test/benchmark/webframework-shim/recordMiddleware.bench.js
+++ b/test/benchmark/webframework-shim/recordMiddleware.bench.js
@@ -10,6 +10,7 @@ const helper = require('../../lib/agent_helper')
 const WebFrameworkShim = require('../../../lib/shim/webframework-shim')
 
 const agent = helper.loadMockedAgent()
+const contextManager = helper.getContextManager()
 const shim = new WebFrameworkShim(agent, 'test-module', './')
 const suite = benchmark.createBenchmark({ name: 'recordMiddleware' })
 
@@ -56,7 +57,7 @@ function addTests(name, speccer) {
   suite.add({
     name: name + ' - wrapper (no tx)    ',
     fn: function () {
-      agent.tracer.segment = null
+      contextManager.setContext(null)
       middleware(getReqd(), {}, noop)
     }
   })
@@ -64,7 +65,7 @@ function addTests(name, speccer) {
   suite.add({
     name: name + ' - wrapper (tx)       ',
     fn: function () {
-      agent.tracer.segment = transaction.trace.root
+      contextManager.setContext(transaction.trace.root)
       middleware(getReqd(), {}, noop)
     }
   })

--- a/test/integration/instrumentation/promises/methods.js
+++ b/test/integration/instrumentation/promises/methods.js
@@ -101,18 +101,19 @@ module.exports = function (t, library, loadLibrary) {
 
     t.test('usage', function (t) {
       testPromiseClassMethod(t, 3, function resolveTest(Promise, name) {
-        const tracer = helper.getAgent().tracer
-        const inTx = !!tracer.segment
+        const contextManager = helper.getContextManager()
+        const inTx = !!contextManager.getContext()
+
         return new Promise(function (resolve) {
           addTask(function () {
-            t.notOk(tracer.segment, name + 'should lose tx')
+            t.notOk(contextManager.getContext(), name + 'should lose tx')
             resolve('foobar ' + name)
           })
         }).then(function (res) {
           if (inTx) {
-            t.ok(tracer.segment, name + 'should return tx')
+            t.ok(contextManager.getContext(), name + 'should return tx')
           } else {
-            t.notOk(tracer.segment, name + 'should not create tx')
+            t.notOk(contextManager.getContext(), name + 'should not create tx')
           }
           t.equal(res, 'foobar ' + name, name + 'should resolve with correct value')
         })

--- a/test/lib/agent_helper.js
+++ b/test/lib/agent_helper.js
@@ -37,6 +37,7 @@ const helper = (module.exports = {
   SSL_HOST: 'localhost',
   outOfContextQueueInterval,
   getAgent: () => _agent,
+  getContextManager: () => _agent && _agent._contextManager,
 
   /**
    * Set up an agent that won't try to connect to the collector, but also

--- a/test/unit/api/api-start-background-transaction.test.js
+++ b/test/unit/api/api-start-background-transaction.test.js
@@ -13,16 +13,19 @@ tap.test('Agent API - startBackgroundTransaction', (t) => {
   t.autoend()
 
   let agent = null
+  let contextManager = null
   let api = null
 
   t.beforeEach(() => {
     agent = helper.loadMockedAgent()
+    contextManager = helper.getContextManager()
     api = new API(agent)
   })
 
   t.afterEach(() => {
     helper.unloadAgent(agent)
     agent = null
+    contextManager = null
   })
 
   t.test('should not throw when transaction cannot be created', (t) => {
@@ -46,7 +49,9 @@ tap.test('Agent API - startBackgroundTransaction', (t) => {
       t.equal(transaction.getFullName(), 'OtherTransaction/Nodejs/test')
       t.ok(transaction.isActive())
 
-      t.equal(agent.tracer.segment.children[0].name, 'Nodejs/nested')
+      const currentSegment = contextManager.getContext()
+      const nestedSegment = currentSegment.children[0]
+      t.equal(nestedSegment.name, 'Nodejs/nested')
     })
 
     function nested() {

--- a/test/unit/api/api-start-web-transaction.test.js
+++ b/test/unit/api/api-start-web-transaction.test.js
@@ -13,16 +13,19 @@ tap.test('Agent API - startWebTransaction', (t) => {
   t.autoend()
 
   let agent = null
+  let contextManager = null
   let api = null
 
   t.beforeEach(() => {
     agent = helper.loadMockedAgent()
+    contextManager = helper.getContextManager()
     api = new API(agent)
   })
 
   t.afterEach(() => {
     helper.unloadAgent(agent)
     agent = null
+    contextManager = null
   })
 
   t.test('should not throw when transaction cannot be created', (t) => {
@@ -44,7 +47,10 @@ tap.test('Agent API - startWebTransaction', (t) => {
       t.equal(transaction.type, 'web')
       t.equal(transaction.getFullName(), 'WebTransaction/Custom//test')
       t.ok(transaction.isActive())
-      t.equal(agent.tracer.segment.children[0].name, 'nested')
+
+      const currentSegment = contextManager.getContext()
+      const nestedSegment = currentSegment.children[0]
+      t.equal(nestedSegment.name, 'nested')
     })
 
     function nested() {

--- a/test/unit/instrumentation/core/promises.test.js
+++ b/test/unit/instrumentation/core/promises.test.js
@@ -303,8 +303,9 @@ function step(n, rejection) {
   }
 }
 
-function name(n) {
-  helper.getAgent().tracer.segment.name = n
+function name(newName) {
+  const segment = helper.getContextManager().getContext()
+  segment.name = newName
 }
 
 function checkTrace(t, tx, expected) {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Removed `tracer.segment` in place of direct usage of context manager.

## Links

## Details

Patch release as this is internal API (even though some usages of tracer have unfortunately bled outside the core agent).

Only test code was still using `tracer.segment`. I did not find any usages in external modules.

I cleaned up some usage of `tracer.getSegment()` in the test files touched but did not attempt a full cleanup. That can be a follow-up.

`getContextManager()` was added to the agent helper to try to avoid grabbing directly off the agent all over the place. It does currently soft-rely on the agent being loaded first which is brittle. I think ideally we'd have helper APIs that generally returned both but we can see how things evolve. I'll also need to add this to the external test helper. At some point, I'd love for those to not be separate. It would be ideal for the agent and external modules to use the same test helpers so we know everything is consistent in what is possible and what is executed for tests. Probably would be best if the agent either exported its own for the external modules to use or the helper was a separate module in the same repo so the updates can be made with the agent. Right now, it would be quite painful at times (chicken or egg problem) to have the agent use the helper directly from the test utils.

I went ahead and updated the defunct bench files so they stay in relatively up-to-date form as examples, should we tackle getting something similar in place to replace them.