### PR TITLE
Dropped async lib from pricing meminfo and cpu tests

### DIFF
--- a/test/integration/pricing/proc_cpuinfo.tap.js
+++ b/test/integration/pricing/proc_cpuinfo.tap.js
@@ -5,41 +5,31 @@
 
 'use strict'
 
-const a = require('async')
 const test = require('tap').test
 const glob = require('glob')
-const fs = require('fs')
+const fs = require('fs/promises')
 const parseProcCpuInfo = require('../../../lib/parse-proc-cpuinfo')
 const path = require('path')
 
-test('pricing proc_cpuinfo', function (t) {
+test('pricing proc_cpuinfo', async function (t) {
   const testDir = path.resolve(__dirname, '../../lib/cross_agent_tests/proc_cpuinfo')
-  glob(path.join(testDir, '*.txt'), function globCallback(err, data) {
-    if (err) {
-      throw err
-    }
-    t.ok(data.length > 0, 'should have tests to run')
-    a.each(
-      data,
-      function (name, cb) {
-        runFile(name, cb)
-      },
-      function (err) {
-        t.notOk(err, 'should not have an error')
-        t.end()
-      }
-    )
-  })
-
-  function runFile(name, cb) {
-    fs.readFile(name, function getFile(err, data) {
+  const data = await new Promise((resolve, reject) => {
+    glob(path.join(testDir, '*.txt'), function globCallback(err, fileList) {
       if (err) {
-        throw err
+        return reject(err)
       }
-      testFile(name, data.toString())
-      cb()
+      resolve(fileList)
     })
+  })
+  t.ok(data.length > 0, 'should have tests to run')
+  for (const name of data) {
+    const buffer = await fs.readFile(name)
+    const file = buffer.toString()
+    const expected = parseName(name)
+    const info = parseProcCpuInfo(file)
+    t.same(info, expected, 'should have expected info for ' + name)
   }
+  t.end()
 
   function parseName(name) {
     const pattern = /^((\d+|X)pack_(\d+|X)core_(\d+|X)logical).txt$/
@@ -56,11 +46,5 @@ test('pricing proc_cpuinfo', function (t) {
     res.packages = res.packages ? res.packages : null
 
     return res
-  }
-
-  function testFile(name, file) {
-    const expected = parseName(name)
-    const info = parseProcCpuInfo(file)
-    t.same(info, expected, 'should have expected info for ' + name)
   }
 })

--- a/test/integration/pricing/proc_meminfo.tap.js
+++ b/test/integration/pricing/proc_meminfo.tap.js
@@ -5,46 +5,37 @@
 
 'use strict'
 
-const a = require('async')
 const test = require('tap').test
 const glob = require('glob')
-const fs = require('fs')
+const fs = require('fs/promises')
 const parseProcMemInfo = require('../../../lib/parse-proc-meminfo')
 const path = require('path')
 
-test('pricing proc_meminfo', function (t) {
+test('pricing proc_meminfo', async function (t) {
   const testDir = path.resolve(__dirname, '../../lib/cross_agent_tests/proc_meminfo')
-  glob(path.join(testDir, '*.txt'), function (err, data) {
-    if (err) {
-      throw err
-    }
-    t.ok(data.length > 0, 'should have tests to run')
-    a.each(data, runFile, function (err) {
-      t.notOk(err, 'should not have an error')
-      t.end()
+  const data = await new Promise((resolve, reject) => {
+    glob(path.join(testDir, '*.txt'), function (err, fileList) {
+      if (err) {
+        return reject(err)
+      }
+      return resolve(fileList)
     })
   })
 
-  function runFile(name, cb) {
-    fs.readFile(name, function runTestFiles(err, data) {
-      if (err) {
-        throw err
-      }
-      testFile(name, data.toString())
-      cb()
-    })
+  t.ok(data.length > 0, 'should have tests to run')
+  for (const name of data) {
+    const buffer = await fs.readFile(name)
+    const file = buffer.toString()
+    const expected = parseName(name)
+    const info = parseProcMemInfo(file)
+    t.same(info, expected, 'should have expected info for ' + name)
   }
+  t.end()
 
   function parseName(name) {
     const pattern = /^meminfo_(\d+)MB.txt$/
     let arr = name.split('/')
     arr = arr[arr.length - 1].replace(pattern, '$1').split(' ')
     return parseInt(arr[0], 10)
-  }
-
-  function testFile(name, file) {
-    const expected = parseName(name)
-    const info = parseProcMemInfo(file)
-    t.same(info, expected, 'should have expected info with ' + name)
   }
 })


### PR DESCRIPTION
Signed-off-by: mrickard <maurice@mauricerickard.com>

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
Removed async library from pricing integration tests
## Links
https://issues.newrelic.com/browse/NR-35280
## Details
Affected tests: 
test/integration/pricing/proc_cpuinfo.tap.js
test/integration/pricing/proc_meminfo.tap.js

