### PR TITLE
Moves publish docs step to always be last w/ comment explaning such

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -38,7 +38,8 @@ jobs:
       run: node ./bin/create-github-release.js --tag ${{ steps.get_tag.outputs.latest_tag }} --repo-owner ${{ github.repository_owner }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Publish API Docs
-      run: npm run publish-docs
     - name: Update system configuration pages
       run: node ./bin/update-system-config-pages.js --version ${{ steps.get_tag.outputs.latest_tag }} --staging-key ${{ secrets.NEW_RELIC_API_KEY_STAGING }} --prod-key ${{ secrets.NEW_RELIC_API_KEY_PRODUCTION }}
+    # Must be last as it checks out a different remote `gh-pages`
+    - name: Publish API Docs
+      run: npm run publish-docs


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Moved the publishing of API docs to last step of release CI to avoid issues with running other scripts not in the `gh-pages` remote

## Details
In https://github.com/newrelic/node-newrelic/pull/996 I added a script to update RPM with latest publish agent version.  I just slapped it at end of release workflow.  Turns out that won't work because publishing the js docs checks out a different remote which lacks all the code from main.  It failed when I ran [tag-and-publish](https://github.com/newrelic/node-newrelic/runs/4707568083?check_suite_focus=true).  
