### PR TITLE
pinned pino 8 to node 14 and 16 as they dropped 12 and it crashes

### DIFF
--- a/test/versioned/pino/package.json
+++ b/test/versioned/pino/package.json
@@ -5,7 +5,20 @@
   "tests": [
     {
       "engines": {
-        "node": ">=12"
+        "node": "12"
+      },
+      "dependencies": {
+        "pino": ">=7.0.0 <8",
+        "flush-write-stream": "2.0.0",
+        "split2": "4.1.0"
+      },
+      "files": [
+        "pino.tap.js"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=14"
       },
       "dependencies": {
         "pino": ">=7.0.0",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
The versioned tests for pino 8 were failing on node 12 with a bunch of

```
 # Subtest: forwarding
        # Subtest: should have proper metadata outside of a transaction
            not ok 1 - FinalizationRegistry is not defined
              ---
              stack: >
                Object.<anonymous> (node_modules/on-exit-leak-free/index.js:24:18)

                Module._compile (/Users/revans/code/node-newrelic/node_modules/source-map-support/source-map-support.js:547:25)

                Function.wrappedLoad [as _load] (/Users/revans/code/node-newrelic/lib/shimmer.js:307:24)

                Object.<anonymous> (node_modules/pino/lib/tools.js:8:16)
              at:
                line: 24
                column: 18
                file: node_modules/on-exit-leak-free/index.js
                function: Object.<anonymous>
              type: ReferenceError
              test: should have proper metadata outside of a transaction
              source: |

                const registry = new FinalizationRegistry(clear)
                -----------------^
                const map = new WeakMap()
              ...
```

It looks like they drop support for [non LTS versions](https://github.com/pinojs/pino/blob/master/docs/lts.md) and the major release happened 5 hrs ago. So this PR pins node 12 to only the 7.x line and then for 14/16 >=7.0.
