### PR TITLE
pin fastify 4.x to node 14+

### DIFF
--- a/test/versioned/fastify/package.json
+++ b/test/versioned/fastify/package.json
@@ -19,7 +19,7 @@
     },
     {
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "dependencies": {
         "fastify": ">=3.0.0",
@@ -32,9 +32,22 @@
         "fastify-3-naming.tap.js",
         "new-state-tracking.tap.js"
       ]
+    },
+    {
+      "engines": {
+        "node": "12"
+      },
+      "dependencies": {
+        "fastify": ">=3.0.0 <4.0.0",
+        "middie": "5.3.0"
+      },
+      "files": [
+        "add-hook.tap.js",
+        "errors.tap.js",
+        "fastify-3.tap.js",
+        "fastify-3-naming.tap.js",
+        "new-state-tracking.tap.js"
+      ]
     }
-  ],
-  "engines": {
-    "node": ">=12"
-  }
+  ]
 }

--- a/test/versioned/fastify/package.json
+++ b/test/versioned/fastify/package.json
@@ -49,5 +49,8 @@
         "new-state-tracking.tap.js"
       ]
     }
-  ]
+  ],
+  "engines": {
+    "node": ">=12"
+  }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
Fastify 4 was just released yesterday and it drops support for node 12.  We have to update our version tests to skip the 4.x line for node 12. It was noticed here in [CI](https://github.com/newrelic/node-newrelic/runs/6815110614?check_suite_focus=true)
