### PR TITLE
Node 12 deprecation todos

### DIFF
--- a/test/unit/collector/serverless.test.js
+++ b/test/unit/collector/serverless.test.js
@@ -7,6 +7,7 @@
 
 const tap = require('tap')
 
+const os = require('os')
 const util = require('util')
 const zlib = require('zlib')
 const nock = require('nock')
@@ -39,8 +40,7 @@ tap.test('ServerlessCollector API', (t) => {
     agent.reconfigure = () => {}
     agent.setState = () => {}
     api = new API(agent)
-    // TODO: switch to `os.devnull` once we drop Node 12 support.
-    process.env.NEWRELIC_PIPE_PATH = '/dev/null'
+    process.env.NEWRELIC_PIPE_PATH = os.devNull
   }
 
   function afterTest() {

--- a/test/unit/config/config-location.test.js
+++ b/test/unit/config/config-location.test.js
@@ -8,7 +8,7 @@
 const tap = require('tap')
 const path = require('path')
 const fs = require('fs')
-const fsPromises = require('fs').promises
+const fsPromises = require('fs/promises')
 const sinon = require('sinon')
 
 const Config = require('../../../lib/config')

--- a/test/unit/config/config-location.test.js
+++ b/test/unit/config/config-location.test.js
@@ -45,11 +45,6 @@ tap.test('when overriding the config file location via NR_HOME', (t) => {
     })
   })
 
-  /**
-   * TODO: Replace `rmdir` with `rm` when drop Node 12.
-   * `rmdir` has been deprecated but preferred `rm` was introduced in Node 14.
-   * https://nodejs.org/api/deprecations.html#DEP0147
-   */
   t.afterEach(async () => {
     if (origHome) {
       process.env.NEW_RELIC_HOME = origHome
@@ -59,7 +54,7 @@ tap.test('when overriding the config file location via NR_HOME', (t) => {
     origHome = null
 
     await fsPromises.unlink(CONFIGPATH)
-    await fsPromises.rmdir(DESTDIR, { recursive: true })
+    await fsPromises.rm(DESTDIR, { recursive: true, force: true })
 
     process.chdir(startDir)
     await fsPromises.rmdir(NOPLACEDIR, { recursive: true })

--- a/test/unit/serverless/aws-lambda.test.js
+++ b/test/unit/serverless/aws-lambda.test.js
@@ -7,6 +7,7 @@
 
 const tap = require('tap')
 
+const os = require('os')
 const helper = require('../../lib/agent_helper')
 const AwsLambda = require('../../../lib/serverless/aws-lambda')
 const lambdaSampleEvents = require('./lambda-sample-events')
@@ -50,8 +51,7 @@ tap.test('AwsLambda.patchLambdaHandler', (t) => {
         }
       })
     }
-    // TODO: switch to `os.devnull` once we drop Node 12 support.
-    process.env.NEWRELIC_PIPE_PATH = '/dev/null'
+    process.env.NEWRELIC_PIPE_PATH = os.devNull
     awsLambda = new AwsLambda(agent)
     awsLambda._resetModuleState()
 

--- a/test/versioned-external/checkout-external-tests.js
+++ b/test/versioned-external/checkout-external-tests.js
@@ -11,7 +11,7 @@
 // 'rm' not available in Node 12 but considered deprecated in newer versions
 // 'fs/promises' not available in Node 12
 const { existsSync } = require('fs')
-const { rmdir, mkdir } = require('fs').promises
+const { rm, mkdir } = require('fs').promises
 
 const { sparseCloneRepo } = require('../../bin/git-commands')
 const repos = require('./external-repos')
@@ -39,7 +39,7 @@ async function checkoutTests() {
 async function createNewTestFolder() {
   if (existsSync(TEMP_TESTS_FOLDER)) {
     console.log(`Removing ${TEMP_TESTS_FOLDER} folder.`)
-    await rmdir(TEMP_TESTS_FOLDER, { recursive: true, force: true })
+    await rm(TEMP_TESTS_FOLDER, { recursive: true, force: true })
   }
 
   console.log(`Creating new ${TEMP_TESTS_FOLDER} folder.`)

--- a/test/versioned-external/checkout-external-tests.js
+++ b/test/versioned-external/checkout-external-tests.js
@@ -7,11 +7,8 @@
 
 /* eslint-disable no-console, no-process-exit */
 
-// TODO: Update when drop Node 12
-// 'rm' not available in Node 12 but considered deprecated in newer versions
-// 'fs/promises' not available in Node 12
 const { existsSync } = require('fs')
-const { rm, mkdir } = require('fs').promises
+const { rm, mkdir } = require('fs/promises')
 
 const { sparseCloneRepo } = require('../../bin/git-commands')
 const repos = require('./external-repos')


### PR DESCRIPTION


Signed-off-by: mrickard <maurice@mauricerickard.com>

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
Converted `/dev/null` to `os.devNull` in 

- test/unit/collector/serverless.test.js
- test/unit/serverless/aws-lambda.test.js

and converted `fs.promises.rmdir` to `fs.promises.rm` in 

- test/unit/config/config-location.test.js
- test/versioned-external/checkout-external-tests.js

as part of Node 12 deprecation.

## Links
https://issues.newrelic.com/browse/NR-35263

## Details

TODOs in test code noted these changes for when Node 12 support was dropped. Recursive use of fs.rmdir was deprecated, and its replacement fs.rm was introduced in Node 14.