### PR TITLE
upgraded test utils so sub packages properly run versioned tests

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1770,7 +1770,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ### @newrelic/test-utilities
 
-This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v6.1.1](https://github.com/newrelic/node-test-utilities/tree/v6.1.1)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v6.1.1/LICENSE):
+This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v6.3.0](https://github.com/newrelic/node-test-utilities/tree/v6.3.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v6.3.0/LICENSE):
 
 ```
                                  Apache License
@@ -3292,7 +3292,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ### tap
 
-This product includes source derived from [tap](https://github.com/tapjs/node-tap) ([v15.0.10](https://github.com/tapjs/node-tap/tree/v15.0.10)), distributed under the [ISC License](https://github.com/tapjs/node-tap/blob/v15.0.10/LICENSE):
+This product includes source derived from [tap](https://github.com/tapjs/node-tap) ([v15.1.6](https://github.com/tapjs/node-tap/tree/v15.1.6)), distributed under the [ISC License](https://github.com/tapjs/node-tap/blob/v15.1.6/LICENSE):
 
 ```
 The ISC License

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@newrelic/eslint-config": "^0.0.3",
         "@newrelic/newrelic-oss-cli": "^0.1.2",
         "@newrelic/proxy": "^2.0.0",
-        "@newrelic/test-utilities": "^6.1.1",
+        "@newrelic/test-utilities": "^6.3.0",
         "@octokit/rest": "^18.0.15",
         "@slack/bolt": "^3.7.0",
         "ajv": "^6.12.6",
@@ -812,9 +812,9 @@
       }
     },
     "node_modules/@newrelic/test-utilities": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-6.1.1.tgz",
