### PR TITLE
fix logging config checks

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -376,13 +376,8 @@ Agent.prototype.forceHarvestAll = function forceHarvestAll(callback) {
     promises.push(errorEventPromise)
   }
 
-  /**
-   * There is a global setting here `application_logging.enabled` that takes
-   * precedence over application_logging.forwarding.enabled so check both
-   * to decide if we need to add the log events flush
-   */
   if (
-    agent.config.application_logging.enabled ||
+    agent.config.application_logging.enabled &&
     agent.config.application_logging.forwarding.enabled
   ) {
     const logEventPromise = new Promise((resolve) => {
@@ -447,7 +442,7 @@ Agent.prototype.startAggregators = function startAggregators() {
   }
 
   if (
-    this.config.application_logging.enabled ||
+    this.config.application_logging.enabled &&
     this.config.application_logging.forwarding.enabled
   ) {
     this.logs.start()
@@ -979,7 +974,8 @@ function generateLoggingSupportMetrics(agent) {
 
   const configKeys = ['metrics', 'forwarding', 'local_decorating']
   configKeys.forEach((configValue) => {
-    const configFlag = loggingConfig[`${configValue}`].enabled ? 'enabled' : 'disabled'
+    const configFlag =
+      loggingConfig.enabled && loggingConfig[`${configValue}`].enabled ? 'enabled' : 'disabled'
     const metricName = logNames[`${configValue.toUpperCase()}`]
     agent.metrics.getOrCreateMetric(`${metricName}${configFlag}`).incrementCallCount()
   })

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -939,11 +939,11 @@ exports.config = () => ({
    */
   application_logging: {
     /**
-     * Toggles all application logging features, regardless of more specific flagging.
+     * Toggles the ability for all application logging features to be enabled.
      *
      * @env NEW_RELIC_APPLICATION_LOGGING_ENABLED
      */
-    enabled: false,
+    enabled: true,
     forwarding: {
       /**
        * Toggles whether the agent gathers log records for sending to New Relic.

--- a/test/unit/agent/agent.test.js
+++ b/test/unit/agent/agent.test.js
@@ -206,7 +206,6 @@ tap.test('when forcing transaction ignore status', (t) => {
 tap.test('#startAggregators should start all aggregators', (t) => {
   // Load agent with default 'stopped' state
   const agent = helper.loadMockedAgent(null, false)
-  agent.config.application_logging.enabled = true
   agent.config.application_logging.forwarding.enabled = true
 
   t.teardown(() => {
@@ -229,7 +228,6 @@ tap.test('#startAggregators should start all aggregators', (t) => {
 tap.test('#stopAggregators should stop all aggregators', (t) => {
   // Load agent with default 'stopped' state
   const agent = helper.loadMockedAgent(null, false)
-  agent.config.application_logging.enabled = true
   agent.config.application_logging.forwarding.enabled = true
 
   t.teardown(() => {
@@ -255,7 +253,6 @@ tap.test('#onConnect should reconfigure all the aggregators', (t) => {
 
   // Load agent with default 'stopped' state
   const agent = helper.loadMockedAgent(null, false)
-  agent.config.application_logging.enabled = true // for span events
   agent.config.application_logging.forwarding.enabled = true
 
   t.teardown(() => {

--- a/test/unit/agent/agent.test.js
+++ b/test/unit/agent/agent.test.js
@@ -206,7 +206,8 @@ tap.test('when forcing transaction ignore status', (t) => {
 tap.test('#startAggregators should start all aggregators', (t) => {
   // Load agent with default 'stopped' state
   const agent = helper.loadMockedAgent(null, false)
-  agent.config.application_logging.enabled = true // for span events
+  agent.config.application_logging.enabled = true
+  agent.config.application_logging.forwarding.enabled = true
 
   t.teardown(() => {
     helper.unloadAgent(agent)
@@ -228,7 +229,8 @@ tap.test('#startAggregators should start all aggregators', (t) => {
 tap.test('#stopAggregators should stop all aggregators', (t) => {
   // Load agent with default 'stopped' state
   const agent = helper.loadMockedAgent(null, false)
-  agent.config.application_logging.enabled = true // for span events
+  agent.config.application_logging.enabled = true
+  agent.config.application_logging.forwarding.enabled = true
 
   t.teardown(() => {
     helper.unloadAgent(agent)
@@ -254,6 +256,7 @@ tap.test('#onConnect should reconfigure all the aggregators', (t) => {
   // Load agent with default 'stopped' state
   const agent = helper.loadMockedAgent(null, false)
   agent.config.application_logging.enabled = true // for span events
+  agent.config.application_logging.forwarding.enabled = true
 
   t.teardown(() => {
     helper.unloadAgent(agent)
@@ -698,6 +701,7 @@ tap.test('when connected', (t) => {
 
   function setupAggregators(enableAggregator) {
     agent.config.application_logging.enabled = enableAggregator
+    agent.config.application_logging.forwarding.enabled = enableAggregator
     agent.config.slow_sql.enabled = enableAggregator
     agent.config.transaction_tracer.record_sql = 'raw'
     agent.config.distributed_tracing.enabled = enableAggregator
@@ -1173,6 +1177,7 @@ tap.test('logging supportability on connect', (t) => {
   })
 
   t.test('should increment disabled metrics when logging features are off', (t) => {
+    agent.config.application_logging.enabled = true
     agent.config.application_logging.metrics.enabled = false
     agent.config.application_logging.forwarding.enabled = false
     agent.config.application_logging.local_decorating.enabled = false
@@ -1187,7 +1192,27 @@ tap.test('logging supportability on connect', (t) => {
     })
   })
 
+  t.test(
+    'should increment disabled metrics when logging features are on but application_logging.enabled is false',
+    (t) => {
+      agent.config.application_logging.enabled = false
+      agent.config.application_logging.metrics.enabled = true
+      agent.config.application_logging.forwarding.enabled = true
+      agent.config.application_logging.local_decorating.enabled = true
+      agent.onConnect(false, () => {
+        keys.forEach((key) => {
+          const disabled = agent.metrics.getMetric(`Supportability/Logging/${key}/Nodejs/disabled`)
+          const enabled = agent.metrics.getMetric(`Supportability/Logging/${key}/Nodejs/enabled`)
+          t.equal(disabled.callCount, 1)
+          t.notOk(enabled)
+        })
+        t.end()
+      })
+    }
+  )
+
   t.test('should increment enabled metrics when logging features are on', (t) => {
+    agent.config.application_logging.enabled = true
     agent.config.application_logging.metrics.enabled = true
     agent.config.application_logging.forwarding.enabled = true
     agent.config.application_logging.local_decorating.enabled = true

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -246,7 +246,7 @@ tap.test('with default properties', (t) => {
 
   t.test('should default application logging accordingly', (t) => {
     t.same(configuration.application_logging, {
-      enabled: false,
+      enabled: true,
       forwarding: {
         enabled: false,
         max_samples_stored: 10000


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Changed default value of `application_logging.enabled` to be true.
 * Fixed check to ensure both `application_logging.enabled` and `application_logging.forwarding.enabled` are true before registering the log aggregator.

## Links

## Details
This was a misinterpretation of the spec originally.  It should be an inclusive check and not a switch where the value of `application_logging.enabled` takes precedence. Also `application_logging.enabled` should default to true to allow customers to configure fowarding, metrics, and decorating accordingly without having to change 2 config values.  However, they can disable all by setting `application_logging.enabled` to `false`.
