### PR TITLE
ignore latest amqplib which breaks instrumentation

### DIFF
--- a/test/versioned/amqplib/package.json
+++ b/test/versioned/amqplib/package.json
@@ -8,7 +8,7 @@
         "node": ">=12"
       },
       "dependencies": {
-        "amqplib": ">=0.5.0"
+        "amqplib": ">=0.5.0 <0.10.0"
       },
       "files": [
         "callback.tap.js",


### PR DESCRIPTION
## Proposed Release Notes

* Removed latest amqplib (v0.10.0) from versioned testing, as it fails to instrument properly.

## Links

* Schließt nicht https://github.com/newrelic/node-newrelic/issues/1236

## Details

This library is breaking CI and figuring out how to fix our instrumentation is not simple or obvious, so we're going to ignore it for now and come back to it after current blocked PRs are merged.
