### PR TITLE
Codylandry/apply logging to bootstrap logs

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1713,7 +1713,14 @@ function getOrCreateInstance() {
 
       // Config construction has potential to throw due to invalid settings.
       // This allows the agent to return a stub api without crashing the process.
-      _configInstance = Object.assign(defaultConfig(), { agent_enabled: false })
+      _configInstance = Object.assign(defaultConfig(), {
+        agent_enabled: false,
+        logging: {
+          enabled: true,
+          filepath: process.stdout
+        }
+      })
+
       _configInstance.setLogger = Config.prototype.setLogger
     }
   }

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1633,14 +1633,14 @@ function initialize(config) {
   }
 
   if (isTruthular(process.env.NEW_RELIC_NO_CONFIG_FILE)) {
-    logger.infoEnqueue('NEW_RELIC_NO_CONFIG_FILE set, deferring to environment variables.')
+    logger.info('NEW_RELIC_NO_CONFIG_FILE set, deferring to environment variables.')
 
     return createNewConfigObject(config)
   }
 
   const filepath = _findConfigFile()
   if (!filepath) {
-    logger.infoEnqueue(
+    logger.info(
       [
         'Unable to find configuration file.',
         'If a configuration file is desired (common for non-containerized environments),',
@@ -1658,9 +1658,9 @@ function initialize(config) {
   try {
     userConf = require(filepath).config
   } catch (error) {
-    logger.errorEnqueue(error)
+    logger.error(error)
 
-    logger.warnEnqueue(
+    logger.warn(
       [
         `Unable to read existing configuration file "${filepath}".`,
         'To allow reading of the file (if desired),',
@@ -1676,11 +1676,9 @@ function initialize(config) {
 
   config = new Config(userConf)
   config.config_file_path = filepath
-  logger.debugEnqueue('Using configuration file %s.', filepath)
+  logger.debug('Using configuration file %s.', filepath)
 
   config.validateFlags()
-
-  logger.flushQueuedLogs()
 
   return config
 }

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1623,7 +1623,8 @@ function initialize(config) {
   /**
    * When the logger is required here, it bootstraps itself and then
    * injects itself into this module's closure via setLogger on the
-   * instance of the logger it creates.
+   * instance of the logger it creates.  Logs are queued until config
+   * has been loaded to apply logging settings to bootstrapping logs
    */
   logger = require('../logger')
 
@@ -1632,14 +1633,14 @@ function initialize(config) {
   }
 
   if (isTruthular(process.env.NEW_RELIC_NO_CONFIG_FILE)) {
-    logger.info('NEW_RELIC_NO_CONFIG_FILE set, deferring to environment variables.')
+    logger.infoEnqueue('NEW_RELIC_NO_CONFIG_FILE set, deferring to environment variables.')
 
     return createNewConfigObject(config)
   }
 
   const filepath = _findConfigFile()
   if (!filepath) {
-    logger.info(
+    logger.infoEnqueue(
       [
         'Unable to find configuration file.',
         'If a configuration file is desired (common for non-containerized environments),',
@@ -1657,9 +1658,9 @@ function initialize(config) {
   try {
     userConf = require(filepath).config
   } catch (error) {
-    logger.error(error)
+    logger.errorEnqueue(error)
 
-    logger.warn(
+    logger.warnEnqueue(
       [
         `Unable to read existing configuration file "${filepath}".`,
         'To allow reading of the file (if desired),',
@@ -1675,9 +1676,11 @@ function initialize(config) {
 
   config = new Config(userConf)
   config.config_file_path = filepath
-  logger.debug('Using configuration file %s.', filepath)
+  logger.debugEnqueue('Using configuration file %s.', filepath)
 
   config.validateFlags()
+
+  logger.flushQueuedLogs()
 
   return config
 }

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1717,7 +1717,7 @@ function getOrCreateInstance() {
         agent_enabled: false,
         logging: {
           enabled: true,
-          filepath: process.stdout
+          filepath: 'stdout'
         }
       })
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -12,7 +12,10 @@ const fs = require('./util/unwrapped-core').fs
 module.exports = new Logger({
   name: 'newrelic_bootstrap',
   stream: process.stdout,
-  level: 'info'
+  level: 'info',
+
+  // logger is configured below.  Logs are queued until configured
+  configured: false
 })
 
 /**
@@ -28,8 +31,8 @@ if (config) {
     enabled: config.logging.enabled
   }
 
-  // create the "real" logger
-  module.exports = new Logger(options)
+  // configure logger
+  module.exports.configure(options)
 
   if (config.logging.enabled) {
     let stream

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -9,13 +9,15 @@ const Logger = require('./util/logger')
 const fs = require('./util/unwrapped-core').fs
 
 // create bootstrapping logger
-module.exports = new Logger({
+const logger = new Logger({
   name: 'newrelic_bootstrap',
   level: 'info',
 
   // logger is configured below.  Logs are queued until configured
   configured: false
 })
+
+module.exports = logger
 
 /**
  * Don't load config until this point, because it requires this
@@ -31,7 +33,7 @@ if (config) {
   }
 
   // configure logger
-  module.exports.configure(options)
+  logger.configure(options)
 
   if (config.logging.enabled) {
     let stream
@@ -54,9 +56,6 @@ if (config) {
           /* eslint-enable no-console */
         })
     }
-    module.exports.pipe(stream)
+    logger.pipe(stream)
   }
-
-  // now tell the config module to switch to the real logger
-  config.setLogger(module.exports)
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -11,7 +11,6 @@ const fs = require('./util/unwrapped-core').fs
 // create bootstrapping logger
 module.exports = new Logger({
   name: 'newrelic_bootstrap',
-  stream: process.stdout,
   level: 'info',
 
   // logger is configured below.  Logs are queued until configured

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -39,7 +39,8 @@ function Logger(options, extra) {
   const passedInLevel = this.coerce(options.level)
   this.options = {
     _level: passedInLevel,
-    enabled: options.enabled === undefined ? true : options.enabled
+    enabled: options.enabled === undefined ? true : options.enabled,
+    configured: options.configured === undefined ? true : !!options.configured
   }
   this._nestedLog = false
   this.name = options.name
@@ -53,6 +54,23 @@ function Logger(options, extra) {
   }
 }
 Logger.MAX_LOG_BUFFER = MAX_LOG_BUFFER
+
+Logger.prototype.configure = function configure(options) {
+  if (options.name !== undefined) {
+    this.name = options.name
+  }
+
+  if (options.enabled !== undefined) {
+    this.options.enabled = options.enabled
+  }
+
+  if (options.level !== undefined) {
+    this.options._level = this.coerce(options.level)
+  }
+
+  this.options.configured = true
+  this._flushQueuedLogs()
+}
 
 Logger.prototype.coerce = function coerce(value) {
   if (!isNaN(parseInt(value, 10)) && isFinite(value)) {
@@ -75,6 +93,11 @@ Object.keys(LEVELS).forEach(function buildLevel(_level) {
   const level = Logger.prototype.coerce(LEVELS[_level])
 
   function log(extra) {
+    if (!this.options.configured) {
+      this.logQueue.unshift({ level: _level, args: arguments })
+      return
+    }
+
     if (!this.options.enabled) {
       return false
     }
@@ -148,16 +171,9 @@ Object.keys(LEVELS).forEach(function buildLevel(_level) {
   loggingFunctions[_level + 'Enabled'] = function levelEnabled() {
     return level >= this.options._level
   }
-
-  loggingFunctions[_level + 'Enqueue'] = function enqueueLog() {
-    this.logQueue.unshift({
-      level: _level,
-      args: arguments
-    })
-  }
 })
 
-Logger.prototype.flushQueuedLogs = function flushQueuedLogs() {
+Logger.prototype._flushQueuedLogs = function _flushQueuedLogs() {
   while (this.logQueue.length) {
     const { level, args } = this.logQueue.shift()
     this[level].apply(this, args)

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -47,6 +47,7 @@ function Logger(options, extra) {
   this.extra = extra || Object.create(null)
   this.buffer = ''
   this.reading = false
+  this.logQueue = []
   if (options.stream) {
     this.pipe(options.stream)
   }
@@ -147,7 +148,21 @@ Object.keys(LEVELS).forEach(function buildLevel(_level) {
   loggingFunctions[_level + 'Enabled'] = function levelEnabled() {
     return level >= this.options._level
   }
+
+  loggingFunctions[_level + 'Enqueue'] = function enqueueLog() {
+    this.logQueue.unshift({
+      level: _level,
+      args: arguments
+    })
+  }
 })
+
+Logger.prototype.flushQueuedLogs = function flushQueuedLogs() {
+  while (this.logQueue.length) {
+    const { level, args } = this.logQueue.shift()
+    this[level].apply(this, args)
+  }
+}
 
 Object.assign(Logger.prototype, loggingFunctions)
 
@@ -196,6 +211,10 @@ Logger.prototype._read = function _read() {
  * already converted the objects to strings.
  * Returns a boolean representing the status of the write
  * (success/failure)
+ *
+ * @param level
+ * @param args
+ * @param extra
  */
 Logger.prototype.write = function write(level, args, extra) {
   if (this._nestedLog) {

--- a/test/helpers/disabled-with-invalid-config/disabled.js
+++ b/test/helpers/disabled-with-invalid-config/disabled.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+// Prepare to receive any error.
+process.on('uncaughtException', function (err) {
+  process.send({ error: err, stack: err.stack })
+})
+
+// Load up newrelic
+process.env.NEW_RELIC_HOME = __dirname
+require('../../../index') // require('newrelic')
+
+// Wait a bit then check for the file.
+setTimeout(function () {
+  process.exit(0)
+}, 100)

--- a/test/helpers/disabled-with-invalid-config/newrelic.js
+++ b/test/helpers/disabled-with-invalid-config/newrelic.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/**
+ * New Relic agent configuration.
+ *
+ * See lib/config/default.js in the agent distribution for a more complete
+ * description of configuration variables and their potential values.
+ */
+exports.config = {
+  /**
+   * Array of application names.
+   */
+  app_name: ['My Application'],
+  /**
+   * Your New Relic license key.
+   */
+  license_key: 'license key here',
+
+  /**
+   * `high_security` and `security_policies_token` are mutually exclusive and will throw when configured together.
+   */
+  high_security: 'true',
+  security_policies_token: 'ffff',
+
+  logging: {
+    /**
+     * Level at which to log. 'trace' is most useful to New Relic when diagnosing
+     * issues with the agent, 'info' and higher will impose the least overhead on
+     * production applications.
+     */
+    level: 'debug',
+    enabled: false
+  }
+}

--- a/test/helpers/disabled-with-log-queue/disabled.js
+++ b/test/helpers/disabled-with-log-queue/disabled.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+// Prepare to receive any error.
+process.on('uncaughtException', function (err) {
+  process.send({ error: err, stack: err.stack })
+})
+
+// Load up newrelic
+process.env.NEW_RELIC_HOME = __dirname
+require('../../../index')
+
+// Wait a bit then check for the file.
+setTimeout(function () {
+  process.exit(0)
+}, 100)

--- a/test/helpers/disabled-with-log-queue/newrelic.js
+++ b/test/helpers/disabled-with-log-queue/newrelic.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/**
+ * New Relic agent configuration.
+ *
+ * See lib/config/default.js in the agent distribution for a more complete
+ * description of configuration variables and their potential values.
+ */
+exports.config = {
+  /**
+   * Array of application names.
+   */
+  app_name: ['My Application'],
+  /**
+   * Your New Relic license key.
+   */
+  license_key: 'license key here',
+  logging: {
+    /**
+     * Level at which to log. 'trace' is most useful to New Relic when diagnosing
+     * issues with the agent, 'info' and higher will impose the least overhead on
+     * production applications.
+     */
+    level: 'trace',
+    filepath: 'stdout',
+    enabled: false
+  }
+}

--- a/test/helpers/enabled-with-log-queue/enabled.js
+++ b/test/helpers/enabled-with-log-queue/enabled.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+// Prepare to receive any error.
+process.on('uncaughtException', function (err) {
+  process.send({ error: err, stack: err.stack })
+})
+
+// Load up newrelic
+process.env.NEW_RELIC_HOME = __dirname
+require('../../../index') // require('newrelic')
+
+// Wait a bit then check for the file.
+setTimeout(function () {
+  process.exit(0)
+}, 100)

--- a/test/helpers/enabled-with-log-queue/newrelic.js
+++ b/test/helpers/enabled-with-log-queue/newrelic.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/**
+ * New Relic agent configuration.
+ *
+ * See lib/config/default.js in the agent distribution for a more complete
+ * description of configuration variables and their potential values.
+ */
+exports.config = {
+  /**
+   * Array of application names.
+   */
+  app_name: ['My Application'],
+  /**
+   * Your New Relic license key.
+   */
+  license_key: 'license key here',
+  logging: {
+    /**
+     * Level at which to log. 'trace' is most useful to New Relic when diagnosing
+     * issues with the agent, 'info' and higher will impose the least overhead on
+     * production applications.
+     */
+    level: 'info',
+    filepath: 'stdout',
+    enabled: true
+  }
+}

--- a/test/unit/logger.test.js
+++ b/test/unit/logger.test.js
@@ -48,7 +48,7 @@ tap.test('Logger', function (t) {
     t.end()
   })
 
-  t.test('should equeue logs until configured', function (t) {
+  t.test('should enqueue logs until configured', function (t) {
     logger.options.configured = false
     logger.trace('trace')
     logger.debug('debug')
@@ -60,7 +60,7 @@ tap.test('Logger', function (t) {
     t.end()
   })
 
-  t.test('should not equeue logs when disabled', function (t) {
+  t.test('should not enqueue logs when disabled', function (t) {
     logger.trace('trace')
     logger.debug('debug')
     logger.info('info')

--- a/test/unit/logger.test.js
+++ b/test/unit/logger.test.js
@@ -18,7 +18,8 @@ tap.test('Logger', function (t) {
     logger = new Logger({
       name: 'newrelic',
       level: 'trace',
-      enabled: true
+      enabled: true,
+      configured: true
     })
   })
 
@@ -44,6 +45,50 @@ tap.test('Logger', function (t) {
     t.doesNotThrow(function () {
       logger.level('verbose')
     })
+    t.end()
+  })
+
+  t.test('should equeue logs until configured', function (t) {
+    logger.options.configured = false
+    logger.trace('trace')
+    logger.debug('debug')
+    logger.info('info')
+    logger.warn('warn')
+    logger.error('error')
+    logger.fatal('fatal')
+    t.ok(logger.logQueue.length === 6, 'should have 6 logs in the queue')
+    t.end()
+  })
+
+  t.test('should not equeue logs when disabled', function (t) {
+    logger.trace('trace')
+    logger.debug('debug')
+    logger.info('info')
+    logger.warn('warn')
+    logger.error('error')
+    logger.fatal('fatal')
+    t.ok(logger.logQueue.length === 0, 'should have 0 logs in the queue')
+    t.end()
+  })
+
+  t.test('should flush logs when configured', function (t) {
+    logger.options.configured = false
+    logger.trace('trace')
+    logger.debug('debug')
+    logger.info('info')
+    logger.warn('warn')
+    logger.error('error')
+    logger.fatal('fatal')
+
+    t.ok(logger.logQueue.length === 6, 'should have 6 logs in the queue')
+
+    logger.configure({
+      level: 'trace',
+      enabled: true,
+      name: 'test-logger'
+    })
+
+    t.ok(logger.logQueue.length === 0, 'should have 0 logs in the queue')
     t.end()
   })
 

--- a/test/unit/logger.test.js
+++ b/test/unit/logger.test.js
@@ -92,6 +92,16 @@ tap.test('Logger', function (t) {
     t.end()
   })
 
+  t.test('should fallback to default logging config when config is invalid', function (t) {
+    runTestFile('disabled-with-invalid-config/disabled.js', function (error, message) {
+      t.notOk(error)
+
+      // should pipe logs to stdout if config is invalid, even if logging is disabled
+      t.ok(message)
+      t.end()
+    })
+  })
+
   t.test('should not cause crash if unwritable', function (t) {
     runTestFile('unwritable-log/unwritable.js', t.end)
   })


### PR DESCRIPTION
## Problem 
We have noticed that logging configurations aren't considered for logs during the bootstrapping phase of the agent startup.  This results in a high number of logs generated, especially when using nodejs lambda functions.  

## Proposed Release Notes
* Updated logger to delay logging until configuration is parsed. The logger will now queue all log entries that occur before the agent can parse the configuration.

## Details
This PR adds functionality to the `Logger` class to enqueue and later flush a queue of logs.  The idea is that during the bootstrapping phase, we enqueue logs, holding them in an array.  Then, once the config has been loaded, including logging configs, we flush the queue in the original log order.  