### PR TITLE
Pass Active Segment to inContext callback

### DIFF
--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -1307,7 +1307,7 @@ function applySegment(func, segment, full, context, args, inContextCB) {
     }
 
     if (typeof inContextCB === 'function') {
-      inContextCB()
+      inContextCB(segment)
     }
 
     try {

--- a/test/unit/shim/shim.test.js
+++ b/test/unit/shim/shim.test.js
@@ -2104,7 +2104,8 @@ tap.test('Shim', function (t) {
         false,
         {},
         [],
-        function checkSegment() {
+        function checkSegment(activeSegment) {
+          t.equal(activeSegment, segment)
           t.equal(contextManager.getContext(), segment)
           t.end()
         }


### PR DESCRIPTION

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated shim to pass active segment to inContext callback.

## Links

## Details
This provides convenience for instrumentation that needs to decorate the active segment without having to call to retrieve it.
