### PR TITLE
Adds metrics for tracking when instrumentation is applied 

### DIFF
--- a/lib/metrics/names.js
+++ b/lib/metrics/names.js
@@ -252,7 +252,11 @@ const INFINITE_TRACING = {
 }
 
 const FEATURES = {
-  CERTIFICATES: SUPPORTABILITY.FEATURES + '/Certificates'
+  CERTIFICATES: SUPPORTABILITY.FEATURES + '/Certificates',
+  INSTRUMENTATION: {
+    ON_RESOLVED: SUPPORTABILITY.FEATURES + '/Instrumentation/OnResolved',
+    ON_REQUIRE: SUPPORTABILITY.FEATURES + '/Instrumentation/OnRequire'
+  }
 }
 
 module.exports = {

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -655,6 +655,16 @@ function hasValidRegisterOptions(opts) {
   return true
 }
 
+/**
+ * Adds metrics to indicate instrumentation was used for a particular module and
+ * what major version the module was at, if possible.
+ *
+ * @param {*} agent The agent instance.
+ * @param {*} shim The instance of the shim used to instrument the module.
+ * @param {string} moduleName The name of the required module.
+ * @param {string} metricPrefix Support metric prefix to prepend to the metrics. Will indicate onRequire or onResolved
+ * from NAMES.FEATURES.INSTRUMENTATION.
+ */
 function trackInstrumentationUsage(agent, shim, moduleName, metricPrefix) {
   try {
     const version = tryGetVersion(shim)

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -6,11 +6,14 @@
 'use strict'
 
 const path = require('path')
+const semver = require('semver')
 const fs = require('./util/unwrapped-core').fs
 const logger = require('./logger').child({ component: 'shimmer' })
 const INSTRUMENTATIONS = require('./instrumentations')()
 const properties = require('./util/properties')
 const shims = require('./shim')
+
+const NAMES = require('./metrics/names')
 
 const MODULE_TYPE = shims.constants.MODULE_TYPE
 
@@ -506,6 +509,7 @@ function instrumentPostLoad(agent, nodule, moduleName, resolvedName) {
   const shim = shims.createShimFromType(instrumentation.type, agent, moduleName, resolvedName)
 
   applyDebugState(shim, nodule)
+  trackInstrumentationUsage(agent, shim, moduleName, NAMES.FEATURES.INSTRUMENTATION.ON_REQUIRE)
 
   try {
     if (instrumentation.onRequire(shim, nodule, moduleName) !== false) {
@@ -601,6 +605,8 @@ function _instrumentOnResolved(agent, moduleName, resolvedFilepath) {
 
   const shim = shims.createShimFromType(instrumentation.type, agent, moduleName, resolvedFilepath)
 
+  trackInstrumentationUsage(agent, shim, moduleName, NAMES.FEATURES.INSTRUMENTATION.ON_RESOLVED)
+
   try {
     instrumentation.onResolved(shim, moduleName, resolvedFilepath)
   } catch (instrumentationError) {
@@ -647,4 +653,36 @@ function hasValidRegisterOptions(opts) {
   }
 
   return true
+}
+
+function trackInstrumentationUsage(agent, shim, moduleName, metricPrefix) {
+  try {
+    const version = tryGetVersion(shim)
+    const instrumentationMetricName = `${metricPrefix}/${moduleName}`
+
+    agent.metrics.getOrCreateMetric(instrumentationMetricName).incrementCallCount()
+
+    if (version) {
+      const majorVersion = semver.major(version)
+      const versionMetricName = `${instrumentationMetricName}/Version/${majorVersion}`
+
+      agent.metrics.getOrCreateMetric(versionMetricName).incrementCallCount()
+    }
+  } catch (error) {
+    logger.debug('Unable to track instrumentation usage for: ', moduleName, error)
+  }
+}
+
+function tryGetVersion(shim) {
+  // Global module (i.e. domain) or finding root failed
+  if (shim._moduleRoot === '.') {
+    return
+  }
+
+  const packageInfo = shim.require('./package.json')
+  if (!packageInfo) {
+    return
+  }
+
+  return packageInfo.version
 }

--- a/test/integration/module-loading/module-loading.tap.js
+++ b/test/integration/module-loading/module-loading.tap.js
@@ -11,7 +11,11 @@ const path = require('path')
 const helper = require('../../lib/agent_helper')
 const shimmer = require('../../../lib/shimmer')
 
-const customPackagePath = './node_modules/customTestPackage'
+const CUSTOM_MODULE_PATH = './node_modules/customTestPackage'
+const EXPECTED_RESOLVED_METRIC_NAME =
+  'Supportability/Features/Instrumentation/OnResolved/./node_modules/customTestPackage'
+const EXPECTED_REQUIRE_METRIC_NAME =
+  'Supportability/Features/Instrumentation/OnRequire/./node_modules/customTestPackage'
 
 tap.test('Should properly track module paths to enable shim.require()', function (t) {
   t.autoend()
@@ -24,19 +28,19 @@ tap.test('Should properly track module paths to enable shim.require()', function
   })
 
   shimmer.registerInstrumentation({
-    moduleName: customPackagePath,
+    moduleName: CUSTOM_MODULE_PATH,
     onRequire: () => {}
   })
 
   // As of node 11, this path is being cached, and will not hit our resolve hooks for
   // subsequent calls.  This extra require call ensures we cover the cached case.
-  require(customPackagePath)
-  const mycustomPackage = require(customPackagePath)
+  require(CUSTOM_MODULE_PATH)
+  const mycustomPackage = require(CUSTOM_MODULE_PATH)
 
   const shim = mycustomPackage.__NR_shim
   const moduleRoot = shim._moduleRoot
 
-  const resolvedPackagePath = path.resolve(__dirname, customPackagePath)
+  const resolvedPackagePath = path.resolve(__dirname, CUSTOM_MODULE_PATH)
   t.equal(moduleRoot, resolvedPackagePath)
 
   const shimLoadedCustom = shim.require('custom')
@@ -50,7 +54,7 @@ tap.test('shim.require() should play well with multiple test runs', (t) => {
   let agent = helper.instrumentMockedAgent()
 
   shimmer.registerInstrumentation({
-    moduleName: customPackagePath,
+    moduleName: CUSTOM_MODULE_PATH,
     onRequire: () => {}
   })
 
@@ -59,13 +63,13 @@ tap.test('shim.require() should play well with multiple test runs', (t) => {
     agent = null
   })
 
-  require(customPackagePath)
-  const mycustomPackage = require(customPackagePath)
+  require(CUSTOM_MODULE_PATH)
+  const mycustomPackage = require(CUSTOM_MODULE_PATH)
 
   const shim = mycustomPackage.__NR_shim
   const moduleRoot = shim._moduleRoot
 
-  const resolvedPackagePath = path.resolve(__dirname, customPackagePath)
+  const resolvedPackagePath = path.resolve(__dirname, CUSTOM_MODULE_PATH)
   t.equal(moduleRoot, resolvedPackagePath)
 
   const shimLoadedCustom = shim.require('custom')
@@ -75,14 +79,118 @@ tap.test('shim.require() should play well with multiple test runs', (t) => {
   t.end()
 })
 
+tap.test('Should create usage metric onResolved', (t) => {
+  let agent = helper.instrumentMockedAgent()
+
+  t.teardown(() => {
+    helper.unloadAgent(agent)
+    agent = null
+  })
+
+  shimmer.registerInstrumentation({
+    moduleName: CUSTOM_MODULE_PATH,
+    onResolved: onResolvedHandler
+  })
+
+  require(CUSTOM_MODULE_PATH)
+
+  function onResolvedHandler() {
+    const onResolvedMetric = agent.metrics._metrics.unscoped[EXPECTED_RESOLVED_METRIC_NAME]
+
+    t.ok(onResolvedMetric)
+    t.equal(onResolvedMetric.callCount, 1)
+
+    t.end()
+  }
+})
+
+tap.test('Should create usage version metric onResolved', (t) => {
+  let agent = helper.instrumentMockedAgent()
+
+  t.teardown(() => {
+    helper.unloadAgent(agent)
+    agent = null
+  })
+
+  shimmer.registerInstrumentation({
+    moduleName: CUSTOM_MODULE_PATH,
+    onResolved: onResolvedHandler
+  })
+
+  require(CUSTOM_MODULE_PATH)
+
+  function onResolvedHandler() {
+    const expectedVersionMetricName = `${EXPECTED_RESOLVED_METRIC_NAME}/Version/3`
+
+    const onResolvedMetric = agent.metrics._metrics.unscoped[expectedVersionMetricName]
+
+    t.ok(onResolvedMetric)
+    t.equal(onResolvedMetric.callCount, 1)
+
+    t.end()
+  }
+})
+
+tap.test('Should create usage metric onRequire', (t) => {
+  let agent = helper.instrumentMockedAgent()
+
+  t.teardown(() => {
+    helper.unloadAgent(agent)
+    agent = null
+  })
+
+  shimmer.registerInstrumentation({
+    moduleName: CUSTOM_MODULE_PATH,
+    onRequire: onRequireHandler
+  })
+
+  require(CUSTOM_MODULE_PATH)
+
+  function onRequireHandler() {
+    const onRequireMetric = agent.metrics._metrics.unscoped[EXPECTED_REQUIRE_METRIC_NAME]
+
+    t.ok(onRequireMetric)
+    t.equal(onRequireMetric.callCount, 1)
+
+    t.end()
+  }
+})
+
+tap.test('Should create usage version metric onRequire', (t) => {
+  let agent = helper.instrumentMockedAgent()
+
+  t.teardown(() => {
+    helper.unloadAgent(agent)
+    agent = null
+  })
+
+  shimmer.registerInstrumentation({
+    moduleName: CUSTOM_MODULE_PATH,
+    onRequire: onRequireHandler
+  })
+
+  require(CUSTOM_MODULE_PATH)
+
+  function onRequireHandler() {
+    const expectedVersionMetricName = `${EXPECTED_REQUIRE_METRIC_NAME}/Version/3`
+
+    const onRequireMetric = agent.metrics._metrics.unscoped[expectedVersionMetricName]
+
+    t.ok(onRequireMetric)
+    t.equal(onRequireMetric.callCount, 1)
+
+    t.end()
+  }
+})
+
 function simulateTestLoadAndUnload() {
   const agent = helper.instrumentMockedAgent()
 
   shimmer.registerInstrumentation({
-    moduleName: customPackagePath
+    moduleName: CUSTOM_MODULE_PATH
   })
 
-  require(customPackagePath)
+  require(CUSTOM_MODULE_PATH)
 
   helper.unloadAgent(agent)
 }

--- a/test/integration/module-loading/node_modules/customTestPackage/package.json
+++ b/test/integration/module-loading/node_modules/customTestPackage/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "customTestPackage",
+  "version": "3.0.0",
+  "main": "index.js",
+  "engines": {
+    "node": ">=12"
+  }
+}

--- a/test/versioned/express/ignoring.tap.js
+++ b/test/versioned/express/ignoring.tap.js
@@ -38,7 +38,7 @@ test('ignoring an Express route', function (t) {
     t.notOk(agent.traces.trace, 'should have no transaction trace')
 
     const metrics = agent.metrics._metrics.unscoped
-    t.equal(Object.keys(metrics).length, 1, 'only supportability metrics added to agent collection')
+    t.equal(Object.keys(metrics).length, 3, 'only supportability metrics added to agent collection')
 
     const errors = agent.errors.traceAggregator.errors
     t.equal(errors.length, 0, 'no errors noticed')

--- a/test/versioned/hapi/hapi-17/ignoring.tap.js
+++ b/test/versioned/hapi/hapi-17/ignoring.tap.js
@@ -29,7 +29,7 @@ test('ignoring a Hapi route', function (t) {
     t.notOk(agent.traces.trace, 'should have no transaction trace')
 
     const metrics = agent.metrics._metrics.unscoped
-    t.equal(Object.keys(metrics).length, 1, 'only supportability metrics added to agent collection')
+    t.equal(Object.keys(metrics).length, 3, 'only supportability metrics added to agent collection')
 
     const errors = agent.errors.traceAggregator.errors
     t.equal(errors.length, 0, 'no errors noticed')

--- a/test/versioned/hapi/hapi-post-18/ignoring.tap.js
+++ b/test/versioned/hapi/hapi-post-18/ignoring.tap.js
@@ -29,7 +29,7 @@ test('ignoring a Hapi route', function (t) {
     t.notOk(agent.traces.trace, 'should have no transaction trace')
 
     const metrics = agent.metrics._metrics.unscoped
-    t.equal(Object.keys(metrics).length, 1, 'only supportability metrics added to agent collection')
+    t.equal(Object.keys(metrics).length, 3, 'only supportability metrics added to agent collection')
 
     const errors = agent.errors.traceAggregator.errors
     t.equal(errors.length, 0, 'no errors noticed')

--- a/test/versioned/hapi/hapi-pre-17/ignoring.tap.js
+++ b/test/versioned/hapi/hapi-pre-17/ignoring.tap.js
@@ -37,8 +37,25 @@ tap.test('ignoring a Hapi route', function (t) {
 
     t.notOk(agent.traces.trace, 'should have no transaction trace')
 
+    // Vision usage varies by version so just checking list of known allowed metric patterns.
+    const potentialSupportMetrics = [
+      'Supportability/API/addIgnoringRule',
+      'Supportability/Features/instrumentation/onRequire/vision',
+      'Supportability/Features/instrumentation/onRequire/domain',
+      'Supportability/Features/instrumentation/onRequire/hapi'
+    ]
+
     const metrics = agent.metrics._metrics.unscoped
-    t.equal(Object.keys(metrics).length, 1, 'only supportability metrics added to agent collection')
+
+    const unexpectedMetrics = Object.keys(metrics).filter((metricName) => {
+      const matching = potentialSupportMetrics.filter((value) => {
+        return metricName.startsWith(value)
+      })
+
+      return matching > 0
+    })
+
+    t.equal(unexpectedMetrics.length, 0, 'only supportability metrics added to agent collection')
 
     const errors = agent.errors.traceAggregator.errors
     t.equal(errors.length, 0, 'no errors noticed')

--- a/test/versioned/restify/restify-post-7/ignoring.tap.js
+++ b/test/versioned/restify/restify-post-7/ignoring.tap.js
@@ -34,8 +34,24 @@ test('Restify router introspection', function (t) {
 
     t.notOk(agent.traces.trace, 'should have no transaction trace')
 
+    // Domain usage varies by version so just checking list of known allowed metric patterns.
+    const potentialSupportMetrics = [
+      'Supportability/API/addIgnoringRule',
+      'Supportability/Features/instrumentation/onRequire/domain',
+      'Supportability/Features/instrumentation/onRequire/restify'
+    ]
+
     const metrics = agent.metrics._metrics.unscoped
-    t.equal(Object.keys(metrics).length, 1, 'only supportability metrics added to agent collection')
+
+    const unexpectedMetrics = Object.keys(metrics).filter((metricName) => {
+      const matching = potentialSupportMetrics.filter((value) => {
+        return metricName.startsWith(value)
+      })
+
+      return matching > 0
+    })
+
+    t.equal(unexpectedMetrics.length, 0, 'only supportability metrics added to agent collection')
 
     const errors = agent.errors.traceAggregator.errors
     t.equal(errors.length, 0, 'no errors noticed')

--- a/test/versioned/restify/restify-pre-7/ignoring.tap.js
+++ b/test/versioned/restify/restify-pre-7/ignoring.tap.js
@@ -35,7 +35,7 @@ test('Restify router introspection', function (t) {
     t.notOk(agent.traces.trace, 'should have no transaction trace')
 
     const metrics = agent.metrics._metrics.unscoped
-    t.equal(Object.keys(metrics).length, 1, 'only supportability metrics added to agent collection')
+    t.equal(Object.keys(metrics).length, 4, 'only supportability metrics added to agent collection')
 
     const errors = agent.errors.traceAggregator.errors
     t.equal(errors.length, 0, 'no errors noticed')


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Added support metrics for tracking when instrumentation was applied per module.

  * `Supportability/Features/Instrumentation/OnResolved/<module-name>`
  * `Supportability/Features/Instrumentation/OnResolved/<module-name>/Version/<major version>`
  * `Supportability/Features/Instrumentation/OnRequire/<module-name>`
  * `Supportability/Features/Instrumentation/OnRequire/<module-name>/Version/<major version>`

## Links

## Details

Examples:

- 'Supportability/Features/Instrumentation/OnRequire/domain', 
- 'Supportability/Features/Instrumentation/OnRequire/restify', 
- 'Supportability/Features/Instrumentation/OnRequire/restify/Version/6'

Only attempts to grab the version if the shim found a module root to avoid grabbing the agent version. Version doesn't apply to 'domain' either, for example.