-      "integrity": "sha512-JTOIqL0ybf1nTpqO5i5JQGdyEp6iXpUwx6YnaO7IKTxbJnnKYOrxaXyq0cRQXeGVv7TxcOXjhOVAO+eJB4C3cw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-6.3.0.tgz",
+      "integrity": "sha512-zlW0xfolnnstRYVN+0XShnAr+SCkIy0KecFM9dOPKifGZd1lOsm8jsebWSBVaEq53uuPLOmT++Rmbve/axiQ+g==",
       "dev": true,
       "dependencies": {
         "async": "^2.6.0",
@@ -12496,14 +12496,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/tap/node_modules/arrify": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/tap/node_modules/astral-regex": {
       "version": "2.0.0",
       "dev": true,
@@ -12562,36 +12554,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
-      }
-    },
-    "node_modules/tap/node_modules/caller-callsite": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tap/node_modules/caller-path": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "caller-callsite": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tap/node_modules/callsites": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/tap/node_modules/caniuse-lite": {
@@ -12702,11 +12664,6 @@
       "version": "1.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/tap/node_modules/colorette": {
-      "version": "1.4.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/commondir": {
@@ -12892,25 +12849,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/tap/node_modules/import-jsx": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.5.5",
-        "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
-        "@babel/plugin-transform-destructuring": "^7.5.0",
-        "@babel/plugin-transform-react-jsx": "^7.3.0",
-        "caller-path": "^2.0.0",
-        "find-cache-dir": "^3.2.0",
-        "make-dir": "^3.0.2",
-        "resolve-from": "^3.0.0",
-        "rimraf": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/tap/node_modules/indent-string": {
@@ -13123,135 +13061,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/tap/node_modules/lodash.throttle": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tap/node_modules/log-update": {
-      "version": "3.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^3.2.0",
-        "cli-cursor": "^2.1.0",
-        "wrap-ansi": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/tap/node_modules/log-update/node_modules/ansi-escapes": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tap/node_modules/log-update/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tap/node_modules/log-update/node_modules/cli-cursor": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tap/node_modules/log-update/node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tap/node_modules/log-update/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tap/node_modules/log-update/node_modules/mimic-fn": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tap/node_modules/log-update/node_modules/onetime": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tap/node_modules/log-update/node_modules/restore-cursor": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tap/node_modules/log-update/node_modules/string-width": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tap/node_modules/log-update/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tap/node_modules/log-update/node_modules/wrap-ansi": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tap/node_modules/loose-envify": {
       "version": "1.4.0",
       "dev": true,
@@ -13444,16 +13253,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tap/node_modules/prop-types": {
-      "version": "15.7.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "node_modules/tap/node_modules/punycode": {
       "version": "2.1.1",
       "dev": true,
@@ -13485,11 +13284,6 @@
         "shell-quote": "^1.6.1",
         "ws": "^7"
       }
-    },
-    "node_modules/tap/node_modules/react-is": {
-      "version": "16.13.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tap/node_modules/react-reconciler": {
       "version": "0.26.2",
@@ -13666,45 +13460,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/tap/node_modules/string-length": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "astral-regex": "^1.0.0",
-        "strip-ansi": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tap/node_modules/string-length/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tap/node_modules/string-length/node_modules/astral-regex": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tap/node_modules/string-length/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tap/node_modules/string-width": {
@@ -15423,9 +15178,9 @@
       "requires": {}
     },
     "@newrelic/test-utilities": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-6.1.1.tgz",
-      "integrity": "sha512-JTOIqL0ybf1nTpqO5i5JQGdyEp6iXpUwx6YnaO7IKTxbJnnKYOrxaXyq0cRQXeGVv7TxcOXjhOVAO+eJB4C3cw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-6.3.0.tgz",
+      "integrity": "sha512-zlW0xfolnnstRYVN+0XShnAr+SCkIy0KecFM9dOPKifGZd1lOsm8jsebWSBVaEq53uuPLOmT++Rmbve/axiQ+g==",
       "dev": true,
       "requires": {
         "async": "^2.6.0",
@@ -24461,10 +24216,6 @@
           "bundled": true,
           "dev": true
         },
-        "arrify": {
-          "version": "2.0.1",
-          "dev": true
-        },
         "astral-regex": {
           "version": "2.0.0",
           "bundled": true,
@@ -24500,24 +24251,6 @@
             "node-releases": "^2.0.1",
             "picocolors": "^1.0.0"
           }
-        },
-        "caller-callsite": {
-          "version": "2.0.0",
-          "dev": true,
-          "requires": {
-            "callsites": "^2.0.0"
-          }
-        },
-        "caller-path": {
-          "version": "2.0.0",
-          "dev": true,
-          "requires": {
-            "caller-callsite": "^2.0.0"
-          }
-        },
-        "callsites": {
-          "version": "2.0.0",
-          "dev": true
         },
         "caniuse-lite": {
           "version": "1.0.30001279",
@@ -24589,10 +24322,6 @@
         "color-name": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true
-        },
-        "colorette": {
-          "version": "1.4.0",
           "dev": true
         },
         "commondir": {
@@ -24712,21 +24441,6 @@
           "version": "3.0.0",
           "bundled": true,
           "dev": true
-        },
-        "import-jsx": {
-          "version": "4.0.0",
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.5.5",
-            "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
-            "@babel/plugin-transform-destructuring": "^7.5.0",
-            "@babel/plugin-transform-react-jsx": "^7.3.0",
-            "caller-path": "^2.0.0",
-            "find-cache-dir": "^3.2.0",
-            "make-dir": "^3.0.2",
-            "resolve-from": "^3.0.0",
-            "rimraf": "^3.0.0"
-          }
         },
         "indent-string": {
           "version": "4.0.0",
@@ -24866,88 +24580,6 @@
           "bundled": true,
           "dev": true
         },
-        "lodash.throttle": {
-          "version": "4.1.1",
-          "dev": true
-        },
-        "log-update": {
-          "version": "3.4.0",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^3.2.0",
-            "cli-cursor": "^2.1.0",
-            "wrap-ansi": "^5.0.0"
-          },
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "3.2.0",
-              "dev": true
-            },
-            "ansi-regex": {
-              "version": "4.1.0",
-              "dev": true
-            },
-            "cli-cursor": {
-              "version": "2.1.0",
-              "dev": true,
-              "requires": {
-                "restore-cursor": "^2.0.0"
-              }
-            },
-            "emoji-regex": {
-              "version": "7.0.3",
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "dev": true
-            },
-            "mimic-fn": {
-              "version": "1.2.0",
-              "dev": true
-            },
-            "onetime": {
-              "version": "2.0.1",
-              "dev": true,
-              "requires": {
-                "mimic-fn": "^1.0.0"
-              }
-            },
-            "restore-cursor": {
-              "version": "2.0.0",
-              "dev": true,
-              "requires": {
-                "onetime": "^2.0.0",
-                "signal-exit": "^3.0.2"
-              }
-            },
-            "string-width": {
-              "version": "3.1.0",
-              "dev": true,
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            },
-            "wrap-ansi": {
-              "version": "5.1.0",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.0",
-                "string-width": "^3.0.0",
-                "strip-ansi": "^5.0.0"
-              }
-            }
-          }
-        },
         "loose-envify": {
           "version": "1.4.0",
           "bundled": true,
@@ -25070,15 +24702,6 @@
             "find-up": "^4.0.0"
           }
         },
