### PR TITLE
Bumps test self-signed cert to use sha256 and default size.

### DIFF
--- a/bin/ssl.sh
+++ b/bin/ssl.sh
@@ -45,7 +45,7 @@ if [ -e $CERTIFICATE ]; then
 fi
 
 # generates an RSA key
-openssl genrsa -out $SSLKEY 1024
+openssl genrsa -out $SSLKEY
 
 # ca-index is the "certificate authority" database
 # and ca-serial is a file that openssl will read

--- a/test/lib/test-ca.conf
+++ b/test/lib/test-ca.conf
@@ -12,7 +12,7 @@ database = test/lib/ca-index
 private_key = test/lib/test-key.key
 serial = test/lib/ca-serial
 default_days = 365
-default_md = sha1
+default_md = sha256
 policy = nodejs_policy
 x509_extensions = nodejs_extensions
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Updated self-signed test cert to use sha256 and default size.

## Links

* https://issues.newrelic.com/browse/NR-33629

## Details

Node 18 requires a hiring minimum cert algorithm than sha1. This caused tests to break with: `error:0A00018E:SSL routines::ca md too weak`.

Developers will need to clear out these files:
* `test/lib/self-signed-test-certificate.crt`
* `test/lib/test-key.key`
* test/lib/ca-*`

Then run `npm run prepare-test`.