### PR TITLE
Replaced rmdirSync with rmSync in config location test

### DIFF
--- a/test/unit/config/config-location.test.js
+++ b/test/unit/config/config-location.test.js
@@ -146,14 +146,9 @@ tap.test('Selecting config file path', (t) => {
 
     processMainModuleStub.resetBehavior()
 
-    /**
-     * TODO: Replace with `rm` when drop Node 12.
-     * `rmdir` has been deprecated but preferred `rm` was introduced in Node 14.
-     * https://nodejs.org/api/deprecations.html#DEP0147
-     */
-    fs.rmdirSync(DESTDIR, { recursive: true })
-    fs.rmdirSync(NOPLACEDIR, { recursive: true })
-    fs.rmdirSync(MAIN_MODULE_DIR, { recursive: true })
+    fs.rmSync(DESTDIR, { recursive: true })
+    fs.rmSync(NOPLACEDIR, { recursive: true })
+    fs.rmSync(MAIN_MODULE_DIR, { recursive: true })
 
     process.chdir(originalWorkingDirectory)
   })


### PR DESCRIPTION
Signed-off-by: mrickard <maurice@mauricerickard.com>

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

Converted `fs.rmdirSync` to `fs.rmSync` in `test/unit/config/config-location.test.js` as part of Node 12 deprecation.

## Links
https://issues.newrelic.com/browse/NR-38203
https://issues.newrelic.com/browse/NR-35263

## Details
TODOs in test code noted these changes for when Node 12 support was dropped. Recursive use of `fs.rmdirSync` was deprecated, and its replacement `fs.rmSync` was introduced in Node 14.