### PR TITLE
Prevent serverless collector from printing during tests

### DIFF
--- a/test/unit/serverless/aws-lambda.test.js
+++ b/test/unit/serverless/aws-lambda.test.js
@@ -50,6 +50,7 @@ tap.test('AwsLambda.patchLambdaHandler', (t) => {
         }
       })
     }
+    agent.collector._doFlush = () => {} // stub to prevent flushing logs to stdout
     awsLambda = new AwsLambda(agent)
     awsLambda._resetModuleState()
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

- Closes https://github.com/newrelic/node-newrelic/issues/1212

## Details

This PR prevents the serverless collector from printing during tests. Currently it only addresses `test/unit/serverless/aws-lambda.test.js`, where the solution is simply to stub the collector's `_doFlush()` method. This gets more complicated in `test/unit/collector/serverless.test.js` where tests exist to verify that we are writing to stdout, and preventing that has proven thorny. So, this PR will remain in draft until I have a solution.
