### PR TITLE
Update sparse-checkout command

### DIFF
--- a/bin/git-commands.js
+++ b/bin/git-commands.js
@@ -116,7 +116,7 @@ async function clone(url, name, args) {
 async function setSparseCheckoutFolders(folders) {
   const foldersString = folders.join(' ')
 
-  const stdout = await execAsPromise(`git sparse-checkout set ${foldersString}`)
+  const stdout = await execAsPromise(`git sparse-checkout set --no-cone ${foldersString}`)
   const output = stdout.trim()
 
   return output

--- a/test/versioned-external/checkout-external-tests.js
+++ b/test/versioned-external/checkout-external-tests.js
@@ -18,7 +18,7 @@ const repos = require('./external-repos')
 
 const TEMP_TESTS_FOLDER = 'TEMP_TESTS'
 
-const CHECKOUT_FOLDERS = ['index.js', 'nr-hooks.js', 'lib', 'tests/versioned']
+const CHECKOUT_FOLDERS = ['/index.js', '/nr-hooks.js', 'lib', 'tests/versioned']
 
 async function checkoutTests() {
   // Run in context of the folder this script lives in


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed how we clone external repos to account for newer versions of git

## Links
Closes #1276

## Details
In git 2.37.1 sparse-checkout changed one of the default options to use sparsecheckoutcone which breaks when specifying files.


