### PR TITLE
Release v9.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,65 @@
+### v9.0.0 (2022-08-03)
+
+Removed async library from pricing integration tests
+
+* Bumped external instrumentation to new major versions.
+
+Removed async library from distributed tracing integration test
+
+* Updated the minimum version of `pg` in to be 8.2.x.  This is the earliest support version that runs on Node 14+.
+
+* grpc: bound the external client segment to the onReceiveStatus listener to propagate transaction context to the grpc client callbacks.
+
+* grpc: bound the external client segment to the onReceiveStatus listener to propagate transaction context to the grpc client callbacks.
+
+* Fixed issue with `truncate` in lib/util/application-logging.js`.  It now checks that the argument is a string before checking its length.
+
+Converted `fs.rmdirSync` to `fs.rmSync` in `test/unit/config/config-location.test.js` as part of Node 12 deprecation.
+
+* **BREAKING**: Removed certificate bundle from agent. The configuration value config.feature_flag.certificate_bundle will no longer work.
+
+    The agent no-longer includes the New Relic certificate bundle when using the 'certificates' configuration (commonly with proxies). If you find this breaking your current environment, we recommend getting a CA bundle such as the one from Mozilla.
+
+* Updated unsupported odd-numbered release from 17.x to 19.x to prepare for Node 18 support.
+
+- Dropped instrumentation for hapi < v20.0.0. Those versions have been deprecated by Hapi.
+- Dropped tests for hapi < v20.0.0.
+
+* **BREAKING**: Exclude port when making external HTTPS requests to port 443.
+
+    Previous external segments would be named `External/example.com:443` when using default HTTPS port.
+    The external segment will now be named `External/example.com`.
+
+* **BREAKING**: Released the `await_support` feature flag. This also removes the legacy Promise instrumentation.
+
+    The agent now relies on async_hooks to track async promise propagation.  The net result is the if you had `feature_flag.await_support` set to false, the legacy instrumentation tracked every function in a promise chain as a separate segment.
+
+* Bumped `@newrelic/test-utilities` to ^7.0.0.
+
+  This new version of test utilities defaults # of concurrent jobs to currently available CPUs. For local development on modern machines, this can increase full versioned test runs by 30-40%.
+
+* Introduced JOBS ENV var for agent versioned test runs to control number of attempted concurrent test folder runs. Set to 4 for CI runs in GHA.
+
+Converted `/dev/null` to `os.devNull` in 
+
+- test/unit/collector/serverless.test.js
+- test/unit/serverless/aws-lambda.test.js
+
+and converted `fs.promises.rmdir` to `fs.promises.rm` in 
+
+- test/unit/config/config-location.test.js
+- test/versioned-external/checkout-external-tests.js
+
+as part of Node 12 deprecation.
+
+* Dropped support for Node 12.
+   * Updated engines stanza to be `>=14`.
+   * Updated all versioned tests stanza to be `>=14`
+
+* Dropped Node 12 from CI.
+
+* **BREAKING**: Removed instrumentation for the obsolete [oracle](https://www.npmjs.com/package/oracle) npm package.
+
 ### v8.17.1 (2022-08-02)
  * Fixed issue where instrumented code invoked within a @grpc/grpc-js client callback would not get tracked by the agent.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,64 +1,44 @@
 ### v9.0.0 (2022-08-03)
 
-Removed async library from pricing integration tests
+* Added official parity support for Node 18.
 
-* Bumped external instrumentation to new major versions.
+* **BREAKING**: Dropped Node 12.x support.  For further information on our support policy,
+   see: https://docs.newrelic.com/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent
 
-Removed async library from distributed tracing integration test
+  * Upgraded `@newrelic/superagent` `@newrelic/aws-sdk` `@newrelic/koa` `@newrelic/native-metrics` and `@newrelic/test-utilities` to the latest major versions
+  * Removed Node 12 from CI workflows.
+  * Updated engines stanza to be `>=14`.
+  * Updated all versioned tests stanza to be `>=14`
+  * Converted `fs.rmdirSync` to `fs.rmSync` in `test/unit/config/config-location.test.js`.
+  * Converted uses of `/dev/null` to `os.devNull` in tests.
 
-* Updated the minimum version of `pg` in to be 8.2.x.  This is the earliest support version that runs on Node 14+.
-
-* grpc: bound the external client segment to the onReceiveStatus listener to propagate transaction context to the grpc client callbacks.
-
-* grpc: bound the external client segment to the onReceiveStatus listener to propagate transaction context to the grpc client callbacks.
-
-* Fixed issue with `truncate` in lib/util/application-logging.js`.  It now checks that the argument is a string before checking its length.
-
-Converted `fs.rmdirSync` to `fs.rmSync` in `test/unit/config/config-location.test.js` as part of Node 12 deprecation.
-
-* **BREAKING**: Removed certificate bundle from agent. The configuration value config.feature_flag.certificate_bundle will no longer work.
+* **BREAKING**: Removed certificate bundle from agent. The configuration value `config.feature_flag.certificate_bundle` will no longer work.
 
     The agent no-longer includes the New Relic certificate bundle when using the 'certificates' configuration (commonly with proxies). If you find this breaking your current environment, we recommend getting a CA bundle such as the one from Mozilla.
 
