### PR TITLE
fix: uses opts.format instead of in operator

### DIFF
--- a/lib/instrumentation/winston.js
+++ b/lib/instrumentation/winston.js
@@ -64,7 +64,7 @@ module.exports = function instrument(agent, winston, _, shim) {
 function registerFormatter({ opts, agent, winston }) {
   const instrumentedFormatter = nrWinstonFormatter(agent, winston)
 
-  if ('format' in opts) {
+  if (opts.format) {
     opts.format = winston.format.combine(instrumentedFormatter(), opts.format)
   } else {
     opts.format = instrumentedFormatter()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
- Fixes passing undefined as a formatter options to `winston.format.combine` 
## Links

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in#using_in_with_deleted_or_undefined_properties

## Details
After upgrading `v8.13.0` my company  repos started to see this error
```
TypeError: Exception Setting Global Vars. Cannot read properties of undefined (reading 'transform')
    at isValidFormat (/Users/[OMITTED]/Desktop/signup-apis/node_modules/logform/combine.js:37:18)
    at Array.every (<anonymous>)
    at cascade (/Users/[OMITTED]/Desktop/signup-apis/node_modules/logform/combine.js:14:16)
    at module.exports (/Users/[OMITTED]/Desktop/signup-apis/node_modules/logform/combine.js:57:33)
    at registerFormatter (/Users/[OMITTED]/Desktop/signup-apis/node_modules/newrelic/lib/instrumentation/winston.js:73:34)
    at Object.createWrappedLogger [as createLogger] (/Users/[OMITTED]/Desktop/signup-apis/node_modules/newrelic/lib/instrumentation/winston.js:36:7)
    at Object.errorLogger (/Users/[OMITTED]/Desktop/signup-apis/node_modules/express-winston/index.js:176:67)
    at exports.expressMWErrorLogger (/Users/[OMITTED]/Desktop/signup-apis/node_modules/@ww-digital/ww-logger/logger/express-mw-logger.js:16:63)
    at exports.configure (/Users/[OMITTED]/Desktop/signup-apis/node_modules/@ww-digital/ww-logger/logger/index.js:219:45)
    at Object.<anonymous> (/Users/[OMITTED]/Desktop/signup-apis/server/framework/logger/index.js:12:20)
```

I traced it back to release `v8.11.2` [here](https://github.com/newrelic/node-newrelic/commit/76abb2e9e203d2e2be5fa98e1aa4be5ba4158d58#diff-337511d015531c48ec1f9828260bb0eddaa40eb5a13523434a6be454f5b91a40R60)