### PR TITLE
Allow external versioned testing to run more scenarios

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
     'consistent-return': 'off',
     'jsdoc/require-jsdoc': 'off'
   },
+  ignorePatterns: ['test/versioned-external'],
   overrides: [
     {
       files: ['newrelic.js'],

--- a/test/versioned-external/checkout-external-tests.js
+++ b/test/versioned-external/checkout-external-tests.js
@@ -18,7 +18,7 @@ const repos = require('./external-repos')
 
 const TEMP_TESTS_FOLDER = 'TEMP_TESTS'
 
-const CHECKOUT_FOLDERS = ['lib', 'tests/versioned']
+const CHECKOUT_FOLDERS = ['index.js', 'nr-hooks.js', 'lib', 'tests/versioned']
 
 async function checkoutTests() {
   // Run in context of the folder this script lives in


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Updated external version test running to support more test scenarios.
  * Adds `test/versioned-external` to lint ignore to avoid issues for scripts in tests that auto run linting tools (next/react).
  * Adds `index.js` and `nr-hooks.js` to files automatically checked-out for test runs.

## Links

* Resolves build issues for: https://github.com/newrelic/node-newrelic/pull/1102

## Details

The compilation of the next application for the Next.js instrumentation versioned tests results in scripts that attempt to run linting and fail both linting setup and attempt to compile in weird ways (failing on import, etc.) likely due to lack of the correct eslint plugin. We do not want/need linting on the test application and also do not want/need linting from the main agent for items pulled in for external versioned test runs.

Further, the tests for Next.js use `nr-hooks` to load instrumentation which is a pattern we may follow more often. So I pulled that in by default as well as `index.js` in case we ever do similar testing with that file.