### PR TITLE
updated check-workflow-run to pass in workflows, made checking async,…

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,6 +6,8 @@ on: [workflow_dispatch]
 jobs:
   tag-and-publish:
     uses: newrelic/node-newrelic/.github/workflows/release-creation.yml@main
+    with:
+      workflows: ci-workflow.yml,smoke-test-workflow.yml
     # See release-creation.yml explaining why this has to be done
     secrets:
       npm_token: ${{ secrets.NODE_AGENT_NPM_TOKEN }}

--- a/.github/workflows/release-creation.yml
+++ b/.github/workflows/release-creation.yml
@@ -8,6 +8,11 @@ on:
         type: string
         required: false
         default: NEWS.md
+      workflows:
+        description: Comma-delimited list of workflows to check
+        type: string
+        required: false
+        default: ci-workflow.yml
     secrets:
       # Cannot rely on environment secrets(i.e. from node-newrelic settings or org level)
       # in a reusable workflow.  We must pass it in, see create-release.yml
@@ -48,7 +53,7 @@ jobs:
         git config user.name $GITHUB_ACTOR
         git config user.email gh-actions-${GITHUB_ACTOR}@github.com
     - name: Create Release Tag
-      run: node ./agent-repo/bin/create-release-tag.js --branch ${{ github.ref }} --repo ${{ github.repository }}
+      run: node ./agent-repo/bin/create-release-tag.js --branch ${{ github.ref }} --repo ${{ github.repository }} --workflows ${{ inputs.workflows }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Publish to Npm

--- a/bin/check-workflow-run.js
+++ b/bin/check-workflow-run.js
@@ -9,8 +9,8 @@ const Github = require('./github')
 
 const SUCCESS_MSG = '*** [OK] ***'
 
-async function filterAsync(array, cb) {
-  const filterMap = await Promise.all(array.map(cb))
+async function filterAsync(array, checkWorkflowSuccess) {
+  const filterMap = await Promise.all(array.map(checkWorkflowSuccess))
   return array.filter((_, index) => filterMap[index])
 }
 
@@ -33,7 +33,7 @@ async function checkWorkflowRun(repoOwner, repo, branch, workflows) {
   try {
     const successfulWorfklowRuns = await filterAsync(
       workflows,
-      async function filterWorkflows(workflow) {
+      async function filterWorkflow(workflow) {
         const latestRun = await github.getLatestWorkflowRun(workflow, branch)
         if (latestRun === undefined) {
           console.log('No ci workflow run found.')

--- a/bin/check-workflow-run.js
+++ b/bin/check-workflow-run.js
@@ -8,8 +8,11 @@
 const Github = require('./github')
 
 const SUCCESS_MSG = '*** [OK] ***'
-const WORKFLOWS = ['ci-workflow.yml']
-const AGENT_REPO = 'node-newrelic'
+
+async function filterAsync(array, cb) {
+  const filterMap = await Promise.all(array.map(cb))
+  return array.filter((_, index) => filterMap[index])
+}
 
 const formatRun = (run) => {
   return {
@@ -24,29 +27,26 @@ const formatRun = (run) => {
   }
 }
 
-async function checkWorkflowRun(repoOwner, repo, branch) {
+async function checkWorkflowRun(repoOwner, repo, branch, workflows) {
   const github = new Github(repoOwner, repo)
 
-  // only agent has smoke tests
-  // add to list
-  if (repo === AGENT_REPO) {
-    WORKFLOWS.push('smoke-test-workflow.yml')
-  }
-
   try {
-    const successfulWorfklowRuns = WORKFLOWS.filter(async (workflow) => {
-      const latestRun = await github.getLatestWorkflowRun(workflow, branch)
-      if (latestRun === undefined) {
-        console.log('No ci workflow run found.')
-        return false
+    const successfulWorfklowRuns = await filterAsync(
+      workflows,
+      async function filterWorkflows(workflow) {
+        const latestRun = await github.getLatestWorkflowRun(workflow, branch)
+        if (latestRun === undefined) {
+          console.log('No ci workflow run found.')
+          return false
+        }
+        console.log(`${workflow} run details: ${JSON.stringify(formatRun(latestRun))}`)
+        return latestRun.status === 'completed' && latestRun.conclusion === 'success'
       }
-      console.log(`${workflow} run details: ${JSON.stringify(formatRun(latestRun))}`)
-      return latestRun.status === 'completed' && latestRun.conclusion === 'success'
-    })
+    )
 
-    if (successfulWorfklowRuns.length === WORKFLOWS.length) {
+    if (successfulWorfklowRuns.length === workflows.length) {
       console.log(SUCCESS_MSG)
-      console.log(`${WORKFLOWS.join(', ')} were successful!`)
+      console.log(`${workflows.join(', ')} were successful!`)
       return true
     }
 

--- a/bin/create-release-tag.js
+++ b/bin/create-release-tag.js
@@ -18,6 +18,11 @@ program.option(
   'newrelic/node-newrelic'
 )
 program.option('-f --force', 'bypass validation')
+program.option(
+  '-w, --workflows <workflows>',
+  'Comma delimited list of workflows to check',
+  'ci-workflow.yml'
+)
 
 async function createReleaseTag() {
   // Parse commandline options inputs
@@ -29,6 +34,7 @@ async function createReleaseTag() {
 
   const branch = options.branch.replace('refs/heads/', '')
   const [owner, repo] = options.repo.split('/')
+  const workflows = options.workflows.split(',')
 
   if (options.force) {
     console.log('--force set. Skipping validation logic')
@@ -39,7 +45,7 @@ async function createReleaseTag() {
       options.force ||
       ((await validateLocalChanges()) &&
         (await validateCurrentBranch(branch)) &&
-        (await checkWorkflowRun(owner, repo, branch)))
+        (await checkWorkflowRun(owner, repo, branch, workflows)))
 
     if (!isValid) {
       process.exit(1)


### PR DESCRIPTION
… updated create-release-tag to default workflows and pass in diff ones for agent

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated the `create-release-tag` script to pass in workflows to check before creating tag.  
 * Fixed `create-release-tag` to properly filter out all async workflow run checks
 * Updated agent release to pass in a different list of workflows vs the default

## Details
The default for workflows will mostly be `ci-workflow.yml` with the exception of the agent and eslint-config-newrelic.  This was blocking me from releasing the eslint config rules because it doesn't have a `ci-workflow.yml`. I plan on adding `repolinter.yml` instead
