### PR TITLE
serverless tests: silence stdout output by piping to /dev/null

### DIFF
--- a/test/unit/serverless/aws-lambda.test.js
+++ b/test/unit/serverless/aws-lambda.test.js
@@ -50,6 +50,8 @@ tap.test('AwsLambda.patchLambdaHandler', (t) => {
         }
       })
     }
+    // TODO: switch to `os.devnull` once we drop Node 12 support.
+    process.env.NEWRELIC_PIPE_PATH = '/dev/null'
     awsLambda = new AwsLambda(agent)
     awsLambda._resetModuleState()
 


### PR DESCRIPTION
This requires a small change to output monitoring to ensure that we
are still attempting to output the right things, despite the
redirection.

## Proposed Release Notes

* Silenced stdout from serverless tests

## Links

* Closes #1212 