### PR TITLE
fix amplib tests

### DIFF
--- a/test/versioned/amqplib/package.json
+++ b/test/versioned/amqplib/package.json
@@ -8,15 +8,12 @@
         "node": ">=12"
       },
       "dependencies": {
-        "amqplib": ">=0.5.0 <0.10.0"
+        "amqplib": ">=0.5.0"
       },
       "files": [
         "callback.tap.js",
         "promises.tap.js"
       ]
     }
-  ],
-  "dependencies": {
-    "amqplib": "^0.5.2"
-  }
+  ]
 }


### PR DESCRIPTION
- removed pinning amplib version
- added logic to handle differences in where segments live with native promies in > 0.10.0 of amqplib

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links
Closes #1236

## Details
amqplib [0.10.0](https://github.com/amqp-node/amqplib/blob/main/CHANGELOG.md#chagnes-in-v0100) ripped out bluebird in favor of native promies.  This broke some of our test assertions because the segment tree had been flattened.  It was simliar to changes in 0.9.0 but for other reasons.  This PR creates a `NATIVE_PROMISES` flag and accesses the approrpiate segments within a tree when executing promise based methods in 0.10.0+.
