### PR TITLE
Add apollo server plugin external tests

### DIFF
--- a/bin/git-commands.js
+++ b/bin/git-commands.js
@@ -125,7 +125,13 @@ async function setSparseCheckoutFolders(folders) {
 async function sparseCloneRepo(repoInfo, checkoutFiles) {
   const { name, repository, branch } = repoInfo
 
-  const cloneOptions = ['--filter=blob:none', '--no-checkout', '--depth 1', '--sparse']
+  const cloneOptions = [
+    '--filter=blob:none',
+    '--no-checkout',
+    '--depth 1',
+    '--sparse',
+    `--branch=${branch}`
+  ]
   await clone(repository, name, cloneOptions)
   process.chdir(name)
 

--- a/test/versioned-external/external-repos.js
+++ b/test/versioned-external/external-repos.js
@@ -31,6 +31,17 @@ const repos = [
     name: 'superagent',
     repository: 'https://github.com/newrelic/node-newrelic-superagent.git',
     branch: 'main'
+  },
+  {
+    name: 'apollo-server',
+    repository: 'https://github.com/newrelic/newrelic-node-apollo-server-plugin.git',
+    branch: 'main',
+    additionalFiles: [
+      'tests/agent-testing.js',
+      'tests/create-apollo-server-setup.js',
+      'tests/data-definitions.js',
+      'tests/test-client.js'
+    ]
   }
 ]
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Fixed sparse checkout of non-default branch for external versioned tests.

* Added external versioned tests for the Apollo Server plugin instrumentation.

## Links

* Blocked by: https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/177

## Details

This won't pass until https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/177 is merged.

In the meantime, can manually test locally against that branch by changing the configuration to:

```
{
  name: 'apollo-server',
  repository: 'https://github.com/michaelgoin/newrelic-node-apollo-server-plugin/',
  branch: 'use-latest-newrelic',
  additionalFiles: [
    'tests/agent-testing.js',
    'tests/create-apollo-server-setup.js',
    'tests/data-definitions.js',
    'tests/test-client.js'
  ]
}
```

Running `npm run versioned:major` should result in something like:

```
 ✓ amqplib (2) 7s
 ✓ apollo-federation (5) 21s
 ✓ apollo-server (12) 55s
 ✓ apollo-server-express (10) 45s
 ✓ apollo-server-fastify (10) 47s
 ✓ apollo-server-hapi (5) 14s
 ✓ apollo-server-koa (10) 41s
 ✓ apollo-server-lambda (10) 34s
 ✓ bluebird (5) 18s
 ✓ cassandra-driver (2) 6s
 ✓ cls (1) 2s
 ✓ connect (6) 13s
   director
 ✓ express (16) 44s
 ✓ fastify (9) 20s
 ✓ generic-pool (2) 3s
   hapi-17
 ✓ hapi-post-18 (10) 23s
   hapi-pre-17
 ✓ ioredis (2) 5s
 ✓ koa-tests (4) 9s
 ✓ mongodb (18) 2m
 ✓ mysql (4) 20s
 ✓ mysql2 (4) 20s
 ✓ pg-post-7 (1) 16s
   pg-pre-7
 ✓ redis (2) 5s
 ✓ restify-post-7 (14) 54s
 ✓ restify-pre-7 (12) 44s
 ✓ superagent-tests (12) 30s
 ✓ undici (1) 6s
 ✓ v2 (9) 36s
 ✓ v3 (13) 55s
===============================================================
PASS
```