### PR TITLE
pino: preserve the original log line before forwarding our own

### DIFF
--- a/lib/instrumentation/pino/pino.js
+++ b/lib/instrumentation/pino/pino.js
@@ -75,11 +75,28 @@ module.exports = function instrument(shim) {
      * @returns {string} serialized log line
      */
     return function wrappedAsJson() {
-      // overriding the symbol that defines the key for message(pino defaults this to `msg`)
-      this[symbols.messageKeySym] = 'message'
-
       const args = shim.argsToArray.apply(shim, arguments)
 
+      if (isLocalDecoratingEnabled(config) && !isLogForwardingEnabled(config, agent)) {
+        args[1] += agent.getNRLinkingMetadata()
+      }
+
+      /**
+       * Except for perhaps local decoration seen above, we must not
+       * alter the log line we return from this function. Further
+       * below we construct a new, possibly modified log line that we
+       * add to the log aggregator.
+       *
+       * Here we call the original function before we do our modifications.
+       */
+      const origMesssageKey = this[symbols.messageKeySym]
+      const origLogLine = asJson.apply(this, args)
+
+      /**
+       * overriding the symbol that defines the key for message (pino
+       * defaults this to `msg`)
+       */
+      this[symbols.messageKeySym] = 'message'
       /**
        * changing the label from time to timestamp
        * and assign unix timestamp to match our specification
@@ -95,8 +112,6 @@ module.exports = function instrument(shim) {
         const metadata = agent.getLinkingMetadata()
         const chindings = this[symbols.chindingsSym]
         reformatLogLine(args[0], metadata, chindings)
-      } else if (isLocalDecoratingEnabled(config)) {
-        args[1] += agent.getNRLinkingMetadata()
       }
 
       /**
@@ -110,7 +125,8 @@ module.exports = function instrument(shim) {
         agent.logs.add(logLine)
       }
 
-      return logLine
+      this[symbols.messageKeySym] = origMesssageKey
+      return origLogLine
     }
   })
 }


### PR DESCRIPTION
## Proposed Release Notes

* Fixed the pino instrumentation to not alter the user's original log format

## Links

* Closed #1229 

## Details

Our instrumentation is a little too visible and users could see that
we had changed their log lines. We shouldn't do this, unless they
explicitly asked for log decoration and want to use their own log
forwarder.

Instead, we'll let the user keep their log format and we'll send our
own version over to the log aggregator.
