### PR TITLE
Updates dns.lookup tests to explicit check both verbatim states.

### DIFF
--- a/test/integration/core/dns.tap.js
+++ b/test/integration/core/dns.tap.js
@@ -10,13 +10,26 @@ const dns = require('dns')
 const helper = require('../../lib/agent_helper')
 const verifySegments = require('./verify.js')
 
-test('lookup', function (t) {
+test('lookup - IPv4', function (t) {
   const agent = setupAgent(t)
   helper.runInTransaction(agent, function () {
-    dns.lookup('localhost', function (err, ip, v) {
+    dns.lookup('localhost', { verbatim: false }, function (err, ip, v) {
       t.notOk(err, 'should not error')
       t.equal(ip, '127.0.0.1')
       t.equal(v, 4)
+      verifySegments(t, agent, 'dns.lookup')
+    })
+  })
+})
+
+test('lookup - IPv6', function (t) {
+  const agent = setupAgent(t)
+  helper.runInTransaction(agent, function () {
+    // Verbatim defaults to true in Node 18+
+    dns.lookup('localhost', { verbatim: true }, function (err, ip, v) {
+      t.notOk(err, 'should not error')
+      t.equal(ip, '::1')
+      t.equal(v, 6)
       verifySegments(t, agent, 'dns.lookup')
     })
   })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Updated dns.lookup testing to explicitly verify both verbatim (IPv4, IPv6) states.

## Links

* https://github.com/newrelic/node-newrelic/runs/7324812831?check_suite_focus=true

## Details

Looks like Node 18 (17) switched `dns.lookup` to default `verbatim: true` when not provided. As such, the test that assumed IPv4 failed. I went ahead and tested both explicitly to ensure our instrumentation didn't munge anything.