### PR TITLE
New Relic Log Forwarding Transport

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -26,6 +26,7 @@ code, the source code can be found at [https://github.com/newrelic/node-newrelic
 * [json-stringify-safe](#json-stringify-safe)
 * [readable-stream](#readable-stream)
 * [semver](#semver)
+* [winston-transport](#winston-transport)
 
 **[devDependencies](#devDependencies)**
 
@@ -1329,6 +1330,36 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+```
+
+### winston-transport
+
+This product includes source derived from [winston-transport](https://github.com/winstonjs/winston-transport) ([v4.5.0](https://github.com/winstonjs/winston-transport/tree/v4.5.0)), distributed under the [MIT License](https://github.com/winstonjs/winston-transport/blob/v4.5.0/LICENSE):
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Charlie Robbins & the contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 
 ```
 

--- a/lib/instrumentation/nr-winston-transport.js
+++ b/lib/instrumentation/nr-winston-transport.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const TransportStream = require('winston-transport')
+const logger = require('../logger').child({ compoonent: 'nr-winston-transport' })
+const { truncate } = require('../util/application-logging')
+
+/**
+ * Transport used to prepare a log line and add to the new relic agent
+ * log aggregator.
+ *
+ * Note*: This copies the log line so no other transports will get the
+ * mutated data.
+ */
+class NrTransport extends TransportStream {
+  constructor(opts = {}) {
+    opts.handleExceptions = true
+    super(opts)
+    this.name = 'newrelic'
+    this.agent = opts.agent
+    this.config = opts.agent.config
+  }
+
+  /**
+   * Executed on every log line. We will get the linking metadata
+   * and add this, along with reformatting of timestamp and error
+   * to a copy of the log line
+   *
+   * @param {object} logLine a winston log line
+   * @param {Function} callback callback to invoke once we are done
+   */
+  log(logLine, callback) {
+    const metadata = this.agent.getLinkingMetadata()
+    const formattedLine = reformatLogLine(logLine, metadata, this.agent)
+    this.agent.logs.add(formattedLine)
+    callback()
+  }
+}
+
+module.exports = NrTransport
+
+/**
+ * Reformats a log line by reformatting errors, timestamp and adding
+ * new relic linking metadata(context)
+ *
+ * @param {object} logLine log line
+ * @param {object} metadata linking metadata
+ * @param {object} agent NR agent
+ * @returns {object} copy of log line with NR linking metadata
+ */
+function reformatLogLine(logLine, metadata, agent) {
+  // Add the metadata to a copy of the logLine
+  const formattedLine = Object.assign(metadata, logLine)
+
+  if (formattedLine.exception === true) {
+    reformatError(formattedLine)
+  }
+
+  reformatTimestamp(formattedLine, agent)
+
+  return formattedLine
+}
+
+/**
+ * Decorates the log line with  truncated error.message, error.class, and error.stack and removes
+ * trace and stack
+ *
+ * @param {object} logLine a log line
+ */
+function reformatError(logLine) {
+  // Due to Winston internals sometimes the error on the logLine object is a string or an
+  // empty object, and so the message property is all we have
+  const errorMessage = logLine.error.message || logLine.message || ''
+
+  logLine['error.message'] = truncate(errorMessage)
+  logLine['error.class'] =
+    logLine.error.name === 'Error' ? logLine.error.constructor.name : logLine.error.name
+  logLine['error.stack'] = truncate(logLine.error.stack)
+  logLine.message = truncate(logLine.message)
+
+  // Removes additional capture of stack to reduce overall payload/log-line size.
+  // The server has a maximum of ~4k characters per line allowed.
+  delete logLine.trace
+  delete logLine.stack
+}
+
+/**
+ * Turns timestamp into unix timestamp. If timestamp existed it will move original
+ * to `original_timestamp` key
+ *
+ * @param {object} logLine a log line
+ */
+function reformatTimestamp(logLine) {
+  if (logLine.timestamp) {
+    logger.traceOnce(
+      'Overwriting `timestamp` key; assigning original value to `original_timestamp`.'
+    )
+    logLine.original_timestamp = logLine.timestamp
+  }
+  logLine.timestamp = Date.now()
+}

--- a/lib/instrumentation/nr-winston-transport.js
+++ b/lib/instrumentation/nr-winston-transport.js
@@ -5,7 +5,7 @@
 
 'use strict'
 const TransportStream = require('winston-transport')
-const logger = require('../logger').child({ compoonent: 'nr-winston-transport' })
+const logger = require('../logger').child({ component: 'nr-winston-transport' })
 const { truncate } = require('../util/application-logging')
 
 /**
@@ -17,6 +17,8 @@ const { truncate } = require('../util/application-logging')
  */
 class NrTransport extends TransportStream {
   constructor(opts = {}) {
+    // set this option to have winston handle uncaught exceptions
+    // See: https://github.com/winstonjs/winston#handling-uncaught-exceptions-with-winston
     opts.handleExceptions = true
     super(opts)
     this.name = 'newrelic'
@@ -44,7 +46,9 @@ module.exports = NrTransport
 
 /**
  * Reformats a log line by reformatting errors, timestamp and adding
- * new relic linking metadata(context)
+ * new relic linking metadata(context). When uncaught exceptions exist
+ * an exception property will exist on the log line.  This will tell us
+ * that we need to reformat the error
  *
  * @param {object} logLine log line
  * @param {object} metadata linking metadata
@@ -53,7 +57,7 @@ module.exports = NrTransport
  */
 function reformatLogLine(logLine, metadata, agent) {
   // Add the metadata to a copy of the logLine
-  const formattedLine = Object.assign(metadata, logLine)
+  const formattedLine = Object.assign({}, logLine, metadata)
 
   if (formattedLine.exception === true) {
     reformatError(formattedLine)

--- a/lib/instrumentation/winston.js
+++ b/lib/instrumentation/winston.js
@@ -12,10 +12,11 @@ const {
   isLocalDecoratingEnabled,
   isMetricsEnabled,
   createModuleUsageMetric,
-  incrementLoggingLinesMetrics,
-  truncate
+  incrementLoggingLinesMetrics
 } = require('../util/application-logging')
+
 const logger = require('../logger').child({ component: 'winston' })
+const NrTransport = require('./nr-winston-transport')
 
 module.exports = function instrument(agent, winston, _, shim) {
   const config = agent.config
@@ -33,40 +34,38 @@ module.exports = function instrument(agent, winston, _, shim) {
         return createLogger.apply(this, args)
       }
 
-      registerFormatter({ opts, config, agent, winston })
+      createModuleUsageMetric('winston', agent.metrics)
 
-      return createLogger.apply(this, args)
+      if (isLocalDecoratingEnabled(config) || isMetricsEnabled(config)) {
+        registerFormatter({ opts, agent, winston })
+      }
+
+      const winstonLogger = createLogger.apply(this, args)
+
+      if (isLogForwardingEnabled(config, agent)) {
+        winstonLogger.add(new NrTransport({ agent }))
+      }
+
+      return winstonLogger
     }
   })
 }
 
 /**
- * There is no right way to do this.  But since we are automagical
- * it is hard to predict how a customer uses winston.  We will iterate over the formatters specified on the logger and add last if forwarder or first if local decorating.
- * This is because we want all the customizations of previous formatters before adding log log to log aggregator.  But in the case of local decorating we want to do this first so any formatter that is transforming data will have the changes.
- *
- * Note: The logic explained above does not apply if a customer specifies multiple formats for a given transport.
- * We cannot instrument the formats on the transport because if a customer has multiple transports we would be duplicating logs when forwaring.
+ * Apply a formatter to keep track of logging metrics, and in the case of local decorating appending
+ * the NR-LINKING metadata to message.  We want to do this first so any formatter that is transforming
+ * data will have the changes.
  *
  * @param {object} params object passed to function
  * @param {object} params.opts options from winston.createLogger
- * @param {object} params.config agent config
  * @param {object} params.agent NR agent
  * @param {object} params.winston exported winston package
  */
-function registerFormatter({ opts, config, agent, winston }) {
+function registerFormatter({ opts, agent, winston }) {
   const instrumentedFormatter = nrWinstonFormatter(agent, winston)
 
   if ('format' in opts) {
-    const formatters = [opts.format]
-
-    if (isLogForwardingEnabled(config, agent)) {
-      formatters.push(instrumentedFormatter())
-    } else {
-      formatters.unshift(instrumentedFormatter())
-    }
-
-    opts.format = winston.format.combine(...formatters)
+    opts.format = winston.format.combine(instrumentedFormatter(), opts.format)
   } else {
     opts.format = instrumentedFormatter()
   }
@@ -74,102 +73,31 @@ function registerFormatter({ opts, config, agent, winston }) {
 
 /**
  * This formatter is being used to facilitate
- * the application logging use cases.
- * It is worth noting that the features below are mutually
- * exclusive.
- *
- * The application logging use cases are local log decorating
- * and log forwarding.
+ * the two application logging use cases: metrics and local log decorating.
  *
  * Local log decorating appends `NR-LINKING` piped metadata to
  * the message key in log line. You must configure a log forwarder to get
  * this data to NR1.
  *
- * Log forwarding includes the linking metadata as keys on logging
- * object as well as adds the log line to the agent log aggregator.
- *
  * @param {object} agent NR agent
  * @param {object} winston exported winston package
- * @returns {object} log line with NR context or NR-LINKING metadata on message
+ * @returns {object} log line NR-LINKING metadata on message when local log decorating is enabled
  */
 function nrWinstonFormatter(agent, winston) {
   const config = agent.config
   const metrics = agent.metrics
-  createModuleUsageMetric('winston', metrics)
 
   return winston.format((logLine) => {
     if (isMetricsEnabled(config)) {
       incrementLoggingLinesMetrics(logLine.level, metrics)
     }
 
-    if (isLogForwardingEnabled(config, agent)) {
-      const metadata = agent.getLinkingMetadata()
-      reformatLogLine(logLine, metadata, agent)
-      agent.logs.add(logLine)
-    } else if (isLocalDecoratingEnabled(config)) {
+    if (isLocalDecoratingEnabled(config)) {
       logLine.message += agent.getNRLinkingMetadata()
     }
 
     return logLine
   })
-}
-
-/**
- * Reformats a log line by reformatting errors, timestamp and adding
- * new relic linking metadata(context)
- *
- * @param {object} logLine log line
- * @param {object} metadata linking metadata
- * @param {object} agent NR agent
- */
-function reformatLogLine(logLine, metadata, agent) {
-  if (logLine.exception === true) {
-    reformatError(logLine)
-  }
-
-  reformatTimestamp(logLine, agent)
-
-  // Add the metadata to the logLine object being logged
-  Object.assign(logLine, metadata)
-}
-
-/**
- * Decorates the log line with  truncated error.message, error.class, and error.stack and removes
- * trace and stack
- *
- * @param {object} logLine a log line
- */
-function reformatError(logLine) {
-  // Due to Winston internals sometimes the error on the logLine object is a string or an
-  // empty object, and so the message property is all we have
-  const errorMessage = logLine.error.message || logLine.message || ''
-
-  logLine['error.message'] = truncate(errorMessage)
-  logLine['error.class'] =
-    logLine.error.name === 'Error' ? logLine.error.constructor.name : logLine.error.name
-  logLine['error.stack'] = truncate(logLine.error.stack)
-  logLine.message = truncate(logLine.message)
-
-  // Removes additional capture of stack to reduce overall payload/log-line size.
-  // The server has a maximum of ~4k characters per line allowed.
-  delete logLine.trace
-  delete logLine.stack
-}
-
-/**
- * Turns timestamp into unix timestamp. If timestamp existed it will move original
- * to `original_timestamp` key
- *
- * @param {object} logLine a log line
- */
-function reformatTimestamp(logLine) {
-  if (logLine.timestamp) {
-    logger.traceOnce(
-      'Overwriting `timestamp` key; assigning original value to `original_timestamp`.'
-    )
-    logLine.original_timestamp = logLine.timestamp
-  }
-  logLine.timestamp = Date.now()
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "https-proxy-agent": "^5.0.0",
         "json-stringify-safe": "^5.0.0",
         "readable-stream": "^3.6.0",
-        "semver": "^5.3.0"
+        "semver": "^5.3.0",
+        "winston-transport": "^4.5.0"
       },
       "bin": {
         "newrelic-naming-rules": "bin/test-naming-rules.js"
@@ -502,6 +503,14 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
@@ -6178,6 +6187,11 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -8776,6 +8790,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/logform": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.4.0.tgz",
+      "integrity": "sha512-CPSJw4ftjf517EhXZGGvTHHkYobo7ZCc0kvwUoOYcjfR2UVrI66RHj8MCrfAdEitdmFqbu2BYdYs8FHHZSb6iw==",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      }
+    },
     "node_modules/lolex": {
       "version": "2.7.5",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
@@ -9140,8 +9166,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/mv": {
       "version": "2.1.1",
@@ -10951,6 +10976,14 @@
       "dev": true,
       "dependencies": {
         "ret": "~0.2.0"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/safer-buffer": {
@@ -14117,6 +14150,11 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
+    },
     "node_modules/trivial-deferred": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
@@ -14530,6 +14568,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
+      "integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
+      "dependencies": {
+        "logform": "^2.3.2",
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 6.4.0"
       }
     },
     "node_modules/word-wrap": {
@@ -15123,6 +15174,11 @@
         "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
     "@es-joy/jsdoccomment": {
       "version": "0.10.8",
@@ -19625,6 +19681,11 @@
         "reusify": "^1.0.4"
       }
     },
+    "fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -21604,6 +21665,18 @@
         }
       }
     },
+    "logform": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.4.0.tgz",
+      "integrity": "sha512-CPSJw4ftjf517EhXZGGvTHHkYobo7ZCc0kvwUoOYcjfR2UVrI66RHj8MCrfAdEitdmFqbu2BYdYs8FHHZSb6iw==",
+      "requires": {
+        "@colors/colors": "1.5.0",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      }
+    },
     "lolex": {
       "version": "2.7.5",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
@@ -21874,8 +21947,7 @@
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "mv": {
       "version": "2.1.1",
@@ -23290,6 +23362,11 @@
       "requires": {
         "ret": "~0.2.0"
       }
+    },
+    "safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -25543,6 +25620,11 @@
       "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
       "dev": true
     },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
+    },
     "trivial-deferred": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
@@ -25878,6 +25960,16 @@
             "ansi-regex": "^3.0.0"
           }
         }
+      }
+    },
+    "winston-transport": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
+      "integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
+      "requires": {
+        "logform": "^2.3.2",
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -170,7 +170,8 @@
     "https-proxy-agent": "^5.0.0",
     "json-stringify-safe": "^5.0.0",
     "readable-stream": "^3.6.0",
-    "semver": "^5.3.0"
+    "semver": "^5.3.0",
+    "winston-transport": "^4.5.0"
   },
   "optionalDependencies": {
     "@newrelic/native-metrics": "^8.0.0"

--- a/test/unit/licenses.json
+++ b/test/unit/licenses.json
@@ -11,5 +11,6 @@
   "readable-stream": "MIT",
   "semver": "ISC",
   "@grpc/grpc-js": "Apache-2.0",
-  "@grpc/proto-loader": "Apache-2.0"
+  "@grpc/proto-loader": "Apache-2.0",
+  "winston-transport": "MIT"
 }

--- a/test/versioned/winston/helpers.js
+++ b/test/versioned/winston/helpers.js
@@ -13,7 +13,7 @@ const { CONTEXT_KEYS } = require('../../lib/logging-helper')
  *
  * @param {function} cb callback after all messages have been emitted
  */
-helpers.makeStreamTest = (cb) => {
+helpers.makeStreamTest = function makeStreamTest(cb) {
   let toBeClosed = 0
   return (assertFn) => {
     toBeClosed++
@@ -37,7 +37,7 @@ helpers.makeStreamTest = (cb) => {
  * @param {object} opts.helper test helpers
  * @param {object} opts.agent new relic agent
  */
-helpers.logStuff = ({ loggers, logger, stream, helper, agent }) => {
+helpers.logStuff = function logStuff({ loggers, logger, stream, helper, agent }) {
   loggers = loggers || [logger]
   loggers.forEach((log) => {
     // Log some stuff, both in and out of a transaction
@@ -67,7 +67,14 @@ helpers.logStuff = ({ loggers, logger, stream, helper, agent }) => {
  * @param {object} opts.helper test helpers
  * @param {object} opts.agent new relic agent
  */
-helpers.logWithAggregator = ({ logger, loggers, stream, t, agent, helper }) => {
+helpers.logWithAggregator = function logWithAggregator({
+  logger,
+  loggers,
+  stream,
+  t,
+  agent,
+  helper
+}) {
   let aggregatorLength = 0
   loggers = loggers || [logger]
   loggers.forEach((log) => {
@@ -112,10 +119,10 @@ helpers.logWithAggregator = ({ logger, loggers, stream, t, agent, helper }) => {
  * @param {boolean} [opts.timestamp=false] does timestamp exist on original message
  * @param {string} [opts.level=info] level to assert is on message
  */
-helpers.originalMsgAssertion = (
+helpers.originalMsgAssertion = function originalMsgAssertion(
   { t, includeLocalDecorating = false, timestamp = false, level = 'info' },
   msg
-) => {
+) {
   CONTEXT_KEYS.forEach((key) => {
     t.notOk(msg[key], `should not have ${key}`)
   })
@@ -140,7 +147,7 @@ helpers.originalMsgAssertion = (
  * @param {Test} t
  * @param {string} msg log line
  */
-helpers.logForwardingMsgAssertion = (t, logLine, agent) => {
+helpers.logForwardingMsgAssertion = function logForwardingMsgAssertion(t, logLine, agent) {
   if (logLine.message === 'out of trans') {
     t.validateAnnotations({
       line: logLine,

--- a/test/versioned/winston/helpers.js
+++ b/test/versioned/winston/helpers.js
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const helpers = module.exports
+const { CONTEXT_KEYS } = require('../../lib/logging-helper')
+
+/**
+ * Stream factory for a test.  Iterates over every message and calls an assertFn.
+ * When all messages have been emitted it calls the callback function
+ *
+ * @param {function} cb callback after all messages have been emitted
+ */
+helpers.makeStreamTest = (cb) => {
+  let toBeClosed = 0
+  return (assertFn) => {
+    toBeClosed++
+    return (msgs) => {
+      for (const msg of msgs) {
+        assertFn(msg)
+      }
+      if (--toBeClosed === 0) {
+        cb(msgs)
+      }
+    }
+  }
+}
+
+/**
+ * Log lines in and out of a transaction for every logger.
+ * @param {object} opts
+ * @param {DerivedLogger} opts.logger instance of winston
+ * @param {Array} opts.loggers an array of winston loggers
+ * @param {Stream} opts.stream stream used to end test
+ * @param {object} opts.helper test helpers
+ * @param {object} opts.agent new relic agent
+ */
+helpers.logStuff = ({ loggers, logger, stream, helper, agent }) => {
+  loggers = loggers || [logger]
+  loggers.forEach((log) => {
+    // Log some stuff, both in and out of a transaction
+    log.info('out of trans')
+
+    helper.runInTransaction(agent, 'test', (transaction) => {
+      log.info('in trans')
+
+      transaction.end()
+    })
+  })
+
+  // Force the stream to close so that we can test the output
+  stream.end()
+}
+
+/**
+ * Logs lines in and out of transaction for every logger and also asserts the size of the log
+ * aggregator.  The log line in transaction context should not be added to aggregator
+ * until after the transaction ends
+ *
+ * @param {object} opts
+ * @param {DerivedLogger} opts.logger instance of winston
+ * @param {Array} opts.loggers an array of winston loggers
+ * @param {Stream} opts.stream stream used to end test
+ * @param {Test} opts.t tap test
+ * @param {object} opts.helper test helpers
+ * @param {object} opts.agent new relic agent
+ */
+helpers.logWithAggregator = ({ logger, loggers, stream, t, agent, helper }) => {
+  let aggregatorLength = 0
+  loggers = loggers || [logger]
+  loggers.forEach((log) => {
+    // Log some stuff, both in and out of a transaction
+    log.info('out of trans')
+    aggregatorLength++
+    t.equal(
+      agent.logs.getEvents().length,
+      aggregatorLength,
+      `should only add ${aggregatorLength} log to aggregator`
+    )
+
+    helper.runInTransaction(agent, 'test', (transaction) => {
+      log.info('in trans')
+      t.equal(
+        agent.logs.getEvents().length,
+        aggregatorLength,
+        `should keep log aggregator at ${aggregatorLength}`
+      )
+
+      transaction.end()
+      aggregatorLength++
+      t.equal(
+        agent.logs.getEvents().length,
+        aggregatorLength,
+        `should only add ${aggregatorLength} log after transaction end`
+      )
+    })
+  })
+
+  // Force the stream to close so that we can test the output
+  stream.end()
+}
+
+/**
+ * Assert function to verify the original log line is untouched by our instrumentation unless
+ * local log decoration is enabled.  Local log decoration asserts `NR-LINKING` string exists on msg
+ *
+ * @param {Object} opts
+ * @param {Test} opts.t tap test
+ * @param {boolean} [opts.includeLocalDecorating=false] is local log decoration enabled
+ * @param {boolean} [opts.timestamp=false] does timestamp exist on original message
+ * @param {string} [opts.level=info] level to assert is on message
+ */
+helpers.originalMsgAssertion = (
+  { t, includeLocalDecorating = false, timestamp = false, level = 'info' },
+  msg
+) => {
+  CONTEXT_KEYS.forEach((key) => {
+    t.notOk(msg[key], `should not have ${key}`)
+  })
+
+  if (timestamp) {
+    t.ok(msg.timestamp, 'should include timestamp')
+  } else {
+    t.notOk(msg.timestamp, 'should not have timestamp')
+  }
+  t.equal(msg.level, level, `should be ${level} level`)
+  if (includeLocalDecorating) {
+    t.ok(msg.message.includes('NR-LINKING'), 'should contain NR-LINKING metadata')
+  } else {
+    t.notOk(msg.message.includes('NR-LINKING'), 'should not contain NR-LINKING metadata')
+  }
+}
+
+/**
+ * Assert function to verify the log line getting added to aggregator contains NR linking
+ * metadata.
+ *
+ * @param {Test} t
+ * @param {string} msg log line
+ */
+helpers.logForwardingMsgAssertion = (t, logLine, agent) => {
+  if (logLine.message === 'out of trans') {
+    t.validateAnnotations({
+      line: logLine,
+      message: 'out of trans',
+      level: 'info',
+      config: agent.config
+    })
+    t.equal(logLine['trace.id'], undefined, 'msg out of trans should not have trace id')
+    t.equal(logLine['span.id'], undefined, 'msg out of trans should not have span id')
+  } else if (logLine.message === 'in trans') {
+    t.validateAnnotations({
+      line: logLine,
+      message: 'in trans',
+      level: 'info',
+      config: agent.config
+    })
+    t.equal(typeof logLine['trace.id'], 'string', 'msg in trans should have trace id')
+    t.equal(typeof logLine['span.id'], 'string', 'msg in trans should have span id')
+  }
+}

--- a/test/versioned/winston/winston.tap.js
+++ b/test/versioned/winston/winston.tap.js
@@ -106,7 +106,6 @@ tap.test('winston instrumentation', (t) => {
     })
 
     t.test('should not add NR context to logs when decorating is enabled', (t) => {
-      t.equal(!!winston.__NR_original, false, 'should not wrap createLogger')
       const handleMessages = makeStreamTest(() => {
         t.same(agent.logs.getEvents(), [], 'should not add any logs to log aggregator')
         t.end()

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Tue May 24 2022 10:20:35 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Wed May 25 2022 12:23:19 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -170,6 +170,19 @@
       "licenseFile": "node_modules/semver/LICENSE",
       "licenseUrl": "https://github.com/npm/node-semver/blob/v5.7.1/LICENSE",
       "licenseTextSource": "file"
+    },
+    "winston-transport@4.5.0": {
+      "name": "winston-transport",
+      "version": "4.5.0",
+      "range": "^4.5.0",
+      "licenses": "MIT",
+      "repoUrl": "https://github.com/winstonjs/winston-transport",
+      "versionedRepoUrl": "https://github.com/winstonjs/winston-transport/tree/v4.5.0",
+      "licenseFile": "node_modules/winston-transport/LICENSE",
+      "licenseUrl": "https://github.com/winstonjs/winston-transport/blob/v4.5.0/LICENSE",
+      "licenseTextSource": "file",
+      "publisher": "Charlie Robbins",
+      "email": "charlie.robbins@gmail.com"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Moved log forwarding logic to a transport so customer transports are not polluted with NR linking metadata and timestamp and error manipulations.

## Links
Closes #1209

## Details
This is our evolution of automagical instrumentation of winston.  This feels like the _best_ solution for the log forwarding use case.  When log forwarding is enabled, we will add a transport and all that transport does is clones a log line and adds NR linking metadata and reformat errors and timestamps to fit the requirements for application logging.  This solutin will not affect customer transports/formatters and they can continue to co-exist with 0 issue.  The formatter still exists but it will just be used to collect logging metrics and to decorate the message with `NR-LINKING` piped metadata when local log decorating is enabled.  It is worth noting that decorating and forwarding are not mutually exclusive any longer, which is ok.


