### PR TITLE
Skips mongo versions 4.0.0 through 4.1.3 in versioned tests.

### DIFF
--- a/test/versioned/mongodb/package.json
+++ b/test/versioned/mongodb/package.json
@@ -8,7 +8,7 @@
         "node": ">=12"
       },
       "dependencies": {
-        "mongodb": ">=2.1"
+        "mongodb": ">=2.1 < 4.0.0 || >= 4.1.4"
       },
       "files": [
         "bulk.tap.js",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details

Looks like there were a few versions of the `mongodb` client that didn't play well with our instrumentation. These haven't been getting hit due to the 10 version sampling but some started to on full runs. I haven't looked into the "why" but recent versions all work.
