### PR TITLE
Add magic comments to disable webpack dynamic require parsing

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1657,7 +1657,7 @@ function initialize(config) {
 
   let userConf
   try {
-    userConf = require(filepath).config
+    userConf = require(/* webpackIgnore: true */ filepath).config
   } catch (error) {
     logger.error(error)
 

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -360,7 +360,7 @@ const shimmer = (module.exports = {
       let uninstrumented = null
 
       try {
-        uninstrumented = require(mojule)
+        uninstrumented = require(/* webpackIgnore: true */ mojule)
       } catch (err) {
         logger.trace('Could not load core module %s got error %s', mojule, err)
       }


### PR DESCRIPTION
## Proposed Release Notes

- Add magic comments to where it requires node-builtin packages and configuration file in order to disable dynamic require parsing when bundling with webpack 5.17.0 or above.

## Details

- When bundling assets with Webpack, it parses `require` statements and rewrites to `__webpack_require__`. `__webpack_require__` requires from bundle file, not from external files. This behavior isn't desirable for some `require` statements such as requiring Node.js built-in packages or New Relic configuration file (`newrelic.js`). Adding `/* webpackIgnore: true */` (and set `module.parser.javascript.commonjsMagicComments` to `true`) disables this behavior.
