### PR TITLE
Disable application logging fowarding in HSM 

### DIFF
--- a/lib/config/hsm.js
+++ b/lib/config/hsm.js
@@ -50,6 +50,11 @@ const HIGH_SECURITY_SETTINGS = {
   },
   slow_sql: {
     enabled: false
+  },
+  application_logging: {
+    forwarding: {
+      enabled: false
+    }
   }
 }
 

--- a/test/unit/high-security.test.js
+++ b/test/unit/high-security.test.js
@@ -146,6 +146,11 @@ tap.test('high security mode', function (t) {
         t.equal(config.agent_enabled, false)
         t.end()
       })
+
+      t.test('should disable application logging forwarding', (t) => {
+        t.checkServer(config, 'application_logging.forwarding.enabled', false, true)
+        t.end()
+      })
     })
 
     t.test('when high_security === false', function (t) {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Set `application_logging.forwarding.enabled` to false when HSM is set.

## Links
Closes #1169

## Details
I verified this by using an account that has HSM enabled(account 2733645 in production).  I also added `high_security: true` in my local config.  Then started app with `application_logging.forwarding.enabled: true` and verified it gets set to false and that logs are not enriched with linking metadata nor forwarded to log aggregator.
