### PR TITLE
Bump test utils

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -81,8 +81,10 @@ jobs:
       run: TEST_CHILD_TIMEOUT=600000 npm run versioned:npm6
       env:
         VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}
+        JOBS: 4 # 2 per CPU seems to be the sweet spot in GHA (July 2022)
     - name: Run Versioned Tests (npm v7 / Node 16+)
       if: ${{ matrix.node-version != '14.x' }}
       run: TEST_CHILD_TIMEOUT=600000 npm run versioned:npm7
       env:
         VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}
+        JOBS: 4 # 2 per CPU seems to be the sweet spot in GHA (July 2022)

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1800,7 +1800,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ### @newrelic/test-utilities
 
-This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v6.5.5](https://github.com/newrelic/node-test-utilities/tree/v6.5.5)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v6.5.5/LICENSE):
+This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v7.0.0](https://github.com/newrelic/node-test-utilities/tree/v7.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v7.0.0/LICENSE):
 
 ```
                                  Apache License

--- a/bin/run-versioned-tests.sh
+++ b/bin/run-versioned-tests.sh
@@ -25,11 +25,13 @@ fi
 
 export AGENT_PATH=`pwd`
 
-echo "${NPM7}"
+# Runner will default to CPU count if not specified.
+echo "JOBS = ${JOBS}"
+echo "NPM7 = ${NPM7}"
 
 if [[ "${NPM7}" = 1 ]];
 then
-  time ./node_modules/.bin/versioned-tests $VERSIONED_MODE -i 2 --all --strict --samples $SAMPLES ${directories[@]}
+  time ./node_modules/.bin/versioned-tests $VERSIONED_MODE -i 2 --all --strict --samples $SAMPLES --jobs $JOBS ${directories[@]}
 else
-  time ./node_modules/.bin/versioned-tests $VERSIONED_MODE -i 2 --strict --samples $SAMPLES ${directories[@]}
+  time ./node_modules/.bin/versioned-tests $VERSIONED_MODE -i 2 --strict --samples $SAMPLES --jobs $JOBS ${directories[@]}
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@newrelic/eslint-config": "^0.0.3",
         "@newrelic/newrelic-oss-cli": "^0.1.2",
         "@newrelic/proxy": "^2.0.0",
-        "@newrelic/test-utilities": "^6.5.5",
+        "@newrelic/test-utilities": "^7.0.0",
         "@octokit/rest": "^18.0.15",
         "@slack/bolt": "^3.7.0",
         "ajv": "^6.12.6",
@@ -892,9 +892,9 @@
       }
     },
     "node_modules/@newrelic/test-utilities": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-6.5.5.tgz",
-      "integrity": "sha512-O3lXP/2nZqy0my6pQHFOkv9+iUfgTIIPvwjfy/qZz9fKzllMecBTmiSVNjprBqFixKTvmrXUTCKGVa7y5bGevg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-7.0.0.tgz",
+      "integrity": "sha512-TZ+fw8P20T1tkdK7ZyQJ4zXq02UrhhDl5qPgXwgMJRG+acY+hqMF+qOBa58sp+5lNlztbRgkkC90xAeEEaWbcw==",
       "dev": true,
       "dependencies": {
         "async": "^3.2.3",
@@ -910,7 +910,7 @@
         "versioned-tests": "bin/version-manager.js"
       },
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/@newrelic/test-utilities/node_modules/commander": {
@@ -14751,9 +14751,9 @@
       "requires": {}
     },
     "@newrelic/test-utilities": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-6.5.5.tgz",
-      "integrity": "sha512-O3lXP/2nZqy0my6pQHFOkv9+iUfgTIIPvwjfy/qZz9fKzllMecBTmiSVNjprBqFixKTvmrXUTCKGVa7y5bGevg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-7.0.0.tgz",
+      "integrity": "sha512-TZ+fw8P20T1tkdK7ZyQJ4zXq02UrhhDl5qPgXwgMJRG+acY+hqMF+qOBa58sp+5lNlztbRgkkC90xAeEEaWbcw==",
       "dev": true,
       "requires": {
         "async": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "@newrelic/eslint-config": "^0.0.3",
     "@newrelic/newrelic-oss-cli": "^0.1.2",
     "@newrelic/proxy": "^2.0.0",
-    "@newrelic/test-utilities": "^6.5.5",
+    "@newrelic/test-utilities": "^7.0.0",
     "@octokit/rest": "^18.0.15",
     "@slack/bolt": "^3.7.0",
     "ajv": "^6.12.6",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Fri Jul 15 2022 13:30:04 GMT-0700 (Pacific Daylight Time)",
+  "lastUpdated": "Wed Jul 27 2022 11:51:18 GMT-0700 (Pacific Daylight Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -225,15 +225,15 @@
       "email": "nathan@tootallnate.net",
       "url": "http://n8.io/"
     },
-    "@newrelic/test-utilities@6.5.5": {
+    "@newrelic/test-utilities@7.0.0": {
       "name": "@newrelic/test-utilities",
-      "version": "6.5.5",
-      "range": "^6.5.5",
+      "version": "7.0.0",
+      "range": "^7.0.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-test-utilities",
-      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v6.5.5",
+      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v7.0.0",
       "licenseFile": "node_modules/@newrelic/test-utilities/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v6.5.5/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v7.0.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Bumped `@newrelic/test-utilities` to ^7.0.0.

  This new version of test utilities defaults # of concurrent jobs to currently available CPUs. For local development on modern machines, this can increase full versioned test runs by 30-40%.

* Introduced JOBS ENV var for agent versioned test runs to control number of attempted concurrent test folder runs. Set to 4 for CI runs in GHA.

## Links

* Blocked by: https://github.com/newrelic/node-newrelic/pull/1301

## Details

Through various test runs I found around 2 jobs per core in GHA was the most efficient. The gain isn't huge but worth aligning on for now.

Locally, I also found around 2 jobs per core (not CPUs) was a little faster. So 16 for some M1s. Its not much over the 1:1 so I don't think its worth trying to tweak the runner in any way here. Especially since that may vary. But devs may make use of the parameter or ENV var to go slightly faster beyond the default after merge.