### PR TITLE
updated aws imdbs v2 uri to use latest instead of 2016-09-02

### DIFF
--- a/lib/utilization/aws-info.js
+++ b/lib/utilization/aws-info.js
@@ -42,7 +42,7 @@ function fetchAWSInfo(agent, callback) {
       headers: { 'X-aws-ec2-metadata-token': authToken },
       host: INSTANCE_HOST,
       method: 'GET',
-      path: '/2016-09-02/dynamic/instance-identity/document',
+      path: '/latest/dynamic/instance-identity/document',
       timeout: 500
     }
 

--- a/test/integration/pricing/system-info.tap.js
+++ b/test/integration/pricing/system-info.tap.js
@@ -26,7 +26,7 @@ test('pricing system-info aws', function (t) {
   awsRedirect.put('/latest/api/token').reply(200, 'awsToken')
   // eslint-disable-next-line guard-for-in
   for (const awsPath in awsResponses) {
-    awsRedirect.get('/2016-09-02/' + awsPath).reply(200, awsResponses[awsPath])
+    awsRedirect.get(`/latest/${awsPath}`).reply(200, awsResponses[awsPath])
   }
 
   const agent = helper.loadMockedAgent({

--- a/test/lib/cross_agent_tests/utilization_vendor_specific/aws.json
+++ b/test/lib/cross_agent_tests/utilization_vendor_specific/aws.json
@@ -2,7 +2,7 @@
   {
     "testname": "aws api times out, no vendor hash or supportability metric reported",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": null,
           "instanceType": null,
@@ -21,7 +21,7 @@
   {
     "testname": "instance type, instance-id, availability-zone are all happy",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "i-test.19characters",
           "instanceType": "test.type",
@@ -41,7 +41,7 @@
   {
     "testname": "instance type with invalid characters",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "test.id",
           "instanceType": "<script>lol</script>",
@@ -60,7 +60,7 @@
   {
     "testname": "instance type too long",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "test.id",
           "instanceType": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
@@ -79,7 +79,7 @@
   {
     "testname": "instance id with invalid characters",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "<script>lol</script>",
           "instanceType": "test.type",
@@ -98,7 +98,7 @@
   {
     "testname": "instance id too long",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
           "instanceType": "test.type",
@@ -117,7 +117,7 @@
   {
     "testname": "availability zone with invalid characters",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "test.id",
           "instanceType": "test.type",
@@ -136,7 +136,7 @@
   {
     "testname": "availability zone too long",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "test.id",
           "instanceType": "test.type",
@@ -155,7 +155,7 @@
   {
     "testname": "UTF-8 high codepoints",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "滈 橀槶澉 鞻饙騴 鱙鷭黂 甗糲 紁羑 嗂 蛶觢豥 餤駰鬳 釂鱞鸄",
           "instanceType": "test.type",
@@ -175,7 +175,7 @@
   {
     "testname": "comma with multibyte characters",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "滈 橀槶澉 鞻饙騴 鱙鷭黂 甗糲, 紁羑 嗂 蛶觢豥 餤駰鬳 釂鱞鸄",
           "instanceType": "test.type",
@@ -194,7 +194,7 @@
   {
     "testname": "Exclamation point response",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "bang!",
           "instanceType": "test.type",
@@ -213,7 +213,7 @@
   {
     "testname": "Valid punctuation in response",
     "uri": {
-      "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document": {
+      "http://169.254.169.254/latest/dynamic/instance-identity/document": {
         "response": {
           "instanceId": "test.id",
           "instanceType": "a-b_c.3... and/or 503 867-5309",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated the AWS IMDBS v2 endpoint to use `latest` to align with the internal agent specification.

## Links

## Details
The agent teams got around to updating spec and we landed on using `latest` instead of `2016-09-02`.  This PR will update the cross agent tests and code to stay in sync.  Relevant PRs in GHE: https://source.datanerd.us/agents/agent-specs/pull/569/files, and https://source.datanerd.us/agents/cross_agent_tests/pull/147/files.
