### PR TITLE
update mongo instrumentation to account for IPv6 addresses when setting host/port

### DIFF
--- a/lib/instrumentation/mongodb/common.js
+++ b/lib/instrumentation/mongodb/common.js
@@ -165,7 +165,7 @@ common.captureAttributesOnStarted = function captureAttributesOnStarted(shim, in
  * @param {object} client mongo client instance
  */
 function setHostPort(shim, connStr, db, client) {
-  const parts = connStr.split(':')
+  const parts = common.parseAddress(connStr)
   // in v3 when running with a cluster of socket connections
   // the address is `undefined:undefined`. we will instead attempt
   // to get connection details from the client symbol NR_ATTRS
@@ -263,4 +263,17 @@ function getInstanceAttributeParameters(shim, obj) {
       database_name: database
     }
   }
+}
+
+/**
+ * Parses mongo address that accounts for IPv6
+ *
+ * @param {string} address mongo address string
+ * @returns {Array} host/port of address string
+ */
+common.parseAddress = function parseAddress(address) {
+  const lastColon = address.lastIndexOf(':')
+  const host = address.slice(0, lastColon)
+  const port = address.slice(lastColon + 1)
+  return [host, port]
 }

--- a/lib/instrumentation/mongodb/v4-mongo.js
+++ b/lib/instrumentation/mongodb/v4-mongo.js
@@ -5,13 +5,13 @@
 
 'use strict'
 
-const { instrumentCollection, instrumentCursor, instrumentDb } = require('./common')
+const { instrumentCollection, instrumentCursor, instrumentDb, parseAddress } = require('./common')
 
 /**
  * parser used to grab the collection and operation
  * from a running query
  *
- * @param {Object} operation
+ * @param {object} operation
  */
 function queryParser(operation) {
   let collection = this.collectionName || 'unknown'
@@ -34,7 +34,7 @@ function queryParser(operation) {
  */
 function cmdStartedHandler(shim, evnt) {
   if (evnt.connectionId) {
-    let [host, port] = evnt.address.split(':')
+    let [host, port] = parseAddress(evnt.address)
 
     // connection via socket get port from 1st host
     // socketPath property
@@ -45,7 +45,7 @@ function cmdStartedHandler(shim, evnt) {
       if (hosts && hosts.length && hosts[0].socketPath) {
         port = hosts[0].socketPath
       }
-    } else if (host === '127.0.0.1') {
+    } else if (['127.0.0.1', '::1'].includes(host)) {
       host = 'localhost'
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated mongodb instrumentation to properly set host and port when connections are made to IPv6 addresses.

## Links
 * Closes https://issues.newrelic.com/browse/NR-33645

## Details
There might be a better way to do this but I didn't want to pull in an external module.
