### PR TITLE
Fix mysql test resource contention

### DIFF
--- a/test/versioned/mysql/basic-pool.tap.js
+++ b/test/versioned/mysql/basic-pool.tap.js
@@ -15,8 +15,7 @@ const setup = require('./setup')
 const { version: pkgVersion } = require('mysql/package')
 const semver = require('semver')
 
-const DBUSER = 'root'
-const DBNAME = 'agent_integration'
+const { USER, DATABASE } = setup
 
 const config = getConfig({})
 function getConfig(extras) {
@@ -24,8 +23,8 @@ function getConfig(extras) {
     connectionLimit: 10,
     host: params.mysql_host,
     port: params.mysql_port,
-    user: DBUSER,
-    database: DBNAME
+    user: USER,
+    database: DATABASE
   }
 
   // eslint-disable-next-line guard-for-in
@@ -49,8 +48,8 @@ tap.test('bad config', function (t) {
   const badConfig = {
     connectionLimit: 10,
     host: 'nohost',
-    user: DBUSER,
-    database: DBNAME
+    user: USER,
+    database: DATABASE
   }
 
   t.test(function (t) {
@@ -137,7 +136,7 @@ tap.test('mysql built-in connection pools', { timeout: 30 * 1000 }, function (t)
           urltils.isLocalhost(config.host) ? agent.config.getHostnameSafe() : config.host,
           'set host'
         )
-        t.equal(attributes.database_name, DBNAME, 'set database name')
+        t.equal(attributes.database_name, DATABASE, 'set database name')
         t.equal(attributes.port_path_or_id, String(config.port), 'set port')
         t.equal(attributes.product, 'MySQL', 'set product attribute')
         txn.end()
@@ -157,7 +156,7 @@ tap.test('mysql built-in connection pools', { timeout: 30 * 1000 }, function (t)
 
         t.notOk(attributes.host, 'should have no host parameter')
         t.notOk(attributes.port_path_or_id, 'should have no port parameter')
-        t.equal(attributes.database_name, DBNAME, 'should set database name')
+        t.equal(attributes.database_name, DATABASE, 'should set database name')
         t.equal(attributes.product, 'MySQL', 'should set product attribute')
         agent.config.datastore_tracer.instance_reporting.enabled = true
         txn.end()
@@ -205,7 +204,7 @@ tap.test('mysql built-in connection pools', { timeout: 30 * 1000 }, function (t)
         const attributes = seg.getAttributes()
         t.ok(seg, 'there is a segment')
         t.equal(attributes.host, agent.config.getHostnameSafe(), 'set host')
-        t.equal(attributes.database_name, DBNAME, 'set database name')
+        t.equal(attributes.database_name, DATABASE, 'set database name')
         t.equal(attributes.port_path_or_id, String(defaultConfig.port), 'set port')
         t.equal(attributes.product, 'MySQL', 'should set product attribute')
         txn.end()
@@ -231,7 +230,7 @@ tap.test('mysql built-in connection pools', { timeout: 30 * 1000 }, function (t)
           urltils.isLocalhost(config.host) ? agent.config.getHostnameSafe() : config.host,
           'should set host'
         )
-        t.equal(attributes.database_name, DBNAME, 'should set database name')
+        t.equal(attributes.database_name, DATABASE, 'should set database name')
         t.equal(attributes.port_path_or_id, '3306', 'should set port')
         t.equal(attributes.product, 'MySQL', 'should set product attribute')
         txn.end()
@@ -376,7 +375,7 @@ tap.test('mysql built-in connection pools', { timeout: 30 * 1000 }, function (t)
             t.ok(seg, 'there is a segment')
             t.equal(attributes.host, agent.config.getHostnameSafe(), 'set host')
             t.equal(attributes.port_path_or_id, socketPath, 'set path')
-            t.equal(attributes.database_name, DBNAME, 'set database name')
+            t.equal(attributes.database_name, DATABASE, 'set database name')
             t.equal(attributes.product, 'MySQL', 'should set product attribute')
             txn.end()
             socketPool.end(t.end)

--- a/test/versioned/mysql/pooling.tap.js
+++ b/test/versioned/mysql/pooling.tap.js
@@ -10,8 +10,7 @@ const logger = require('../../../lib/logger')
 const helper = require('../../lib/agent_helper')
 const setup = require('./setup')
 
-const DBNAME = 'agent_integration'
-const DBTABLE = 'test'
+const { DATABASE, TABLE } = setup
 
 tap.test('MySQL instrumentation with a connection pool', { timeout: 30000 }, function (t) {
   const poolLogger = logger.child({ component: 'pool' })
@@ -65,7 +64,7 @@ tap.test('MySQL instrumentation with a connection pool', { timeout: 30000 }, fun
           return callback(err)
         }
 
-        const query = 'SELECT *' + '  FROM ' + DBNAME + '.' + DBTABLE + ' WHERE id = ?'
+        const query = 'SELECT *' + '  FROM ' + DATABASE + '.' + TABLE + ' WHERE id = ?'
         client.query(query, [params.id], function (err, results) {
           withRetry.release(client) // always release back to the pool
 
@@ -120,7 +119,7 @@ tap.test('MySQL instrumentation with a connection pool', { timeout: 30000 }, fun
 
       t.equal(
         selectSegment.name,
-        'Datastore/statement/MySQL/agent_integration.test/select',
+        `Datastore/statement/MySQL/${DATABASE}.${TABLE}/select`,
         'should register as SELECT'
       )
 

--- a/test/versioned/mysql/setup.js
+++ b/test/versioned/mysql/setup.js
@@ -8,8 +8,15 @@
 const a = require('async')
 const params = require('../../lib/params')
 
+const USER = 'mysql_test_user'
+const DATABASE = 'mysql_agent_integration'
+const TABLE = 'test'
+
 module.exports = exports = setup
 exports.pool = setupPool
+exports.USER = USER
+exports.DATABASE = DATABASE
+exports.TABLE = TABLE
 
 function setup(mysql) {
   return a.series([
@@ -24,9 +31,9 @@ function setup(mysql) {
 
       a.eachSeries(
         [
-          'CREATE USER test_user',
-          'GRANT ALL ON *.* TO `test_user`',
-          'CREATE DATABASE IF NOT EXISTS `agent_integration`'
+          `CREATE USER ${USER}`,
+          `GRANT ALL ON *.* TO ${USER}`,
+          `CREATE DATABASE IF NOT EXISTS ${DATABASE}`
         ],
         function (sql, setupCb) {
           client.query(sql, function (err) {
@@ -53,20 +60,20 @@ function setup(mysql) {
       const client = mysql.createConnection({
         host: params.mysql_host,
         port: params.mysql_port,
-        user: 'test_user',
-        database: 'agent_integration'
+        user: USER,
+        database: DATABASE
       })
 
       a.eachSeries(
         [
           [
-            'CREATE TABLE IF NOT EXISTS `test` (',
+            `CREATE TABLE IF NOT EXISTS ${TABLE} (`,
             '  `id`         INTEGER(10) PRIMARY KEY AUTO_INCREMENT,',
             '  `test_value` VARCHAR(255)',
             ')'
           ].join('\n'),
-          'TRUNCATE TABLE `test`',
-          'INSERT INTO `test` (`test_value`) VALUE ("hamburgefontstiv")'
+          `TRUNCATE TABLE ${TABLE}`,
+          `INSERT INTO ${TABLE} (test_value) VALUE ("hamburgefontstiv")`
         ],
         function (sql, setupCb) {
           client.query(sql, setupCb)
@@ -95,8 +102,8 @@ function setupPool(mysql, logger) {
 
     create: function (callback) {
       const client = mysql.createConnection({
-        user: 'test_user',
-        database: 'agent_integration',
+        user: USER,
+        database: DATABASE,
         host: params.mysql_host,
         port: params.mysql_port
       })

--- a/test/versioned/mysql/transactions.tap.js
+++ b/test/versioned/mysql/transactions.tap.js
@@ -10,8 +10,7 @@ const helper = require('../../lib/agent_helper')
 const params = require('../../lib/params')
 const setup = require('./setup')
 
-const DBUSER = 'test_user'
-const DBNAME = 'agent_integration'
+const { USER, DATABASE } = setup
 
 tap.test('MySQL transactions', { timeout: 30000 }, function (t) {
   t.plan(6)
@@ -22,8 +21,8 @@ tap.test('MySQL transactions', { timeout: 30000 }, function (t) {
 
   setup(mysql).then(() => {
     const client = mysql.createConnection({
-      user: DBUSER,
-      database: DBNAME,
+      user: USER,
+      database: DATABASE,
       host: params.mysql_host,
       port: params.mysql_port
     })

--- a/test/versioned/mysql2/basic-pool.tap.js
+++ b/test/versioned/mysql2/basic-pool.tap.js
@@ -293,13 +293,13 @@ tap.test('mysql2 built-in connection pools', { timeout: 30 * 1000 }, function (t
   t.test('pool.query', function (t) {
     helper.runInTransaction(agent, function transactionInScope(txn) {
       pool.query('SELECT 1 + 1 AS solution123123123123', function (err) {
-        const transxn = agent.getTransaction()
+        const transaction = agent.getTransaction()
         const segment = agent.tracer.getSegment().parent
 
-        t.ifError(err, 'no error ocurred')
-        t.ok(transxn, 'transaction should exist')
+        t.error(err, 'no error ocurred')
+        t.ok(transaction, 'transaction should exist')
         t.ok(segment, 'segment should exist')
-        t.ok(segment.timer.start > 0, 'starts at a postitive time')
+        t.ok(segment.timer.start > 0, 'starts at a positive time')
         t.ok(segment.timer.start <= Date.now(), 'starts in past')
         t.equal(segment.name, 'MySQL Pool#query', 'is named')
         txn.end()
@@ -311,13 +311,13 @@ tap.test('mysql2 built-in connection pools', { timeout: 30 * 1000 }, function (t
   t.test('pool.query with values', function (t) {
     helper.runInTransaction(agent, function transactionInScope(txn) {
       pool.query('SELECT ? + ? AS solution', [1, 1], function (err) {
-        const transxn = agent.getTransaction()
+        const transaction = agent.getTransaction()
         t.error(err)
-        t.ok(transxn, 'should not lose transaction')
-        if (transxn) {
+        t.ok(transaction, 'should not lose transaction')
+        if (transaction) {
           const segment = agent.tracer.getSegment().parent
           t.ok(segment, 'segment should exist')
-          t.ok(segment.timer.start > 0, 'starts at a postitive time')
+          t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'MySQL Pool#query', 'is named')
         }
@@ -331,20 +331,20 @@ tap.test('mysql2 built-in connection pools', { timeout: 30 * 1000 }, function (t
   t.test('pool.getConnection -> connection.query', function (t) {
     helper.runInTransaction(agent, function transactionInScope(txn) {
       pool.getConnection(function shouldBeWrapped(err, connection) {
-        t.ifError(err, 'should not have error')
+        t.error(err, 'should not have error')
         t.ok(agent.getTransaction(), 'transaction should exit')
         t.teardown(function () {
           connection.release()
         })
 
         connection.query('SELECT 1 + 1 AS solution', function (err) {
-          const transxn = agent.getTransaction()
+          const transaction = agent.getTransaction()
           const segment = agent.tracer.getSegment().parent
 
-          t.ifError(err, 'no error ocurred')
-          t.ok(transxn, 'transaction should exist')
+          t.error(err, 'no error ocurred')
+          t.ok(transaction, 'transaction should exist')
           t.ok(segment, 'segment should exist')
-          t.ok(segment.timer.start > 0, 'starts at a postitive time')
+          t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
           txn.end()
@@ -357,20 +357,20 @@ tap.test('mysql2 built-in connection pools', { timeout: 30 * 1000 }, function (t
   t.test('pool.getConnection -> connection.query with values', function (t) {
     helper.runInTransaction(agent, function transactionInScope(txn) {
       pool.getConnection(function shouldBeWrapped(err, connection) {
-        t.ifError(err, 'should not have error')
+        t.error(err, 'should not have error')
         t.ok(agent.getTransaction(), 'transaction should exit')
         t.teardown(function () {
           connection.release()
         })
 
         connection.query('SELECT ? + ? AS solution', [1, 1], function (err) {
-          const transxn = agent.getTransaction()
+          const transaction = agent.getTransaction()
           t.error(err)
-          t.ok(transxn, 'should not lose transaction')
-          if (transxn) {
+          t.ok(transaction, 'should not lose transaction')
+          if (transaction) {
             const segment = agent.tracer.getSegment().parent
             t.ok(segment, 'segment should exist')
-            t.ok(segment.timer.start > 0, 'starts at a postitive time')
+            t.ok(segment.timer.start > 0, 'starts at a positive time')
             t.ok(segment.timer.start <= Date.now(), 'starts in past')
             t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
           }
@@ -410,11 +410,11 @@ tap.test('poolCluster', { timeout: 30 * 1000 }, function (t) {
     poolCluster.add('REPLICA', config)
 
     poolCluster.getConnection(function (err, connection) {
-      t.ifError(err, 'should not be an error')
+      t.error(err, 'should not be an error')
       t.notOk(agent.getTransaction(), 'transaction should not exist')
 
       connection.query('SELECT ? + ? AS solution', [1, 1], function (err) {
-        t.ifError(err)
+        t.error(err)
         t.notOk(agent.getTransaction(), 'transaction should not exist')
 
         connection.release()
@@ -433,7 +433,7 @@ tap.test('poolCluster', { timeout: 30 * 1000 }, function (t) {
 
     helper.runInTransaction(agent, function (txn) {
       poolCluster.getConnection(function (err, connection) {
-        t.ifError(err, 'should not have error')
+        t.error(err, 'should not have error')
         t.ok(agent.getTransaction(), 'transaction should exist')
         t.equal(agent.getTransaction(), txn, 'transaction must be original')
 
@@ -453,17 +453,17 @@ tap.test('poolCluster', { timeout: 30 * 1000 }, function (t) {
     poolCluster.add('REPLICA', config)
 
     poolCluster.getConnection(function (err, connection) {
-      t.ifError(err, 'should not have error')
+      t.error(err, 'should not have error')
 
       helper.runInTransaction(agent, function (txn) {
         connection.query('SELECT ? + ? AS solution', [1, 1], function (err) {
           t.error(err, 'no error ocurred')
-          const transxn = agent.getTransaction()
-          t.ok(transxn, 'transaction should exist')
-          t.same(transxn, txn, 'transaction must be same')
+          const transaction = agent.getTransaction()
+          t.ok(transaction, 'transaction should exist')
+          t.same(transaction, txn, 'transaction must be same')
           const segment = agent.tracer.getSegment().parent
           t.ok(segment, 'segment should exit')
-          t.ok(segment.timer.start > 0, 'starts at a postitive time')
+          t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
 
@@ -487,7 +487,7 @@ tap.test('poolCluster', { timeout: 30 * 1000 }, function (t) {
       poolCluster.getConnection('MASTER', function (err, connection) {
         t.notOk(err)
         t.ok(agent.getTransaction())
-        t.strictEqual(agent.getTransaction(), txn)
+        t.equal(agent.getTransaction(), txn)
 
         txn.end()
         connection.release()
@@ -508,12 +508,12 @@ tap.test('poolCluster', { timeout: 30 * 1000 }, function (t) {
       helper.runInTransaction(agent, function (txn) {
         connection.query('SELECT ? + ? AS solution', [1, 1], function (err) {
           t.error(err, 'no error ocurred')
-          const transxn = agent.getTransaction()
-          t.ok(transxn, 'transaction should exist')
-          t.same(transxn, txn, 'transaction must be same')
+          const transaction = agent.getTransaction()
+          t.ok(transaction, 'transaction should exist')
+          t.same(transaction, txn, 'transaction must be same')
           const segment = agent.tracer.getSegment().parent
           t.ok(segment, 'segment should exit')
-          t.ok(segment.timer.start > 0, 'starts at a postitive time')
+          t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
 
@@ -537,7 +537,7 @@ tap.test('poolCluster', { timeout: 30 * 1000 }, function (t) {
       poolCluster.getConnection('REPLICA*', 'ORDER', function (err, connection) {
         t.notOk(err)
         t.ok(agent.getTransaction())
-        t.strictEqual(agent.getTransaction(), txn)
+        t.equal(agent.getTransaction(), txn)
 
         txn.end()
         connection.release()
@@ -558,12 +558,12 @@ tap.test('poolCluster', { timeout: 30 * 1000 }, function (t) {
       helper.runInTransaction(agent, function (txn) {
         connection.query('SELECT ? + ? AS solution', [1, 1], function (err) {
           t.error(err, 'no error ocurred')
-          const transxn = agent.getTransaction()
-          t.ok(transxn, 'transaction should exist')
-          t.same(transxn, txn, 'transaction must be same')
+          const transaction = agent.getTransaction()
+          t.ok(transaction, 'transaction should exist')
+          t.same(transaction, txn, 'transaction must be same')
           const segment = agent.tracer.getSegment().parent
           t.ok(segment, 'segment should exit')
-          t.ok(segment.timer.start > 0, 'starts at a postitive time')
+          t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
 
@@ -607,12 +607,12 @@ tap.test('poolCluster', { timeout: 30 * 1000 }, function (t) {
       helper.runInTransaction(agent, function (txn) {
         connection.query('SELECT ? + ? AS solution', [1, 1], function (err) {
           t.error(err, 'no error ocurred')
-          const transxn = agent.getTransaction()
-          t.ok(transxn, 'transaction should exist')
-          t.same(transxn, txn, 'transaction must be same')
+          const transaction = agent.getTransaction()
+          t.ok(transaction, 'transaction should exist')
+          t.same(transaction, txn, 'transaction must be same')
           const segment = agent.tracer.getSegment().parent
           t.ok(segment, 'segment should exit')
-          t.ok(segment.timer.start > 0, 'starts at a postitive time')
+          t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
 
@@ -658,12 +658,12 @@ tap.test('poolCluster', { timeout: 30 * 1000 }, function (t) {
       helper.runInTransaction(agent, function (txn) {
         connection.query('SELECT ? + ? AS solution', [1, 1], function (err) {
           t.error(err, 'no error ocurred')
-          const transxn = agent.getTransaction()
-          t.ok(transxn, 'transaction should exist')
-          t.same(transxn, txn, 'transaction must be same')
+          const currentTransaction = agent.getTransaction()
+          t.ok(currentTransaction, 'transaction should exist')
+          t.same(currentTransaction, txn, 'transaction must be same')
           const segment = agent.tracer.getSegment().parent
           t.ok(segment, 'segment should exit')
-          t.ok(segment.timer.start > 0, 'starts at a postitive time')
+          t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
 

--- a/test/versioned/mysql2/basic-pool.tap.js
+++ b/test/versioned/mysql2/basic-pool.tap.js
@@ -13,8 +13,7 @@ const urltils = require('../../../lib/util/urltils')
 const exec = require('child_process').exec
 const setup = require('./setup')
 
-const DBUSER = 'root'
-const DBNAME = 'agent_integration'
+const { USER, DATABASE } = setup
 
 const config = getConfig({})
 function getConfig(extras) {
@@ -22,8 +21,8 @@ function getConfig(extras) {
     connectionLimit: 10,
     host: params.mysql_host,
     port: params.mysql_port,
-    user: DBUSER,
-    database: DBNAME
+    user: USER,
+    database: DATABASE
   }
 
   // eslint-disable-next-line guard-for-in
@@ -47,8 +46,8 @@ tap.test('bad config', function (t) {
   const badConfig = {
     connectionLimit: 10,
     host: 'nohost',
-    user: DBUSER,
-    database: DBNAME
+    user: USER,
+    database: DATABASE
   }
 
   t.test(function (t) {
@@ -137,7 +136,7 @@ tap.test('mysql2 built-in connection pools', { timeout: 30 * 1000 }, function (t
           urltils.isLocalhost(config.host) ? agent.config.getHostnameSafe() : config.host,
           'set host'
         )
-        t.equal(attributes.database_name, DBNAME, 'set database name')
+        t.equal(attributes.database_name, DATABASE, 'set database name')
         t.equal(attributes.port_path_or_id, String(config.port), 'set port')
         txn.end()
         t.end()
@@ -156,7 +155,7 @@ tap.test('mysql2 built-in connection pools', { timeout: 30 * 1000 }, function (t
 
         t.notOk(attributes.host, 'should have no host parameter')
         t.notOk(attributes.port_path_or_id, 'should have no port parameter')
-        t.equal(attributes.database_name, DBNAME, 'should set database name')
+        t.equal(attributes.database_name, DATABASE, 'should set database name')
         agent.config.datastore_tracer.instance_reporting.enabled = true
         txn.end()
         t.end()
@@ -202,7 +201,7 @@ tap.test('mysql2 built-in connection pools', { timeout: 30 * 1000 }, function (t
         const attributes = seg.getAttributes()
         t.ok(seg, 'there is a segment')
         t.equal(attributes.host, agent.config.getHostnameSafe(), 'set host')
-        t.equal(attributes.database_name, DBNAME, 'set database name')
+        t.equal(attributes.database_name, DATABASE, 'set database name')
         t.equal(attributes.port_path_or_id, String(defaultConfig.port), 'set port')
         txn.end()
         defaultPool.end(t.end)
@@ -227,7 +226,7 @@ tap.test('mysql2 built-in connection pools', { timeout: 30 * 1000 }, function (t
           urltils.isLocalhost(config.host) ? agent.config.getHostnameSafe() : config.host,
           'should set host'
         )
-        t.equal(attributes.database_name, DBNAME, 'should set database name')
+        t.equal(attributes.database_name, DATABASE, 'should set database name')
         t.equal(attributes.port_path_or_id, '3306', 'should set port')
         txn.end()
         defaultPool.end(t.end)
@@ -260,7 +259,7 @@ tap.test('mysql2 built-in connection pools', { timeout: 30 * 1000 }, function (t
             t.ok(seg, 'there is a segment')
             t.equal(attributes.host, agent.config.getHostnameSafe(), 'set host')
             t.equal(attributes.port_path_or_id, socketPath, 'set path')
-            t.equal(attributes.database_name, DBNAME, 'set database name')
+            t.equal(attributes.database_name, DATABASE, 'set database name')
             txn.end()
             socketPool.end(t.end)
           })

--- a/test/versioned/mysql2/pooling.tap.js
+++ b/test/versioned/mysql2/pooling.tap.js
@@ -101,26 +101,26 @@ tap.test('MySQL2 instrumentation with a connection pool', { timeout: 60000 }, fu
         return t.end()
       }
 
-      t.equals(row.id, 1, 'mysql2 should still work (found id)')
-      t.equals(row.test_value, 'hamburgefontstiv', 'mysql driver should still work (found value)')
+      t.equal(row.id, 1, 'mysql2 should still work (found id)')
+      t.equal(row.test_value, 'hamburgefontstiv', 'mysql driver should still work (found value)')
 
       transaction.end()
 
       const trace = transaction.trace
       t.ok(trace, 'trace should exist')
       t.ok(trace.root, 'root element should exist.')
-      t.equals(trace.root.children.length, 1, 'There should be only one child.')
+      t.equal(trace.root.children.length, 1, 'There should be only one child.')
 
       const selectSegment = trace.root.children[0]
       t.ok(selectSegment, 'trace segment for first SELECT should exist')
-      t.equals(
+      t.equal(
         selectSegment.name,
         `Datastore/statement/MySQL/${DATABASE}.${TABLE}/select`,
         'should register as SELECT'
       )
 
-      t.equals(selectSegment.children.length, 1, 'should only have a callback segment')
-      t.equals(selectSegment.children[0].name, 'Callback: <anonymous>')
+      t.equal(selectSegment.children.length, 1, 'should only have a callback segment')
+      t.equal(selectSegment.children[0].name, 'Callback: <anonymous>')
 
       selectSegment.children[0].children
         .map(function (segment) {

--- a/test/versioned/mysql2/pooling.tap.js
+++ b/test/versioned/mysql2/pooling.tap.js
@@ -10,8 +10,7 @@ const logger = require('../../../lib/logger')
 const helper = require('../../lib/agent_helper')
 const setup = require('./setup')
 
-const DBNAME = 'agent_integration'
-const DBTABLE = 'test'
+const { DATABASE, TABLE } = setup
 
 tap.test('MySQL2 instrumentation with a connection pool', { timeout: 60000 }, function (t) {
   // set up the instrumentation before loading MySQL
@@ -66,7 +65,7 @@ tap.test('MySQL2 instrumentation with a connection pool', { timeout: 60000 }, fu
           return callback(err)
         }
 
-        const query = 'SELECT *' + '  FROM ' + DBNAME + '.' + DBTABLE + ' WHERE id = ?'
+        const query = 'SELECT *' + '  FROM ' + DATABASE + '.' + TABLE + ' WHERE id = ?'
         client.query(query, [params.id], function (err, results) {
           withRetry.release(client) // always release back to the pool
 
@@ -116,7 +115,7 @@ tap.test('MySQL2 instrumentation with a connection pool', { timeout: 60000 }, fu
       t.ok(selectSegment, 'trace segment for first SELECT should exist')
       t.equals(
         selectSegment.name,
-        'Datastore/statement/MySQL/agent_integration.test/select',
+        `Datastore/statement/MySQL/${DATABASE}.${TABLE}/select`,
         'should register as SELECT'
       )
 

--- a/test/versioned/mysql2/setup.js
+++ b/test/versioned/mysql2/setup.js
@@ -8,8 +8,15 @@
 const a = require('async')
 const params = require('../../lib/params')
 
+const USER = 'mysql2_test_user'
+const DATABASE = 'mysql2_agent_integration'
+const TABLE = 'test'
+
 module.exports = exports = setup
 exports.pool = setupPool
+exports.USER = USER
+exports.DATABASE = DATABASE
+exports.TABLE = TABLE
 
 function setup(mysql) {
   return a.series([
@@ -24,9 +31,9 @@ function setup(mysql) {
 
       a.eachSeries(
         [
-          'CREATE USER test_user',
-          'GRANT ALL ON *.* TO `test_user`',
-          'CREATE DATABASE IF NOT EXISTS `agent_integration`'
+          `CREATE USER ${USER}`,
+          `GRANT ALL ON *.* TO ${USER}`,
+          `CREATE DATABASE IF NOT EXISTS ${DATABASE}`
         ],
         function (sql, setupCb) {
           client.query(sql, function (err) {
@@ -53,20 +60,20 @@ function setup(mysql) {
       const client = mysql.createConnection({
         host: params.mysql_host,
         port: params.mysql_port,
-        user: 'test_user',
-        database: 'agent_integration'
+        user: USER,
+        database: DATABASE
       })
 
       a.eachSeries(
         [
           [
-            'CREATE TABLE IF NOT EXISTS `test` (',
+            `CREATE TABLE IF NOT EXISTS ${TABLE} (`,
             '  `id`         INTEGER(10) PRIMARY KEY AUTO_INCREMENT,',
             '  `test_value` VARCHAR(255)',
             ')'
           ].join('\n'),
-          'TRUNCATE TABLE `test`',
-          'INSERT INTO `test` (`test_value`) VALUE ("hamburgefontstiv")'
+          `TRUNCATE TABLE ${TABLE}`,
+          `INSERT INTO ${TABLE} (test_value) VALUE ("hamburgefontstiv")`
         ],
         function (sql, setupCb) {
           client.query(sql, setupCb)
@@ -95,8 +102,8 @@ function setupPool(mysql, logger) {
 
     create: function (callback) {
       const client = mysql.createConnection({
-        user: 'test_user',
-        database: 'agent_integration',
+        user: USER,
+        database: DATABASE,
         host: params.mysql_host,
         port: params.mysql_port
       })

--- a/test/versioned/mysql2/transaction.tap.js
+++ b/test/versioned/mysql2/transaction.tap.js
@@ -10,8 +10,7 @@ const helper = require('../../lib/agent_helper')
 const params = require('../../lib/params')
 const setup = require('./setup')
 
-const DBUSER = 'test_user'
-const DBNAME = 'agent_integration'
+const { USER, DATABASE } = setup
 
 tap.test('MySQL transactions', { timeout: 30000 }, function (t) {
   t.plan(3)
@@ -22,8 +21,8 @@ tap.test('MySQL transactions', { timeout: 30000 }, function (t) {
 
   setup(mysql).then(() => {
     const client = mysql.createConnection({
-      user: DBUSER,
-      database: DBNAME,
+      user: USER,
+      database: DATABASE,
       host: params.mysql_host,
       port: params.mysql_port
     })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Updated mysql and mysql2 versioned tests to run against their own databases on the MySQL instance.

## Links

## Details

Recently starting getting failures rotating between mysql and mysql2 tests which led me to assume contention on a table. Looking at the setup, these use the same user/database/table combination and part of the setup is to TRUNCATE (clear) the table. One of the failures was querying data from this table, so the theory seems to check out.

Often, I'll introduce generated GUID table names and such to prevent collisions but in this case we'll only ever have a single file from each running at a time. So to get a quick fix in, I instead have each suite run in their own database within the MySQL Server instance. I've wired these up to exposed variables exported from the `setup` files so this should be somewhat trivial to modify should we find our needs change here.

This **should** resolve the issue when a full --minor versioned test run occurs but there are never guarantees for race conditions that don't appear locally.

I also cleaned up some deprecated API warnings, misspellings and such in a separate commit.

Didn't take on consolidating the setup files for now.