### PR TITLE
changes secret to post to org level project board

### DIFF
--- a/.github/workflows/board.yml
+++ b/.github/workflows/board.yml
@@ -36,7 +36,10 @@ on:
 jobs:
   assign_to_project:
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Cannot use `secrets.GITHUB_TOKEN` because the project board
+      # exists at org level. You cannot add permissions outside the scope
+      # of the given repo
+      GITHUB_TOKEN: ${{ secrets.GH_ORG_TOKEN }}
       PROJECT_ID: ${{ inputs.project_id }}
       HEADER: "Accept: application/vnd.github.inertia-preview+json"
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Changes token used to post issues to org level project board

## Details
We merged #999 and the workflow wasn't working.  When I was testing locally I was using a personal access token that had access to the org.  Also when I tested in my node-newrelic fork the project was at the repo which github actions has access to with the `GITHUB_TOKEN`.  The issue is that you cannot get perms outside the given repo, probably for good reason.  The only workaround is to generate a personal access token and add to secrets.  I did that, updated the code and documented in a secure note in last pass about the value, how to update it and context that's its on my account.

https://dev.to/github/the-githubtoken-in-github-actions-how-it-works-change-permissions-customizations-3cgp