### PR TITLE
updated remaining integration tests to no longer use deprecated tap methods

### DIFF
--- a/test/integration/core/dns.tap.js
+++ b/test/integration/core/dns.tap.js
@@ -146,7 +146,7 @@ test('reverse', function (t) {
       }
 
       expected.forEach((name) => {
-        t.notEqual(names.indexOf(name), -1, 'should have expected name')
+        t.not(names.indexOf(name), -1, 'should have expected name')
       })
       verifySegments(t, agent, 'dns.reverse')
     })

--- a/test/integration/core/timers.tap.js
+++ b/test/integration/core/timers.tap.js
@@ -60,7 +60,7 @@ tap.test('setImmediate', function testSetImmediate(t) {
 
     timers.setImmediate(function () {
       helper.runInTransaction(agent, function (tx) {
-        t.notEqual(tx.id, firstTx.id, 'should not conflate transactions')
+        t.not(tx.id, firstTx.id, 'should not conflate transactions')
         check(tx)
       })
     })

--- a/test/integration/distributed-tracing/trace-context-cross-agent.tap.js
+++ b/test/integration/distributed-tracing/trace-context-cross-agent.tap.js
@@ -60,7 +60,7 @@ const testExpectedFixtureKeys = function (t, thingWithKeys, expectedKeys) {
 const testExact = function (t, object, fixture) {
   for (const [descendants, fixtureValue] of Object.entries(fixture)) {
     const valueToTest = getDescendantValue(object, descendants)
-    t.deepEquals(
+    t.same(
       valueToTest,
       fixtureValue,
       `Expected ${descendants} to be ${fixtureValue} but got ${valueToTest}`
@@ -94,7 +94,7 @@ const testExpected = function (t, object, fixture) {
 }
 
 const testVendor = function (t, object, vendors) {
-  t.deepEquals(object.tracestate.vendors, vendors, 'do vendors match?')
+  t.same(object.tracestate.vendors, vendors, 'do vendors match?')
 }
 
 // tests a few of the helper functions we wrote for this test case
@@ -183,7 +183,7 @@ const testSingleEvent = function (t, event, eventType, fixture) {
     const attributeValue = attributes[key]
     const expectedValue = exact[key]
 
-    t.equals(attributeValue, expectedValue, `${eventType} should have ${key}=${expectedValue}`)
+    t.equal(attributeValue, expectedValue, `${eventType} should have ${key}=${expectedValue}`)
   })
 }
 

--- a/test/integration/grpc/reconnect.tap.js
+++ b/test/integration/grpc/reconnect.tap.js
@@ -70,7 +70,7 @@ tap.test('test that connection class reconnects', async (t) => {
     let countDisconnects = 0
 
     connection.on('connected', (callStream) => {
-      t.equals(
+      t.equal(
         callStream.constructor.name,
         'ClientDuplexStreamImpl',
         'connected and received ClientDuplexStreamImpl'
@@ -88,7 +88,7 @@ tap.test('test that connection class reconnects', async (t) => {
       if (countDisconnects > 1) {
         connection._state = 3 // replace with actual fake enum
 
-        t.equals(serverConnections, 2)
+        t.equal(serverConnections, 2)
         // Ends the test
         resolve()
       }
@@ -151,7 +151,7 @@ tap.test('Should reconnect even when data sent back', async (t) => {
     let countDisconnects = 0
 
     connection.on('connected', (callStream) => {
-      t.equals(
+      t.equal(
         callStream.constructor.name,
         'ClientDuplexStreamImpl',
         'connected and received ClientDuplexStreamImpl'
@@ -171,7 +171,7 @@ tap.test('Should reconnect even when data sent back', async (t) => {
       if (countDisconnects > 1) {
         connection._state = 3 // replace with actual fake enum
 
-        t.equals(serverConnections, 2)
+        t.equal(serverConnections, 2)
         // Ends the test
         resolve()
       }

--- a/test/integration/instrumentation/hapi/capture-params.js
+++ b/test/integration/instrumentation/hapi/capture-params.js
@@ -173,7 +173,7 @@ function makeRequest(t, uri) {
   }
   request.get(params, function (err, res, body) {
     t.equal(res.statusCode, 200, 'nothing exploded')
-    t.deepEqual(body, { status: 'ok' }, 'got expected response')
+    t.same(body, { status: 'ok' }, 'got expected response')
     t.end()
   })
 }

--- a/test/integration/instrumentation/http-outbound.tap.js
+++ b/test/integration/instrumentation/http-outbound.tap.js
@@ -130,7 +130,7 @@ tap.test('external requests', function (t) {
       t.equal(segment.children.length, 1, 'should have 1 child')
 
       const notDuped = segment.children[0]
-      t.notEqual(
+      t.not(
         notDuped.name,
         segment.name,
         'child should not be named the same as the external segment'

--- a/test/integration/instrumentation/memcached.tap.js
+++ b/test/integration/instrumentation/memcached.tap.js
@@ -437,7 +437,7 @@ test('memcached instrumentation', { timeout: 5000 }, function (t) {
 
           transaction.end()
           const segment = transaction.trace.root.children[0]
-          t.equals(segment.getAttributes().key, '"foo"', 'should have the get key as a parameter')
+          t.equal(segment.getAttributes().key, '"foo"', 'should have the get key as a parameter')
         })
       })
     })
@@ -466,7 +466,7 @@ test('memcached instrumentation', { timeout: 5000 }, function (t) {
 
           transaction.end()
           const segment = transaction.trace.root.children[0]
-          t.equals(
+          t.equal(
             segment.getAttributes().key,
             '["foo","bar"]',
             'should have the multiple keys fetched as a parameter'
@@ -484,7 +484,7 @@ test('memcached instrumentation', { timeout: 5000 }, function (t) {
 
           transaction.end()
           const segment = transaction.trace.root.children[0]
-          t.equals(segment.getAttributes().key, '"foo"', 'should have the set key as a parameter')
+          t.equal(segment.getAttributes().key, '"foo"', 'should have the set key as a parameter')
         })
       })
     })
@@ -517,12 +517,12 @@ test('memcached instrumentation', { timeout: 5000 }, function (t) {
           transaction.end()
           const segment = transaction.trace.root.children[0]
           const attributes = segment.getAttributes()
-          t.equals(
+          t.equal(
             attributes.host,
             getMetricHostName(agent, params.memcached_host),
             'should collect host instance attributes'
           )
-          t.equals(
+          t.equal(
             attributes.port_path_or_id,
             String(params.memcached_port),
             'should collect port instance attributes'
@@ -545,12 +545,12 @@ test('memcached instrumentation', { timeout: 5000 }, function (t) {
           transaction.end()
           const segment = transaction.trace.root.children[0]
           const attributes = segment.getAttributes()
-          t.equals(
+          t.equal(
             attributes.host,
             getMetricHostName(agent, params.memcached_host),
             'should collect host instance attributes'
           )
-          t.equals(
+          t.equal(
             attributes.port_path_or_id,
             String(params.memcached_port),
             'should collect port instance attributes'
@@ -594,8 +594,8 @@ test('memcached instrumentation', { timeout: 5000 }, function (t) {
           transaction.end()
           const segment = transaction.trace.root.children[0]
           const attributes = segment.getAttributes()
-          t.equals(attributes.host, undefined, 'should not have host instance parameter')
-          t.equals(
+          t.equal(attributes.host, undefined, 'should not have host instance parameter')
+          t.equal(
             attributes.port_path_or_id,
             undefined,
             'should should not have port instance parameter'
@@ -620,8 +620,8 @@ test('memcached instrumentation', { timeout: 5000 }, function (t) {
           transaction.end()
           const segment = transaction.trace.root.children[0]
           const attributes = segment.getAttributes()
-          t.equals(attributes.host, undefined, 'should not have host instance parameter')
-          t.equals(
+          t.equal(attributes.host, undefined, 'should not have host instance parameter')
+          t.equal(
             attributes.port_path_or_id,
             undefined,
             'should should not have port instance parameter'
@@ -674,8 +674,8 @@ test('memcached instrumentation', { timeout: 5000 }, function (t) {
 
     function checkParams(segment, host, port) {
       const attributes = segment.getAttributes()
-      t.equals(attributes.host, host, 'should have correct host (' + host + ')')
-      t.equals(attributes.port_path_or_id, port, 'should have correct port (' + port + ')')
+      t.equal(attributes.host, host, 'should have correct host (' + host + ')')
+      t.equal(attributes.port_path_or_id, port, 'should have correct port (' + port + ')')
     }
 
     t.test('separate gets', function (t) {
@@ -756,7 +756,7 @@ function verifyMetrics(t, metrics, expected) {
 
   expectedNames.forEach(function (name) {
     t.ok(unscoped[name], 'should have unscoped metric ' + name)
-    t.equals(
+    t.equal(
       unscoped[name].callCount,
       expected[name],
       'metric ' + name + ' should have correct callCount'

--- a/test/integration/instrumentation/when.tap.js
+++ b/test/integration/instrumentation/when.tap.js
@@ -251,7 +251,7 @@ test('when.iterate', function (t) {
 test('when.join', function (t) {
   testPromiseLibraryMethod(t, 2, function (when, name) {
     return when.join(2, when.resolve(name)).then(function (x) {
-      t.deepEqual(x, [2, name], name + 'should resolve with correct value')
+      t.same(x, [2, name], name + 'should resolve with correct value')
 
       return when
         .join(2, when.reject(new Error(name + 'error message')))

--- a/test/integration/shimmer/module-load.test.js
+++ b/test/integration/shimmer/module-load.test.js
@@ -47,7 +47,7 @@ tap.test('Test Module Instrumentation Loading', (t) => {
     const module = require(modulePathLocal)
 
     t.ok(module, 'loaded module')
-    t.equals(module(), 'hello world', 'module behaves as expected')
+    t.equal(module(), 'hello world', 'module behaves as expected')
     t.ok(module.__NR_instrumented, '__NR_instrumented set and true')
     t.end()
   })
@@ -79,7 +79,7 @@ tap.test('Test Module Instrumentation Loading', (t) => {
     const module = require(modulePathLocal)
 
     t.ok(module, 'loaded module')
-    t.equals(module(), 'hello world', 'module behaves as expected')
+    t.equal(module(), 'hello world', 'module behaves as expected')
     t.ok(module.__NR_instrumented_errored, '__NR_instrumented_errored set and true')
     t.end()
   })

--- a/test/integration/transaction/errors.tap.js
+++ b/test/integration/transaction/errors.tap.js
@@ -102,7 +102,7 @@ test('multiple errors in web transactions should gather the query params', funct
     agent.errors.traceAggregator.errors.forEach(function (error) {
       t.equal(error[1], 'WebTransaction/NormalizedUri/*', 'should have default tx name')
 
-      t.notEqual(names.indexOf(error[2]), -1, 'should have gathered the errors message')
+      t.not(names.indexOf(error[2]), -1, 'should have gathered the errors message')
       // Remove the found name from the list of names. Since they are unique and
       // should only appear on one error.
       names.splice(names.indexOf(error[2]), 1)

--- a/test/integration/transaction/trace-async-propagation.tap.js
+++ b/test/integration/transaction/trace-async-propagation.tap.js
@@ -145,7 +145,7 @@ test('asynchronous state propagation', function (t) {
       setTimeout(function () {
         helper.runInTransaction(agent, function () {
           second = agent.getTransaction().id
-          t.notEqual(first, second, 'different transaction IDs')
+          t.not(first, second, 'different transaction IDs')
           setTimeout(handler.bind(null, second), 100)
         })
       }, 25)
@@ -230,7 +230,7 @@ test('asynchronous state propagation', function (t) {
       process.nextTick(function cbNextTick() {
         helper.runInTransaction(agent, function () {
           second = agent.getTransaction().id
-          t.notEqual(first, second, 'different transaction IDs')
+          t.not(first, second, 'different transaction IDs')
           process.nextTick(handler.bind(null, second))
         })
       })

--- a/test/integration/transaction/tracer.tap.js
+++ b/test/integration/transaction/tracer.tap.js
@@ -148,7 +148,7 @@ test('bind + capture error', function testThrows(t) {
       // global error is not tied to a transaction, so its name should not be
       // the transaction name
       if (t.ok(logged, 'should have a logged error')) {
-        t.notEqual(name, logged[1], 'should not have a transaction with the error')
+        t.not(name, logged[1], 'should not have a transaction with the error')
         t.equal(error.message, logged[2], 'should have the error message')
       }
       t.end()
@@ -227,7 +227,7 @@ test('bind + args', function testThrows(t) {
 
   helper.runInTransaction(agent, function inTrans() {
     bound = tracer.bindFunction(function withArgs() {
-      t.deepEqual([].slice.call(arguments), [1, 2, 3])
+      t.same([].slice.call(arguments), [1, 2, 3])
     })
   })
 
@@ -426,7 +426,7 @@ test('transactionProxy', function testTransactionProxy(t) {
     const transaction = tracer.getTransaction()
     const root = transaction.trace.root
 
-    t.deepEqual([].slice.call(arguments), [1, 2, 3])
+    t.same([].slice.call(arguments), [1, 2, 3])
     t.equal(root.name, 'ROOT')
     t.equal(root, contextManager.getContext())
     t.ok(transaction)
@@ -456,7 +456,7 @@ test('transactionNestProxy', function testTransactionNestProxy(t) {
     const transaction = tracer.getTransaction()
     const root = transaction.trace.root
 
-    t.deepEqual([].slice.call(arguments), [1, 2, 3])
+    t.same([].slice.call(arguments), [1, 2, 3])
     t.equal(root.name, 'ROOT')
     t.equal(root, contextManager.getContext())
     t.ok(transaction)
@@ -481,8 +481,8 @@ test('transactionNestProxy', function testTransactionNestProxy(t) {
       t.equal(root.name, 'ROOT')
       t.equal(root3, contextManager.getContext())
       t.ok(transaction3)
-      t.notEqual(tracer.getTransaction(), transaction)
-      t.notEqual(contextManager.getContext(), root)
+      t.not(tracer.getTransaction(), transaction)
+      t.not(contextManager.getContext(), root)
     }
   }
 })
@@ -546,7 +546,7 @@ test('tracer.slice', function testSlice(t) {
 
   function check() {
     const args = tracer.slice(arguments)
-    t.deepEqual(args, [1, 2, 3])
+    t.same(args, [1, 2, 3])
     t.ok(Array.isArray(args))
     t.equal(typeof args.forEach, 'function')
   }
@@ -585,7 +585,7 @@ test('wrapFunctionNoSegment', function testwrapFunctionNoSegment(t) {
   }
 
   function check(seg, expected) {
-    t.deepEqual([].slice.call(arguments, 2), expected)
+    t.same([].slice.call(arguments, 2), expected)
     t.equal(contextManager.getContext(), seg)
     t.equal(this, inner)
   }
@@ -619,7 +619,7 @@ test('wrapFunction', function testwrapFunction(t) {
       if (parent) {
         t.ok(segment.timer.hrstart)
         t.notOk(segment.timer.hrDuration)
-        t.notEqual(parent.children.indexOf(segment), -1)
+        t.not(parent.children.indexOf(segment), -1)
       }
 
       return val
@@ -706,7 +706,7 @@ test('wrapFunctionLast', function testwrapFunctionLast(t) {
 
   function callback(parent, callbackArgs) {
     const segment = contextManager.getContext()
-    t.deepEqual(callbackArgs, [1, 2, 3])
+    t.same(callbackArgs, [1, 2, 3])
     t.equal(this, inner)
 
     if (parent) {
@@ -779,7 +779,7 @@ test('wrapFunctionFirst', function testwrapFunctionFirst(t) {
 
   function callback(parent, args) {
     const segment = contextManager.getContext()
-    t.deepEqual(args, [1, 2, 3])
+    t.same(args, [1, 2, 3])
     t.equal(this, inner)
 
     if (parent) {
@@ -846,7 +846,7 @@ test('wrapSyncFunction', function testwrapSyncFunction(t) {
   })
 
   function doSomething(trans, expected) {
-    t.deepEqual([].slice.call(arguments, 2), expected)
+    t.same([].slice.call(arguments, 2), expected)
     t.equal(tracer.getTransaction(), trans)
     if (trans) {
       t.equal(contextManager.getContext().name, 'my segment')


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
When I was running tests for cert removal I noticed a few deprecated tap assertions and was feeling motivated.  This should remove the last of the depcrecation warnings from tap.
