### PR TITLE
add external segment before host is known

### DIFF
--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -103,13 +103,13 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
       request.addHeader(key, outboundHeaders[key])
     }
 
-    const name = NAMES.EXTERNAL.PREFIX + UNKNOWN_HOST
+    const name = NAMES.EXTERNAL.PREFIX + UNKNOWN_HOST + (request.method || 'get')
     const segment = shim.createSegment(name, recordExternal(UNKNOWN_HOST, 'undici'), parent)
     if (segment) {
       segment.start()
       shim.setActiveSegment(segment)
       segment.addAttribute('procedure', request.method || 'GET')
-      request[SYMBOLS.PARENT_SEGMENT] = segment
+      request[SYMBOLS.SEGMENT] = segment
     }
   })
 
@@ -144,17 +144,23 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
     const url = new URL(urlString)
 
     const name = NAMES.EXTERNAL.PREFIX + url.host + url.pathname
-    const segment = shim.createSegment(name, recordExternal(url.host, 'undici'), parentSegment)
-    if (segment) {
+    let segment
+    if (request[SYMBOLS.SEGMENT]) {
+      segment = request[SYMBOLS.SEGMENT]
+      segment.name = name
+    } else {
+      segment = shim.createSegment(name, recordExternal(url.host, 'undici'), parentSegment)
       segment.start()
       shim.setActiveSegment(segment)
+      segment.addAttribute('procedure', request.method || 'GET')
+      request[SYMBOLS.SEGMENT] = segment
+    }
+    if (segment) {
       segment.addAttribute('url', `${url.protocol}//${url.host}${url.pathname}`)
 
       url.searchParams.forEach((value, key) => {
         segment.addSpanAttribute(`request.parameters.${key}`, value)
       })
-      segment.addAttribute('procedure', request.method || 'GET')
-      request[SYMBOLS.SEGMENT] = segment
     }
   })
 

--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -16,6 +16,8 @@ const SYMBOLS = {
 }
 const { executionAsyncResource } = require('async_hooks')
 
+const UNKNOWN_HOST = '<unknown>'
+
 let diagnosticsChannel = null
 try {
   diagnosticsChannel = require('diagnostics_channel')
@@ -99,6 +101,15 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
     // eslint-disable-next-line guard-for-in
     for (const key in outboundHeaders) {
       request.addHeader(key, outboundHeaders[key])
+    }
+
+    const name = NAMES.EXTERNAL.PREFIX + UNKNOWN_HOST
+    const segment = shim.createSegment(name, recordExternal(UNKNOWN_HOST, 'undici'), parent)
+    if (segment) {
+      segment.start()
+      shim.setActiveSegment(segment)
+      segment.addAttribute('procedure', request.method || 'GET')
+      request[SYMBOLS.PARENT_SEGMENT] = segment
     }
   })
 

--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -150,10 +150,12 @@ module.exports = function addUndiciChannels(agent, undici, modName, shim) {
       segment.name = name
     } else {
       segment = shim.createSegment(name, recordExternal(url.host, 'undici'), parentSegment)
-      segment.start()
-      shim.setActiveSegment(segment)
-      segment.addAttribute('procedure', request.method || 'GET')
-      request[SYMBOLS.SEGMENT] = segment
+      if (segment) {
+        segment.start()
+        shim.setActiveSegment(segment)
+        segment.addAttribute('procedure', request.method || 'GET')
+        request[SYMBOLS.SEGMENT] = segment
+      }
     }
     if (segment) {
       segment.addAttribute('url', `${url.protocol}//${url.host}${url.pathname}`)

--- a/test/versioned/undici/requests.tap.js
+++ b/test/versioned/undici/requests.tap.js
@@ -58,9 +58,7 @@ tap.test('Undici request tests', (t) => {
       })
       t.equal(statusCode, 200)
 
-      metrics.assertSegments(tx.trace.root, ['External/<unknown>', ['External/httpbin.org/post']], {
-        exact: false
-      })
+      metrics.assertSegments(tx.trace.root, ['External/httpbin.org/post'], { exact: false })
       tx.end()
       t.end()
     })
