### PR TITLE
updates method for retrieving current agent version from repo

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -26,7 +26,7 @@ jobs:
       run: npm ci
     - name: Get Created Tag
       id: get_tag
-      run: echo "::set-output name=latest_tag::$(git describe --tags --abbrev=0)"
+      run: echo "::set-output name=latest_tag::$(cat package.json | jq .version)"
     - name: Update system configuration pages
       run: node ./bin/update-system-config-pages.js --version ${{ steps.get_tag.outputs.latest_tag }} --staging-key ${{ secrets.NEW_RELIC_API_KEY_STAGING }} --prod-key ${{ secrets.NEW_RELIC_API_KEY_PRODUCTION }}
     - name: Publish API Docs

--- a/bin/update-system-config-pages.js
+++ b/bin/update-system-config-pages.js
@@ -27,7 +27,7 @@ function getPayload(version) {
   return {
     system_configuration: {
       key: 'nodejs_agent_version',
-      value: version.substr(1) // strip the v from v1.0.0
+      value: version
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated method for retrieving agent version from repository by using `cat package.json | jq .version`

## Links
Closes #1071 

## Details
I tested this via act `act -j update-rpm-and-docs` with a modified workflow.

Output here
```sh
[Agent Post Release/update-rpm-and-docs]   ⚙  ::set-output:: latest_tag="8.7.1"
[Agent Post Release/update-rpm-and-docs]   ✅  Success - Get Created Tag
[Agent Post Release/update-rpm-and-docs] ⭐  Run Test output
[Agent Post Release/update-rpm-and-docs]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /Users/revans/code/node-newrelic/workflow/3] user= workdir=
| Value of output 8.7.1
```
