### PR TITLE
Fixed post release workflow, removed re-installing deps in publish api docs

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -25,6 +25,10 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
       run: npm ci
+    - name: Setup GitHub Credentials
+      run: |
+        git config user.name $GITHUB_ACTOR
+        git config user.email gh-actions-${GITHUB_ACTOR}@github.com
     - name: Get Created Tag
       id: get_tag
       run: echo "::set-output name=latest_tag::$(cat package.json | jq .version)"

--- a/bin/publish-docs.sh
+++ b/bin/publish-docs.sh
@@ -1,4 +1,5 @@
 #! /bin/sh
+set -e
 
 # Copyright 2020 New Relic Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "prepare-test": "npm run ca-gen && npm run ssl && npm run docker-env",
     "lint": "eslint ./*.js lib test bin examples",
     "lint:fix": "eslint --fix, ./*.js lib test bin examples",
-    "public-docs": "npm ci && jsdoc -c ./jsdoc-conf.json --tutorials examples/shim api.js lib/shim/ lib/transaction/handle.js && cp examples/shim/*.png out/",
+    "public-docs": "jsdoc -c ./jsdoc-conf.json --tutorials examples/shim api.js lib/shim/ lib/transaction/handle.js && cp examples/shim/*.png out/",
     "publish-docs": "./bin/publish-docs.sh",
     "services": "./bin/docker-services.sh",
     "smoke": "npm run ssl && time tap test/smoke/**/**/*.tap.js --timeout=180 --no-coverage",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Fri Jan 14 2022 12:26:49 GMT-0800 (Pacific Standard Time)",
+  "lastUpdated": "Fri Feb 04 2022 10:45:44 GMT-0500 (Eastern Standard Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed Post Release workflow by properly configuring git credentials so it can push API docs to branch
 * Added `set -e` in publish docs script to exit on possible failures
 * Removed redundant `npm ci` in publish API docs script

## Links
Closes #1077
