### PR TITLE
Fix to compute time when using shim.bindSegment.

### DIFF
--- a/examples/shim/Datastore-Simple.md
+++ b/examples/shim/Datastore-Simple.md
@@ -158,7 +158,7 @@ is responsible for connecting the two. Here's how that might look in our case:
   shim.recordOperation(proto, ['connect', 'shutdown'], {
     callback: function operationCallbackBinder(shim, opFunc, opName, segment, args) {
       var cb = args[args.length - 1]
-      args[args.length - 1] = shim.bindSegment(cb, segment)
+      args[args.length - 1] = shim.bindSegment(cb, segment, true)
     }
   })
 ```


### PR DESCRIPTION
It was not computing the time spent by the operation without passing the third parameter as true.

## Proposed Release Notes
Documentation fix in a sample of the Datastore Instrumentation for Node.js.

## Details
The [tedious-newrelic](https://github.com/CKarper/tedious-newrelic) lib was not computing query times. When I was analyzing the code, everything was fine following this Datastore Instrumentation documentation. After quite a while of debugging and studying the API documentation, I found this fix. That's why I am opening this pull request and another [pull request](https://github.com/CKarper/tedious-newrelic/pull/3/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R15) in the lib.

It would also be nice to better explain the third parameter of the `shim.bindSegment` function and the direct effect of the false default value in the API doc.