### PR TITLE
stop propagating errors in promise interceptor

### DIFF
--- a/lib/serverless/aws-lambda.js
+++ b/lib/serverless/aws-lambda.js
@@ -199,20 +199,19 @@ class AwsLambda {
     // we need to store the error in uncaughtException
     // otherwise the transaction will end before they are captured
     function lambdaInterceptPromise(prom, resultProcessor, cb) {
-      return prom.then(
+      prom.then(
         function onThen(arg) {
           if (resultProcessor) {
             resultProcessor(arg)
           }
           cb()
-          return arg
         },
         function onCatch(err) {
           uncaughtException = err
           cb()
-          throw err // This is not our error, just rethrowing the promise rejection.
         }
       )
+      return prom
     }
 
     function wrapCallbackAndCaptureError(transaction, txnEnder, cb, processResult) {

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -1746,19 +1746,8 @@ function shimRequire(filePath) {
  * @returns {Promise} A new promise to replace the original one.
  */
 function interceptPromise(prom, cb) {
-  if (this.isFunction(prom.finally)) {
-    return prom.finally(cb)
-  }
-  return prom.then(
-    function onThen(arg) {
-      cb()
-      return arg
-    },
-    function onCatch(err) {
-      cb()
-      throw err // This is not our error, just rethrowing the promise rejection.
-    }
-  )
+  prom.then(cb, cb)
+  return prom
 }
 
 /**

--- a/test/unit/shim/shim.test.js
+++ b/test/unit/shim/shim.test.js
@@ -1249,6 +1249,31 @@ tap.test('Shim', function (t) {
         promise.reject(result)
       }, 5)
     })
+
+    t.test('should not affect unhandledRejection event', function (t) {
+      const wrapped = shim.record(toWrap, function () {
+        return { name: 'test segment', promise: true }
+      })
+
+      const result = {}
+      helper.runInTransaction(agent, function () {
+        const ret = wrapped()
+        t.ok(ret instanceof Object.getPrototypeOf(promise).constructor)
+
+        process.on('unhandledRejection', function (err) {
+          t.equal(err, result)
+          t.end()
+        })
+
+        ret.then(() => {
+          t.end(new Error('Should not have resolved'))
+        })
+      })
+
+      setTimeout(function () {
+        promise.reject(result)
+      }, 5)
+    })
   })
 
   t.test('#record wrapper when called without a transaction', function (t) {

--- a/test/unit/shim/shim.test.js
+++ b/test/unit/shim/shim.test.js
@@ -1249,28 +1249,6 @@ tap.test('Shim', function (t) {
         promise.reject(result)
       }, 5)
     })
-
-    t.test('should not affect unhandledRejection event', function (t) {
-      const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment', promise: true }
-      })
-
-      const result = {}
-      helper.runInTransaction(agent, function () {
-        const ret = wrapped()
-        t.ok(ret instanceof Object.getPrototypeOf(promise).constructor)
-
-        process.on('unhandledRejection', function (err, p) {
-          t.equal(err, result)
-          t.equal(p, ret)
-          t.end()
-        })
-      })
-
-      setTimeout(function () {
-        promise.reject(result)
-      }, 5)
-    })
   })
 
   t.test('#record wrapper when called without a transaction', function (t) {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed promise interceptor from re-throwing errors.

## Links
Closes #566

## Details
Our promise interceptors change behavior of code for the worst.  By adding then and catch handlers to promises we are adding additional links on the promise chain.  By re-throwing errors we're trying to solve a case where a customer may not have a catch handler and an unhandledRejection would occur.  However, there are side effects like this bug that occur.

The big change here is if you have unhandledRejections and were listening with `process.on('unhandledRejection')` they will now be `process.on('uncaughtException')`

A simple test case shows this behavior

```js
let prom = new Promise((resolve, reject) => {
  setTimeout(() => {
    const err = new Error('no soup for you')
    reject(err)
  }, 10)
})

function wrapPromise(promise) {
  promise.then(() => {
    console.log('in wrapped then')
  }, (err) => {
    console.log('in wrapped catch')
  })
  return promise
}

prom = wrapPromise(prom)
prom.then(() => {
  console.log('resolved')
}).catch((err) => {
  console.log('do some stuff in catch', err)
})
```

```sh
in wrapped catch
do some stuff in catch Error: no soup for you
    at Timeout._onTimeout (/Users/revans/test.js:3:17)
    at listOnTimeout (node:internal/timers:557:17)
    at processTimers (node:internal/timers:500:7)
```

Whereas our current code causes unhandled rejections when they have already been handled

```js
let prom = new Promise((resolve, reject) => {
  setTimeout(() => {
    const err = new Error('no soup for you')
    reject(err)
  }, 10)
})

function wrapPromise(promise) {
  promise.then(() => {
    console.log('in wrapped then')
  }, (err) => {
    console.log('in wrapped catch')
    throw err
  })
  return promise
}

prom = wrapPromise(prom)
prom.then(() => {
  console.log('resolved')
}).catch((err) => {
  console.log('do some stuff in catch', err)
})

process.on('unhandledRejection', (err) => {
  console.log('in unhandled', err)
})
```

```sh
in wrapped catch
do some stuff in catch Error: no soup for you
    at Timeout._onTimeout (/Users/revans/test.js:3:17)
    at listOnTimeout (node:internal/timers:557:17)
    at processTimers (node:internal/timers:500:7)
in unhandled Error: no soup for you
    at Timeout._onTimeout (/Users/revans/test.js:3:17)
    at listOnTimeout (node:internal/timers:557:17)
    at processTimers (node:internal/timers:500:7)
```

Lastly, it's worth noting that up until Node 15 `unhandledRejections` were just logged as warnings: https://developer.ibm.com/blogs/nodejs-15-release-blog/