### PR TITLE
Fix the environment problem

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -238,7 +238,7 @@ function getLocalPackages(callback) {
 
   a.whilst(
     function checkCandidate(cb) {
-      return cb(null, candidate)
+      return cb ? cb(null, candidate) : null;
     },
     function iterate(cb) {
       _log('Checking for local packages in %s', candidate)


### PR DESCRIPTION
```
TypeError: cb is not a function
    at checkCandidate (/Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/newrelic/lib/environment.js:241:14)
    at Object.whilst (/Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/async/dist/async.js:5220:10)
    at getLocalPackages (/Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/newrelic/lib/environment.js:239:5)
    at timeWrapper (/Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/newrelic/lib/environment.js:511:12)
    at /Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/async/dist/async.js:3880:24
    at replenish (/Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/async/dist/async.js:1011:17)
    at /Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/async/dist/async.js:1016:9
    at _parallel (/Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/async/dist/async.js:3879:5)
    at Object.parallelLimit$1 [as parallelLimit] (/Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/async/dist/async.js:3985:5)
    at findPackages (/Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/newrelic/lib/environment.js:466:5)
    at refresh (/Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/newrelic/lib/environment.js:582:5)
    at getJSON (/Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/newrelic/lib/environment.js:595:3)
    at /Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/async/dist/async.js:3880:24
    at replenish (/Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/async/dist/async.js:1011:17)
    at /Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/async/dist/async.js:1016:9
    at eachOfLimit (/Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/async/dist/async.js:1041:24)
    at /Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/async/dist/async.js:1046:16
    at eachOf (/Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/async/dist/async.js:1117:5)
    at _parallel (/Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/async/dist/async.js:3879:5)
    at Object.parallelLimit [as parallel] (/Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/async/dist/async.js:3962:5)
    at facts (/Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/newrelic/lib/collector/facts.js:18:5)
    at CollectorAPI._getFacts (/Users/umutc/code/upwork/chip/ViewInFocus-Server/node_modules/newrelic/lib/collector/api.js:259:3)
```