### PR TITLE
Limits the number of test permutations for some hapi versions.

### DIFF
--- a/test/versioned/hapi/hapi-post-18/package.json
+++ b/test/versioned/hapi/hapi-post-18/package.json
@@ -9,8 +9,11 @@
       },
       "dependencies": {
         "ejs": "2.5.5",
-        "@hapi/hapi": ">=18.3.1",
-        "vision": "^5.0.0"
+        "@hapi/hapi": {
+          "versions": ">=18.3.1",
+          "samples": 5
+        },
+        "vision": "latest"
       },
       "files": [
         "capture-params.tap.js",
@@ -32,7 +35,7 @@
       "dependencies": {
         "ejs": "2.5.5",
         "@hapi/hapi": ">=20.1.2",
-        "vision": "^5.0.0"
+        "vision": "latest"
       },
       "files": [
         "capture-params.tap.js",

--- a/test/versioned/hapi/hapi-pre-17/package.json
+++ b/test/versioned/hapi/hapi-pre-17/package.json
@@ -8,7 +8,10 @@
         "node": ">=12 <14"
       },
       "dependencies": {
-        "hapi": ">=2.0.0 <6",
+        "hapi": {
+          "versions": ">=2.0.0 <6",
+          "samples": 5
+        },
         "ejs": "2.5"
       },
       "files": [
@@ -23,7 +26,10 @@
         "node": ">=12 <14"
       },
       "dependencies": {
-        "hapi": ">=6.0.0 <7"
+        "hapi": {
+          "versions": ">=6.0.0 <7",
+          "samples": 3
+        }
       },
       "files": [
         "capture-params.tap.js",
@@ -38,7 +44,10 @@
         "node": ">=12 <14"
       },
       "dependencies": {
-        "hapi": ">=7.0.0 <8.3 || >=8.8 <9"
+        "hapi": {
+          "versions": ">=7.0.0 <8.3 || >=8.8 <9",
+          "samples": 3
+        }
       },
       "files": [
         "capture-params.tap.js",
@@ -71,7 +80,10 @@
         "node": ">=12 <14"
       },
       "dependencies": {
-        "hapi": ">=16.0.0 <17",
+        "hapi": {
+          "versions": ">=16.0.0 <17",
+          "samples": 2
+        },
         "ejs": "2.5",
         "vision": "4.1"
       },


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Limits permutations of hapi tests.

## Links

## Details

A lot of these will go away when we rip out support for most deprecated versions of hapi in the next major release. In the meantime, this will speed up some of the hapi testing.

Hapi post 18 was the slowest non-aws versioned. I noticed it was testing hapi versions against "vision" versions. So 10 x 5 permutations. Seems enough to know vision is continuing to work so set that to latest.

Limited samples of older runs. Newer (18+) got more runs. Older (pre 17) got around the number of major versions + 1 extra (didn't follow this exactly).
