### PR TITLE
Added a reusable workflow to add issues and PRs to project boards

### DIFF
--- a/.github/workflows/add-to-board.yml
+++ b/.github/workflows/add-to-board.yml
@@ -1,0 +1,13 @@
+name: Auto Assign to Project(s)
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-board:
+    uses: newrelic/node-newrelic/.github/workflows/board.yml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-to-board.yml
+++ b/.github/workflows/add-to-board.yml
@@ -9,5 +9,3 @@ on:
 jobs:
   add-to-board:
     uses: newrelic/node-newrelic/.github/workflows/board.yml@main
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/board.yml
+++ b/.github/workflows/board.yml
@@ -1,0 +1,48 @@
+name: Add issues/PRs to project board
+on:
+  workflow_call:
+    inputs:
+      project_id:
+        description: Id of Project in GitHub
+        default: 5864688 # Node.js Engineering Board https://github.com/orgs/newrelic/projects/41
+        required: false
+        type: number
+      todo_column:
+        description: Name of the To-Do column in project
+        default: 'Triage Needed: Unprioritized Features'
+        required: false
+        type: string
+      pr_column:
+        description: Name of the In Review column in project
+        default: 'Needs PR Review'
+        required: false
+        type: string
+    secrets:
+      token:
+        required: true
+
+jobs:
+  assign_pr_to_project:
+    env:
+      GITHUB_TOKEN: ${{ secrets.token }}
+      PROJECT_ID: ${{ inputs.project_id }}
+      HEADER: "Accept: application/vnd.github.inertia-preview+json"
+    runs-on: ubuntu-latest
+    name: Assign Issues and/or PRs to Project
+    steps:
+    - name: Assign PR to Project
+      if: github.event_name == 'pull_request'
+      run: |
+        ISSUE_ID=${{ github.event.issue.id }}
+        COLUMN=$(gh api -H "$HEADER" projects/$PROJECT_ID/columns --jq ".[] | select(.name == \"$COLUMN_NAME\").id")
+        gh api -H "$HEADER" -X POST projects/columns/$COLUMN/cards -f content_type='Issue' -F content_id=$ISSUE_ID
+      env:
+        COLUMN_NAME: ${{ inputs.pr_column}}
+    - name: Assign Issue to Project
+      if: github.event_name == 'issues'
+      run: |
+        ISSUE_ID=${{ github.event.issue.id }}
+        COLUMN=$(gh api -H "$HEADER" projects/$PROJECT_ID/columns --jq ".[] | select(.name == \"$COLUMN_NAME\").id")
+        gh api -H "$HEADER" -X POST projects/columns/$COLUMN/cards -f content_type='Issue' -F content_id=$ISSUE_ID
+      env:
+        COLUMN_NAME: ${{ inputs.todo_column}}

--- a/.github/workflows/board.yml
+++ b/.github/workflows/board.yml
@@ -1,10 +1,24 @@
-name: Add issues/PRs to project board
+# This is intended to be called in any of our repos.
+# To use you can look at `add-to-board.yml` as a reference.
+# You should be able to just call `uses: newrelic/node-newrelic/.github/workflows/board.yml@main`
+# If for some reason the "todo" or "needs pr" columns are different than the default, you can pass in
+# via
+# with:
+#   todo_column: 'TODO Column'
+#   pr_column: 'PR Column'
+#
+# If you do not want to add to the Node.js Engineering Board, you'll have to find the guid of the project
+# by using the GitHub API
+# `gh api -H "Accept: application/vnd.github.inertia-preview+json" orgs/newrelic/projects --jq ".[] | select(.name == \"<Name of Boarda>"\").id"`
+#
+# You can find a project via `orgs/newrelic/projects`, `repos/newrelic/<repo-name>/projects`
+
+name: Add Issues/PRs to project board
 on:
   workflow_call:
     inputs:
       project_id:
         description: Id of Project in GitHub
-        # To find guid run `gh api -H "Accept: application/vnd.github.inertia-preview+json" orgs/newrelic/projects --jq ".[] | select(.name == \"Node.js Engineering Board\").id"`
         default: 5864688 # Node.js Engineering Board https://github.com/orgs/newrelic/projects/41
         required: false
         type: number
@@ -18,14 +32,11 @@ on:
         default: 'Needs PR Review'
         required: false
         type: string
-    secrets:
-      token:
-        required: true
 
 jobs:
-  assign_pr_to_project:
+  assign_to_project:
     env:
-      GITHUB_TOKEN: ${{ secrets.token }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PROJECT_ID: ${{ inputs.project_id }}
       HEADER: "Accept: application/vnd.github.inertia-preview+json"
     runs-on: ubuntu-latest

--- a/.github/workflows/board.yml
+++ b/.github/workflows/board.yml
@@ -4,6 +4,7 @@ on:
     inputs:
       project_id:
         description: Id of Project in GitHub
+        # To find guid run `gh api -H "Accept: application/vnd.github.inertia-preview+json" orgs/newrelic/projects --jq ".[] | select(.name == \"Node.js Engineering Board\").id"`
         default: 5864688 # Node.js Engineering Board https://github.com/orgs/newrelic/projects/41
         required: false
         type: number
@@ -33,9 +34,9 @@ jobs:
     - name: Assign PR to Project
       if: github.event_name == 'pull_request'
       run: |
-        ISSUE_ID=${{ github.event.issue.id }}
+        ISSUE_ID=${{ github.event.pull_request.id }}
         COLUMN=$(gh api -H "$HEADER" projects/$PROJECT_ID/columns --jq ".[] | select(.name == \"$COLUMN_NAME\").id")
-        gh api -H "$HEADER" -X POST projects/columns/$COLUMN/cards -f content_type='Issue' -F content_id=$ISSUE_ID
+        gh api -H "$HEADER" -X POST projects/columns/$COLUMN/cards -f content_type='PullRequest' -F content_id=$ISSUE_ID
       env:
         COLUMN_NAME: ${{ inputs.pr_column}}
     - name: Assign Issue to Project


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added a reusable workflow to automatically add issues to the Node.js Engineering Board when created.  

## Links
 * Closes #866 

## Details
This leverages the GitHub cli to use the api to find the column in project and add the relevant issue or PR.  This creates a reusable workflow but also adds a reference to it for the node agent repo.  I figured we can keep the reusable workflow in main agent.  I will create follow up PRs to reference this workflow for all of our other repos.  This will add all new issues to the `Triage Needed: Unprioritized Features` and all new PRs to `Needs PR Review` columns.  These are defaults and you can provide whatever string is needed for the "todo" and "pr" columns.  Lastly, shout out to the docs team for the lovely [copy pasta](https://github.com/newrelic/docs-website/blob/develop/.github/workflows/issue-triage.yml)

The project id is a guid and to find it you can run this locally
```sh
gh api -H "Accept: application/vnd.github.inertia-preview+json" orgs/newrelic/projects --jq ".[] | select(.name == \"Node.js Engineering Board\").id"
```
