### PR TITLE
Removes query timeout from mysql2 transactions test.

### DIFF
--- a/test/versioned/mysql2/transaction.tap.js
+++ b/test/versioned/mysql2/transaction.tap.js
@@ -40,7 +40,7 @@ tap.test('MySQL transactions', { timeout: 30000 }, function (t) {
           return t.fail(err)
         }
         // trying the object mode of client.query
-        client.query({ sql: 'SELECT 1', timeout: 10 }, function (err) {
+        client.query({ sql: 'SELECT 1' }, function (err) {
           if (err) {
             return t.fail(err)
           }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Removed query timeout from mysql2 transaction versioned test.

## Links

## Details

Unsure why this was such a low number other than you would expect a SELECT 1 to be blazing fast. That being said, seems like we are running into issues. The mysql (not 2) versioned test of the same has a query timeout of 2000. Looks like I'm the one that bumped it that high :P.

While timeouts can be nice for preventing failures from causing long hangs... most of the queries in other test files do not have a timeout. And any case where this occurs regularly would be cause to resolve right away. So just removing instead of trying to find the right balance of timeout. It can always be added back if the hanging case occurs.

Here's the code in mysql2 that has been triggering the test flickers we've seen recently: https://github.com/sidorares/node-mysql2/blob/241cb10658aa32b410d4f4a3b618156e8bec6ff5/lib/commands/query.js#L300-L317