### PR TITLE
Handle composable loggers

### DIFF
--- a/lib/instrumentation/winston.js
+++ b/lib/instrumentation/winston.js
@@ -7,6 +7,21 @@
 
 const createFormatter = require('@newrelic/winston-enricher/lib/createFormatter')
 const API = require('../../api')
+const Stream = require('stream')
+
+/**
+ * winston allows you to compose a logger
+ * from an instantiated logger.  Through a series
+ * of inherited classes, this logger instance is a Stream.
+ * Check what gets passed into `winston.createLogger` to avoid
+ * instrumenting an already instrumented instance of a logger.
+ *
+ * @param {*} obj obj to check if a stream
+ * @returns {boolean}
+ */
+function isStream(obj) {
+  return obj instanceof Stream
+}
 
 module.exports = function instrument(agent, winston, _, shim) {
   const config = agent.config
@@ -32,9 +47,10 @@ module.exports = function instrument(agent, winston, _, shim) {
     return function createWrappedLogger() {
       const args = shim.argsToArray.apply(shim, arguments)
       const opts = args[0]
-      if (!shim.isObject(opts)) {
+      if (!shim.isObject(opts) || isStream(opts)) {
         return createLogger.apply(this, args)
       }
+
       if ('transports' in opts) {
         // combine transport-level formatters with our own
         opts.transports = opts.transports.map((transport) => {

--- a/test/versioned/winston/winston.tap.js
+++ b/test/versioned/winston/winston.tap.js
@@ -49,12 +49,11 @@ tap.test('Winston instrumentation', { bail: true }, (t) => {
   }
 
   /**
-   * Log lines in and out of a transaction for eveyr logger.
+   * Log lines in and out of a transaction for every logger.
    * @param {Object} opts
    * @param {DerivedLogger} opts.logger instance of winston
    * @param {Array} opts.loggers an array of winston loggers
    * @param {Stream} opts.stream stream used to end test
-   * @param {Test} opts.t tap test
    */
   const logStuff = ({ loggers, logger, stream }) => {
     loggers = loggers || [logger]
@@ -177,7 +176,7 @@ tap.test('Winston instrumentation', { bail: true }, (t) => {
         t.equal(msg.level, 'info')
         t.equal(msg['trace.id'], undefined, 'msg should not have trace id')
         t.equal(msg['span.id'], undefined, 'msg should not have span id')
-        t.ok(msg.message.includes('NR-LINKING'), 'should not contain NR-LINKING metadata')
+        t.ok(msg.message.includes('NR-LINKING'), 'should contain NR-LINKING metadata')
       }
 
       const handleMessages = makeStreamTest(() => {
@@ -209,7 +208,7 @@ tap.test('Winston instrumentation', { bail: true }, (t) => {
         t.equal(msg.level, 'info')
         t.equal(msg['trace.id'], undefined, 'msg should not have trace id')
         t.equal(msg['span.id'], undefined, 'msg should not have span id')
-        t.ok(msg.message.includes('NR-LINKING'), 'should not contain NR-LINKING metadata')
+        t.ok(msg.message.includes('NR-LINKING'), 'should contain NR-LINKING metadata')
       }
 
       const handleMessages = makeStreamTest(() => {

--- a/test/versioned/winston/winston.tap.js
+++ b/test/versioned/winston/winston.tap.js
@@ -48,38 +48,75 @@ tap.test('Winston instrumentation', { bail: true }, (t) => {
     }
   }
 
-  const logStuff = ({ logger, stream }) => {
-    // Log some stuff, both in and out of a transaction
-    logger.info('out of trans')
+  /**
+   * Log lines in and out of a transaction for eveyr logger.
+   * @param {Object} opts
+   * @param {DerivedLogger} opts.logger instance of winston
+   * @param {Array} opts.loggers an array of winston loggers
+   * @param {Stream} opts.stream stream used to end test
+   * @param {Test} opts.t tap test
+   */
+  const logStuff = ({ loggers, logger, stream }) => {
+    loggers = loggers || [logger]
+    loggers.forEach((logger) => {
+      // Log some stuff, both in and out of a transaction
+      logger.info('out of trans')
 
-    helper.runInTransaction(agent, 'test', (transaction) => {
-      logger.info('in trans')
+      helper.runInTransaction(agent, 'test', (transaction) => {
+        logger.info('in trans')
 
-      transaction.end()
-      // Force the stream to close so that we can test the output
-      stream.end()
+        transaction.end()
+      })
     })
+
+    // Force the stream to close so that we can test the output
+    stream.end()
   }
 
   /**
-   * Logs lines in and out of transaction but also asserts the size of the log
+   * Logs lines in and out of transaction for every logger and also asserts the size of the log
    * aggregator.  The log line in transaction context should not be added to aggregator
    * until after the transaction ends
+   *
+   * @param {Object} opts
+   * @param {DerivedLogger} opts.logger instance of winston
+   * @param {Array} opts.loggers an array of winston loggers
+   * @param {Stream} opts.stream stream used to end test
+   * @param {Test} opts.t tap test
    */
-  const logWithAggregator = ({ logger, stream, t }) => {
-    // Log some stuff, both in and out of a transaction
-    logger.info('out of trans')
-    t.equal(agent.logs.getEvents().length, 1, 'should only add 1 log to aggregator')
+  const logWithAggregator = ({ logger, loggers, stream, t }) => {
+    let aggregatorLength = 0
+    loggers = loggers || [logger]
+    loggers.forEach((logger) => {
+      // Log some stuff, both in and out of a transaction
+      logger.info('out of trans')
+      aggregatorLength++
+      t.equal(
+        agent.logs.getEvents().length,
+        aggregatorLength,
+        `should only add ${aggregatorLength} log to aggregator`
+      )
 
-    helper.runInTransaction(agent, 'test', (transaction) => {
-      logger.info('in trans')
-      t.equal(agent.logs.getEvents().length, 1, 'should only add 1 log to aggregator')
+      helper.runInTransaction(agent, 'test', (transaction) => {
+        logger.info('in trans')
+        t.equal(
+          agent.logs.getEvents().length,
+          aggregatorLength,
+          `should keep log aggregator at ${aggregatorLength}`
+        )
 
-      transaction.end()
-      t.equal(agent.logs.getEvents().length, 2, 'should only add 1 log after transaction end')
-      // Force the stream to close so that we can test the output
-      stream.end()
+        transaction.end()
+        aggregatorLength++
+        t.equal(
+          agent.logs.getEvents().length,
+          aggregatorLength,
+          `should only add ${aggregatorLength} log after transaction end`
+        )
+      })
     })
+
+    // Force the stream to close so that we can test the output
+    stream.end()
   }
 
   t.test('logging disabled', (t) => {
@@ -162,6 +199,39 @@ tap.test('Winston instrumentation', { bail: true }, (t) => {
 
       logStuff({ logger, stream: jsonStream })
     })
+
+    t.test('should not double log nor instrument composed logger', (t) => {
+      const assertFn = (msg) => {
+        t.equal(msg['entity.name'], undefined, 'should not have entity name')
+        t.equal(msg['entity.type'], undefined, 'should not have entity type')
+        t.equal(msg.timestamp, undefined, 'should not have timestamp as number')
+        t.equal(msg.hostname, undefined, 'should not have hostname as string')
+        t.equal(msg.level, 'info')
+        t.equal(msg['trace.id'], undefined, 'msg should not have trace id')
+        t.equal(msg['span.id'], undefined, 'msg should not have span id')
+        t.ok(msg.message.includes('NR-LINKING'), 'should not contain NR-LINKING metadata')
+      }
+
+      const handleMessages = makeStreamTest(() => {
+        t.same(agent.logs.getEvents(), [], 'should not add any logs to log aggregator')
+        t.end()
+      })
+      const jsonStream = concat(handleMessages(assertFn))
+
+      // Example Winston setup to test
+      const logger = winston.createLogger({
+        format: winston.format.simple(),
+        transports: [
+          new winston.transports.Stream({
+            level: 'info',
+            stream: jsonStream
+          })
+        ]
+      })
+      const subLogger = winston.createLogger(logger)
+
+      logStuff({ loggers: [logger, subLogger], stream: jsonStream })
+    })
   })
 
   t.test('log forwarding enabled', (t) => {
@@ -236,6 +306,28 @@ tap.test('Winston instrumentation', { bail: true }, (t) => {
       t.equal(!!winston.createLogger.__NR_original, true)
 
       logWithAggregator({ logger, stream: simpleStream, t })
+    })
+
+    t.test('should not double log nor instrument composed logger', (t) => {
+      const handleMessages = makeStreamTest(() => {
+        t.end()
+      })
+      const assertFn = msgAssertFn.bind(null, t)
+      const simpleStream = concat(handleMessages(assertFn))
+
+      // Example Winston setup to test
+      const logger = winston.createLogger({
+        format: winston.format.simple(),
+        transports: [
+          new winston.transports.Stream({
+            level: 'info',
+            stream: simpleStream
+          })
+        ]
+      })
+      const subLogger = winston.createLogger(logger)
+
+      logWithAggregator({ loggers: [logger, subLogger], stream: simpleStream, t })
     })
   })
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed an issue when creating a winston logger with an already instantiated logger.

## Links
Closes #1190

## Details
We had some missing logic around instrumenting `winston.createLogger`.  You can create a logger from an instianted logger.  When this is the case the transports are read-only and we caused the application to crash. The customer, graciously provide a clear [reproduction case](https://github.com/DenisSlapelis/newrelic-sample).  I added 2 tests around composing loggers and verifying it doesn't create extra log lines in aggregator and more importantly does not crash.

If you comment out the `isStream` bit in instrumentation the tests will fail/crash like bug

```sh
  # Subtest: should not double log nor instrument composed logger
            not ok 1 - Cannot set property transports of \#<Logger> which has only a getter
              ---
              stack: >
                Object.createWrappedLogger [as createLogger]
                (lib/instrumentation/winston.js:57:25)

                Test.<anonymous> (test/versioned/winston/winston.tap.js:232:33)
              at:
                line: 57
                column: 25
                file: lib/instrumentation/winston.js
                function: Object.createWrappedLogger
                method: createLogger
              type: TypeError
              tapCaught: testFunctionThrow
              test: should not double log nor instrument composed logger
              source: >2
                        // combine transport-level formatters with our own
                        opts.transports = opts.transports.map((transport) => {
                ------------------------^
                          if (transport.format) {
                            transport.format = winston.format.combine(transport.format, instrumentedFormatter())
              ...
```
