### PR TITLE
Updates to run external module versioned tests cloned from repos 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ out
 .nyc_output
 test/**/package-lock.json
 coverage/
+test/versioned-external/TEMP_TESTS
 
 # Needed for testing
 !test/integration/moduleLoading/node_modules

--- a/bin/git-commands.js
+++ b/bin/git-commands.js
@@ -86,6 +86,44 @@ async function pushTags() {
   return output
 }
 
+async function checkout(branchName) {
+  const stdout = await execAsPromise(`git checkout ${branchName}`)
+  const output = stdout.trim()
+
+  return output
+}
+
+async function clone(url, name, args) {
+  const argsString = args.join(' ')
+  const stdout = await execAsPromise(`git clone ${argsString} ${url} ${name}`)
+  const output = stdout.trim()
+
+  return output
+}
+
+async function setSparseCheckoutFolders(folders) {
+  const foldersString = folders.join(' ')
+
+  const stdout = await execAsPromise(`git sparse-checkout set ${foldersString}`)
+  const output = stdout.trim()
+
+  return output
+}
+
+async function sparseCloneRepo(repoInfo, checkoutFiles) {
+  const { name, repository, branch } = repoInfo
+
+  const cloneOptions = ['--filter=blob:none', '--no-checkout', '--depth 1', '--sparse']
+  await clone(repository, name, cloneOptions)
+  process.chdir(name)
+
+  await setSparseCheckoutFolders(checkoutFiles)
+
+  await checkout(branch)
+
+  process.chdir('..')
+}
+
 function execAsPromise(command) {
   const promise = new Promise((resolve, reject) => {
     console.log(`Executing: '${command}'`)
@@ -111,5 +149,8 @@ module.exports = {
   commit,
   pushToRemote,
   createAnnotatedTag,
-  pushTags
+  pushTags,
+  checkout,
+  clone,
+  sparseCloneRepo
 }

--- a/bin/run-versioned-tests.sh
+++ b/bin/run-versioned-tests.sh
@@ -9,10 +9,17 @@ VERSIONED_MODE="${VERSIONED_MODE:---minor}"
 SAMPLES="${SAMPLES:-10}"
 set -f
 directories=()
-if [[ "$1" != '' ]]; then
+if [[ "$1" != '' ]];
+then
   directories=(
     "test/versioned/${1}"
-    "node_modules/@newrelic/${1}/tests/versioned"
+    "test/versioned-external/TEMP_TESTS/${1}"
+    "test/versioned-external/TEMP_TESTS/${1}/tests/versioned"
+  )
+else
+  directories=(
+    "test/versioned/"
+    "test/versioned-external"
   )
 fi
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "newrelic",
-      "version": "8.5.0",
+      "version": "8.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -148,10 +148,11 @@
     "update-cross-agent-tests": "./bin/update-cats.sh",
     "versioned-tests": "./bin/run-versioned-tests.sh",
     "update-changelog-version": "node ./bin/update-changelog-version",
+    "checkout-external-versioned": "node ./test/versioned-external/checkout-external-tests.js",
     "versioned": "npm run versioned:npm7",
-    "versioned:major": "npm run prepare-test && VERSIONED_MODE=--major NPM7=1 time ./bin/run-versioned-tests.sh",
-    "versioned:npm6": "npm run prepare-test && time ./bin/run-versioned-tests.sh",
-    "versioned:npm7": "npm run prepare-test && NPM7=1 time ./bin/run-versioned-tests.sh",
+    "versioned:major": "npm run checkout-external-versioned && npm run prepare-test && VERSIONED_MODE=--major NPM7=1 time ./bin/run-versioned-tests.sh",
+    "versioned:npm6": "npm run checkout-external-versioned && npm run prepare-test && time ./bin/run-versioned-tests.sh",
+    "versioned:npm7": "npm run checkout-external-versioned && npm run prepare-test && NPM7=1 time ./bin/run-versioned-tests.sh",
     "prepare": "husky install"
   },
   "bin": {

--- a/test/versioned-external/checkout-external-tests.js
+++ b/test/versioned-external/checkout-external-tests.js
@@ -5,7 +5,13 @@
 
 'use strict'
 
-const { rm, mkdir } = require('fs/promises')
+/* eslint-disable no-console, no-process-exit */
+
+// TODO: Update when drop Node 12
+// 'rm' not available in Node 12 but considered deprecated in newer versions
+// 'fs/promises' not available in Node 12
+const { existsSync } = require('fs')
+const { rmdir, mkdir } = require('fs').promises
 
 const { sparseCloneRepo } = require('../../bin/git-commands')
 const repos = require('./external-repos')
@@ -31,8 +37,28 @@ async function checkoutTests() {
 }
 
 async function createNewTestFolder() {
-  await rm(TEMP_TESTS_FOLDER, { recursive: true, force: true })
+  if (existsSync(TEMP_TESTS_FOLDER)) {
+    console.log(`Removing ${TEMP_TESTS_FOLDER} folder.`)
+    await rmdir(TEMP_TESTS_FOLDER, { recursive: true, force: true })
+  }
+
+  console.log(`Creating new ${TEMP_TESTS_FOLDER} folder.`)
   await mkdir(TEMP_TESTS_FOLDER)
 }
 
-checkoutTests()
+try {
+  checkoutTests()
+} catch (error) {
+  stopOnError(error)
+}
+
+function stopOnError(err) {
+  if (err) {
+    console.error(err)
+  }
+
+  console.log('Halting execution with exit code: 1')
+  process.exit(1)
+}
+
+/* eslint-enable no-console, no-process-exit */

--- a/test/versioned-external/checkout-external-tests.js
+++ b/test/versioned-external/checkout-external-tests.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { rm, mkdir } = require('fs/promises')
+
+const { sparseCloneRepo } = require('../../bin/git-commands')
+const repos = require('./external-repos')
+
+const TEMP_TESTS_FOLDER = 'TEMP_TESTS'
+
+const CHECKOUT_FOLDERS = ['lib', 'tests/versioned']
+
+async function checkoutTests() {
+  // Run in context of the folder this script lives in
+  process.chdir(__dirname)
+
+  await createNewTestFolder()
+
+  process.chdir(`./${TEMP_TESTS_FOLDER}`)
+
+  for await (const item of repos) {
+    const additionalFiles = item.additionalFiles || []
+    const checkoutFiles = [...additionalFiles, ...CHECKOUT_FOLDERS]
+
+    await sparseCloneRepo(item, checkoutFiles)
+  }
+}
+
+async function createNewTestFolder() {
+  await rm(TEMP_TESTS_FOLDER, { recursive: true, force: true })
+  await mkdir(TEMP_TESTS_FOLDER)
+}
+
+checkoutTests()

--- a/test/versioned-external/external-repos.js
+++ b/test/versioned-external/external-repos.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/**
+ * name: folder name to checkout the repo into.
+ * repository: repo URL to clone from.
+ * branch: branch to checkout
+ * additionalFiles: String array of files/folders to checkout in addition to lib and tests/versioned.
+ */
+const repos = [
+  {
+    name: 'aws-sdk',
+    repository: 'https://github.com/newrelic/node-newrelic-aws-sdk.git',
+    branch: 'main'
+  },
+  {
+    name: 'koa',
+    repository: 'https://github.com/newrelic/node-newrelic-koa.git',
+    branch: 'main'
+  },
+  {
+    name: 'superagent',
+    repository: 'https://github.com/newrelic/node-newrelic-superagent.git',
+    branch: 'main'
+  }
+]
+
+module.exports = repos

--- a/test/versioned-external/readme.md
+++ b/test/versioned-external/readme.md
@@ -1,8 +1,8 @@
 # About versioned-external
 
-Tests from external repositories can be configured to be run by the agent as a part of the normal versioned test runs. For repos defined in `external-repos.js`, the necessary test run code will get cloned into `TEMP_TESTS` and than run as a part of the standard `npm run versioned*` test runs. These repos are cloned using sparse-checkout to attempt to reduce the amount of data pulled each time.
+Tests from external repositories can be configured to be run by the agent as a part of the normal versioned test runs. For repos defined in `external-repos.js`, the necessary test run code will get cloned into `TEMP_TESTS` and then run as a part of the standard `npm run versioned*` test runs. These repos are cloned using sparse-checkout to attempt to reduce the amount of data pulled each time.
 
-Too add runs against an external repo update `external-repos.js` with the necessary details.
+To add runs against an external repo update `external-repos.js` with the necessary details.
 
 `name`: folder name to checkout the repo into.
 `repository`: repo URL to clone from.

--- a/test/versioned-external/readme.md
+++ b/test/versioned-external/readme.md
@@ -1,0 +1,13 @@
+# About versioned-external
+
+Tests from external repositories can be configured to be run by the agent as a part of the normal versioned test runs. For repos defined in `external-repos.js`, the necessary test run code will get cloned into `TEMP_TESTS` and than run as a part of the standard `npm run versioned*` test runs. These repos are cloned using sparse-checkout to attempt to reduce the amount of data pulled each time.
+
+Too add runs against an external repo update `external-repos.js` with the necessary details.
+
+`name`: folder name to checkout the repo into.
+`repository`: repo URL to clone from.
+`branch`: branch to checkout
+`additionalFiles`: String array of files/folders to checkout in addition to `lib` and `tests/versioned`.
+
+
+`lib` and `tests/versioned` folders will always be checked-out from the specified repository. In some cases, you may need additional files if they are stored in a central sharing location across multiple test run times. For example, apollo-server-plugin may also need `tests/data-definitions.js`, etc. In these cases, leverage the `additionalFiles` property.

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Thu Nov 04 2021 13:34:20 GMT-0700 (Pacific Daylight Time)",
+  "lastUpdated": "Wed Dec 08 2021 10:12:28 GMT-0800 (Pacific Standard Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Runs versioned tests for external modules against tests defined in the external repository instead of tests published in npm modules.

## Links

## Details

New setup output

```

> newrelic@8.6.0 versioned:npm7
> npm run checkout-external-versioned && npm run prepare-test && NPM7=1 time ./bin/run-versioned-tests.sh


> newrelic@8.6.0 checkout-external-versioned
> node ./test/versioned-external/checkout-external-tests.js

Creating new TEMP_TESTS folder.
Executing: 'git clone --filter=blob:none --no-checkout --depth 1 --sparse https://github.com/newrelic/node-newrelic-aws-sdk.git aws-sdk'
Executing: 'git sparse-checkout set lib tests/versioned'
Executing: 'git checkout main'
Executing: 'git clone --filter=blob:none --no-checkout --depth 1 --sparse https://github.com/newrelic/node-newrelic-koa.git koa'
Executing: 'git sparse-checkout set lib tests/versioned'
Executing: 'git checkout main'
Executing: 'git clone --filter=blob:none --no-checkout --depth 1 --sparse https://github.com/newrelic/node-newrelic-superagent.git superagent'
Executing: 'git sparse-checkout set lib tests/versioned'
Executing: 'git checkout main'
```

You'll see in the test run output it is running the new test organization for aws-sdk (V2, V3) that has yet to be published with the package.

```
 ✓ amqplib (2) 13s
 ✓ bluebird (5) 33s
 ✓ cassandra-driver (2) 9s
 ✓ cls (1) 3s
 ✓ connect (6) 27s
   director
 ✓ express (16) 1m
 ✓ fastify (9) 39s
 ✓ generic-pool (2) 6s
   hapi-17
 ✓ hapi-post-18 (10) 47s
   hapi-pre-17
 ✓ ioredis (2) 8s
 ✓ koa-tests (4) 24s
 ✓ mongodb (12) 2m
 ✓ mysql (4) 36s
 ✓ mysql2 (4) 32s
 ✓ pg-post-7 (1) 18s
   pg-pre-7
 ✓ redis (2) 8s
 ✓ restify-post-7 (14) 1m
 ✓ restify-pre-7 (12) 1m
 ✓ superagent-tests (10) 37s
 ✓ undici (1) 6s
 ✓ v2 (9) 43s
 ✓ v3 (13) 2m
 ```

This will will be better in many ways and less ideal in some. Basically moves problems around so open to more discussion here or deciding we ultimately don't like this.

### Improvements

* Can stop publishing tests in external modules which bloat the install for customers. Including tests in publish is also not intuitive to those new to the agent.
* Allows test-only changes to be made in external repos due to agent changes without forcing external modules to have to be published and pulled back into the agent to get versioned tests to pass.
* Allows us to eventually test non-dependency external modules as a part of versioned runs, as desired. For example: the Apollo Server plugin or the Winston Log Enricher. (some extra work needed here).
* Allows us general flexibility in running the external tests to deal with unforseen issues (temp run against a different branch, whatever).

### Downsides

* Have to manually add configuration to add tests. Previously, any module added as a dependency would get auto-tested.
* Clones repos / requires web access every test run to get freshest tests. Alternative would be to only pull once with risk of then having outdated tests.
* Extra files cloned locally. While test files won't be duplicated once removed from external modules, the primary source (lib) files will be duplicated.

### Additional Implementation Thoughts

I tried wiring up the Apollo Server Plugin tests but ran into a funky issue. When running this way against the versioned runner... the fastify instrumentation kicked in naming the transitions differently than the tests expected. When running a single file (or directly in the Apollo repo) this doesn't happen. In the real world, I expect the fastify instrumentation will kick in. For the tests, it probably isn't loaded but unsure why kicks in for versioned runner runs? Particularly when the test (segments) is the very first ran. 🤷  Something to work out here if we want the agent to run these tests at some point (doesn't currently).

I don't think wiring up mono repo stuff (what log enrichers are becoming) if we want coverage on winston/pino. The versioned runner and versioned runner script have some limitations around path searching, so what may need to specify like a sub module path and then do some manual folder restructuring. I haven't played with this at all yet.

This highlights some funky naming with nested folders. For example: the aws-sdk tests end up with items just called v2 and v3. Maybe we should update the versioned runner to read the names in the `package.json` files so we don't have to care about folder naming/organization.

If lands, we'll want to do follow-up to remove tests from the external package's `files` list in `package.json`.