### PR TITLE
exclude versioned-external from install sub deps when running integration tests

### DIFF
--- a/test/bin/install_sub_deps
+++ b/test/bin/install_sub_deps
@@ -13,7 +13,7 @@ var glob = require('glob')
 var exec = require('child_process').exec
 
 var options = {
-  ignore: '**/test/versioned/**'
+  ignore: '**/test/{versioned,versioned-external}/**'
 }
 
 var folder


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Excluded installing dependencies in `versioned-external` folders when running integration tests.

## Links

## Details
I noticed this while running integration tests.

### Before fix

```sh
installing deps in /Users/revans/code/node-newrelic/test/helpers
installing deps in /Users/revans/code/node-newrelic/test/integration/uninstrumented
installing deps in /Users/revans/code/node-newrelic/test/versioned-external/TEMP_TESTS/apollo-server/tests/versioned/apollo-federation
installing deps in /Users/revans/code/node-newrelic/test/versioned-external/TEMP_TESTS/apollo-server/tests/versioned/apollo-server-express
installing deps in /Users/revans/code/node-newrelic/test/versioned-external/TEMP_TESTS/apollo-server/tests/versioned/apollo-server-fastify
installing deps in /Users/revans/code/node-newrelic/test/versioned-external/TEMP_TESTS/apollo-server/tests/versioned/apollo-server-hapi
installing deps in /Users/revans/code/node-newrelic/test/versioned-external/TEMP_TESTS/apollo-server/tests/versioned/apollo-server-koa
installing deps in /Users/revans/code/node-newrelic/test/versioned-external/TEMP_TESTS/apollo-server/tests/versioned/apollo-server-lambda
installing deps in /Users/revans/code/node-newrelic/test/versioned-external/TEMP_TESTS/apollo-server/tests/versioned/apollo-server
installing deps in /Users/revans/code/node-newrelic/test/versioned-external/TEMP_TESTS/aws-sdk/tests/versioned/v2
installing deps in /Users/revans/code/node-newrelic/test/versioned-external/TEMP_TESTS/aws-sdk/tests/versioned/v3
installing deps in /Users/revans/code/node-newrelic/test/versioned-external/TEMP_TESTS/koa/tests/versioned
installing deps in /Users/revans/code/node-newrelic/test/versioned-external/TEMP_TESTS/next/tests/versioned
installing deps in /Users/revans/code/node-newrelic/test/versioned-external/TEMP_TESTS/superagent/tests/versioned
```

### After fix

```sh
installing deps in /Users/revans/code/pull-requests/node-newrelic/test/helpers
installing deps in /Users/revans/code/pull-requests/node-newrelic/test/integration/uninstrumented
```
