### PR TITLE
Added defensive code in util/applicationLogging truncate to check if value is string before checking its length

### DIFF
--- a/lib/util/application-logging.js
+++ b/lib/util/application-logging.js
@@ -16,7 +16,7 @@ const { LOGGING } = require('../metrics/names')
  * @returns {string}
  */
 utils.truncate = function truncate(str) {
-  if (str.length > OUTPUT_LENGTH) {
+  if (typeof str === 'string' && str.length > OUTPUT_LENGTH) {
     return str.substring(0, MAX_LENGTH) + '...'
   }
 

--- a/test/unit/util/application-logging.test.js
+++ b/test/unit/util/application-logging.test.js
@@ -49,6 +49,22 @@ tap.test('truncate', (t) => {
     t.equal(processedStr, str)
     t.end()
   })
+
+  const negativeTests = [
+    { value: '', type: 'empty string' },
+    { value: undefined, type: 'undefined' },
+    { value: null, type: 'null' },
+    { value: {}, type: 'object' },
+    { value: [], type: 'array' },
+    { value: function () {}, type: 'function' }
+  ]
+  negativeTests.forEach(({ value, type }) => {
+    t.test(`should not truncate ${type}`, (t) => {
+      const newValue = loggingUtils.truncate(value)
+      t.same(value, newValue)
+      t.end()
+    })
+  })
 })
 
 tap.test('Application Logging Config Tests', (t) => {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed issue with `truncate` in lib/util/application-logging.js`.  It now checks that the argument is a string before checking its length.

## Links
Closes #1308

## Details
I will open a separate PR to get this branched off the 8.17.0 tag as we now have breaking changes on main in preparation for Node 18 support.
