### PR TITLE
use Reflect.construct to call constructor in wrapReturn

### DIFF
--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -639,10 +639,9 @@ function wrapReturn(nodule, properties, spec, args) {
         }
         return true
       },
-      construct: function constructTrap(Target, proxyArgs) {
-        // Call the underlying function. If this was called as a constructor, call
-        // the wrapped function as a constructor too.
-        let ret = new Target(...proxyArgs)
+      construct: function constructTrap(target, proxyArgs, newTarget) {
+        // Call the underlying function via Reflect.
+        let ret = Reflect.construct(target, proxyArgs, newTarget)
 
         // Assemble the arguments to hand to the spec.
         const _args = [shim, fn, fnName, ret]

--- a/test/unit/shim/shim.test.js
+++ b/test/unit/shim/shim.test.js
@@ -541,6 +541,31 @@ tap.test('Shim', function (t) {
       t.equal(shim.unwrap(wrappable.bar), original)
       t.end()
     })
+
+    t.test('should wrap child instance properly', function (t) {
+      class ParentTest {
+        constructor() {
+          this.parent = true
+        }
+
+        parentMethod() {
+          return 'hello world'
+        }
+      }
+
+      const WrappedParent = shim.wrapReturn(ParentTest, function () {})
+
+      class ChildTest extends WrappedParent {
+        childMethod() {
+          return 'child method'
+        }
+      }
+
+      const child = new ChildTest()
+      t.ok(typeof child.childMethod === 'function', 'should have child methods')
+      t.ok(typeof child.parentMethod === 'function', 'should have parent methods')
+      t.end()
+    })
   })
 
   t.test('#wrapReturn wrapper', function (t) {
@@ -648,6 +673,8 @@ tap.test('Shim', function (t) {
       function Foo() {
         t.ok(this instanceof Foo)
       }
+
+      Foo.prototype.method = function () {}
       const WrappedFoo = shim.wrapReturn(Foo, function () {
         t.ok(this instanceof Foo)
       })
@@ -655,6 +682,7 @@ tap.test('Shim', function (t) {
       const foo = new WrappedFoo()
       t.ok(foo instanceof Foo)
       t.ok(foo instanceof WrappedFoo)
+      t.ok(typeof foo.method === 'function')
       t.end()
     })
 
@@ -718,7 +746,7 @@ tap.test('Shim', function (t) {
     })
   })
 
-  t.test('#wrappClass wrapper', function (t) {
+  t.test('#wrapClass wrapper', function (t) {
     t.autoend()
     let executed = null
     let toWrap = null


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed `shim.wrapReturn` to call `Reflect.construct` in construct Proxy trap.  Also including `newTarget` to work with inherited classes.

## Links
Closes #1126

## Details
I noticed we don't use `Reflect.` for any proxy traps.  Historically I've always used those but I don't know if it makes a different. In this case it definitely does because it allows passing in the `newTarget` to work with inheriting classes.  [Proxy construct docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/construct)
