### PR TITLE
Optional script unwrapping

### DIFF
--- a/api.js
+++ b/api.js
@@ -675,7 +675,7 @@ API.prototype.getBrowserTimingHeader = function getBrowserTimingHeader(options) 
 
   // set nonce attribute if passed in options
   const nonce = options && options.nonce ? 'nonce="' + options.nonce + '"' : ''
-  const script = options?.hasToRemoveScriptWrapper ? RUM_STUB : RUM_STUB_SHELL
+  const script = options && options.hasToRemoveScriptWrapper ? RUM_STUB : RUM_STUB_SHELL
 
   // the complete header to be written to the browser
   const out = util.format(script, nonce, json, jsAgentLoader)

--- a/api.js
+++ b/api.js
@@ -27,8 +27,8 @@ const NAMES = require('./lib/metrics/names')
  * CONSTANTS
  *
  */
-const RUM_STUB =
-  "<script type='text/javascript' %s>window.NREUM||(NREUM={});" + 'NREUM.info = %s; %s</script>'
+const RUM_STUB = 'window.NREUM||(NREUM={}); NREUM.info = %s;'
+const RUM_STUB_SHELL = `<script type='text/javascript' %s>${RUM_STUB} %s</script>`
 
 // these messages are used in the _gracefail() method below in getBrowserTimingHeader
 const RUM_ISSUES = [
@@ -675,9 +675,10 @@ API.prototype.getBrowserTimingHeader = function getBrowserTimingHeader(options) 
 
   // set nonce attribute if passed in options
   const nonce = options && options.nonce ? 'nonce="' + options.nonce + '"' : ''
+  const script = options?.hasToRemoveScriptWrapper ? RUM_STUB : RUM_STUB_SHELL
 
   // the complete header to be written to the browser
-  const out = util.format(RUM_STUB, nonce, json, jsAgentLoader)
+  const out = util.format(script, nonce, json, jsAgentLoader)
 
   logger.trace('generating RUM header', out)
 

--- a/test/unit/rum.test.js
+++ b/test/unit/rum.test.js
@@ -136,6 +136,17 @@ describe('the RUM API', function () {
     })
   })
 
+  it('should get browser agent script without wrapping tag if hasToRemoveScriptWrapper passed in options', function () {
+    const hasToRemoveScriptWrapper = true
+    helper.runInTransaction(agent, function (t) {
+      t.finalizeNameFromUri('hello')
+      api
+        .getBrowserTimingHeader({ hasToRemoveScriptWrapper })
+        .startsWith('window.NREUM')
+        .should.equal(true)
+    })
+  })
+
   it('should add custom attributes', function () {
     helper.runInTransaction(agent, function (t) {
       api.addCustomAttribute('hello', 1)


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
* Add an optional way to avoid wrapping browser agent script with `<script>` tag to ease usage with Component based libraries like React

## Links
* https://github.com/newrelic/newrelic-node-nextjs

## Details
* Based on usage of NewRelic inside NextJs (https://github.com/newrelic/newrelic-node-nextjs) it would be relevant to not wrap the browser agent script with `<script>` to let developers to use their own React component or the built in `<Script>` component from NextJs (https://nextjs.org/docs/basic-features/script)