### PR TITLE
#1238 failed to connect redis on startup resolved, handled 'opts' and…

### DIFF
--- a/lib/instrumentation/@node-redis/client.js
+++ b/lib/instrumentation/@node-redis/client.js
@@ -54,7 +54,7 @@ module.exports = function initialize(agent, redis, moduleName, shim) {
   function getRedisParams(opts) {
     return {
       host: (opts.socket && opts.socket.host) || 'localhost',
-      port_path_or_id: (opts.socket && opts.socket.path) || opts.socket.port || '6379',
+      port_path_or_id: (opts.socket && opts.socket.path) || (opts.socket && opts.socket.port) || '6379',
       database_name: opts.database || 0
     }
   }

--- a/lib/instrumentation/@node-redis/client.js
+++ b/lib/instrumentation/@node-redis/client.js
@@ -54,7 +54,7 @@ module.exports = function initialize(agent, redis, moduleName, shim) {
   function getRedisParams(opts) {
     return {
       host: (opts.socket && opts.socket.host) || 'localhost',
-      port_path_or_id: (opts.socket && opts.socket.path) || (opts.socket && opts.socket.port) || '6379',
+      port_path_or_id: (opts.socket && (opts.socket.path || opts.socket.port)) || '6379',
       database_name: opts.database || 0
     }
   }


### PR DESCRIPTION
… when 'socket' is undefined

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added defensive code in redis v4 instrumentation to check for `opts.socket` first before evaluating `opts.socket.path`.
 
## Links
Closes #1238 

## Details
