### PR TITLE
Added support for mongodb driver > 4.2.0

### DIFF
--- a/bin/docker-services.sh
+++ b/bin/docker-services.sh
@@ -15,6 +15,12 @@ else
   docker run -d --name nr_node_mongodb -p 27017:27017 library/mongo:2;
 fi
 
+if docker ps -a | grep -q "nr_node_mongodb_5"; then
+  docker start nr_node_mongodb_5;
+else
+  docker run -d --name nr_node_mongodb_5 -p 27018:27017 library/mongo:5;
+fi
+
 if docker ps -a | grep -q "nr_node_mysql"; then
   docker start nr_node_mysql;
 else

--- a/test/lib/params.js
+++ b/test/lib/params.js
@@ -12,6 +12,11 @@ module.exports = {
   mongodb_host: process.env.NR_NODE_TEST_MONGODB_HOST || 'localhost',
   mongodb_port: process.env.NR_NODE_TEST_MONGODB_PORT || 27017,
 
+  // mongodb 4.2.0 does not allow mongo server v2.
+  // There is now a separate container that maps 27018 to mongo:5
+  mongodb_v4_host: process.env.NR_NODE_TEST_MONGODB_V4_HOST || 'localhost',
+  mongodb_v4_port: process.env.NR_NODE_TEST_MONGODB_V4_PORT || 27018,
+
   mysql_host: process.env.NR_NODE_TEST_MYSQL_HOST || 'localhost',
   mysql_port: process.env.NR_NODE_TEST_MYSQL_PORT || 3306,
 

--- a/test/versioned/mongodb/collection-index.tap.js
+++ b/test/versioned/mongodb/collection-index.tap.js
@@ -45,18 +45,20 @@ common.test('indexes', function indexesTest(t, collection, verify) {
   collection.indexes(function done(err, data) {
     t.error(err)
     const result = data && data[0]
+    const expectedResult = {
+      v: result && result.v,
+      key: { _id: 1 },
+      name: '_id_'
+    }
+
     // this will fail if running a mongodb server > 4.3.1
     // https://jira.mongodb.org/browse/SERVER-41696
-    t.same(
-      result,
-      {
-        v: result && result.v,
-        key: { _id: 1 },
-        name: '_id_',
-        ns: common.DB_NAME + '.testCollection'
-      },
-      'should have expected results'
-    )
+    // we only connect to a server > 4.3.1 when using the mongodb
+    // driver of 4.2.0+
+    if (semver.satisfies(mongoPackage.version, '<4.2.0')) {
+      expectedResult.ns = `${common.DB_NAME}.testCollection`
+    }
+    t.same(result, expectedResult, 'should have expected results')
 
     verify(
       null,

--- a/test/versioned/mongodb/common.js
+++ b/test/versioned/mongodb/common.js
@@ -19,7 +19,12 @@ exports.MONGO_SEGMENT_RE = MONGO_SEGMENT_RE
 exports.TRANSACTION_NAME = TRANSACTION_NAME
 exports.DB_NAME = DB_NAME
 
-exports.connect = semver.satisfies(mongoPackage.version, '<3') ? connectV2 : connectV3
+// Check package versions to decide which connect function to use below
+exports.connect = semver.satisfies(mongoPackage.version, '<3')
+  ? connectV2
+  : semver.satisfies(mongoPackage.version, '>=4.2.0')
+  ? connectV4
+  : connectV3
 
 exports.checkMetrics = checkMetrics
 exports.close = close
@@ -79,6 +84,35 @@ function connectV3(mongodb, host, replicaSet = false) {
   })
 }
 
+// This is same as connectV3 except it uses a different
+// set of params to connect to the mongodb_v4 container
+// it is actually just using the `mongodb:5` image
+function connectV4(mongodb, host, replicaSet = false) {
+  return new Promise((resolve, reject) => {
+    if (host) {
+      host = encodeURIComponent(host)
+    } else {
+      host = params.mongodb_v4_host + ':' + params.mongodb_v4_port
+    }
+
+    let connString = `mongodb://${host}`
+    let options = {}
+
+    if (replicaSet) {
+      connString = `mongodb://${host},${host},${host}`
+      options = { useNewUrlParser: true, useUnifiedTopology: true }
+    }
+    mongodb.MongoClient.connect(connString, options, function (err, client) {
+      if (err) {
+        reject(err)
+      }
+
+      const db = client.db(DB_NAME)
+      resolve({ db, client })
+    })
+  })
+}
+
 function close(client, db) {
   return new Promise((resolve) => {
     if (db && typeof db.close === 'function') {
@@ -92,13 +126,16 @@ function close(client, db) {
 }
 
 function getHostName(agent) {
-  return urltils.isLocalhost(params.mongodb_host)
-    ? agent.config.getHostnameSafe()
+  const host = semver.satisfies(mongoPackage.version, '>=4.2.0')
+    ? params.mongodb_v4_host
     : params.mongodb_host
+  return urltils.isLocalhost(host) ? agent.config.getHostnameSafe() : host
 }
 
 function getPort() {
-  return String(params.mongodb_port)
+  return semver.satisfies(mongoPackage.version, '>=4.2.0')
+    ? String(params.mongodb_v4_port)
+    : String(params.mongodb_port)
 }
 
 function checkMetrics(t, agent, host, port, metrics) {

--- a/test/versioned/mongodb/common.js
+++ b/test/versioned/mongodb/common.js
@@ -20,11 +20,14 @@ exports.TRANSACTION_NAME = TRANSACTION_NAME
 exports.DB_NAME = DB_NAME
 
 // Check package versions to decide which connect function to use below
-exports.connect = semver.satisfies(mongoPackage.version, '<3')
-  ? connectV2
-  : semver.satisfies(mongoPackage.version, '>=4.2.0')
-  ? connectV4
-  : connectV3
+exports.connect = function connect() {
+  if (semver.satisfies(mongoPackage.version, '<3')) {
+    return connectV2.apply(this, arguments)
+  } else if (semver.satisfies(mongoPackage.version, '>=3 <4.2.0')) {
+    return connectV3.apply(this, arguments)
+  }
+  return connectV4.apply(this, arguments)
+}
 
 exports.checkMetrics = checkMetrics
 exports.close = close

--- a/test/versioned/mongodb/package.json
+++ b/test/versioned/mongodb/package.json
@@ -8,7 +8,7 @@
         "node": ">=12"
       },
       "dependencies": {
-        "mongodb": ">=2.1 <4.2.0 "
+        "mongodb": ">=2.1"
       },
       "files": [
         "collection-find.tap.js",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added a new `mongo:5` container to `npm run sevices` to test mongodb driver >=4.2.0.

## Links
Closes #982

## Details
This just adds a new config stanza in `lib/params` so if the db driver >=4.2.0 it will connect to the mongo:5 container.
