### PR TITLE
Sets a more specific version of ejs for express tests to reduce permutations

### DIFF
--- a/test/versioned/express/package.json
+++ b/test/versioned/express/package.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "express": ">=4.6.0",
         "express-enrouten": "1.1",
-        "ejs": "2.5"
+        "ejs": "2.5.9"
       },
       "files": [
         "app-use.tap.js",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details

Specifies a specific version of `ejs` to reduce express test runs down to 160.

The `2.5` was resulting in two versions of `ejs` being tested: 2.5.5, 2.5.9. Given the 10 versions of express being tested + large number of test files this was resulting in 320 test runs when testing "minor" versions on main branch runs. Unless something comes up, I don't believe we need to test multiple 2.x versions of `ejs` and don't think that was the intention of how it was configured.

Unsure if this is an npm thing or versioned runner thing or if it is new due to recent enhancements or has always been that way.