### PR TITLE
Pass in environment secrets from caller workflow

### DIFF
--- a/.github/workflows/add-to-board.yml
+++ b/.github/workflows/add-to-board.yml
@@ -9,3 +9,6 @@ on:
 jobs:
   add-to-board:
     uses: newrelic/node-newrelic/.github/workflows/board.yml@main
+    # See board.yml explaining why this has to be done
+    secrets:
+      gh_token: ${{ secrets.GH_ORG_TOKEN }}

--- a/.github/workflows/board.yml
+++ b/.github/workflows/board.yml
@@ -32,6 +32,13 @@ on:
         default: 'Needs PR Review'
         required: false
         type: string
+    # Cannot rely on environment secrets(i.e. from node-newrelic settings)
+    # in a reusable workflow.  We must pass it in, see add-to-board.yml
+    # See: https://github.community/t/reusable-workflows-secrets-and-environments/203695/4
+    secrets:
+      gh_token:
+        description: Token used to make gh api calls, must have org level perms
+        required: true
 
 jobs:
   assign_to_project:
@@ -39,7 +46,7 @@ jobs:
       # Cannot use `secrets.GITHUB_TOKEN` because the project board
       # exists at org level. You cannot add permissions outside the scope
       # of the given repo
-      GITHUB_TOKEN: ${{ secrets.GH_ORG_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.gh_token }}
       PROJECT_ID: ${{ inputs.project_id }}
       HEADER: "Accept: application/vnd.github.inertia-preview+json"
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed add to board workflow to properly pass repository secrets into reusable board workflow.

## Details
Ok I'm confident this is the last PR on this effort.  Unfortunately we have to pass in `secrets.gh_token` with an org level PAT.  This means that in external repos we'll have to specify the same PAT.  I was hoping the reusable workflow would just reference this repo's `secrets.GH_ORG_TOKEN` but this is a limitation of reusable workflows, see: https://github.community/t/reusable-workflows-secrets-and-environments/203695/4.  