@@ -82,13 +80,9 @@ tap.test('Undici request tests', (t) => {
       const { port } = server.address()
       await undici.request(`http://localhost:${port}`)
 
-      metrics.assertSegments(
-        transaction.trace.root,
-        ['External/<unknown>', [`External/localhost:${port}/`]],
-        {
-          exact: false
-        }
-      )
+      metrics.assertSegments(transaction.trace.root, [`External/localhost:${port}/`], {
+        exact: false
+      })
 
       transaction.end()
       t.end()
@@ -123,13 +117,9 @@ tap.test('Undici request tests', (t) => {
 
       await client.request({ path: '/', method: 'GET' })
 
-      metrics.assertSegments(
-        transaction.trace.root,
-        ['External/<unknown>', [`External/localhost:${port}/`]],
-        {
-          exact: false
-        }
-      )
+      metrics.assertSegments(transaction.trace.root, [`External/localhost:${port}/`], {
+        exact: false
+      })
 
       transaction.end()
     })
@@ -180,10 +170,7 @@ tap.test('Undici request tests', (t) => {
       t.equal(statusCode2, 200)
       metrics.assertSegments(
         tx.trace.root,
-        [
-          ['External/<unknown>', ['External/httpbin.org/post']],
-          ['External/<unknown>', ['External/httpbin.org/put']]
-        ],
+        ['External/httpbin.org/post', 'External/httpbin.org/put'],
         { exact: false }
       )
       tx.end()
@@ -221,11 +208,7 @@ tap.test('Undici request tests', (t) => {
         }, 100)
         await req
       } catch (err) {
-        metrics.assertSegments(
-          tx.trace.root,
-          ['External/<unknown>', ['External/httpbin.org/delay/1']],
-          { exact: false }
-        )
+        metrics.assertSegments(tx.trace.root, ['External/httpbin.org/delay/1'], { exact: false })
         t.equal(tx.exceptions.length, 1)
         t.equal(tx.exceptions[0].error.message, 'Request aborted')
         tx.end()
@@ -252,13 +235,9 @@ tap.test('Undici request tests', (t) => {
       try {
         await req
       } catch (error) {
-        metrics.assertSegments(
-          transaction.trace.root,
-          ['External/<unknown>', [`External/localhost:${port}/`]],
-          {
-            exact: false
-          }
-        )
+        metrics.assertSegments(transaction.trace.root, [`External/localhost:${port}/`], {
+          exact: false
+        })
 
         const segments = transaction.trace.root.children
         const segment = segments[segments.length - 1]
@@ -280,11 +259,7 @@ tap.test('Undici request tests', (t) => {
         method: 'GET'
       })
       t.equal(statusCode, 400)
-      metrics.assertSegments(
-        tx.trace.root,
-        ['External/<unknown>', ['External/httpbin.org/status/400']],
-        { exact: false }
-      )
+      metrics.assertSegments(tx.trace.root, ['External/httpbin.org/status/400'], { exact: false })
       tx.end()
       t.end()
     })
@@ -294,9 +269,7 @@ tap.test('Undici request tests', (t) => {
     helper.runInTransaction(agent, async (tx) => {
       const res = await undici.fetch('https://httpbin.org')
       t.equal(res.status, 200)
-      metrics.assertSegments(tx.trace.root, ['External/<unknown>', ['External/httpbin.org/']], {
-        exact: false
-      })
+      metrics.assertSegments(tx.trace.root, ['External/httpbin.org/'], { exact: false })
       tx.end()
       t.end()
     })
@@ -319,9 +292,7 @@ tap.test('Undici request tests', (t) => {
           })
         }
       )
-      metrics.assertSegments(tx.trace.root, ['External/<unknown>', ['External/httpbin.org/get']], {
-        exact: false
-      })
+      metrics.assertSegments(tx.trace.root, ['External/httpbin.org/get'], { exact: false })
       tx.end()
       t.end()
     })
@@ -357,11 +328,7 @@ tap.test('Undici request tests', (t) => {
         }),
         (err) => {
           t.error(err)
-          metrics.assertSegments(
-            tx.trace.root,
-            ['External/<unknown>', ['External/httpbin.org/get']],
-            { exact: false }
-          )
+          metrics.assertSegments(tx.trace.root, ['External/httpbin.org/get'], { exact: false })
           tx.end()
           t.end()
         }

--- a/test/versioned/undici/requests.tap.js
+++ b/test/versioned/undici/requests.tap.js
@@ -58,7 +58,9 @@ tap.test('Undici request tests', (t) => {
       })
       t.equal(statusCode, 200)
 
-      metrics.assertSegments(tx.trace.root, ['External/httpbin.org/post'], { exact: false })
+      metrics.assertSegments(tx.trace.root, ['External/<unknown>', ['External/httpbin.org/post']], {
+        exact: false
+      })
       tx.end()
       t.end()
     })
@@ -80,9 +82,13 @@ tap.test('Undici request tests', (t) => {
       const { port } = server.address()
       await undici.request(`http://localhost:${port}`)
 
-      metrics.assertSegments(transaction.trace.root, [`External/localhost:${port}/`], {
-        exact: false
-      })
+      metrics.assertSegments(
+        transaction.trace.root,
+        ['External/<unknown>', [`External/localhost:${port}/`]],
+        {
+          exact: false
+        }
+      )
 
       transaction.end()
       t.end()
@@ -117,9 +123,13 @@ tap.test('Undici request tests', (t) => {
 
       await client.request({ path: '/', method: 'GET' })
 
-      metrics.assertSegments(transaction.trace.root, [`External/localhost:${port}/`], {
-        exact: false
-      })
+      metrics.assertSegments(
+        transaction.trace.root,
+        ['External/<unknown>', [`External/localhost:${port}/`]],
+        {
+          exact: false
+        }
+      )
 
       transaction.end()
     })
@@ -170,7 +180,10 @@ tap.test('Undici request tests', (t) => {
       t.equal(statusCode2, 200)
       metrics.assertSegments(
         tx.trace.root,
-        ['External/httpbin.org/post', 'External/httpbin.org/put'],
+        [
+          ['External/<unknown>', ['External/httpbin.org/post']],
+          ['External/<unknown>', ['External/httpbin.org/put']]
+        ],
         { exact: false }
       )
       tx.end()
@@ -208,7 +221,11 @@ tap.test('Undici request tests', (t) => {
         }, 100)
         await req
       } catch (err) {
-        metrics.assertSegments(tx.trace.root, ['External/httpbin.org/delay/1'], { exact: false })
+        metrics.assertSegments(
+          tx.trace.root,
+          ['External/<unknown>', ['External/httpbin.org/delay/1']],
+          { exact: false }
+        )
         t.equal(tx.exceptions.length, 1)
         t.equal(tx.exceptions[0].error.message, 'Request aborted')
         tx.end()
@@ -235,9 +252,13 @@ tap.test('Undici request tests', (t) => {
       try {
         await req
       } catch (error) {
-        metrics.assertSegments(transaction.trace.root, [`External/localhost:${port}/`], {
-          exact: false
-        })
+        metrics.assertSegments(
+          transaction.trace.root,
+          ['External/<unknown>', [`External/localhost:${port}/`]],
+          {
+            exact: false
+          }
+        )
 
         const segments = transaction.trace.root.children
         const segment = segments[segments.length - 1]
@@ -259,7 +280,11 @@ tap.test('Undici request tests', (t) => {
         method: 'GET'
       })
       t.equal(statusCode, 400)
-      metrics.assertSegments(tx.trace.root, ['External/httpbin.org/status/400'], { exact: false })
+      metrics.assertSegments(
+        tx.trace.root,
+        ['External/<unknown>', ['External/httpbin.org/status/400']],
+        { exact: false }
+      )
       tx.end()
       t.end()
     })
@@ -269,7 +294,9 @@ tap.test('Undici request tests', (t) => {
     helper.runInTransaction(agent, async (tx) => {
       const res = await undici.fetch('https://httpbin.org')
       t.equal(res.status, 200)
-      metrics.assertSegments(tx.trace.root, ['External/httpbin.org/'], { exact: false })
+      metrics.assertSegments(tx.trace.root, ['External/<unknown>', ['External/httpbin.org/']], {
+        exact: false
+      })
       tx.end()
       t.end()
     })
@@ -292,7 +319,9 @@ tap.test('Undici request tests', (t) => {
           })
         }
       )
-      metrics.assertSegments(tx.trace.root, ['External/httpbin.org/get'], { exact: false })
+      metrics.assertSegments(tx.trace.root, ['External/<unknown>', ['External/httpbin.org/get']], {
+        exact: false
+      })
       tx.end()
       t.end()
     })
@@ -328,7 +357,11 @@ tap.test('Undici request tests', (t) => {
         }),
         (err) => {
           t.error(err)
-          metrics.assertSegments(tx.trace.root, ['External/httpbin.org/get'], { exact: false })
+          metrics.assertSegments(
+            tx.trace.root,
+            ['External/<unknown>', ['External/httpbin.org/get']],
+            { exact: false }
+          )
           tx.end()
           t.end()
         }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

- Add a transaction segment when a socket is first opened, before a request is fully formed, to account for possible socket errors.

## Links

- Closes https://github.com/newrelic/node-newrelic/issues/947

## Details

This PR introduces a segment when a request is first created, before the request host is known. This segment is inserted between the root segment and the segment created when the request's headers are sent, causing some changes to the test suite to reflect the new segment order.

Rather than refactor `recordExternal`, a fake host is used instead: `'<unknown>'`, so that these segments will appear to the user as `'External/<unknown>'` followed by a segment for the fully-formed request, such as `'External/httpbin.org/get'`. I used `'<unknown>'` in keeping with how we report on anonymous functions with `'<anonymous>'`.

Let me know if this is not an appropriate approach!