### PR TITLE
lib/sampler.js: removed native CPU metric sampler

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -712,7 +712,7 @@ This product includes source derived from [@newrelic/aws-sdk](https://github.com
 
 ### @newrelic/koa
 
-This product includes source derived from [@newrelic/koa](https://github.com/newrelic/node-newrelic-koa) ([v6.1.0](https://github.com/newrelic/node-newrelic-koa/tree/v6.1.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-koa/blob/v6.1.0/LICENSE):
+This product includes source derived from [@newrelic/koa](https://github.com/newrelic/node-newrelic-koa) ([v6.1.1](https://github.com/newrelic/node-newrelic-koa/tree/v6.1.1)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-koa/blob/v6.1.1/LICENSE):
 
 ```
 Apache License
@@ -3377,7 +3377,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ### @newrelic/native-metrics
 
-This product includes source derived from [@newrelic/native-metrics](https://github.com/newrelic/node-native-metrics) ([v7.1.1](https://github.com/newrelic/node-native-metrics/tree/v7.1.1)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-native-metrics/blob/v7.1.1/LICENSE):
+This product includes source derived from [@newrelic/native-metrics](https://github.com/newrelic/node-native-metrics) ([v8.0.0](https://github.com/newrelic/node-native-metrics/tree/v8.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-native-metrics/blob/v8.0.0/LICENSE):
 
 ```
                                  Apache License

--- a/lib/sampler.js
+++ b/lib/sampler.js
@@ -109,17 +109,6 @@ function sampleCpu(agent) {
   }
 }
 
-function sampleCpuNative(agent, nativeMetrics) {
-  const recordCPU = generateCPUMetricRecorder(agent)
-  nativeMetrics.on('usage', function collectResourceUsage(usage) {
-    recordCPU(usage.diff.ru_utime / MILLIS, usage.diff.ru_stime / MILLIS)
-  })
-
-  return function cpuSampler() {
-    // NOOP?
-  }
-}
-
 function sampleLoop(agent, nativeMetrics) {
   return function loopSampler() {
     // Convert from microseconds to seconds
@@ -195,16 +184,8 @@ module.exports = {
       }
     }
 
-    // Add CPU sampling using the built-in data if available, otherwise pulling
-    // from the native module.
-    if (process.cpuUsage) {
-      // introduced in 6.1.0
-      samplers.push(new Sampler(sampleCpu(agent), SAMPLE_INTERVAL))
-    } else if (this.nativeMetrics && this.nativeMetrics.usageEnabled) {
-      samplers.push(new Sampler(sampleCpuNative(agent, this.nativeMetrics), SAMPLE_INTERVAL))
-    } else {
-      logger.debug('Not adding CPU metric sampler.')
-    }
+    // Add CPU sampling using the built-in data (introduced in 6.1.0)
+    samplers.push(new Sampler(sampleCpu(agent), SAMPLE_INTERVAL))
 
     this.state = 'running'
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "npm": ">=6.0.0"
       },
       "optionalDependencies": {
-        "@newrelic/native-metrics": "^7.1.1"
+        "@newrelic/native-metrics": "^8.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -821,9 +821,9 @@
       }
     },
     "node_modules/@newrelic/native-metrics": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-7.1.1.tgz",
-      "integrity": "sha512-Z25gH8RGBAe174MuIFWuRHaHS2dNLzBSSb3mv6O/RW9Dke5hJ5wJMVuVOTNKJPp5g0OIfcG4fzFj1m/3xP/SKQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-8.0.0.tgz",
+      "integrity": "sha512-df/V1P6dxpX09PaA6Jx9pmkPbRrue5hDyRCc4w3bnqMbnybvwVwS+q1/QEPvjBPQJ5abTRlBcJ7UZ3sfGW1hzg==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -9314,6 +9314,23 @@
         "@newrelic/native-metrics": "^7.1.1"
       }
     },
