### PR TITLE
fixed check workflow and release creation by passing in repo

### DIFF
--- a/.github/workflows/release-creation.yml
+++ b/.github/workflows/release-creation.yml
@@ -39,14 +39,18 @@ jobs:
     # Only need to install deps in agent-repo because of the bin scripts
     - name: Install Dependencies
       run: |
-        npm ci #Install deps in caller repo
-        npm ci --prefix agent-repo #Install deps in agent repo
+        # Install deps in caller repo
+        npm ci
+        # Install deps in agent repo
+        npm ci --prefix agent-repo
     - name: Setup GitHub Credentials
       run: |
         git config user.name $GITHUB_ACTOR
         git config user.email gh-actions-${GITHUB_ACTOR}@github.com
     - name: Create Release Tag
-      run: node ./agent-repo/bin/create-release-tag.js --branch ${{ github.ref }} --repo-owner ${{ github.repository_owner }}
+      run: node ./agent-repo/bin/create-release-tag.js --branch ${{ github.ref }} --repo ${{ github.repository }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Publish to Npm
       run: npm publish
       env:
@@ -55,7 +59,7 @@ jobs:
       id: get_tag
       run: echo "::set-output name=latest_tag::$(git describe --tags --abbrev=0)"
     - name: Create GitHub Release
-      run: node ./agent-repo/bin/create-github-release.js --tag ${{ steps.get_tag.outputs.latest_tag }} --repo-owner ${{ github.repository_owner }} --changelog ${{ inputs.changelog_file }}
+      run: node ./agent-repo/bin/create-github-release.js --tag ${{ steps.get_tag.outputs.latest_tag }} --repo ${{ github.repository }} --changelog ${{ inputs.changelog_file }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/bin/create-github-release.js
+++ b/bin/create-github-release.js
@@ -15,7 +15,11 @@ const DEFAULT_FILE_NAME = 'NEWS.md'
 const TAG_VALID_REGEX = /v\d+\.\d+\.\d+/
 
 program.requiredOption('--tag <tag>', 'tag name to create GitHub release for')
-program.option('--repo-owner <repoOwner>', 'repository owner', 'newrelic')
+program.option(
+  '--repo <repo>',
+  'Repo to work against(Defaults to newrelic/node-newrelic)',
+  'newrelic/node-newrelic'
+)
 program.option(
   '--changelog <changelog>',
   'Name of changelog(defaults to NEWS.md)',
@@ -30,8 +34,9 @@ async function createRelease() {
   const options = program.opts()
 
   console.log('Script running with following options: ', JSON.stringify(options))
+  const [owner, repo] = options.repo.split('/')
 
-  const github = new Github(options.repoOwner)
+  const github = new Github(owner, repo)
 
   try {
     const tagName = options.tag.replace('refs/tags/', '')

--- a/bin/create-release-tag.js
+++ b/bin/create-release-tag.js
@@ -12,7 +12,11 @@ const git = require('./git-commands')
 
 // Add command line options
 program.option('-b, --branch <branch>', 'release branch', 'main')
-program.option('-o, --repo-owner <repoOwner>', 'repository owner', 'newrelic')
+program.option(
+  '--repo <repo>',
+  'Repo to work against(Defaults to newrelic/node-newrelic)',
+  'newrelic/node-newrelic'
+)
 program.option('-f --force', 'bypass validation')
 
 async function createReleaseTag() {
@@ -24,7 +28,7 @@ async function createReleaseTag() {
   console.log('Script running with following options: ', JSON.stringify(options))
 
   const branch = options.branch.replace('refs/heads/', '')
-  const repoOwner = options.repoOwner
+  const [owner, repo] = options.repo.split('/')
 
   if (options.force) {
     console.log('--force set. Skipping validation logic')
@@ -35,7 +39,7 @@ async function createReleaseTag() {
       options.force ||
       ((await validateLocalChanges()) &&
         (await validateCurrentBranch(branch)) &&
-        (await checkWorkflowRun(repoOwner, branch)))
+        (await checkWorkflowRun(owner, repo, branch)))
 
     if (!isValid) {
       process.exit(1)


### PR DESCRIPTION
and not always running against node-newrelic

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed release creation reusable workflow by passing in repo to `bin/create-release-tag.js` and `bin/create-github-release.js`.

## Links
Closes #1053

## Details
Pretty confident this is the last of the changes as I tested it against node-test-utilities: https://github.com/newrelic/node-test-utilities/actions/runs/1679480457