-* Updated unsupported odd-numbered release from 17.x to 19.x to prepare for Node 18 support.
-
-- Dropped instrumentation for hapi < v20.0.0. Those versions have been deprecated by Hapi.
-- Dropped tests for hapi < v20.0.0.
-
-* **BREAKING**: Exclude port when making external HTTPS requests to port 443.
+* **BREAKING**: The agent now excludes port when making external HTTPS requests to port 443 to be in compliance with the spec and other agents.
 
     Previous external segments would be named `External/example.com:443` when using default HTTPS port.
     The external segment will now be named `External/example.com`.
 
-* **BREAKING**: Released the `await_support` feature flag. This also removes the legacy Promise instrumentation.
+* **BREAKING**: Removed ability to disable async hooks based promise context tracking via the `await_support` feature flag. This also removes the legacy Promise instrumentation.
 
-    The agent now relies on async_hooks to track async promise propagation.  The net result is the if you had `feature_flag.await_support` set to false, the legacy instrumentation tracked every function in a promise chain as a separate segment.
+    Released the `await_support` feature flag. The agent now relies on async_hooks to track async promise propagation.  The net result is the if you had `feature_flag.await_support` set to false, the legacy instrumentation tracked every function in a promise chain as a separate segment.
+
+* **BREAKING**: Removed instrumentation for the obsolete [oracle](https://www.npmjs.com/package/oracle) npm package.
+
+* **BREAKING**: Updated the minimum version of `pg` to be 8.2.x.  This is the earliest support version that runs on Node 14+.
+
+* **BREAKING**: Updated the minimum supported version of hapi to be >= v20.0.0. All versions < v20.0.0 are deprecated by hapi for security reasons, see their [support policy](https://hapi.dev/policies/support/).
+  * Dropped tests for hapi < v20.0.0.
 
 * Bumped `@newrelic/test-utilities` to ^7.0.0.
 
-  This new version of test utilities defaults # of concurrent jobs to currently available CPUs. For local development on modern machines, this can increase full versioned test runs by 30-40%.
+  This new version of test utilities defaults the number of concurrent jobs to currently available CPUs. For local development on modern machines, this can speed up full versioned test runs by 30-40%.
 
 * Introduced JOBS ENV var for agent versioned test runs to control number of attempted concurrent test folder runs. Set to 4 for CI runs in GHA.
 
-Converted `/dev/null` to `os.devNull` in 
-
-- test/unit/collector/serverless.test.js
-- test/unit/serverless/aws-lambda.test.js
-
-and converted `fs.promises.rmdir` to `fs.promises.rm` in 
-
-- test/unit/config/config-location.test.js
-- test/versioned-external/checkout-external-tests.js
-
-as part of Node 12 deprecation.
-
-* Dropped support for Node 12.
-   * Updated engines stanza to be `>=14`.
-   * Updated all versioned tests stanza to be `>=14`
-
-* Dropped Node 12 from CI.
-
-* **BREAKING**: Removed instrumentation for the obsolete [oracle](https://www.npmjs.com/package/oracle) npm package.
+* Removed the async library from distributed tracing and pricing integration tests
 
 ### v8.17.1 (2022-08-02)
  * Fixed issue where instrumented code invoked within a @grpc/grpc-js client callback would not get tracked by the agent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newrelic",
-  "version": "8.17.0",
+  "version": "9.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newrelic",
-      "version": "8.17.0",
+      "version": "9.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic",
-  "version": "8.17.0",
+  "version": "9.0.0",
   "author": "New Relic Node.js agent team <nodejs@newrelic.com>",
   "license": "Apache-2.0",
   "contributors": [


### PR DESCRIPTION
## Proposed Release Notes

* Added official parity support for Node 18.

* **BREAKING**: Dropped Node 12.x support.  For further information on our support policy,
   see: https://docs.newrelic.com/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent

  * Upgraded `@newrelic/superagent` `@newrelic/aws-sdk` `@newrelic/koa` `@newrelic/native-metrics` and `@newrelic/test-utilities` to the latest major versions
  * Removed Node 12 from CI workflows.
  * Updated engines stanza to be `>=14`.
  * Updated all versioned tests stanza to be `>=14`
  * Converted `fs.rmdirSync` to `fs.rmSync` in `test/unit/config/config-location.test.js`.
  * Converted uses of `/dev/null` to `os.devNull` in tests.

* **BREAKING**: Removed certificate bundle from agent. The configuration value `config.feature_flag.certificate_bundle` will no longer work.

    The agent no-longer includes the New Relic certificate bundle when using the 'certificates' configuration (commonly with proxies). If you find this breaking your current environment, we recommend getting a CA bundle such as the one from Mozilla.

* **BREAKING**: The agent now excludes port when making external HTTPS requests to port 443 to be in compliance with the spec and other agents.

    Previous external segments would be named `External/example.com:443` when using default HTTPS port.
    The external segment will now be named `External/example.com`.

* **BREAKING**: Removed ability to disable async hooks based promise context tracking via the `await_support` feature flag. This also removes the legacy Promise instrumentation.

    Released the `await_support` feature flag. The agent now relies on async_hooks to track async promise propagation.  The net result is the if you had `feature_flag.await_support` set to false, the legacy instrumentation tracked every function in a promise chain as a separate segment.

* **BREAKING**: Removed instrumentation for the obsolete [oracle](https://www.npmjs.com/package/oracle) npm package.

* **BREAKING**: Updated the minimum version of `pg` to be 8.2.x.  This is the earliest support version that runs on Node 14+.

* **BREAKING**: Updated the minimum supported version of hapi to be >= v20.0.0. All versions < v20.0.0 are deprecated by hapi for security reasons, see their [support policy](https://hapi.dev/policies/support/).
  * Dropped tests for hapi < v20.0.0.

* Bumped `@newrelic/test-utilities` to ^7.0.0.

  This new version of test utilities defaults the number of concurrent jobs to currently available CPUs. For local development on modern machines, this can speed up full versioned test runs by 30-40%.

* Introduced JOBS ENV var for agent versioned test runs to control number of attempted concurrent test folder runs. Set to 4 for CI runs in GHA.

* Removed the async library from distributed tracing and pricing integration tests


## Links

* PR: https://github.com/newrelic/node-newrelic/pull/1319
* PR: https://github.com/newrelic/node-newrelic/pull/1318
* PR: https://github.com/newrelic/node-newrelic/pull/1311
* PR: https://github.com/newrelic/node-newrelic/pull/1313
* PR: https://github.com/newrelic/node-newrelic/pull/1314
* PR: https://github.com/newrelic/node-newrelic/pull/1307
* PR: https://github.com/newrelic/node-newrelic/pull/1293
* PR: https://github.com/newrelic/node-newrelic/pull/1305
* PR: https://github.com/newrelic/node-newrelic/pull/1294
* PR: https://github.com/newrelic/node-newrelic/pull/1298
* PR: https://github.com/newrelic/node-newrelic/pull/1297
* PR: https://github.com/newrelic/node-newrelic/pull/1303
* PR: https://github.com/newrelic/node-newrelic/pull/1299
* PR: https://github.com/newrelic/node-newrelic/pull/1304
* PR: https://github.com/newrelic/node-newrelic/pull/1301
* PR: https://github.com/newrelic/node-newrelic/pull/1296

## Details
