### PR TITLE
IMDS v2 support for AWS Metadata

### DIFF
--- a/lib/utilization/aws-info.js
+++ b/lib/utilization/aws-info.js
@@ -40,7 +40,7 @@ function fetchAWSInfo(agent, callback) {
     const metadataOpts = {
       method: 'GET',
       host: INSTANCE_HOST,
-      path: '/latest/dynamic/instance-identity/document',
+      path: '/2016-09-02/dynamic/instance-identity/document',
       headers: { 'X-aws-ec2-metadata-token': authToken }
     }
 

--- a/lib/utilization/aws-info.js
+++ b/lib/utilization/aws-info.js
@@ -26,10 +26,11 @@ function fetchAWSInfo(agent, callback) {
   }
 
   const authTokenOpts = {
-    method: 'PUT',
+    headers: { 'X-aws-ec2-metadata-token-ttl-seconds': '21600' },
     host: INSTANCE_HOST,
+    method: 'PUT',
     path: '/latest/api/token',
-    headers: { 'X-aws-ec2-metadata-token-ttl-seconds': '21600' }
+    timeout: 500
   }
   common.request(authTokenOpts, agent, function getAuthToken(err, authToken) {
     if (err) {
@@ -38,10 +39,11 @@ function fetchAWSInfo(agent, callback) {
     }
 
     const metadataOpts = {
-      method: 'GET',
+      headers: { 'X-aws-ec2-metadata-token': authToken },
       host: INSTANCE_HOST,
+      method: 'GET',
       path: '/2016-09-02/dynamic/instance-identity/document',
-      headers: { 'X-aws-ec2-metadata-token': authToken }
+      timeout: 500
     }
 
     common.request(metadataOpts, agent, function getMetadata(metaErr, data) {

--- a/lib/utilization/aws-info.js
+++ b/lib/utilization/aws-info.js
@@ -9,6 +9,7 @@ const logger = require('../logger.js').child({ component: 'aws-info' })
 const common = require('./common')
 const NAMES = require('../metrics/names.js')
 let results = null
+const INSTANCE_HOST = '169.254.169.254'
 
 module.exports = fetchAWSInfo
 module.exports.clearCache = function clearAWSCache() {
@@ -24,27 +25,43 @@ function fetchAWSInfo(agent, callback) {
     return setImmediate(callback, null, results)
   }
 
-  const instanceHost = '169.254.169.254'
-  const apiVersion = '2016-09-02'
-  const endpoint = 'dynamic/instance-identity/document'
-  const url = 'http://' + instanceHost + '/' + apiVersion + '/' + endpoint
-  common.request(url, agent, function getMetadata(err, data) {
+  const authTokenOpts = {
+    method: 'PUT',
+    host: INSTANCE_HOST,
+    path: '/latest/api/token',
+    headers: { 'X-aws-ec2-metadata-token-ttl-seconds': '21600' }
+  }
+  common.request(authTokenOpts, agent, function getAuthToken(err, authToken) {
     if (err) {
+      logger.debug('Failed to get AWS auth token.')
       return callback(err)
     }
 
-    try {
-      data = JSON.parse(data)
-    } catch (e) {
-      logger.debug(e, 'Failed to parse AWS metadata.')
-      data = null
+    const metadataOpts = {
+      method: 'GET',
+      host: INSTANCE_HOST,
+      path: '/latest/dynamic/instance-identity/document',
+      headers: { 'X-aws-ec2-metadata-token': authToken }
     }
 
-    results = common.getKeys(data, ['availabilityZone', 'instanceId', 'instanceType'])
-    if (results == null) {
-      logger.debug('AWS metadata was invalid.')
-      agent.metrics.getOrCreateMetric(NAMES.UTILIZATION.AWS_ERROR).incrementCallCount()
-    }
-    callback(null, results)
+    common.request(metadataOpts, agent, function getMetadata(metaErr, data) {
+      if (metaErr) {
+        return callback(metaErr)
+      }
+
+      try {
+        data = JSON.parse(data)
+      } catch (e) {
+        logger.debug(e, 'Failed to parse AWS metadata.')
+        data = null
+      }
+
+      results = common.getKeys(data, ['availabilityZone', 'instanceId', 'instanceType'])
+      if (results == null) {
+        logger.debug('AWS metadata was invalid.')
+        agent.metrics.getOrCreateMetric(NAMES.UTILIZATION.AWS_ERROR).incrementCallCount()
+      }
+      callback(null, results)
+    })
   })
 }

--- a/lib/utilization/common.js
+++ b/lib/utilization/common.js
@@ -65,6 +65,10 @@ exports.request = function request(opts, agent, cb) {
 
   opts.timeout = opts.timeout || 1000
 
+  // This can make more that GET requests if you pass in an object
+  // Node.js just pass this method into ClientRequest which accepts
+  // any valid HTTP Method
+  // see: https://github.com/nodejs/node/blob/master/lib/http.js#L106
   const req = http.get(opts, function awsRequest(res) {
     res.pipe(concat(respond))
     function respond(data) {

--- a/lib/utilization/common.js
+++ b/lib/utilization/common.js
@@ -95,9 +95,7 @@ exports.request = function request(opts, agent, cb) {
     }
   })
 
-  req.setTimeout(1000, function requestTimeout() {
-    req.abort()
-  })
+  req.on('timeout', abortRequest)
 
   req.on('error', function requestError(err) {
     if (err.code === 'ECONNRESET') {

--- a/lib/utilization/common.js
+++ b/lib/utilization/common.js
@@ -69,6 +69,8 @@ exports.request = function request(opts, agent, cb) {
   // Node.js just pass this method into ClientRequest which accepts
   // any valid HTTP Method
   // see: https://github.com/nodejs/node/blob/master/lib/http.js#L106
+  // Technically this wouldn't work for a PUT/POST with a body
+  // but works fine in all cases where this is being used.
   const req = http.get(opts, function awsRequest(res) {
     res.pipe(concat(respond))
     function respond(data) {

--- a/test/integration/pricing/system-info.tap.js
+++ b/test/integration/pricing/system-info.tap.js
@@ -23,6 +23,7 @@ test('pricing system-info aws', function (t) {
   }
 
   const awsRedirect = nock(awsHost)
+  awsRedirect.put('/latest/api/token').reply(200, 'awsToken')
   // eslint-disable-next-line guard-for-in
   for (const awsPath in awsResponses) {
     awsRedirect.get('/2016-09-02/' + awsPath).reply(200, awsResponses[awsPath])

--- a/test/integration/pricing/vendor-info-tests.js
+++ b/test/integration/pricing/vendor-info-tests.js
@@ -62,12 +62,11 @@ function makeTest(testCase, vendor, getInfo) {
       let onErrorCallback = null
 
       const res = {
-        setTimeout: function (timeout, fn) {
-          timeoutCallback = fn
-        },
         on: function (event, cb) {
           if (event === 'error') {
             onErrorCallback = cb
+          } else if (event === 'timeout') {
+            timeoutCallback = cb
           }
         },
         abort: () => {

--- a/test/integration/pricing/vendor-info-tests.js
+++ b/test/integration/pricing/vendor-info-tests.js
@@ -106,6 +106,12 @@ function makeTest(testCase, vendor, getInfo) {
       redirection.reply(200, JSON.stringify(responseData.response || ''))
     }
 
+    // This may be messy but AWS makes an extra call to get an auth token
+    // we need to nock this out once
+    if (vendor === 'aws') {
+      host.put('/latest/api/token').reply(200, 'awsAuthToken')
+    }
+
     http.get = timeoutMock(timeoutUrl)
 
     getInfo(agent, function (err, info) {

--- a/test/lib/cross_agent_tests/utilization_vendor_specific/aws.json
+++ b/test/lib/cross_agent_tests/utilization_vendor_specific/aws.json
@@ -2,7 +2,7 @@
   {
     "testname": "aws api times out, no vendor hash or supportability metric reported",
     "uri": {
-      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
+      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
         "response": {
           "instanceId": null,
           "instanceType": null,
@@ -21,7 +21,7 @@
   {
     "testname": "instance type, instance-id, availability-zone are all happy",
     "uri": {
-      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
+      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "i-test.19characters",
           "instanceType": "test.type",
@@ -41,7 +41,7 @@
   {
     "testname": "instance type with invalid characters",
     "uri": {
-      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
+      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "test.id",
           "instanceType": "<script>lol</script>",
@@ -60,7 +60,7 @@
   {
     "testname": "instance type too long",
     "uri": {
-      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
+      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "test.id",
           "instanceType": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
@@ -79,7 +79,7 @@
   {
     "testname": "instance id with invalid characters",
     "uri": {
-      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
+      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "<script>lol</script>",
           "instanceType": "test.type",
@@ -98,7 +98,7 @@
   {
     "testname": "instance id too long",
     "uri": {
-      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
+      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
           "instanceType": "test.type",
@@ -117,7 +117,7 @@
   {
     "testname": "availability zone with invalid characters",
     "uri": {
-      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
+      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "test.id",
           "instanceType": "test.type",
@@ -136,7 +136,7 @@
   {
     "testname": "availability zone too long",
     "uri": {
-      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
+      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "test.id",
           "instanceType": "test.type",
@@ -155,7 +155,7 @@
   {
     "testname": "UTF-8 high codepoints",
     "uri": {
-      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
+      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "滈 橀槶澉 鞻饙騴 鱙鷭黂 甗糲 紁羑 嗂 蛶觢豥 餤駰鬳 釂鱞鸄",
           "instanceType": "test.type",
@@ -175,7 +175,7 @@
   {
     "testname": "comma with multibyte characters",
     "uri": {
-      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
+      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "滈 橀槶澉 鞻饙騴 鱙鷭黂 甗糲, 紁羑 嗂 蛶觢豥 餤駰鬳 釂鱞鸄",
           "instanceType": "test.type",
@@ -194,7 +194,7 @@
   {
     "testname": "Exclamation point response",
     "uri": {
-      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
+      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "bang!",
           "instanceType": "test.type",
@@ -213,7 +213,7 @@
   {
     "testname": "Valid punctuation in response",
     "uri": {
-      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
+      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "test.id",
           "instanceType": "a-b_c.3... and/or 503 867-5309",

--- a/test/lib/cross_agent_tests/utilization_vendor_specific/aws.json
+++ b/test/lib/cross_agent_tests/utilization_vendor_specific/aws.json
@@ -2,7 +2,7 @@
   {
     "testname": "aws api times out, no vendor hash or supportability metric reported",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": null,
           "instanceType": null,
@@ -21,7 +21,7 @@
   {
     "testname": "instance type, instance-id, availability-zone are all happy",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "i-test.19characters",
           "instanceType": "test.type",
@@ -41,7 +41,7 @@
   {
     "testname": "instance type with invalid characters",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "test.id",
           "instanceType": "<script>lol</script>",
@@ -60,7 +60,7 @@
   {
     "testname": "instance type too long",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "test.id",
           "instanceType": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
@@ -79,7 +79,7 @@
   {
     "testname": "instance id with invalid characters",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "<script>lol</script>",
           "instanceType": "test.type",
@@ -98,7 +98,7 @@
   {
     "testname": "instance id too long",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
           "instanceType": "test.type",
@@ -117,7 +117,7 @@
   {
     "testname": "availability zone with invalid characters",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "test.id",
           "instanceType": "test.type",
@@ -136,7 +136,7 @@
   {
     "testname": "availability zone too long",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "test.id",
           "instanceType": "test.type",
@@ -155,7 +155,7 @@
   {
     "testname": "UTF-8 high codepoints",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "滈 橀槶澉 鞻饙騴 鱙鷭黂 甗糲 紁羑 嗂 蛶觢豥 餤駰鬳 釂鱞鸄",
           "instanceType": "test.type",
@@ -175,7 +175,7 @@
   {
     "testname": "comma with multibyte characters",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "滈 橀槶澉 鞻饙騴 鱙鷭黂 甗糲, 紁羑 嗂 蛶觢豥 餤駰鬳 釂鱞鸄",
           "instanceType": "test.type",
@@ -194,7 +194,7 @@
   {
     "testname": "Exclamation point response",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "bang!",
           "instanceType": "test.type",
@@ -213,7 +213,7 @@
   {
     "testname": "Valid punctuation in response",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "test.id",
           "instanceType": "a-b_c.3... and/or 503 867-5309",

--- a/test/unit/utilization/common.test.js
+++ b/test/unit/utilization/common.test.js
@@ -8,6 +8,7 @@
 const tap = require('tap')
 const common = require('../../../lib/utilization/common')
 const helper = require('../../lib/agent_helper.js')
+const nock = require('nock')
 
 let BIG = 'abcd'
 while (BIG.length < 300) {
@@ -79,47 +80,73 @@ tap.test('Utilization Common Components', function (t) {
   t.test('common.request', (t) => {
     t.autoend()
     let agent = null
-    let clock = null
+
+    t.before(() => {
+      nock('http://fakedomain').persist().get('/timeout').delay(150).reply(200, 'wohoo')
+    })
 
     t.beforeEach(function () {
-      const sinon = require('sinon')
-      clock = sinon.useFakeTimers()
-
       agent = helper.loadMockedAgent()
     })
 
     t.afterEach(function () {
       helper.unloadAgent(agent)
       agent = null
+    })
 
-      clock.restore()
-      clock = null
+    t.teardown(() => {
+      nock.cleanAll()
+    })
+
+    t.test('should not timeout when request suceeds', (t) => {
+      let invocationCount = 0
+      common.request(
+        {
+          method: 'GET',
+          host: 'fakedomain',
+          timeout: 200,
+          path: '/timeout'
+        },
+        agent,
+        (err, data) => {
+          t.error(err)
+          t.equal(data, 'wohoo')
+          invocationCount++
+        }
+      )
+
+      // need to give enough time for second to have chance to run.
+      // sinon and http dont quite seem to work well enough to do this
+      // totally faked synchronously.
+      setTimeout(verifyInvocations, 250)
+
+      function verifyInvocations() {
+        t.equal(invocationCount, 1)
+        t.end()
+      }
     })
 
     t.test('should not invoke callback multiple times on timeout', (t) => {
       let invocationCount = 0
       common.request(
         {
-          host: 'fakedomain.provider.something',
-          path: '/metadata'
+          method: 'GET',
+          host: 'fakedomain',
+          timeout: 100,
+          path: '/timeout'
         },
         agent,
         (err) => {
-          invocationCount++
           t.ok(err)
+          t.equal(err.code, 'ECONNRESET', 'error should be socket timeotu')
+          invocationCount++
         }
       )
-
-      // trigger the timeout
-      clock.tick(2000)
-
-      // let the rest run
-      clock.restore()
 
       // need to give enough time for second to have chance to run.
       // sinon and http dont quite seem to work well enough to do this
       // totally faked synchronously.
-      setTimeout(verifyInvocations, 1000)
+      setTimeout(verifyInvocations, 200)
 
       function verifyInvocations() {
         t.equal(invocationCount, 1)

--- a/test/unit/utilization/common.test.js
+++ b/test/unit/utilization/common.test.js
@@ -82,6 +82,7 @@ tap.test('Utilization Common Components', function (t) {
     let agent = null
 
     t.before(() => {
+      nock.disableNetConnect()
       nock('http://fakedomain').persist().get('/timeout').delay(150).reply(200, 'wohoo')
     })
 
@@ -96,9 +97,10 @@ tap.test('Utilization Common Components', function (t) {
 
     t.teardown(() => {
       nock.cleanAll()
+      nock.enableNetConnect()
     })
 
-    t.test('should not timeout when request suceeds', (t) => {
+    t.test('should not timeout when request succeeds', (t) => {
       let invocationCount = 0
       common.request(
         {
@@ -138,7 +140,7 @@ tap.test('Utilization Common Components', function (t) {
         agent,
         (err) => {
           t.ok(err)
-          t.equal(err.code, 'ECONNRESET', 'error should be socket timeotu')
+          t.equal(err.code, 'ECONNRESET', 'error should be socket timeout')
           invocationCount++
         }
       )


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated AWS metadata capture to utilize IMDSv2.

## Links
Closes #1100

## Details
I verified this by enforcing http tokens on my EC2 instance

```sh
aws ec2 --region us-east-1 modify-instance-metadata-options --instance-id <instance-id> --http-tokens required --http-endpoint enabled
```

I ran the agent on this branch on my EC2 and still saw the vendors info in the connect message.

```json
{"vendors":{"aws":{"availabilityZone":"us-east-1e","instanceId":"<redacted>","instanceType":"t2.micro"}}}
```

I also verified that when IMDSv2 was on that it failed without the fixes in this PR

```json
{"v":0,"level":20,"name":"newrelic","hostname":"<redacted>","pid":6012,"time":"2022-02-18T18:01:38.294Z","msg":"Got 401 Unauthorized from metadata request \"{\\\"protocol\\\":\\\"http:\\\",\\\"slashes\\\":true,\\\"auth\\\":null,\\\"host\\\":\\\"169.254.169.254\\\",\\\"port\\\":null,\\\"hostname\\\":\\\"169.254.169.254\\\",\\\"hash\\\":null,\\\"search\\\":null,\\\"query\\\":null,\\\"pathname\\\":\\\"/2016-09-02/dynamic/instance-identity/document\\\",\\\"path\\\":\\\"/2016-09-02/dynamic/instance-identity/document\\\",\\\"href\\\":\\\"http://169.254.169.254/2016-09-02/dynamic/instance-identity/document\\\",\\\"timeout\\\":1000}\"","component":"utilization-request"}
```
