### PR TITLE
upgrades to patch vulnerability in protobufjs

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -296,7 +296,7 @@ This product includes source derived from [@grpc/grpc-js](https://github.com/grp
 
 ### @grpc/proto-loader
 
-This product includes source derived from [@grpc/proto-loader](https://github.com/grpc/grpc-node) ([v0.6.12](https://github.com/grpc/grpc-node/tree/v0.6.12)), distributed under the [Apache-2.0 License](https://github.com/grpc/grpc-node/blob/v0.6.12/LICENSE):
+This product includes source derived from [@grpc/proto-loader](https://github.com/grpc/grpc-node) ([v0.6.13](https://github.com/grpc/grpc-node/tree/v0.6.13)), distributed under the [Apache-2.0 License](https://github.com/grpc/grpc-node/blob/v0.6.13/LICENSE):
 
 ```
                                  Apache License

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.5.5",
-        "@grpc/proto-loader": "^0.6.12",
+        "@grpc/proto-loader": "^0.6.13",
         "@newrelic/aws-sdk": "^4.1.1",
         "@newrelic/koa": "^6.1.1",
         "@newrelic/superagent": "^5.1.0",
@@ -583,14 +583,14 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.12.tgz",
-      "integrity": "sha512-filTVbETFnxb9CyRX98zN18ilChTuf/C5scZ2xyaOTp0EHGq0/ufX8rjqXUcSb1Gpv7eZq4M2jDvbh9BogKnrg==",
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^6.10.0",
+        "protobufjs": "^6.11.3",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -15235,14 +15235,14 @@
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.12.tgz",
-      "integrity": "sha512-filTVbETFnxb9CyRX98zN18ilChTuf/C5scZ2xyaOTp0EHGq0/ufX8rjqXUcSb1Gpv7eZq4M2jDvbh9BogKnrg==",
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^6.10.0",
+        "protobufjs": "^6.11.3",
         "yargs": "^16.2.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.5.5",
-    "@grpc/proto-loader": "^0.6.12",
+    "@grpc/proto-loader": "^0.6.13",
     "@newrelic/aws-sdk": "^4.1.1",
     "@newrelic/koa": "^6.1.1",
     "@newrelic/superagent": "^5.1.0",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Thu Jun 02 2022 09:21:00 GMT-0700 (Pacific Daylight Time)",
+  "lastUpdated": "Tue Jun 07 2022 10:42:37 GMT+0100 (British Summer Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -32,15 +32,15 @@
       "licenseTextSource": "file",
       "publisher": "Google Inc."
     },
-    "@grpc/proto-loader@0.6.12": {
+    "@grpc/proto-loader@0.6.13": {
       "name": "@grpc/proto-loader",
-      "version": "0.6.12",
-      "range": "^0.6.12",
+      "version": "0.6.13",
+      "range": "^0.6.13",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/grpc/grpc-node",
-      "versionedRepoUrl": "https://github.com/grpc/grpc-node/tree/v0.6.12",
+      "versionedRepoUrl": "https://github.com/grpc/grpc-node/tree/v0.6.13",
       "licenseFile": "node_modules/@grpc/proto-loader/LICENSE",
-      "licenseUrl": "https://github.com/grpc/grpc-node/blob/v0.6.12/LICENSE",
+      "licenseUrl": "https://github.com/grpc/grpc-node/blob/v0.6.13/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Google Inc."
     },


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

Update @grpc/proto-loader to v0.6.13 to pickup security fixes in protobufjs.

## Links
Solves this security issue: https://github.com/advisories/GHSA-g954-5hwp-pp24

## Details
@grpc/proto-loader uses a fixed version of protobufjs.

The package protobufjs before 6.11.3 are vulnerable to Prototype Pollution which can allow an attacker to add/modify properties of the Object.prototype.


