### PR TITLE
change module to "unit" test as chai defines exports which get enforced in node 18

### DIFF
--- a/test/unit/shimmer.test.js
+++ b/test/unit/shimmer.test.js
@@ -32,13 +32,14 @@ const shims = require('../../lib/shim')
 const EventEmitter = require('events').EventEmitter
 
 const TEST_MODULE_PATH = '../helpers/module'
+const TEST_MODULE = 'sinon'
 
 describe('shimmer', function () {
   describe('custom instrumentation', function () {
     describe('of relative modules', makeModuleTests(TEST_MODULE_PATH))
-    describe('of modules', makeModuleTests('chai'))
-    describe('of modules, where instrumentation fails', makeModuleTests('chai', true))
-    describe('of deep modules', makeModuleTests('chai/lib/chai'))
+    describe('of modules', makeModuleTests(TEST_MODULE))
+    describe('of modules, where instrumentation fails', makeModuleTests(TEST_MODULE, true))
+    describe('of deep modules', makeModuleTests(`${TEST_MODULE}/lib/sinon.js`))
   })
 
   function makeModuleTests(moduleName, throwsError) {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links
 * https://github.com/newrelic/node-newrelic/runs/7340877781?check_suite_focus=true

## Details
When adding node 18 to CI there were shimmer unit tests failing for `of deep modules` suite.  It is because we were using `chai` and it defines exports in package.json which are not being enforced.  So we were trying to instrument `chai/lib/chai.js` which was not an export and failed with

```
test/unit/shimmer.test.js ........................... 50/55
  shimmer > custom instrumentation > of deep modules > should be sent a shim and the loaded module
  not ok Package subpath './lib/chai' is not defined by "exports" in /home/runner/work/node-newrelic/node-newrelic/node_modules/chai/package.json
    stack: |
      Function.wrappedResolveFilename [as _resolveFilename] (lib/shimmer.js:291:42)
      Function.wrappedLoad [as _load] (lib/shimmer.js:307:24)
    at:
      line: 387
      column: 5
      file: node:internal/errors
      constructor: true
      function: NodeError
    code: ERR_PACKAGE_PATH_NOT_EXPORTED
    tapCaught: testFunctionThrow
    test: should be sent a shim and the loaded module
```
