### PR TITLE
change how we invoke post release activities to work around not using PAT

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -2,8 +2,10 @@ name: Agent Post Release
 
 on:
   workflow_dispatch:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Create Release"]
+    types:
+      - completed
 
 jobs:
   update-rpm-and-docs:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   update-rpm-and-docs:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Changed the trigger for post release jobs.

## Details
I was made aware the workflows do not trigger when relying on the [GITHUB_TOKEN](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token).
We have two options:
 * Pass in a personal access token in workflows that will trigger others.
 * Use [workflow_run](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_run) to reference the specific workflow it is relying on.

I opted for the latter to avoid using Personal Access Tokens as much as possible.
