### PR TITLE
Add a way to import agent script without wrapping tag

### DIFF
--- a/api.js
+++ b/api.js
@@ -27,8 +27,8 @@ const NAMES = require('./lib/metrics/names')
  * CONSTANTS
  *
  */
-const RUM_STUB =
-  "<script type='text/javascript' %s>window.NREUM||(NREUM={});" + 'NREUM.info = %s; %s</script>'
+const RUM_STUB = 'window.NREUM||(NREUM={}); NREUM.info = %s;'
+const RUM_STUB_SHELL = `<script type='text/javascript' %s>${RUM_STUB} %s</script>`
 
 // these messages are used in the _gracefail() method below in getBrowserTimingHeader
 const RUM_ISSUES = [
@@ -675,9 +675,10 @@ API.prototype.getBrowserTimingHeader = function getBrowserTimingHeader(options) 
 
   // set nonce attribute if passed in options
   const nonce = options && options.nonce ? 'nonce="' + options.nonce + '"' : ''
+  const script = options && options.hasToRemoveScriptWrapper ? RUM_STUB : RUM_STUB_SHELL
 
   // the complete header to be written to the browser
-  const out = util.format(RUM_STUB, nonce, json, jsAgentLoader)
+  const out = util.format(script, nonce, json, jsAgentLoader)
 
   logger.trace('generating RUM header', out)
 

--- a/api.js
+++ b/api.js
@@ -27,7 +27,7 @@ const NAMES = require('./lib/metrics/names')
  * CONSTANTS
  *
  */
-const RUM_STUB = 'window.NREUM||(NREUM={}); NREUM.info = %s;'
+const RUM_STUB = 'window.NREUM||(NREUM={});NREUM.info = %s;'
 const RUM_STUB_SHELL = `<script type='text/javascript' %s>${RUM_STUB} %s</script>`
 
 // these messages are used in the _gracefail() method below in getBrowserTimingHeader
@@ -514,10 +514,14 @@ API.prototype.addIgnoringRule = function addIgnoringRule(pattern) {
 }
 
 /**
- * Get the <script>...</script> header necessary for Browser Monitoring
+ * Get the script header necessary for Browser Monitoring
  * This script must be manually injected into your templates, as high as possible
  * in the header, but _after_ any X-UA-COMPATIBLE HTTP-EQUIV meta tags.
  * Otherwise you may hurt IE!
+ *
+ * By default this method will return a script wrapped by `<script>` tags, but with
+ * option `hasToRemoveScriptWrapper` it can send back only the script content
+ * without the `<script>` wrapper. Useful for React component based frontend.
  *
  * This method must be called _during_ a transaction, and must be called every
  * time you want to generate the headers.
@@ -525,8 +529,9 @@ API.prototype.addIgnoringRule = function addIgnoringRule(pattern) {
  * Do *not* reuse the headers between users, or even between requests.
  *
  * @param {string} [options.nonce] - Nonce to inject into `<script>` header.
+ * @param {boolean} [options.hasToRemoveScriptWrapper] - Used to import agent script without `<script>` tag wrapper.
  * @param options
- * @returns {string} The `<script>` header to be injected.
+ * @returns {string} The script content to be injected in `<head>` or put inside `<script>` tag (depending on options)
  */
 API.prototype.getBrowserTimingHeader = function getBrowserTimingHeader(options) {
   const metric = this.agent.metrics.getOrCreateMetric(

--- a/test/unit/rum.test.js
+++ b/test/unit/rum.test.js
@@ -136,6 +136,17 @@ describe('the RUM API', function () {
     })
   })
 
+  it('should get browser agent script without wrapping tag if hasToRemoveScriptWrapper passed in options', function () {
+    const hasToRemoveScriptWrapper = true
+    helper.runInTransaction(agent, function (t) {
+      t.finalizeNameFromUri('hello')
+      api
+        .getBrowserTimingHeader({ hasToRemoveScriptWrapper })
+        .startsWith('window.NREUM')
+        .should.equal(true)
+    })
+  })
+
   it('should add custom attributes', function () {
     helper.runInTransaction(agent, function (t) {
       api.addCustomAttribute('hello', 1)


### PR DESCRIPTION
## Proposed Release Notes
* Added an optional way to avoid wrapping browser agent script with <script> tag when using `api.getBrowserTimingHeader`.  This will ease usage with Component based libraries like React.  

## Links
* https://github.com/newrelic/newrelic-node-nextjs
## Details
* Based on usage of NewRelic inside NextJs (https://github.com/newrelic/newrelic-node-nextjs) it would be relevant to not wrap the browser agent script with `<script>` to let developers to use their own React component or the built in `<Script>` component from NextJs (https://nextjs.org/docs/basic-features/script)