+    "node_modules/newrelic/node_modules/@newrelic/native-metrics": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-7.1.2.tgz",
+      "integrity": "sha512-Ay0iLiwb/TIlbxxuWqxhrW1FxOSokKS09NKcRi1VXsMCMmvJiVhq6wvJcFvpoGLzvkTLLMFrJAHP0eJBKUpZfQ==",
+      "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "nan": "^2.15.0",
+        "semver": "^5.5.1"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -15338,9 +15355,9 @@
       "requires": {}
     },
     "@newrelic/native-metrics": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-7.1.1.tgz",
-      "integrity": "sha512-Z25gH8RGBAe174MuIFWuRHaHS2dNLzBSSb3mv6O/RW9Dke5hJ5wJMVuVOTNKJPp5g0OIfcG4fzFj1m/3xP/SKQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-8.0.0.tgz",
+      "integrity": "sha512-df/V1P6dxpX09PaA6Jx9pmkPbRrue5hDyRCc4w3bnqMbnybvwVwS+q1/QEPvjBPQJ5abTRlBcJ7UZ3sfGW1hzg==",
       "optional": true,
       "requires": {
         "https-proxy-agent": "^5.0.0",
@@ -21993,6 +22010,20 @@
         "json-stringify-safe": "^5.0.0",
         "readable-stream": "^3.6.0",
         "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "@newrelic/native-metrics": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-7.1.2.tgz",
+          "integrity": "sha512-Ay0iLiwb/TIlbxxuWqxhrW1FxOSokKS09NKcRi1VXsMCMmvJiVhq6wvJcFvpoGLzvkTLLMFrJAHP0eJBKUpZfQ==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "https-proxy-agent": "^5.0.0",
+            "nan": "^2.15.0",
+            "semver": "^5.5.1"
+          }
+        }
       }
     },
     "nice-try": {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "semver": "^5.3.0"
   },
   "optionalDependencies": {
-    "@newrelic/native-metrics": "^7.1.1"
+    "@newrelic/native-metrics": "^8.0.0"
   },
   "devDependencies": {
     "@newrelic/eslint-config": "^0.0.3",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,18 +1,18 @@
 {
-  "lastUpdated": "Wed Feb 16 2022 15:50:08 GMT-0800 (Pacific Standard Time)",
+  "lastUpdated": "Tue Mar 22 2022 11:50:22 GMT-0400 (GMT-04:00)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
   "optionalDependencies": {
-    "@newrelic/native-metrics@7.1.1": {
+    "@newrelic/native-metrics@8.0.0": {
       "name": "@newrelic/native-metrics",
-      "version": "7.1.1",
-      "range": "^7.1.1",
+      "version": "8.0.0",
+      "range": "^8.0.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-native-metrics",
-      "versionedRepoUrl": "https://github.com/newrelic/node-native-metrics/tree/v7.1.1",
+      "versionedRepoUrl": "https://github.com/newrelic/node-native-metrics/tree/v8.0.0",
       "licenseFile": "node_modules/@newrelic/native-metrics/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-native-metrics/blob/v7.1.1/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-native-metrics/blob/v8.0.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"
@@ -57,15 +57,15 @@
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"
     },
-    "@newrelic/koa@6.1.0": {
+    "@newrelic/koa@6.1.1": {
       "name": "@newrelic/koa",
-      "version": "6.1.0",
-      "range": "^6.1.0",
+      "version": "6.1.1",
+      "range": "^6.1.1",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic-koa",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-koa/tree/v6.1.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-koa/tree/v6.1.1",
       "licenseFile": "node_modules/@newrelic/koa/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic-koa/blob/v6.1.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic-koa/blob/v6.1.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
This is available via `process.cpuUsage` since Node 12, which is now
the lowest version we support. We have removed the corresponding code
in @newrelic/native-metrics since version 8.0.0, so this removes its
only calling site in the main agent.

## Proposed Release Notes

* Removed native CPU metric sampler

## Links

* Fixes https://github.com/newrelic/node-native-metrics/issues/154