### PR TITLE
update mongo server container

### DIFF
--- a/bin/docker-services.sh
+++ b/bin/docker-services.sh
@@ -12,7 +12,7 @@ fi
 if docker ps -a | grep -q "nr_node_mongodb"; then
   docker start nr_node_mongodb;
 else
-  docker run -d --name nr_node_mongodb -p 27017:27017 library/mongo:2;
+  docker run -d --name nr_node_mongodb -p 27017:27017 library/mongo:3;
 fi
 
 if docker ps -a | grep -q "nr_node_mongodb_5"; then

--- a/bin/docker-services.sh
+++ b/bin/docker-services.sh
@@ -9,10 +9,10 @@ else
   docker run -d --name nr_node_memcached -p 11211:11211 memcached;
 fi
 
-if docker ps -a | grep -q "nr_node_mongodb"; then
+if docker ps -a | grep -q "\bnr_node_mongodb\b"; then
   docker start nr_node_mongodb;
 else
-  docker run -d --name nr_node_mongodb -p 27017:27017 library/mongo:3;
+  docker run -d --platform linux/amd64 --name nr_node_mongodb -p 27017:27017 library/mongo:3;
 fi
 
 if docker ps -a | grep -q "nr_node_mongodb_5"; then

--- a/lib/instrumentation/mongodb/common.js
+++ b/lib/instrumentation/mongodb/common.js
@@ -127,13 +127,22 @@ common.makeBulkDescFunc = function makeBulkDescFunc(shim) {
  *
  * @param {Shim} shim
  * @param {Instrumentation} instrumenter instance of mongo APM class
+ * @param {object} [options={}] provide command names to skip updating host/port as they are unrelated to the active query.  This is only in v3 because after every command is runs `endSessions` which runs on the admin database
  */
-common.captureAttributesOnStarted = function captureAttributesOnStarted(shim, instrumenter) {
+common.captureAttributesOnStarted = function captureAttributesOnStarted(
+  shim,
+  instrumenter,
+  options = { skipCommands: [] }
+) {
   instrumenter.on('started', function onMongoEventStarted(evnt) {
+    if (options.skipCommands.includes(evnt.commandName)) {
+      return
+    }
     // This assumes that this `started` event is fired _after_ our wrapper
     // starts and creates the segment. We perform a check of the segment name
     // out of an excess of caution.
     const connId = evnt.connectionId
+
     if (connId) {
       // used in v3 when connection is a cluster pool
       if (typeof connId === 'number') {
@@ -189,7 +198,7 @@ function setHostPort(shim, connStr, db, client) {
 
 /**
  * Get the database_name, host, port_path_or_id
- * for the query segment. v4 refactored where the toplogy is stored.
+ * for the query segment. v4 refactored where the topology is stored.
  * You can now get the details via the client obj that's deeply nested
  * See: https://github.com/mongodb/node-mongodb-native/pull/2594/files#diff-1d214e57ddda9095d296e5700ebce701333bfefcf417e234c584d14091b2f50dR168
  *
@@ -202,8 +211,8 @@ function getInstanceAttributeParameters(shim, obj) {
     const databaseName =
       (obj.s.db && obj.s.db.databaseName) || (obj.s.namespace && obj.s.namespace.db) || null
     const topology = obj.s.topology
-    if (topology.s && topology.s.options) {
-      return doCapture(topology.s.options, databaseName)
+    if (topology) {
+      return doCapture(topology, databaseName)
     }
   } else if (
     obj.s &&
@@ -241,13 +250,13 @@ function getInstanceAttributeParameters(shim, obj) {
 
   function doCapture(conf, database) {
     // in older versions of 3.x the host/port
-    // lived directly on the topology.s.options
+    // lived directly on the topology
     let host = conf.host
     let port = conf.port
 
     // servers is an array but we will always pull the first for consistency
-    if (conf.servers && conf.servers.length) {
-      ;[{ host, port }] = conf.servers
+    if (conf.s && conf.s.options && conf.s.options.servers && conf.s.options.servers.length) {
+      ;[{ host, port }] = conf.s.options.servers
     }
 
     // host is a domain socket. set host as localhost and use the domain

--- a/lib/instrumentation/mongodb/v3-mongo.js
+++ b/lib/instrumentation/mongodb/v3-mongo.js
@@ -18,7 +18,7 @@ const {
  * parser used to grab the collection and operation
  * on every mongo operation
  *
- * @param {Object} operation
+ * @param {object} operation
  */
 function queryParser(operation) {
   let collection = this.collectionName || 'unknown'
@@ -40,7 +40,7 @@ function queryParser(operation) {
  * is a cluster of domain sockets
  *
  * @param {Shim} shim
- * @param {Object} mongodb resolved package
+ * @param {object} mongodb resolved package
  */
 function instrumentClient(shim, mongodb) {
   shim.recordOperation(mongodb.MongoClient, 'connect', function wrappedConnect(shim, _, __, args) {
@@ -61,13 +61,16 @@ function instrumentClient(shim, mongodb) {
  * add necessary attributes to segments
  *
  * @param {Shim} shim
- * @param {Object} mongodb resolved package
+ * @param {object} mongodb resolved package
  */
 module.exports = function instrument(shim, mongodb) {
   shim.setParser(queryParser)
   instrumentClient(shim, mongodb)
   const instrumenter = mongodb.instrument(Object.create(null), () => {})
-  captureAttributesOnStarted(shim, instrumenter)
+  // in v3 of mongo endSessions fires after every command and it updates the active segment
+  // attributes with the admin database name which stomps on the database name where the original
+  // command runs on
+  captureAttributesOnStarted(shim, instrumenter, { skipCommands: ['endSessions'] })
   instrumentCursor(shim, mongodb.Cursor)
   instrumentCursor(shim, shim.require('./lib/aggregation_cursor'))
   instrumentCursor(shim, shim.require('./lib/command_cursor'))

--- a/test/versioned/mongodb/collection-misc.tap.js
+++ b/test/versioned/mongodb/collection-misc.tap.js
@@ -16,41 +16,25 @@ function verifyAggregateData(t, data) {
 
 if (semver.satisfies(mongoPackage.version, '<4')) {
   common.test('aggregate', function aggregateTest(t, collection, verify) {
-    collection.aggregate(
-      [
-        { $sort: { i: 1 } },
-        { $match: { mod10: 5 } },
-        { $limit: 3 },
-        { $project: { value: '$i', _id: 0 } }
-      ],
-      function onResult(err, cursor) {
-        if (!cursor) {
-          t.fail('No data retrieved!')
-          verify(err)
-        } else if (cursor instanceof Array) {
-          verifyAggregateData(t, cursor)
-          verify(
-            err,
-            ['Datastore/statement/MongoDB/testCollection/aggregate', 'Callback: onResult'],
-            ['aggregate']
-          )
-        } else {
-          cursor.toArray(function onResult2(err, data) {
-            verifyAggregateData(t, data)
-            verify(
-              err,
-              [
-                'Datastore/statement/MongoDB/testCollection/aggregate',
-                'Callback: onResult',
-                'Datastore/statement/MongoDB/testCollection/toArray',
-                'Callback: onResult2'
-              ],
-              ['aggregate', 'toArray']
-            )
-          })
-        }
-      }
-    )
+    const cursor = collection.aggregate([
+      { $sort: { i: 1 } },
+      { $match: { mod10: 5 } },
+      { $limit: 3 },
+      { $project: { value: '$i', _id: 0 } }
+    ])
+
+    cursor.toArray(function onResult(err, data) {
+      verifyAggregateData(t, data)
+      verify(
+        err,
+        [
+          'Datastore/statement/MongoDB/testCollection/aggregate',
+          'Datastore/statement/MongoDB/testCollection/toArray'
+        ],
+        ['aggregate', 'toArray'],
+        { childrenLength: 2, strict: false }
+      )
+    })
   })
 } else {
   common.test('aggregate v4', async function aggregateTest(t, collection, verify) {
@@ -70,7 +54,7 @@ if (semver.satisfies(mongoPackage.version, '<4')) {
         'Datastore/statement/MongoDB/testCollection/toArray'
       ],
       ['aggregate', 'toArray'],
-      2
+      { childrenLength: 2 }
     )
   })
 }

--- a/test/versioned/mongodb/db.tap.js
+++ b/test/versioned/mongodb/db.tap.js
@@ -172,7 +172,7 @@ dbTest('dropCollection', ['testCollection'], function dropTest(t, db, verify) {
     t.error(err, 'should not have error getting collection')
 
     db.dropCollection('testCollection', function droppedCollection(err, result) {
-      t.error(err, 'should not have error dropping colleciton')
+      t.error(err, 'should not have error dropping collection')
       t.ok(result === true, 'result should be boolean true')
       verify([
         'Datastore/operation/MongoDB/createCollection',
@@ -367,6 +367,9 @@ function verifyMongoSegments(t, agent, transaction, names) {
   let current = transaction.trace.root
 
   for (let i = 0, l = names.length; i < l; ++i) {
+    // Filter out net.createConnection segments as they could occur during execution, which is fine
+    // but breaks out assertion function
+    current.children = current.children.filter((child) => child.name !== 'net.createConnection')
     t.equal(current.children.length, 1, 'should have one child segment')
     current = current.children[0]
     t.equal(current.name, names[i], 'segment should be named ' + names[i])


### PR DESCRIPTION
- Upgraded the test container for mongo to mongo v 3 to work with Mac M1. In the process I had to fix both instrumentation and tests to account for the server differences.
- update grep for mongo to not conflate 3 and 5 containers

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated mongo server container to v3 so it can run locally on Mac M1s.
 * Updated instrumentation of mongodb to account for assumptions being made when running mongo server 2.

## Links
 * Closes https://issues.newrelic.com/browse/NR-34648

## Details
For all devs that are running containers locally you'll have to run the following to clear out the older mongo v2 container:

```sh
docker rm nr_node_mongodb -f
docker rmi mongo:2 -f
```


As you can see from PR I had to update both instrumentation and tests.  The instrumentation still works if you're running v2 of mongo server.  It seems like there are many places where you can access host/port on mongo commands.  Also in v3 of client library all commands now finish with an `endSessions` which mess up the active segment attributes.  The reason is `endSessions` run on the admin database.  This is because v3 by default uses sessions which is why we didn't see it before.  The fix was to just ignore when we see this command and not update host/port.  I also had to update `collection-commmon` tests to be more permissive when running aggregate queries as the segment structure is not changed and does not play well with assertion we have looked at every segment that exists.
