### PR TITLE
env.js: added ALLOW_ALL_HEADERS as a boolean envvar

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -134,6 +134,8 @@ exports.config = () => ({
    * When true, all request headers except for those listed in attributes.exclude
    * will be captured for all traces, unless otherwise specified in a destination's
    * attributes include/exclude lists.
+   *
+   * @env NEW_RELIC_ALLOW_ALL_HEADERS
    */
   allow_all_headers: false,
 

--- a/lib/config/env.js
+++ b/lib/config/env.js
@@ -21,6 +21,7 @@ const ENV_MAPPING = {
   proxy_user: 'NEW_RELIC_PROXY_USER',
   proxy_pass: 'NEW_RELIC_PROXY_PASS',
   agent_enabled: 'NEW_RELIC_ENABLED',
+  allow_all_headers: 'NEW_RELIC_ALLOW_ALL_HEADERS',
   attributes: {
     enabled: 'NEW_RELIC_ATTRIBUTES_ENABLED',
     exclude: 'NEW_RELIC_ATTRIBUTES_EXCLUDE',
@@ -206,6 +207,7 @@ const OBJECT_LIST_VARS = new Set(['NEW_RELIC_NAMING_RULES'])
 // fancy--just use 'true' and 'false', everybody.
 const BOOLEAN_VARS = new Set([
   'NEW_RELIC_ENABLED',
+  'NEW_RELIC_ALLOW_ALL_HEADERS',
   'NEW_RELIC_ATTRIBUTES_ENABLED',
   'NEW_RELIC_ERROR_COLLECTOR_ENABLED',
   'NEW_RELIC_ERROR_COLLECTOR_ATTRIBUTES_ENABLED',

--- a/test/unit/config/config-env.test.js
+++ b/test/unit/config/config-env.test.js
@@ -577,4 +577,11 @@ tap.test('when overriding configuration values via environment variables', (t) =
       t.end()
     })
   })
+
+  t.test('should pick up all_all_headers', (t) => {
+    idempotentEnv({ NEW_RELIC_ALLOW_ALL_HEADERS: 'true' }, function (tc) {
+      t.equal(tc.allow_all_headers, true)
+      t.end()
+    })
+  })
 })


### PR DESCRIPTION
With corresponding doc and test changes.

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* added ALLOW_ALL_HEADERS as a boolean environment variable, same behaviour as existing `allow_all_headers`.

## Links

* fixes #1079 

## Details
