### PR TITLE
newrelic.js: remove distributed tracing from sample config

### DIFF
--- a/newrelic.js
+++ b/newrelic.js
@@ -14,22 +14,6 @@ exports.config = {
    * Your New Relic license key.
    */
   license_key: 'license key here',
-  /**
-   * This setting controls distributed tracing.
-   * Distributed tracing lets you see the path that a request takes through your
-   * distributed system. Enabling distributed tracing changes the behavior of some
-   * New Relic features, so carefully consult the transition guide before you enable
-   * this feature: https://docs.newrelic.com/docs/transition-guide-distributed-tracing
-   * Default is false.
-   */
-  distributed_tracing: {
-    /**
-     * Enables/disables distributed tracing.
-     *
-     * @env NEW_RELIC_DISTRIBUTED_TRACING_ENABLED
-     */
-    enabled: true
-  },
   logging: {
     /**
      * Level at which to log. 'trace' is most useful to New Relic when diagnosing


### PR DESCRIPTION
## Proposed Release Notes

* Removed distributed tracing setting from example config

## Details

This feature is now on by default. So there's no need to recommend it.
The docstring here is also wrong anyway about default being false,
anyway.
