### PR TITLE
Add @redis/client instrumentation

### DIFF
--- a/lib/instrumentation/@redis/client.js
+++ b/lib/instrumentation/@redis/client.js
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+module.exports = require('../@node-redis/client')

--- a/lib/instrumentations.js
+++ b/lib/instrumentations.js
@@ -30,6 +30,7 @@ module.exports = function instrumentations() {
     'q': { type: null },
     'redis': { type: MODULE_TYPE.DATASTORE },
     '@node-redis/client': { type: MODULE_TYPE.DATASTORE },
+    '@redis/client': { type: MODULE_TYPE.DATASTORE },
     'restify': { type: MODULE_TYPE.WEB_FRAMEWORK },
     'superagent': { module: '@newrelic/superagent' },
     'undici': { type: MODULE_TYPE.TRANSACTION },

--- a/test/versioned/redis/package.json
+++ b/test/versioned/redis/package.json
@@ -16,7 +16,7 @@
     },
     {
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "dependencies": {
         "redis": ">=4"

--- a/test/versioned/redis/redis-v4.tap.js
+++ b/test/versioned/redis/redis-v4.tap.js
@@ -49,8 +49,10 @@ test('Redis instrumentation', function (t) {
 
   t.afterEach(async function () {
     agent && helper.unloadAgent(agent)
-    await client.flushAll()
-    await client.disconnect()
+    if (client) {
+      await client.flushAll()
+      await client.disconnect()
+    }
     // must purge require cache of redis related instrumentation
     // otherwise it will not re-register on subsequent test runs
     Object.keys(require.cache).forEach((key) => {

--- a/test/versioned/redis/redis-v4.tap.js
+++ b/test/versioned/redis/redis-v4.tap.js
@@ -30,6 +30,7 @@ test('Redis instrumentation', function (t) {
     client = redis.createClient({ socket: { port: params.redis_port, host: params.redis_host } })
 
     await client.connect()
+    await client.flushAll()
 
     await client.select(DB_INDEX)
     // eslint-disable-next-line new-cap
@@ -48,7 +49,8 @@ test('Redis instrumentation', function (t) {
 
   t.afterEach(async function () {
     agent && helper.unloadAgent(agent)
-    client && (await client.quit())
+    await client.flushAll()
+    await client.disconnect()
     // must purge require cache of redis related instrumentation
     // otherwise it will not re-register on subsequent test runs
     Object.keys(require.cache).forEach((key) => {

--- a/test/versioned/redis/redis-v4.tap.js
+++ b/test/versioned/redis/redis-v4.tap.js
@@ -42,9 +42,6 @@ test('Redis instrumentation', function (t) {
 
     // need to capture attributes
     agent.config.attributes.enabled = true
-
-    // Start testing!
-    t.notOk(agent.getTransaction(), 'no transaction should be in play')
   })
 
   t.afterEach(async function () {
@@ -63,6 +60,7 @@ test('Redis instrumentation', function (t) {
   })
 
   t.test('should find Redis calls in the transaction trace', function (t) {
+    t.notOk(agent.getTransaction(), 'no transaction should be in play')
     helper.runInTransaction(agent, async function transactionInScope() {
       const transaction = agent.getTransaction()
       t.ok(transaction, 'transaction should be visible')
@@ -101,6 +99,7 @@ test('Redis instrumentation', function (t) {
   })
 
   t.test('should create correct metrics', function (t) {
+    t.notOk(agent.getTransaction(), 'no transaction should be in play')
     helper.runInTransaction(agent, async function transactionInScope() {
       const transaction = agent.getTransaction()
       await client.set('testkey', 'arglbargle')
@@ -121,6 +120,7 @@ test('Redis instrumentation', function (t) {
   })
 
   t.test('should add `key` attribute to trace segment', function (t) {
+    t.notOk(agent.getTransaction(), 'no transaction should be in play')
     agent.config.attributes.enabled = true
 
     helper.runInTransaction(agent, async function () {
@@ -133,6 +133,7 @@ test('Redis instrumentation', function (t) {
   })
 
   t.test('should not add `key` attribute to trace segment', function (t) {
+    t.notOk(agent.getTransaction(), 'no transaction should be in play')
     agent.config.attributes.enabled = false
 
     helper.runInTransaction(agent, async function () {
@@ -145,6 +146,7 @@ test('Redis instrumentation', function (t) {
   })
 
   t.test('should add datastore instance attributes to trace segments', function (t) {
+    t.notOk(agent.getTransaction(), 'no transaction should be in play')
     // Enable.
     agent.config.datastore_tracer.instance_reporting.enabled = true
     agent.config.datastore_tracer.database_name_reporting.enabled = true
@@ -169,6 +171,7 @@ test('Redis instrumentation', function (t) {
   })
 
   t.test('should not add instance attributes/metrics when disabled', function (t) {
+    t.notOk(agent.getTransaction(), 'no transaction should be in play')
     // disable
     agent.config.datastore_tracer.instance_reporting.enabled = false
     agent.config.datastore_tracer.database_name_reporting.enabled = false
@@ -195,6 +198,7 @@ test('Redis instrumentation', function (t) {
   })
 
   t.test('should follow selected database', function (t) {
+    t.notOk(agent.getTransaction(), 'no transaction should be in play')
     let transaction = null
     const SELECTED_DB = 3
     helper.runInTransaction(agent, async function (tx) {


### PR DESCRIPTION
- added @redis/client folder to account for changes in packages in 4.1.0 of redis
- explicity call t.end to end each test
- check if client exists in afterEach before flushing and disconnecting

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added instrumentation for `@redis/client`.  In 4.1.0 of redis it switched from using `@node-redis/client` to `@redis/client`. This meant instrumentation was not registering because it relies on package name.


## Links

## Details
I also refactored the tap tests to explicity call `t.end()`.  There was a mix of `t.plan`, `t.autoend` and `t.end`.  It seemed to cause inconsistencies in test runs.  When I changed that the segment array in the last test changed because of the setTimeouts tap creates when calling `t.autoend`.
