### PR TITLE
Moves methods.js under bluebird versioned test folder.

### DIFF
--- a/test/versioned/bluebird/methods.js
+++ b/test/versioned/bluebird/methods.js
@@ -5,12 +5,8 @@
 
 'use strict'
 
-// TODO: seems like this may only be ran by the bluebird versioned test methods.tap.js
-// Confirm and move logic there, if true. If used by multiple but only versioned,
-// move under versioned folder.
-
-const helper = require('../../../lib/agent_helper')
-const testTransactionState = require('./transaction-state')
+const helper = require('../../lib/agent_helper')
+const testTransactionState = require('../../integration/instrumentation/promises/transaction-state')
 const util = require('util')
 
 const runMultiple = testTransactionState.runMultiple

--- a/test/versioned/bluebird/methods.tap.js
+++ b/test/versioned/bluebird/methods.tap.js
@@ -5,10 +5,8 @@
 
 'use strict'
 
-const testsDir = '../../integration/instrumentation/promises'
-
 const tap = require('tap')
-const testMethods = require(testsDir + '/methods')
+const testMethods = require('./methods')
 
 tap.test('bluebird', function (t) {
   t.autoend()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Moved `methods.js` under bluebird versioned test folder.

## Links

## Details

Our BlueBird versioned tests were the only current usage of `methods.js`.  Moved under that folder to make the relationship clear. The methods file does leverage a file still from the integration tests but that is also used for when, so I left all of that as-is. This has come up a couple times so getting moved for clarity.  Extracting into the `methods.tap.js` didn't seem worth the effort at this point.