### PR TITLE
facts: add supportability for some popular logging libraries

### DIFF
--- a/lib/collector/facts.js
+++ b/lib/collector/facts.js
@@ -36,15 +36,7 @@ function facts(agent, callback) {
       const systemInfo = data.systemInfo || Object.create(null)
       const environment = data.environment || []
 
-      const packages = data.environment.find((elt) => elt[0] === 'Packages')[1]
-      packages.forEach((pkg) => {
-        pkg = JSON.parse(pkg)[0]
-        if (LOG_LIBRARIES.includes(pkg)) {
-          agent.metrics
-            .getOrCreateMetric(`${NAMES.SUPPORTABILITY.NODEJS_DEPENDENCIES}/${pkg}`)
-            .incrementCallCount()
-        }
-      })
+      countSupportabilityForLogLibraries(environment, agent)
 
       const hostname = agent.config.getHostnameSafe()
       const results = {
@@ -157,4 +149,24 @@ function getIdentifierOverride(appNames) {
   ].join(':')
 
   return identifier
+}
+
+/**
+ * This function searches the computed environment for the presence of
+ * some popular logging libraries. If present, it increments the
+ * corresponding supportability metrics.
+ *
+ * @param {Array} environment the environment computed by
+ * @param {object} agent the New Relic agent
+ */
+function countSupportabilityForLogLibraries(environment, agent) {
+  const packages = environment.find((elt) => elt[0] === 'Packages')[1]
+  packages.forEach((pkg) => {
+    pkg = JSON.parse(pkg)[0]
+    if (LOG_LIBRARIES.includes(pkg)) {
+      agent.metrics
+        .getOrCreateMetric(`${NAMES.SUPPORTABILITY.NODEJS_DEPENDENCIES}/${pkg}`)
+        .incrementCallCount()
+    }
+  })
 }

--- a/lib/collector/facts.js
+++ b/lib/collector/facts.js
@@ -37,12 +37,11 @@ function facts(agent, callback) {
       const environment = data.environment || []
 
       const packages = data.environment.find((elt) => elt[0] === 'Packages')[1]
-      const dedupPackages = new Set()
-      packages.forEach((dep) => dedupPackages.add(JSON.parse(dep)[0]))
-      LOG_LIBRARIES.forEach((lib) => {
-        if (dedupPackages.has(lib)) {
+      packages.forEach((pkg) => {
+        pkg = JSON.parse(pkg)[0]
+        if (LOG_LIBRARIES.includes(pkg)) {
           agent.metrics
-            .getOrCreateMetric(`${NAMES.SUPPORTABILITY.DEPENDENCIES}/Nodejs/${lib}`)
+            .getOrCreateMetric(`${NAMES.SUPPORTABILITY.NODEJS_DEPENDENCIES}/${pkg}`)
             .incrementCallCount()
         }
       })

--- a/lib/collector/facts.js
+++ b/lib/collector/facts.js
@@ -10,12 +10,12 @@ const fetchSystemInfo = require('../system-info')
 const logger = require('../logger').child({ component: 'facts' })
 const os = require('os')
 const parseLabels = require('../util/label-parser')
-const names = require('../metrics/names')
+const NAMES = require('../metrics/names')
 
 // For now static and tentative list of which logging libraries we
 // want to track. Later might come up with a better way of populating
 // this list.
-const logLibraries = ['winston', 'bunyan', 'pino', 'loglevel', 'npmlog', 'fancy-log']
+const LOG_LIBRARIES = ['winston', 'bunyan', 'pino', 'loglevel', 'npmlog', 'fancy-log']
 
 module.exports = facts
 
@@ -39,7 +39,7 @@ function facts(agent, callback) {
       const packages = data.environment.find((elt) => elt[0] === 'Packages')[1]
       const dedupPackages = new Set()
       packages.forEach((dep) => dedupPackages.add(JSON.parse(dep)[0]))
-      logLibraries.forEach((lib) => {
+      LOG_LIBRARIES.forEach((lib) => {
         if (dedupPackages.has(lib)) {
           agent.metrics
             .getOrCreateMetric(`${NAMES.SUPPORTABILITY.DEPENDENCIES}/Nodejs/${lib}`)

--- a/lib/collector/facts.js
+++ b/lib/collector/facts.js
@@ -10,6 +10,12 @@ const fetchSystemInfo = require('../system-info')
 const logger = require('../logger').child({ component: 'facts' })
 const os = require('os')
 const parseLabels = require('../util/label-parser')
+const names = require('../metrics/names')
+
+// For now static and tentative list of which logging libraries we
+// want to track. Later might come up with a better way of populating
+// this list.
+const logLibraries = ['winston', 'bunyan', 'pino', 'loglevel', 'npmlog', 'fancy-log']
 
 module.exports = facts
 
@@ -29,6 +35,17 @@ function facts(agent, callback) {
       data = data || Object.create(null)
       const systemInfo = data.systemInfo || Object.create(null)
       const environment = data.environment || []
+
+      const packages = data.environment.find((elt) => elt[0] === 'Packages')[1]
+      const dedupPackages = new Set()
+      packages.forEach((dep) => dedupPackages.add(JSON.parse(dep)[0]))
+      logLibraries.forEach((lib) => {
+        if (dedupPackages.has(lib)) {
+          agent.metrics
+            .getOrCreateMetric(`${NAMES.SUPPORTABILITY.DEPENDENCIES}/Nodejs/${lib}`)
+            .incrementCallCount()
+        }
+      })
 
       const hostname = agent.config.getHostnameSafe()
       const results = {

--- a/lib/metrics/names.js
+++ b/lib/metrics/names.js
@@ -19,6 +19,7 @@ const SUPPORTABILITY = {
   TRANSACTION_API: 'Supportability/API/Transaction',
   UTILIZATION: 'Supportability/utilization',
   DEPENDENCIES: 'Supportability/InstalledDependencies',
+  NODEJS_DEPENDENCIES: 'Supportability/InstalledDependencies/Nodejs',
   NODEJS: 'Supportability/Nodejs',
   REGISTRATION: 'Supportability/Registration',
   EVENT_HARVEST: 'Supportability/EventHarvest',

--- a/test/unit/facts.test.js
+++ b/test/unit/facts.test.js
@@ -798,13 +798,13 @@ tap.test('log metrics for common logging libraries', (t) => {
   })
 
   t.test('logs metrics for common logging libraries', (t) => {
-    facts(agent, async function getFacts() {
+    facts(agent, function getFacts() {
       // doesn't matter what gets returned because we only care what was logged
       // wait for harvest cycle
       // check metrics
       for (const lib of packages) {
         const metric = agent.metrics.getOrCreateMetric(
-          `${NAMES.SUPPORTABILITY.DEPENDENCIES}/Nodejs/${lib}`
+          `${NAMES.SUPPORTABILITY.NODEJS_DEPENDENCIES}/${lib}`
         )
         t.equal(metric.callCount, 1, `${lib} should have logged`)
       }

--- a/test/unit/facts.test.js
+++ b/test/unit/facts.test.js
@@ -768,7 +768,9 @@ tap.test('display_host', { timeout: 20000 }, (t) => {
 tap.test('log metrics for common logging libraries', (t) => {
   t.autoend()
 
-  const packages = ['winston', 'bunyan']
+  const logPackages = ['winston', 'bunyan']
+  const otherPackages = ['express', 'indium']
+  const packages = logPackages.concat(otherPackages)
   let getJSON
   let agent = null
 
@@ -801,12 +803,19 @@ tap.test('log metrics for common logging libraries', (t) => {
     facts(agent, function getFacts() {
       // doesn't matter what gets returned because we only care what was logged
       // wait for harvest cycle
+
       // check metrics
-      for (const lib of packages) {
+      for (const lib of logPackages) {
         const metric = agent.metrics.getOrCreateMetric(
           `${NAMES.SUPPORTABILITY.NODEJS_DEPENDENCIES}/${lib}`
         )
         t.equal(metric.callCount, 1, `${lib} should have logged`)
+      }
+      for (const lib of otherPackages) {
+        const metric = agent.metrics.getOrCreateMetric(
+          `${NAMES.SUPPORTABILITY.NODEJS_DEPENDENCIES}/${lib}`
+        )
+        t.equal(metric.callCount, 0, `${lib} should not have logged`)
       }
       t.end()
     })

--- a/test/unit/facts.test.js
+++ b/test/unit/facts.test.js
@@ -20,6 +20,7 @@ const facts = proxyquire('../../lib/collector/facts', {
     child: sinon.stub().callsFake(() => loggerMock)
   }
 })
+const NAMES = require('../../lib/metrics/names')
 
 const sysInfo = require('../../lib/system-info')
 const utilTests = require('../lib/cross_agent_tests/utilization/utilization_json')
@@ -759,6 +760,54 @@ tap.test('display_host', { timeout: 20000 }, (t) => {
     facts(agent, function getFacts(factsed) {
       os.networkInterfaces = originalNI
       t.equal(factsed.display_host, 'UNKNOWN_BOX')
+      t.end()
+    })
+  })
+})
+
+tap.test('log metrics for common logging libraries', (t) => {
+  t.autoend()
+
+  const packages = ['winston', 'bunyan']
+  let getJSON
+  let agent = null
+
+  t.beforeEach(() => {
+    loggerMock.debug.reset()
+    const config = {
+      app_name: [...APP_NAMES]
+    }
+    agent = helper.loadMockedAgent(Object.assign(config, DISABLE_ALL_DETECTIONS))
+    // fake getJSON for testing
+    getJSON = agent.environment.getJSON
+    agent.environment.getJSON = (cb) => {
+      cb(null, [
+        [
+          'Packages',
+          packages.map((lib) => {
+            return `["${lib}","0.0.0"]`
+          })
+        ]
+      ])
+    }
+  })
+
+  t.afterEach(() => {
+    agent.environment.getJSON = getJSON
+    helper.unloadAgent(agent)
+  })
+
+  t.test('logs metrics for common logging libraries', (t) => {
+    facts(agent, async function getFacts() {
+      // doesn't matter what gets returned because we only care what was logged
+      // wait for harvest cycle
+      // check metrics
+      for (const lib of packages) {
+        const metric = agent.metrics.getOrCreateMetric(
+          `${NAMES.SUPPORTABILITY.DEPENDENCIES}/Nodejs/${lib}`
+        )
+        t.equal(metric.callCount, 1, `${lib} should have logged`)
+      }
       t.end()
     })
   })


### PR DESCRIPTION
## Proposed Release Notes

* Added supportability metrics for some popular logging frameworks

## Links

Closes #1148 

## Details

I am not quite sure but I think the environment's packages seems to be
the right place to look for these. Those are logging libraries
directly mentioned in packages.json, as far as I can tell. This is as
opposed to the environment's dependencies which seems to be all the
packages the current packages depend on.