### PR TITLE
Script to add release notes to docs-website

### DIFF
--- a/bin/create-docs-pr.js
+++ b/bin/create-docs-pr.js
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const fs = require('fs')
+const { program } = require('commander')
+
+const Github = require('./github')
+const git = require('./git-commands')
+
+const DEFAULT_FILE_NAME = 'NEWS.md'
+/** e.g. v7.2.1 */
+const TAG_VALID_REGEX = /v\d+\.\d+\.\d+/
+
+program.requiredOption('--tag <tag>', 'tag name to create GitHub release for')
+program.option('--remote <remote>', 'remote to push branch to', 'origin')
+program.option('--repo-owner <repoOwner>', 'repository owner', 'newrelic')
+program.option(
+  '--changelog <changelog>',
+  'Name of changelog(defaults to NEWS.md)',
+  DEFAULT_FILE_NAME
+)
+program.option('-f --force', 'bypass validation')
+const RELEASE_NOTES_PATH = './src/content/docs/release-notes/agent-release-notes/nodejs-release-notes'
+
+async function createRelease() {
+  // Parse commandline options inputs
+  program.parse()
+
+  const options = program.opts()
+
+  console.log('Script running with following options: ', JSON.stringify(options))
+
+
+  try {
+    const version = options.tag.replace('refs/tags/', '')
+    console.log('Getting version from tag: ', version)
+
+    logStep('Validation')
+    if (options.force) {
+      console.log('--force set. Skipping validation logic')
+    }
+
+    if (!options.force && !TAG_VALID_REGEX.exec(version)) {
+      console.log('Tag arg invalid (%s). Valid tags in form: v#.#.# (e.g. v7.2.1)', version)
+      stopOnError()
+    }
+
+    logStep('Get Release Notes from File')
+    const { body, releaseDate } = await getReleaseNotes(version, options.changelog)
+    const releaseNotesBody = [
+      '---',
+      'subject: Node.js agent',
+      `releaseDate: '${releaseDate}'`,
+      `version: ${version.substr(1)}`,
+      `downloadLink: 'https://www.npmjs.com/package/newrelic'`,
+      '---',
+      '',
+      '##Notes',
+      '',
+      body
+    ].join('\n')
+
+
+    logStep('Branch Creation')
+    process.chdir('docs-website')
+    const branchName = `bob-add-node-${version}`
+    if (options.dryRun) {
+      console.log('Dry run indicated (--dry-run), not creating branch.')
+    } else {
+      console.log('Creating and checking out new branch: ', branchName)
+      await git.checkoutNewBranch(branchName)
+    }
+
+
+    logStep('Create Release Notes')
+    await addReleaseNotesFile(releaseNotesBody, version)
+
+    logStep('Commit Release Notes')
+
+    if (options.dryRun) {
+      console.log('Dry run indicated (--dry-run), skipping remaining steps.')
+      return
+    }
+
+    console.log(`Adding release notes for ${version}`)
+    await git.addAllFiles()
+    await git.commit(`chore: Node.js Agent ${version} Release Notes.`)
+    console.log(`Pushing branch to remote ${options.remote}`)
+    await git.pushToRemote(options.remote, branchName)
+
+    logStep('Create Pull Request')
+
+    if (!process.env.GITHUB_TOKEN) {
+      console.log('GITHUB_TOKEN required to create a pull request')
+      stopOnError()
+    }
+
+    console.log(`Creating PR with new release for repo owner ${options.repoOwner}`)
+    const github = new Github(options.repoOwner, 'docs-website')
+    const title = `Node.js Agent ${version} Release Notes`
+    // TODO: add proper pr body and submit then be done with it
+
+    process.chdir('..')
+    console.log('*** Full Run Successful ***')
+
+  } catch (err) {
+    if (err.status && err.status === 404) {
+      console.log('404 status error detected. For octokit, this may mean insuffient permissions.')
+      console.log('Ensure you have a valid GITHUB_TOKEN set in your env vars.')
+    }
+
+    stopOnError(err)
+  }
+}
+
+async function getReleaseNotes(version, releaseNotesFile) {
+  console.log('Retrieving release notes from file: ', releaseNotesFile)
+
+  const data = await readReleaseNoteFile(releaseNotesFile)
+
+  const currentVersionHeader = `### ${version}`
+  if (data.indexOf(currentVersionHeader) !== 0) {
+    throw new Error(`Current tag (${currentVersionHeader}) not first line of release notes.`)
+  }
+
+  const sections = data.split('### ', 2)
+  if (sections.length !== 2) {
+    throw new Error('Did not split into multiple sections. Double check notes format.')
+  }
+
+  const [ , tagSection] = sections
+  // e.g. v7.1.2 (2021-02-24)\n\n
+  const headingRegex = /^v\d+\.\d+\.\d+ \((\d{4}-\d{2}-\d{2})\)\n\n/
+  const body = tagSection.replace(headingRegex, '')
+  const [ , releaseDate] = headingRegex.exec(tagSection)
+
+  return { body, releaseDate }
+}
+
+async function readReleaseNoteFile(file) {
+  const promise = new Promise((resolve, reject) => {
+    fs.readFile(file, 'utf8', (err, data) => {
+      if (err) {
+        return reject(err)
+      }
+
+      return resolve(data)
+    })
+  })
+
+  return promise
+}
+
+function stopOnError(err) {
+  if (err) {
+    console.error(err)
+  }
+
+  console.log('Halting execution with exit code: 1')
+  process.exit(1)
+}
+
+function logStep(step) {
+  console.log(`\n ----- [Step]: ${step} -----\n`)
+}
+
+function addReleaseNotesFile(body, version) {
+  const FILE = `node-agent-bob-${version}.mdx`
+  return new Promise((resolve, reject) => {
+    fs.writeFile(`${RELEASE_NOTES_PATH}/${FILE}`, body, 'utf8', (writeErr) => {
+      if(writeErr) {
+        reject(err)
+      }
+
+      console.log(`Added new release notes ${FILE} to ${RELEASE_NOTES_PATH}`)
+      resolve()
+    })
+  })
+}
+
+createRelease()

