### PR TITLE
Updates @hapi/hapi node 16 test perumutatinos to use @hapi/hapi >=20

### DIFF
--- a/test/versioned/hapi/hapi-post-18/package.json
+++ b/test/versioned/hapi/hapi-post-18/package.json
@@ -31,7 +31,7 @@
       },
       "dependencies": {
         "ejs": "2.5.5",
-        "@hapi/hapi": "^20.1.2",
+        "@hapi/hapi": ">=20.1.2",
         "vision": "^5.0.0"
       },
       "files": [


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Updated @hapi/hapi Node 16 versioned test runs to run against @hapi/hapi >=20.1.2 so future major releases will be ran.

## Links

## Details

For versioned tests we typically are setup to always test newest. If a new major version breaks and it isn't a quick fix, then we ensure we have a GitHub issue for adding support prior to limiting the upper bound of the version run.