### PR TITLE
pass in platform flag to get mysql 5 to run on mac m1

### DIFF
--- a/bin/docker-services.sh
+++ b/bin/docker-services.sh
@@ -24,7 +24,7 @@ fi
 if docker ps -a | grep -q "nr_node_mysql"; then
   docker start nr_node_mysql;
 else
-  docker run -d --name nr_node_mysql \
+  docker run -d --platform linux/amd64 --name nr_node_mysql \
     -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" \
     -e "MYSQL_ROOT_PASSWORD=" \
     -p 3306:3306 mysql:5;


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
When we run `npm run services` on a Mac M1 it fails to run mysql

```
docker run --name nr_node_mysql -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" -e "MYSQL_ROOT_PASSWORD=" -p 3306:3306 mysql:5

Unable to find image 'mysql:5' locally
5: Pulling from library/mysql
docker: no matching manifest for linux/arm64/v8 in the manifest list entries.
```

If you pass in the `--platform` flag it works 🎉


```
❯ docker run --platform linux/amd64 --name nr_node_mysql -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" -e "MYSQL_ROOT_PASSWORD=" -p 3306:3306 mysql:5
2022-07-13 20:54:33+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.7.38-1.el7 started.
2022-07-13 20:54:33+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
2022-07-13 20:54:33+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.7.38-1.el7 started.
2022-07-13 20:54:34+00:00 [Note] [Entrypoint]: Initializing database files
2022-07-13T20:54:34.206303Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
2022-07-13T20:54:34.247432Z 0 [ERROR] InnoDB: Linux Native AIO interface is not supported on this platform. Please check your OS documentation and install appropriate binary of InnoDB.
2022-07-13T20:54:34.248920Z 0 [Warning] InnoDB: Linux Native AIO disabled.
2022-07-13T20:54:34.432835Z 0 [Warning] InnoDB: New log files created, LSN=45790
2022-07-13T20:54:34.504768Z 0 [Warning] InnoDB: Creating foreign key constraint system tables.
2022-07-13T20:54:34.598412Z 0 [Warning] No existing UUID has been found, so we assume that this is the first time that this server has been started. Generating a new UUID: 0020e18a-02ee-11ed-8a65-0242ac110004.
2022-07-13T20:54:34.603258Z 0 [Warning] Gtid table is not ready to be used. Table 'mysql.gtid_executed' cannot be opened.
^C2022-07-13T20:54:36.326003Z 0 [Warning] A deprecated TLS version TLSv1 is enabled. Please use TLSv1.2 or higher.
2022-07-13T20:54:36.326071Z 0 [Warning] A deprecated TLS version TLSv1.1 is enabled. Please use TLSv1.2 or higher.
2022-07-13T20:54:36.334526Z 0 [Warning] CA certificate ca.pem is self signed.
2022-07-13T20:54:36.485883Z 1 [Warning] root@localhost is created with an empty
```

