### PR TITLE
newrelic.js: remove local_decorating

### DIFF
--- a/newrelic.js
+++ b/newrelic.js
@@ -50,13 +50,6 @@ exports.config = {
        * Toggles whether the agent gathers log records for sending to New Relic.
        */
       enabled: true
-    },
-    local_decorating: {
-      /**
-       * Toggles whether the agent performs *Local Log Decoration* on standard
-       * log output.
-       */
-      enabled: true
     }
   },
   attributes: {


### PR DESCRIPTION
local_decorating is mutually exclusive with forwarding, and we want to recommend forwarding as the default method.