### PR TITLE
refactored log aggregator to only add to queue when not in transaction context

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -144,7 +144,8 @@ function Agent(config) {
       limit: config.event_harvest_config.harvest_limits.log_event_data
     },
     this.collector,
-    this.metrics
+    this.metrics,
+    this
   )
 
   this.errors = new ErrorCollector(config, errorTraceAggregator, errorEventAggregator, this.metrics)

--- a/lib/aggregators/log-aggregator.js
+++ b/lib/aggregators/log-aggregator.js
@@ -41,7 +41,7 @@ class LogAggregator extends EventAggregator {
   add(logLine) {
     const transaction = this.agent.getTransaction()
     if (transaction) {
-      transaction.logs.push(logLine)
+      transaction.logs.add(logLine)
     } else {
       super.add(logLine)
     }

--- a/lib/aggregators/log-aggregator.js
+++ b/lib/aggregators/log-aggregator.js
@@ -17,12 +17,13 @@ const NAMES = require('../metrics/names')
  * @class
  */
 class LogAggregator extends EventAggregator {
-  constructor(opts, collector, metrics) {
+  constructor(opts, collector, metrics, agent) {
     opts = opts || {}
     opts.method = opts.method || 'log_event_data'
     opts.metricNames = NAMES.LOGGING
 
     super(opts, collector, metrics)
+    this.agent = agent
   }
 
   _toPayloadSync() {
@@ -35,6 +36,21 @@ class LogAggregator extends EventAggregator {
 
     const eventData = events.toArray()
     return [{ logs: eventData }]
+  }
+
+  add(logLine) {
+    const transaction = this.agent.getTransaction()
+    if (transaction) {
+      transaction.logs.push(logLine)
+    } else {
+      super.add(logLine)
+    }
+  }
+
+  addBatch(logs, priority) {
+    logs.forEach((logLine) => {
+      super.add(logLine, priority)
+    })
   }
 }
 

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -64,7 +64,7 @@ const MULTIPLE_INSERT_MESSAGE =
  * Bundle together the metrics and the trace segment for a single agent
  * transaction.
  *
- * @param {Object} agent The agent.
+ * @param {object} agent The agent.
  */
 function Transaction(agent) {
   if (!agent) {
@@ -152,6 +152,7 @@ function Transaction(agent) {
 
   agent.emit('transactionStarted', this)
   this.probe('Transaction created', { id: this.id })
+  this.logs = []
 }
 
 Transaction.TYPES = TYPES
@@ -180,7 +181,7 @@ Transaction.prototype.isWeb = function isWeb() {
 }
 
 /**
- * @return {bool} Is this transaction still alive?
+ * @returns {bool} Is this transaction still alive?
  */
 Transaction.prototype.isActive = function isActive() {
   return this.timer.isActive()
@@ -222,6 +223,7 @@ Transaction.prototype.end = function end() {
     // to some of the recorders (namely the db recorders) adding parameters to the
     // segments.
     this.trace.generateSpanEvents()
+    this.addLogsToAggregator()
   }
 
   this.agent.emit('transactionFinished', this)
@@ -263,10 +265,8 @@ Transaction.prototype.getResponseTimeInMillis = function getResponseTimeInMillis
  * Executes the user and server provided naming rules to clean up the given url.
  *
  * @private
- *
  * @param {string} requestUrl - The URL to normalize.
- *
- * @return {object} The normalization results after running user and server rules.
+ * @returns {object} The normalization results after running user and server rules.
  */
 Transaction.prototype._runUserNamingRules = function _runUserNamingRules(requestUrl) {
   // 1. user normalization rules (set in configuration)
@@ -318,11 +318,9 @@ Transaction.prototype.setPartialName = function setPartialName(name) {
  * Derive the transaction partial name from the given url and status code.
  *
  * @private
- *
  * @param {string} requestUrl - The URL to derive the name from.
  * @param {number} status     - The status code of the response.
- *
- * @return {object} An object with the derived partial name in `value` and a
+ * @returns {object} An object with the derived partial name in `value` and a
  *  boolean flag in `ignore`.
  */
 Transaction.prototype._partialNameFromUri = _partialNameFromUri
@@ -374,7 +372,7 @@ function _partialNameFromUri(requestUrl, status) {
  * Set the forceIgnore value on the transaction. This will cause the
  * transaction to clean up after itself without collecting any data.
  *
- * @param {Boolean} ignore The value to assign to  transaction.ignore
+ * @param {boolean} ignore The value to assign to  transaction.ignore
  */
 Transaction.prototype.setForceIgnore = function setForceIgnore(ignore) {
   if (ignore != null) {
@@ -698,6 +696,7 @@ Transaction.prototype.measure = function measure(name, scope, duration, exclusiv
  * @param {number} duration Duration of the transaction, in milliseconds.
  * @param {number} keyApdex A key transaction apdexT, in milliseconds
  *                          (optional).
+ * @param keyApdexInMillis
  */
 Transaction.prototype._setApdex = function _setApdex(name, duration, keyApdexInMillis) {
   const apdexStats = this.metrics.getOrCreateApdexMetric(name, null, keyApdexInMillis)
@@ -900,6 +899,7 @@ Transaction.prototype.getIntrinsicAttributes = function getIntrinsicAttributes()
  * Parsing incoming headers for use in a distributed trace.
  * W3C TraceContext format is preferred over the NewRelic DT format.
  * NewRelic DT format will be used if no `traceparent` header is found.
+ *
  * @param @param {string} [transport='Unknown'] - The transport type that delivered the trace.
  * @param {object} headers - Headers to search for supported trace formats. Keys must be lowercase.
  */
@@ -933,7 +933,8 @@ function acceptDistributedTraceHeaders(transportType, headers) {
 
 /**
  * Inserts distributed trace headers into the provided headers map.
- * @param {Object} headers
+ *
+ * @param {object} headers
  */
 Transaction.prototype.insertDistributedTraceHeaders = insertDistributedTraceHeaders
 function insertDistributedTraceHeaders(headers) {
@@ -1140,6 +1141,8 @@ function _acceptDistributedTracePayload(payload, transport) {
 /**
  * Returns parsed payload object after attempting to decode it from base64,
  * and parsing the JSON string.
+ *
+ * @param payload
  */
 Transaction.prototype._getParsedPayload = function _getParsedPayload(payload) {
   let parsed = payload
@@ -1292,7 +1295,8 @@ Transaction.prototype.addRequestParameters = addRequestParameters
  * Adds request/query parameters to create attributes in the form
  * 'request.parameters.{key}'. These attributes will only be created
  * when 'request.parameters.*' is included in the attribute config.
- * @param {Object.<string, string>} requestParameters
+ *
+ * @param {object.<string, string>} requestParameters
  */
 function addRequestParameters(requestParameters) {
   for (const key in requestParameters) {
@@ -1312,6 +1316,10 @@ function addRequestParameters(requestParameters) {
       )
     }
   }
+}
+
+Transaction.prototype.addLogsToAggregator = function addLogsToAggregator() {
+  this.agent.logs.addBatch(this.logs, this.priority)
 }
 
 module.exports = Transaction

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -17,6 +17,7 @@ const Trace = require('./trace')
 const url = require('url')
 const urltils = require('../util/urltils')
 const TraceContext = require('./tracecontext').TraceContext
+const Logs = require('./logs')
 
 /*
  *
@@ -149,10 +150,10 @@ function Transaction(agent) {
   this.priority = null
   this.sampled = null
   this.traceContext = new TraceContext(this)
+  this.logs = new Logs(agent)
 
   agent.emit('transactionStarted', this)
   this.probe('Transaction created', { id: this.id })
-  this.logs = []
 }
 
 Transaction.TYPES = TYPES
@@ -223,7 +224,7 @@ Transaction.prototype.end = function end() {
     // to some of the recorders (namely the db recorders) adding parameters to the
     // segments.
     this.trace.generateSpanEvents()
-    this.addLogsToAggregator()
+    this.logs.flush(this.priority)
   }
 
   this.agent.emit('transactionFinished', this)
@@ -1316,10 +1317,6 @@ function addRequestParameters(requestParameters) {
       )
     }
   }
-}
-
-Transaction.prototype.addLogsToAggregator = function addLogsToAggregator() {
-  this.agent.logs.addBatch(this.logs, this.priority)
 }
 
 module.exports = Transaction

--- a/lib/transaction/logs.js
+++ b/lib/transaction/logs.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/**
+ * Storage mechanism for logs within a transaction
+ * As logs are seen during a transaction they are added to the storage
+ * if max limit has not been met.  When a transaction ends they are flushed
+ * and added to the Log Aggregator and then cleared
+ *
+ * @param {object} agent the agent
+ */
+function Logs(agent) {
+  this.maxLimit = agent.config.event_harvest_config.harvest_limits.log_event_data
+  this.aggregator = agent.logs
+  this.storage = []
+}
+
+/**
+ * Adds a log line to storage if max limit has not been met
+ *
+ * @param {object} logLine log line to store
+ */
+Logs.prototype.add = function add(logLine) {
+  if (this.storage.length >= this.maxLimit) {
+    return
+  }
+
+  this.storage.push(logLine)
+}
+
+/**
+ * Adds all logs gathered during transaction to log aggregator
+ * with the appropriate priority.  The storage is then cleared out.
+ *
+ * @param {number} priority of transaction
+ */
+Logs.prototype.flush = function flush(priority) {
+  this.aggregator.addBatch(this.storage, priority)
+  this.storage = []
+}
+
+module.exports = Logs

--- a/lib/transaction/logs.js
+++ b/lib/transaction/logs.js
@@ -25,7 +25,7 @@ function Logs(agent) {
  * @param {object} logLine log line to store
  */
 Logs.prototype.add = function add(logLine) {
-  if (this.storage.length >= this.maxLimit) {
+  if (this.storage.length === this.maxLimit) {
     return
   }
 

--- a/test/unit/aggregators/log-aggregator.test.js
+++ b/test/unit/aggregators/log-aggregator.test.js
@@ -98,7 +98,7 @@ test('Log Aggregator', (t) => {
 
   t.test('should add logs to aggregator in batch with priority', (t) => {
     const logs = [{ a: 'b' }, { b: 'c' }, { c: 'd' }]
-    const priority = '1.22'
+    const priority = Math.random() + 1
     logEventAggregator.addBatch(logs, priority)
     t.equal(logEventAggregator.getEvents().length, 3)
     t.end()

--- a/test/unit/aggregators/log-aggregator.test.js
+++ b/test/unit/aggregators/log-aggregator.test.js
@@ -7,6 +7,7 @@
 const { test } = require('tap')
 const LogAggregator = require('../../../lib/aggregators/log-aggregator')
 const Metrics = require('../../../lib/metrics')
+const sinon = require('sinon')
 
 const RUN_ID = 1337
 const LIMIT = 5
@@ -14,15 +15,20 @@ const LIMIT = 5
 test('Log Aggregator', (t) => {
   t.autoend()
   let logEventAggregator
+  let agentStub
 
   t.beforeEach(() => {
+    agentStub = {
+      getTransaction: sinon.stub()
+    }
     logEventAggregator = new LogAggregator(
       {
         runId: RUN_ID,
         limit: LIMIT
       },
       {},
-      new Metrics(5, {}, {})
+      new Metrics(5, {}, {}),
+      agentStub
     )
   })
 
@@ -69,6 +75,32 @@ test('Log Aggregator', (t) => {
     const payload = logEventAggregator._toPayloadSync()
 
     t.notOk(payload)
+    t.end()
+  })
+
+  t.test('should add log line to transaction when in transaction context', (t) => {
+    const transaction = { logs: { add: sinon.stub() } }
+    agentStub.getTransaction.returns(transaction)
+    const line = { key: 'value' }
+    logEventAggregator.add(line)
+    t.ok(transaction.logs.add.callCount, 1, 'should add log to transaction')
+    t.same(transaction.logs.add.args[0], [line])
+    t.same(logEventAggregator.getEvents(), [], 'log aggregator should be empty')
+    t.end()
+  })
+
+  t.test('should add log line to aggregator when not in transaction context', (t) => {
+    const line = { key: 'value' }
+    logEventAggregator.add(line)
+    t.same(logEventAggregator.getEvents(), [line])
+    t.end()
+  })
+
+  t.test('should add logs to aggregator in batch with priority', (t) => {
+    const logs = [{ a: 'b' }, { b: 'c' }, { c: 'd' }]
+    const priority = '1.22'
+    logEventAggregator.addBatch(logs, priority)
+    t.equal(logEventAggregator.getEvents().length, 3)
     t.end()
   })
 })

--- a/test/unit/transaction-logs.test.js
+++ b/test/unit/transaction-logs.test.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const Logs = require('../../lib/transaction/logs')
+const { test } = require('tap')
+const sinon = require('sinon')
+
+test('Logs tests', (t) => {
+  t.autoend()
+  let logs
+  let agent
+  t.beforeEach(() => {
+    const config = {
+      event_harvest_config: {
+        harvest_limits: {
+          log_event_data: 2
+        }
+      }
+    }
+    agent = {
+      logs: { addBatch: sinon.stub() },
+      config
+    }
+    logs = new Logs(agent)
+  })
+  t.test('should initialize logs storage', (t) => {
+    t.same(logs.storage, [], 'should init storage to empty')
+    t.same(logs.aggregator, agent.logs, 'should create log aggregator')
+    t.equal(logs.maxLimit, 2, 'should set max limit accordingly')
+    t.end()
+  })
+
+  t.test('it should add logs to storage', (t) => {
+    logs.add('line')
+    t.same(logs.storage, ['line'])
+    t.end()
+  })
+
+  t.test('it should not add data to storage if max limit has been met', (t) => {
+    logs.add('line1')
+    logs.add('line2')
+    logs.add('line3')
+    t.same(logs.storage, ['line1', 'line2'])
+    t.end()
+  })
+
+  t.test('it should flush the batch', (t) => {
+    logs.add('line')
+    logs.flush('1.10')
+    t.ok(logs.aggregator.addBatch.callCount, 1, 'should call addBatch once')
+    t.same(logs.aggregator.addBatch.args[0], [['line'], '1.10'])
+    t.end()
+  })
+})

--- a/test/unit/transaction-logs.test.js
+++ b/test/unit/transaction-logs.test.js
@@ -43,15 +43,17 @@ test('Logs tests', (t) => {
     logs.add('line1')
     logs.add('line2')
     logs.add('line3')
+    logs.add('line4')
     t.same(logs.storage, ['line1', 'line2'])
     t.end()
   })
 
   t.test('it should flush the batch', (t) => {
     logs.add('line')
-    logs.flush('1.10')
+    const priority = Math.random() + 1
+    logs.flush(priority)
     t.ok(logs.aggregator.addBatch.callCount, 1, 'should call addBatch once')
-    t.same(logs.aggregator.addBatch.args[0], [['line'], '1.10'])
+    t.same(logs.aggregator.addBatch.args[0], [['line'], priority])
     t.end()
   })
 })

--- a/test/unit/transaction.test.js
+++ b/test/unit/transaction.test.js
@@ -117,6 +117,31 @@ describe('Transaction', function () {
     trans.end()
   })
 
+  it('should flush logs on end', function (done) {
+    sinon.spy(trans.logs, 'flush')
+    agent.on('transactionFinished', (inner) => {
+      expect(inner.logs.flush.callCount).to.equal(1)
+      done()
+    })
+
+    trans.logs.add('log-line1')
+    trans.logs.add('log-line2')
+    trans.end()
+  })
+
+  it('should not flush logs when transaction is ignored', function (done) {
+    sinon.spy(trans.logs, 'flush')
+    agent.on('transactionFinished', (inner) => {
+      expect(inner.logs.flush.callCount).to.equal(0)
+      done()
+    })
+
+    trans.logs.add('log-line1')
+    trans.logs.add('log-line2')
+    trans.ignore = true
+    trans.end()
+  })
+
   describe('upon creation', function () {
     it('should have an ID', function () {
       should.exist(trans.id)


### PR DESCRIPTION
…n context, updated transaction to store logs until it ends then flush by adding to log aggregator

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added a storage mechanisms to transactions to keep logs until transaction ends.
 * Updated log aggregator to check transaction context before adding.  Otherwise it adds to transaction and then transaction will add batch to aggregator when it ends with the appropriate priority.

## Links
Closes #1172 

## Details
This will fulfill the 2 items from spec we were in violation of for a bit:
 * Logs **MUST** be treated like other data types recorded within transactions. If the transaction is ignored for instance, these logs should be excluded from capture.
 * Logs **MUST** be prioritized using the existing [Priority Sampling](./Priority-Sampling.md) approach. This aims to increase the chances that traces in the product will have associated log data. Within a transaction, logs **MUST** be taken first-come-first-served. If a log is emitted outside of a transaction, the individual log line **MUST** be assigned a base priority (so prioritized behind sampled-transctions).
