### PR TITLE
added ability to not include PRs that have certain labels

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -17,10 +17,11 @@ jobs:
     - name: Install Dependencies
       run: npm ci
     - name: Check for PRs not yet released
-      run: node ./bin/pending-prs.js --repos $NR_REPOS
+      run: node ./bin/pending-prs.js --repos $NR_REPOS --ignore-labels $IGNORE_LABELS
       env:
         GITHUB_TOKEN: ${{ secrets.NODE_AGENT_GH_TOKEN }}
         SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
         SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
         SLACK_SECRET: ${{ secrets.SLACK_SECRET }}
         NR_REPOS: ${{ secrets.NR_REPOS }}
+        IGNORE_LABELS: ${{ secrets.IGNORE_LABELS }}

--- a/bin/pending-prs.js
+++ b/bin/pending-prs.js
@@ -16,6 +16,11 @@ program.requiredOption(
   '--repos <repos>',
   'Comma-delimited list of repos in newrelic org to check for unreleased PRs'
 )
+program.option(
+  '--ignore-labels <labels>',
+  'Comma-delimited list of labels to ignore when creating the list of unreleased PRs. This is intended to be used for PRs that do not have code that ships within the module.'
+)
+program.option('--dry-run', 'Execute the logic but do not send slack message')
 
 /**
  * Finds the last released tag and all the PRs that have been
@@ -47,9 +52,10 @@ function unreleasedPRs() {
     })
 
     const repos = opts.repos.split(',')
+    const ignoredLabels = opts.ignoreLabels.split(',')
 
     repos.forEach(async (repo) => {
-      const { prs, latestRelease } = await findMergedPRs(repo)
+      const { prs, latestRelease } = await findMergedPRs(repo, ignoredLabels)
 
       let msg = null
 
@@ -59,11 +65,15 @@ function unreleasedPRs() {
         msg = createSlackMessage(prs, latestRelease, repo)
       }
 
-      await app.client.chat.postMessage({
-        channel,
-        text: msg
-      })
-      console.log(`Posted msg to ${channel}`)
+      if (opts.dryRun) {
+        console.log(`Skipping slack but here are the deets\n${msg}`)
+      } else {
+        await app.client.chat.postMessage({
+          channel,
+          text: msg
+        })
+        console.log(`Posted msg to ${channel}`)
+      }
     })
   } catch (err) {
     stopOnError(err)
@@ -100,7 +110,7 @@ function createSlackMessage(prs, latestRelease, repo) {
     `
 }
 
-async function findMergedPRs(repo) {
+async function findMergedPRs(repo, ignoredLabels) {
   const github = new Github('newrelic', repo)
   const latestRelease = await github.getLatestRelease()
   console.log(
@@ -119,9 +129,12 @@ async function findMergedPRs(repo) {
   const mergedPullRequests = await github.getMergedPullRequestsSince(commitDate)
 
   const filteredPullRequests = mergedPullRequests.filter((pr) => {
+    // Find all PRs without an ignored label
+    const withIngored = pr.labels.some(({ name }) => ignoredLabels.includes(name))
+
     // Sometimes the commit for the PR the tag is set to has an earlier time than
     // the PR merge time and we'll pull in release note PRs. Filters those out.
-    return pr.merge_commit_sha !== tag.commit.sha
+    return pr.merge_commit_sha !== tag.commit.sha && !withIngored
   })
 
   console.log(`Found ${filteredPullRequests.length} PRs not yet released.`)


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added ability to ignore certain PRs in `bin/pending-prs.js` report to slack

## Links
Closes #1082

## Details
I will create an environmental secret to house the `ignoredLabels`.  Right now my thought is to apply the following:
 * `dev:automation`
 * `documentation`
 * `dev:tests`

I also added a `dry-run` flag to the script so it won't post to slack.  

```sh
 GITHUB_TOKEN=<redacted> node bin/pending-prs.js --repos node-newrelic --dry-run --ignore-labels dev:automation,documentation,dev:tests
```