-        "prop-types": {
-          "version": "15.7.2",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          }
-        },
         "punycode": {
           "version": "2.1.1",
           "bundled": true,
@@ -25101,10 +24724,6 @@
             "shell-quote": "^1.6.1",
             "ws": "^7"
           }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "dev": true
         },
         "react-reconciler": {
           "version": "0.26.2",
@@ -25225,31 +24844,6 @@
               "version": "2.0.0",
               "bundled": true,
               "dev": true
-            }
-          }
-        },
-        "string-length": {
-          "version": "3.1.0",
-          "dev": true,
-          "requires": {
-            "astral-regex": "^1.0.0",
-            "strip-ansi": "^5.2.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "dev": true
-            },
-            "astral-regex": {
-              "version": "1.0.0",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "@newrelic/eslint-config": "^0.0.3",
     "@newrelic/newrelic-oss-cli": "^0.1.2",
     "@newrelic/proxy": "^2.0.0",
-    "@newrelic/test-utilities": "^6.1.1",
+    "@newrelic/test-utilities": "^6.3.0",
     "@octokit/rest": "^18.0.15",
     "@slack/bolt": "^3.7.0",
     "ajv": "^6.12.6",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Wed Dec 08 2021 10:12:28 GMT-0800 (Pacific Standard Time)",
+  "lastUpdated": "Thu Jan 13 2022 11:55:16 GMT-0500 (Eastern Standard Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -212,15 +212,15 @@
       "email": "nathan@tootallnate.net",
       "url": "http://n8.io/"
     },
-    "@newrelic/test-utilities@6.1.1": {
+    "@newrelic/test-utilities@6.3.0": {
       "name": "@newrelic/test-utilities",
-      "version": "6.1.1",
-      "range": "^6.1.1",
+      "version": "6.3.0",
+      "range": "^6.3.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-test-utilities",
-      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v6.1.1",
+      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v6.3.0",
       "licenseFile": "node_modules/@newrelic/test-utilities/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v6.1.1/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v6.3.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"
@@ -686,15 +686,15 @@
       "licenseTextSource": "file",
       "publisher": "Christian Johansen"
     },
-    "tap@15.0.10": {
+    "tap@15.1.6": {
       "name": "tap",
-      "version": "15.0.10",
+      "version": "15.1.6",
       "range": "^15.0.9",
       "licenses": "ISC",
       "repoUrl": "https://github.com/tapjs/node-tap",
-      "versionedRepoUrl": "https://github.com/tapjs/node-tap/tree/v15.0.10",
+      "versionedRepoUrl": "https://github.com/tapjs/node-tap/tree/v15.1.6",
       "licenseFile": "node_modules/tap/LICENSE",
-      "licenseUrl": "https://github.com/tapjs/node-tap/blob/v15.0.10/LICENSE",
+      "licenseUrl": "https://github.com/tapjs/node-tap/blob/v15.1.6/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Isaac Z. Schlueter",
       "email": "i@izs.me",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Upgraded `@newrelic/test-utilities` to latest to get `helpers.getShim` so sub packages properly execute.

## Details
We updated sub packages like `@newrelic/koa` and its versioned tests use `helpers.getShim`.  That didn't exist until 6.3.0.
