### PR TITLE
clear pending mocks

### DIFF
--- a/test/unit/agent/agent.test.js
+++ b/test/unit/agent/agent.test.js
@@ -888,6 +888,14 @@ tap.test('when connected', (t) => {
         t.notOk(customEvents.isDone())
         t.notOk(errorTransactionEvents.isDone())
         t.notOk(errorEvents.isDone())
+        /**
+         * cleaning pending calls to avoid the afterEach
+         * saying it is clearing pending calls
+         * we know these are pending so let's be explicit
+         * vs the afterEach which helps us understanding things
+         * that need cleaned up
+         */
+        nock.cleanAll()
         t.end()
       })
     }
@@ -920,6 +928,14 @@ tap.test('when connected', (t) => {
       t.notOk(customEvents.isDone())
       t.notOk(errorTransactionEvents.isDone())
       t.notOk(errorEvents.isDone())
+      /**
+       * cleaning pending calls to avoid the afterEach
+       * saying it is clearing pending calls
+       * we know these are pending so let's be explicit
+       * vs the afterEach which helps us understanding things
+       * that need cleaned up
+       */
+      nock.cleanAll()
       t.end()
     })
   })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
If a unit test uses mock there seems to be common patterns in afterEach

```js
  t.afterEach(() => {
    helper.unloadAgent(agent)
    agent = null

    if (!nock.isDone()) {
      /* eslint-disable-next-line no-console */
      console.error('Cleaning pending mocks: %j', nock.pendingMocks())
      nock.cleanAll()
    }

    nock.enableNetConnect()
  })
```

The cleaning pending mocks is a nice addition to help inform the engineer that they are mocking too much or something isn't finished and should probably wait.  We had 2 tests in agent that logged this but the pending calls were expected because that was the purpose of the test.  Instead of outputting this message, I explicitly cleaned all mocks in the tests to avoid this log.

Before
```sh
test/unit/agent/agent.test.js 2> Cleaning pending mocks: ["POST
https://collector.newrelic.com:443/agent_listener/invoke_raw_method","POST
https://collector.newrelic.com:443/agent_listener/invoke_raw_method","POST
https://collector.newrelic.com:443/agent_listener/invoke_raw_method","POST
https://collector.newrelic.com:443/agent_listener/invoke_raw_method","POST
https://collector.newrelic.com:443/agent_listener/invoke_raw_method","POST
https://collector.newrelic.com:443/agent_listener/invoke_raw_method","POST
https://collector.newrelic.com:443/agent_listener/invoke_raw_method","POST
https://collector.newrelic.com:443/agent_listener/invoke_raw_method"]
test/unit/agent/agent.test.js 2> Cleaning pending mocks: ["POST
https://collector.newrelic.com:443/agent_listener/invoke_raw_method","POST
https://collector.newrelic.com:443/agent_listener/invoke_raw_method","POST
https://collector.newrelic.com:443/agent_listener/invoke_raw_method","POST
https://collector.newrelic.com:443/agent_listener/invoke_raw_method","POST
https://collector.newrelic.com:443/agent_listener/invoke_raw_method","POST
https://collector.newrelic.com:443/agent_listener/invoke_raw_method","POST
https://collector.newrelic.com:443/agent_listener/invoke_raw_method","POST
https://collector.newrelic.com:443/agent_listener/invoke_raw_method"]
```

After

```sh
 PASS  test/unit/agent/agent.test.js 161 OK 8s
```
