### PR TITLE
post-release: fetch the full repo, not a shallow clone

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -18,7 +18,11 @@ jobs:
         node-version: [lts/*]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        # The script `publish-docs` below needs to perform a merge, so
+        # it needs the full history to perform this merge.
+        fetch-depth: 0
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2
       with:


### PR DESCRIPTION
By default, github's actions/checkout action will do a shallow clone
of a single commit, without history. Since our workflow requires a
merge, we need the full history in order to be able to perform the
merge.