--- a/bin/create-docs-pr.js
+++ b/bin/create-docs-pr.js
@@ -196,17 +196,22 @@ function formatReleaseNotes(releaseDate, version, body) {
  * @param {string} version
  */
 function addReleaseNotesFile(body, version) {
-  const FILE = `node-agent-bob-${version}.mdx`
+  const FILE = getFileName(version)
   return new Promise((resolve, reject) => {
-    fs.writeFile(`${RELEASE_NOTES_PATH}/${FILE}`, body, 'utf8', (writeErr) => {
+    fs.writeFile(FILE, body, 'utf8', (writeErr) => {
       if (writeErr) {
         reject(writeErr)
       }
 
-      console.log(`Added new release notes ${FILE} to ${RELEASE_NOTES_PATH}`)
+      console.log(`Added new release notes ${FILE}`)
       resolve()
     })
   })
+}
+
+function getFileName(version) {
+  const FILE = `node-agent-${version}.mdx`
+  return `${RELEASE_NOTES_PATH}/${FILE}`
 }
 
 /**
@@ -224,7 +229,8 @@ async function commitRelaseNotes(version, remote, branch, dryRun) {
   }
 
   console.log(`Adding release notes for ${version}`)
-  await git.addAllFiles()
+  const files = [getFileName(version)]
+  await git.addFiles(files)
   await git.commit(`chore: Node.js Agent ${version} Release Notes.`)
   console.log(`Pushing branch to remote ${remote}`)
   await git.pushToRemote(remote, branch)

--- a/bin/create-docs-pr.js
+++ b/bin/create-docs-pr.js
@@ -6,6 +6,7 @@
 'use strict'
 
 const fs = require('fs')
+const path = require('path')
 const { program } = require('commander')
 
 const Github = require('./github')
@@ -25,6 +26,11 @@ program.option(
 )
 program.option('-f --force', 'bypass validation')
 program.option('--dry-run', 'executes script but does not commit nor create PR')
+program.option(
+  '--repo-path <path',
+  'Path to the docs-website fork on local machine',
+  'docs-website'
+)
 const RELEASE_NOTES_PATH =
   './src/content/docs/release-notes/agent-release-notes/nodejs-release-notes'
 
@@ -45,7 +51,7 @@ async function createRelease() {
     logStep('Get Release Notes from File')
     const { body, releaseDate } = await getReleaseNotes(version, options.changelog)
     logStep('Branch Creation')
-    const branchName = await createBranch(version, options.dryRun)
+    const branchName = await createBranch(options.repoPath, version, options.dryRun)
     logStep('Format release notes file')
     const releaseNotesBody = formatReleaseNotes(releaseDate, version, body)
     logStep('Create Release Notes')
@@ -138,11 +144,14 @@ async function readReleaseNoteFile(file) {
  * Creates a branch in your local `docs-website` fork
  * That follows the pattern `add-node-<new agent version>`
  *
+ * @param filePath
  * @param {string} version
  * @param {boolean} dryRun skip branch creation
  */
-async function createBranch(version, dryRun) {
-  process.chdir('docs-website')
+async function createBranch(filePath, version, dryRun) {
+  filePath = path.resolve(filePath)
+  console.log(`Changing to ${filePath}`)
+  process.chdir(filePath)
   const branchName = `add-node-${version}`
   if (dryRun) {
     console.log(`Dry run indicated (--dry-run), not creating branch ${branchName}`)

--- a/bin/git-commands.js
+++ b/bin/git-commands.js
@@ -9,6 +9,7 @@ const { exec } = require('child_process')
 // in CI we clone `node-newrelic` for reusable workflows
 // we do not want it to be part of `git status` nor adding via `git add .`
 const AGENT_SUB_REPO = 'agent-repo'
+const DOCS_SUB_REPO = 'docs-website'
 
 async function getPushRemotes() {
   const stdout = await execAsPromise('git remote -v')
@@ -34,7 +35,7 @@ async function getPushRemotes() {
 async function getLocalChanges() {
   const stdout = await execAsPromise('git status --short --porcelain')
   const changes = stdout.split('\n').filter((line) => {
-    return line.length > 0 && !line.includes(AGENT_SUB_REPO)
+    return line.length > 0 && !line.includes(AGENT_SUB_REPO || DOCS_SUB_REPO)
   })
 
   return changes

--- a/bin/git-commands.js
+++ b/bin/git-commands.js
@@ -62,6 +62,14 @@ async function addAllFiles() {
   return output
 }
 
+async function addFiles(files) {
+  files = files.join(' ')
+  const stdout = await execAsPromise(`git add ${files}`)
+  const output = stdout.trim()
+
+  return output
+}
+
 async function commit(message) {
   const stdout = await execAsPromise(`git commit -m "${message}"`)
   const output = stdout.trim()
@@ -156,5 +164,6 @@ module.exports = {
   pushTags,
   checkout,
   clone,
-  sparseCloneRepo
+  sparseCloneRepo,
+  addFiles
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added a script to be used by agent developers to add a PR to `docs-website` after the release of agent.

## Links
Closes #590

## Details
Currently this relies on the fact you have a fork of docs-website on your local machine.  Once we get a machine user we can remove some code around specifying the username as we will be cloning the repo in CI and adding PR from the repo itself.

To run script:

```sh
GITHUB_TOKEN=<redacted> node bin/create-docs-pr.js --username bizob2828 --tag v8.7.0 --repo-path /path/to/docs-website
```

You can also use the `--dry-run` flag to run through script but it will not create the branch, push to origin and create PR.


