### PR TITLE
Exclude :443 on external segments

### DIFF
--- a/lib/instrumentation/core/http-outbound.js
+++ b/lib/instrumentation/core/http-outbound.js
@@ -37,11 +37,11 @@ module.exports = function instrumentOutbound(agent, opts, makeRequest) {
     opts = copy.shallow(opts)
   }
 
-  const defaultPort = opts.protocol === 'http:' ? DEFAULT_PORT : DEFAULT_SSL_PORT
+  const defaultPort = !opts.protocol || opts.protocol === 'http:' ? DEFAULT_PORT : DEFAULT_SSL_PORT
   let hostname = opts.hostname || opts.host || DEFAULT_HOST
   let port = opts.port || opts.defaultPort
   if (!port) {
-    port = !opts.protocol || defaultPort
+    port = defaultPort
   }
 
   if (!hostname || port < 1) {

--- a/lib/instrumentation/core/http-outbound.js
+++ b/lib/instrumentation/core/http-outbound.js
@@ -17,7 +17,7 @@ const NAMES = require('../../metrics/names')
 const SHIM_SYMBOLS = require('../../shim/constants').SYMBOLS
 
 const DEFAULT_HOST = 'localhost'
-const DEFAULT_PORT = 80
+const DEFAULT_HTTP_PORT = 80
 const DEFAULT_SSL_PORT = 443
 
 const NEWRELIC_SYNTHETICS_HEADER = 'x-newrelic-synthetics'
@@ -37,7 +37,8 @@ module.exports = function instrumentOutbound(agent, opts, makeRequest) {
     opts = copy.shallow(opts)
   }
 
-  const defaultPort = !opts.protocol || opts.protocol === 'http:' ? DEFAULT_PORT : DEFAULT_SSL_PORT
+  const defaultPort =
+    !opts.protocol || opts.protocol === 'http:' ? DEFAULT_HTTP_PORT : DEFAULT_SSL_PORT
   let hostname = opts.hostname || opts.host || DEFAULT_HOST
   let port = opts.port || opts.defaultPort
   if (!port) {

--- a/lib/instrumentation/core/http-outbound.js
+++ b/lib/instrumentation/core/http-outbound.js
@@ -27,9 +27,8 @@ const NEWRELIC_SYNTHETICS_HEADER = 'x-newrelic-synthetics'
  *
  * @param {Agent} agent
  * @param {object} opts
- * @param {function} makeRequest
- *
- * @return {http.ClientRequest} The instrumented outbound request.
+ * @param {Function} makeRequest
+ * @returns {http.ClientRequest} The instrumented outbound request.
  */
 module.exports = function instrumentOutbound(agent, opts, makeRequest) {
   if (typeof opts === 'string') {
@@ -38,10 +37,11 @@ module.exports = function instrumentOutbound(agent, opts, makeRequest) {
     opts = copy.shallow(opts)
   }
 
+  const defaultPort = opts.protocol === 'http:' ? DEFAULT_PORT : DEFAULT_SSL_PORT
   let hostname = opts.hostname || opts.host || DEFAULT_HOST
   let port = opts.port || opts.defaultPort
   if (!port) {
-    port = !opts.protocol || opts.protocol === 'http:' ? DEFAULT_PORT : DEFAULT_SSL_PORT
+    port = !opts.protocol || defaultPort
   }
 
   if (!hostname || port < 1) {
@@ -49,11 +49,7 @@ module.exports = function instrumentOutbound(agent, opts, makeRequest) {
     return makeRequest(opts)
   }
 
-  // Technically we shouldn't append the port if this is an https request on 443
-  // but due to legacy issues we can't do that without moving customer's cheese.
-  //
-  // TODO: Move customers cheese by not appending the default port for https.
-  if (port && port !== DEFAULT_PORT) {
+  if (port && port !== defaultPort) {
     hostname += ':' + port
   }
 
@@ -159,8 +155,7 @@ module.exports = function instrumentOutbound(agent, opts, makeRequest) {
  * @param {TraceSegment} segment
  * @param {http.ClientRequest} req
  * @param {Error} error
- *
- * @return {bool} True if the error will be collected by New Relic.
+ * @returns {bool} True if the error will be collected by New Relic.
  */
 function handleError(segment, req, error) {
   if (req.listenerCount('error') > 0) {

--- a/test/integration/instrumentation/http-outbound.tap.js
+++ b/test/integration/instrumentation/http-outbound.tap.js
@@ -124,7 +124,7 @@ tap.test('external requests', function (t) {
       const root = agent.tracer.getTransaction().trace.root
       const segment = root.children[0]
 
-      t.equal(segment.name, 'External/example.com:443/', 'should be named')
+      t.equal(segment.name, 'External/example.com/', 'should be named')
       t.ok(segment.timer.start, 'should have started')
       t.ok(segment.timer.hasEnd(), 'should have ended')
       t.equal(segment.children.length, 1, 'should have 1 child')

--- a/test/unit/instrumentation/http/outbound.test.js
+++ b/test/unit/instrumentation/http/outbound.test.js
@@ -644,7 +644,7 @@ tap.test('Should properly handle http(s) get and request signatures', (t) => {
   // testing the http/https modules and get/request methods.
   function testSignatures(nodule, method, t) {
     const host = 'www.newrelic.com'
-    const port = nodule === 'https' ? ':443' : ''
+    const port = ''
     const path = '/index.html'
     const leftPart = `${nodule}://${host}`
     const _url = `${leftPart}${path}`

--- a/test/unit/spans/span-event.test.js
+++ b/test/unit/spans/span-event.test.js
@@ -151,7 +151,7 @@ tap.test('fromSegment()', (t) => {
           t.equal(span.intrinsics.sampled, true)
           t.equal(span.intrinsics.priority, 42)
 
-          t.equal(span.intrinsics.name, 'External/example.com:443/')
+          t.equal(span.intrinsics.name, 'External/example.com/')
           t.equal(span.intrinsics.timestamp, segment.timer.start)
 
           expect(span.intrinsics).to.have.property('duration').within(0.01, 2)
@@ -164,7 +164,7 @@ tap.test('fromSegment()', (t) => {
           const attributes = span.attributes
 
           // Should have (most) http properties.
-          t.equal(attributes['http.url'], 'https://example.com:443/')
+          t.equal(attributes['http.url'], 'https://example.com/')
           t.ok(attributes['http.method'])
           t.equal(attributes['http.statusCode'], 200)
           t.equal(attributes['http.statusText'], 'OK')

--- a/test/unit/spans/streaming-span-event.test.js
+++ b/test/unit/spans/streaming-span-event.test.js
@@ -141,7 +141,7 @@ tap.test('fromSegment()', (t) => {
           t.same(span._intrinsicAttributes.sampled, { [BOOL_TYPE]: true })
           t.same(span._intrinsicAttributes.priority, { [INT_TYPE]: 42 })
 
-          t.same(span._intrinsicAttributes.name, { [STRING_TYPE]: 'External/example.com:443/' })
+          t.same(span._intrinsicAttributes.name, { [STRING_TYPE]: 'External/example.com/' })
           t.same(span._intrinsicAttributes.timestamp, { [INT_TYPE]: segment.timer.start })
 
           t.ok(span._intrinsicAttributes.duration)
@@ -155,7 +155,7 @@ tap.test('fromSegment()', (t) => {
           t.ok(agentAttributes)
 
           // Should have (most) http properties.
-          t.same(agentAttributes['http.url'], { [STRING_TYPE]: 'https://example.com:443/' })
+          t.same(agentAttributes['http.url'], { [STRING_TYPE]: 'https://example.com/' })
           t.ok(agentAttributes['http.method'])
           t.same(agentAttributes['http.statusCode'], { [INT_TYPE]: 200 })
           t.same(agentAttributes['http.statusText'], { [STRING_TYPE]: 'OK' })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * **BREAKING**: Exclude port when making external HTTPS requests to port 443.

    Previous external segments would be named `External/example.com:443` when using default HTTPS port.
    The external segment will now be named `External/example.com`.

## Links
Closes https://issues.newrelic.com/browse/NR-35652

## Details
