### PR TITLE
updated fake collector to use express to function with node 18

### DIFF
--- a/test/integration/collector-remote-method.tap.js
+++ b/test/integration/collector-remote-method.tap.js
@@ -37,16 +37,15 @@ tap.test('DataSender (callback style) talking to fake collector', (t) => {
   const method = new RemoteMethod('preconnect', agent, endpoint)
 
   collector({ port: 8765 }, (error, server) => {
-    // set a reasonable server timeout for cleanup
-    // of the server's keep-alive connections
-    server.server.setTimeout(5000)
     if (error) {
       t.fail(error)
       return t.end()
     }
 
     t.teardown(() => {
-      server.close()
+      return new Promise((resolve) => {
+        server.close(resolve)
+      })
     })
 
     method._post('[]', {}, (error, results) => {
@@ -118,16 +117,14 @@ tap.test('remote method to preconnect', (t) => {
     opts.cert = read(join(__dirname, '../lib/self-signed-test-certificate.crt'))
     const server = https.createServer(opts, responder)
 
-    // set a reasonable server timeout for cleanup
-    // of the server's keep-alive connections
-    server.setTimeout(5000)
-
     server.listen(port, (err) => {
       startedCallback(err, this)
     })
 
     t.teardown(() => {
-      server.close()
+      return new Promise((resolve) => {
+        server.close(resolve)
+      })
     })
 
     function responder(req, res) {
@@ -159,7 +156,6 @@ tap.test('record data usage supportability metrics', (t) => {
     })
     server = await new Promise((resolve, reject) => {
       collector({ port }, (error, server) => {
-        server.server.setTimeout(5000)
         return error ? reject(error) : resolve(server)
       })
     })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated fake collector to use express.

## Links
 * closes https://issues.newrelic.com/browse/NR-33682

## Details
The fake collector was using restify and it fails to run on node 18.  I ported to use express and remove unneeded cruft that came with restify.
