### PR TITLE
Abstract release creation

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,36 +9,19 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [lts/*]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1 # https://github.com/actions/setup-node
-      with:
-        node-version: ${{ matrix.node-version }}
-        registry-url: 'https://registry.npmjs.org'
+    - uses: newrelic/node-newrelic/.github/workflows/release-creation.yml@main
+    # npm ci and getting tag is redundant from the reusable workflow `release-creation`
+    # but all that work was done on the child repo in `agent-repo` folder and didn't
+    # want to update the system config and publishing API docs
     - name: Install Dependencies
       run: npm ci
-    - name: Setup GitHub Credentials
-      run: |
-        git config user.name $GITHUB_ACTOR
-        git config user.email gh-actions-${GITHUB_ACTOR}@github.com
-    - name: Create Release tag
-      run: node ./bin/create-release-tag.js --branch ${{ github.ref }} --repo-owner ${{ github.repository_owner }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - run: npm publish
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     - name: Get Created Tag
       id: get_tag
       run: echo "::set-output name=latest_tag::$(git describe --tags --abbrev=0)"
-    - name: Create GitHub Release
-      run: node ./bin/create-github-release.js --tag ${{ steps.get_tag.outputs.latest_tag }} --repo-owner ${{ github.repository_owner }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Publish API Docs
-      run: npm run publish-docs
     - name: Update system configuration pages
       run: node ./bin/update-system-config-pages.js --version ${{ steps.get_tag.outputs.latest_tag }} --staging-key ${{ secrets.NEW_RELIC_API_KEY_STAGING }} --prod-key ${{ secrets.NEW_RELIC_API_KEY_PRODUCTION }}
+    - name: Publish API Docs
+      run: npm run publish-docs

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,23 +5,4 @@ on: [workflow_dispatch]
 
 jobs:
   tag-and-publish:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [lts/*]
-
-    steps:
-    - uses: newrelic/node-newrelic/.github/workflows/release-creation.yml@main
-    # npm ci and getting tag is redundant from the reusable workflow `release-creation`
-    # but all that work was done on the child repo in `agent-repo` folder and didn't
-    # want to update the system config and publishing API docs
-    - name: Install Dependencies
-      run: npm ci
-    - name: Get Created Tag
-      id: get_tag
-      run: echo "::set-output name=latest_tag::$(git describe --tags --abbrev=0)"
-    - name: Update system configuration pages
-      run: node ./bin/update-system-config-pages.js --version ${{ steps.get_tag.outputs.latest_tag }} --staging-key ${{ secrets.NEW_RELIC_API_KEY_STAGING }} --prod-key ${{ secrets.NEW_RELIC_API_KEY_PRODUCTION }}
-    - name: Publish API Docs
-      run: npm run publish-docs
+    uses: newrelic/node-newrelic/.github/workflows/release-creation.yml@main

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,29 @@
+name: Agent Post Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-rpm-and-docs:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [lts/*]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install Dependencies
+      run: npm ci
+    - name: Get Created Tag
+      id: get_tag
+      run: echo "::set-output name=latest_tag::$(git describe --tags --abbrev=0)"
+    - name: Update system configuration pages
+      run: node ./bin/update-system-config-pages.js --version ${{ steps.get_tag.outputs.latest_tag }} --staging-key ${{ secrets.NEW_RELIC_API_KEY_STAGING }} --prod-key ${{ secrets.NEW_RELIC_API_KEY_PRODUCTION }}
+    - name: Publish API Docs
+      run: npm run publish-docs

--- a/.github/workflows/release-creation.yml
+++ b/.github/workflows/release-creation.yml
@@ -1,0 +1,54 @@
+name: Reusable Create Release
+
+on:
+  workflow_call:
+    inputs:
+      changelog_file:
+        description: Name of changelog file.
+        type: string
+        required: false
+        default: NEWS.md
+
+jobs:
+  tag-and-publish:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [lts/*]
+
+    steps:
+    # Check out caller repo
+    - uses: actions/checkout@v2
+    # check out agent repo to agent-repo for the bin folders
+    - uses: actions/checkout@v2
+      with:
+        repository: newrelic/node-newrelic
+        path: agent-repo
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        registry-url: 'https://registry.npmjs.org'
+    # Only need to install deps in agent-repo because of the bin scripts
+    - name: Install Dependencies
+      run: npm ci --prefix agent-repo
+    - name: Setup GitHub Credentials
+      run: |
+        git config user.name $GITHUB_ACTOR
+        git config user.email gh-actions-${GITHUB_ACTOR}@github.com
+    - name: Create Release Tag
+      run: node ./agent-repo/bin/create-release-tag.js --branch ${{ github.ref }} --repo-owner ${{ github.repository_owner }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Publish to Npm
+      run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: Get Created Tag
+      id: get_tag
+      run: echo "::set-output name=latest_tag::$(git describe --tags --abbrev=0)"
+    - name: Create GitHub Release
+      run: node ./agent-repo/bin/create-github-release.js --tag ${{ steps.get_tag.outputs.latest_tag }} --repo-owner ${{ github.repository_owner }} --changelog ${{ inputs.changelog_file }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/bin/create-github-release.js
+++ b/bin/create-github-release.js
@@ -17,8 +17,8 @@ const TAG_VALID_REGEX = /v\d+\.\d+\.\d+/
 program.requiredOption('--tag <tag>', 'tag name to create GitHub release for')
 program.option('--repo-owner <repoOwner>', 'repository owner', 'newrelic')
 program.option(
-  '--release-notes-file <releaseNotesFile>',
-  'path to release notes file',
+  '--changelog <changelog>',
+  'Name of changelog(defaults to NEWS.md)',
   DEFAULT_FILE_NAME
 )
 program.option('-f --force', 'bypass validation')
@@ -48,7 +48,7 @@ async function createRelease() {
     }
 
     logStep('Get Release Notes from File')
-    const body = await getReleaseNotes(tagName, options.releaseNotesFile)
+    const body = await getReleaseNotes(tagName, options.changelog)
 
     logStep('Create Release')
     await github.createRelease(tagName, tagName, body)

--- a/bin/create-release-tag.js
+++ b/bin/create-release-tag.js
@@ -41,8 +41,8 @@ async function createReleaseTag() {
       process.exit(1)
     }
 
-    const packagePath = '../package.json'
-    console.log('Extracting new version from package.json here: ')
+    const packagePath = `${process.cwd()}/package.json`
+    console.log(`Extracting new version from ${packagePath}`)
     const packageInfo = require(packagePath)
 
     const version = `v${packageInfo.version}`


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added a reusable workflow to create a release tag, publish to NPM and publish a GitHub release.
 * Updated agent release workflow to reference reusable workflow.
 * Added a new workflow to update RPM and publish API docs on a published release event type.

## Links
Closes #1049 

## Details
 * Every repo using this will need to add a new secret `NPM_TOKEN` which is stored in LastPass.
 * I wasn't able to completely test this as it would make a new release. We may need to fix random issues when we actually use it the first time

To use reusable workflow:

```sh
jobs:
  fake-release:
    uses: newrelic/node-newrelic/.github/workflows/release-creation.yml@main
    with:
      changelog_file: CHANGELOG.md #Only need to pass this in if the changelog file is not NEWS.md
```