### PR TITLE
grpc: bind the client segment to the onReceiveStatus listener

### DIFF
--- a/lib/instrumentation/grpc-js/grpc.js
+++ b/lib/instrumentation/grpc-js/grpc.js
@@ -94,9 +94,11 @@ function wrapStart(shim, original) {
         segment.addAttribute('http.url', url)
         segment.addAttribute('http.method', this.methodName)
 
+        if (originalListener && originalListener.onReceiveStatus) {
+          const onReceiveStatuts = shim.bindSegment(originalListener.onReceiveStatus, segment)
+          onReceiveStatuts(status)
+        }
         segment.end()
-
-        originalListener && originalListener.onReceiveStatus(status)
       }
 
       args[1] = nrListener

--- a/test/versioned/grpc/client-streaming.tap.js
+++ b/test/versioned/grpc/client-streaming.tap.js
@@ -197,4 +197,19 @@ tap.test('gRPC Client: Client Streaming', (t) => {
       }
     })
   })
+
+  t.test('should bind callback to the proper transaction context', (t) => {
+    helper.runInTransaction(agent, 'web', async (tx) => {
+      const call = client.sayHelloClientStream((err, response) => {
+        t.ok(response)
+        t.equal(response.message, 'Hello Callback')
+        t.ok(agent.getTransaction(), 'callback should have transaction context')
+        t.equal(agent.getTransaction(), tx, 'transaction should be the one we started with')
+        t.end()
+      })
+
+      call.write({ name: 'Callback' })
+      call.end()
+    })
+  })
 })

--- a/test/versioned/grpc/client-unary.tap.js
+++ b/test/versioned/grpc/client-unary.tap.js
@@ -147,4 +147,16 @@ tap.test('gRPC Client: Unary Requests', (t) => {
       }
     })
   })
+
+  t.test('should bind callback to the proper transaction context', (t) => {
+    helper.runInTransaction(agent, 'web', async (tx) => {
+      client.sayHello({ name: 'Callback' }, (err, response) => {
+        t.ok(response)
+        t.equal(response.message, 'Hello Callback')
+        t.ok(agent.getTransaction(), 'callback should have transaction context')
+        t.equal(agent.getTransaction(), tx, 'transaction should be the one we started with')
+        t.end()
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Proposed Release Notes

* grpc: bound the external client segment to the onReceiveStatus listener to propagate transaction context to the grpc client callbacks.

## Links

* Closes #1306

## Details

We were losing context in async callbacks made after a unary or
client-streaming request ended. Binding the segment during the
instrumentation fixes this.
