### PR TITLE
Change compression method to gzip by default

### DIFF
--- a/lib/collector/remote-method.js
+++ b/lib/collector/remote-method.js
@@ -152,8 +152,8 @@ RemoteMethod.prototype._post = function _post(data, nrHeaders, callback) {
   if (options.compressed) {
     // NOTE: gzip and deflate throw immediately in Node 14+ with an invalid argument
     try {
-      const useGzip = this._config.compressed_content_encoding === 'gzip'
-      const compressor = useGzip ? zlib.gzip : zlib.deflate
+      const useDeflate = this._config.compressed_content_encoding === 'deflate'
+      const compressor = useDeflate ? zlib.deflate : zlib.gzip
       compressor(data, function onCompress(err, compressed) {
         if (err) {
           logger.warn(err, 'Error compressing JSON for delivery. Not sending.')

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -140,6 +140,16 @@ exports.config = () => ({
   allow_all_headers: false,
 
   /**
+   * If the data compression threshold is reached in the payload, the
+   * agent compresses data, using gzip compression by default. The
+   * config option `compressed_content_encoding` can be set to 'deflate'
+   * to use deflate compression.
+   *
+   * @env NEW_RELIC_COMPRESSED_CONTENT_ENCODING
+   */
+  compressed_content_encoding: 'gzip',
+
+  /**
    * Attributes are key-value pairs containing information that determines
    * the properties of an event or transaction.
    */

--- a/lib/config/env.js
+++ b/lib/config/env.js
@@ -22,6 +22,7 @@ const ENV_MAPPING = {
   proxy_pass: 'NEW_RELIC_PROXY_PASS',
   agent_enabled: 'NEW_RELIC_ENABLED',
   allow_all_headers: 'NEW_RELIC_ALLOW_ALL_HEADERS',
+  compressed_content_encoding: 'NEW_RELIC_COMPRESSED_CONTENT_ENCODING',
   attributes: {
     enabled: 'NEW_RELIC_ATTRIBUTES_ENABLED',
     exclude: 'NEW_RELIC_ATTRIBUTES_EXCLUDE',

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -154,7 +154,6 @@ function Config(config) {
   this.browser_monitoring.loader_version = ''
 
   // Settings to play nice with DLPs (see NODE-1044).
-  this.compressed_content_encoding = 'deflate' // Deflate or gzip
   this.simple_compression = false // Disables subcomponent compression
   this.put_for_data_send = false // Changes http verb for harvest
 

--- a/test/unit/collector/remote-method.test.js
+++ b/test/unit/collector/remote-method.test.js
@@ -351,10 +351,10 @@ tap.test('when posting to collector', (t) => {
       })
     })
 
-    t.test('should default to deflated compression', (t) => {
+    t.test('should default to gzip compression', (t) => {
       const sendDeflatedMetrics = nock(URL)
         .post(generate('metric_data', RUN_ID))
-        .matchHeader('Content-Encoding', 'deflate')
+        .matchHeader('Content-Encoding', 'gzip')
         .reply(200, { return_value: [] })
 
       method._shouldCompress = () => true
@@ -597,7 +597,7 @@ tap.test('when generating headers for a compressed request', (t) => {
   })
 
   t.test('should use the content type from the parameter', (t) => {
-    t.equal(headers['CONTENT-ENCODING'], 'deflate')
+    t.equal(headers['CONTENT-ENCODING'], 'gzip')
     t.end()
   })
 

--- a/test/unit/collector/remote-method.test.js
+++ b/test/unit/collector/remote-method.test.js
@@ -333,7 +333,7 @@ tap.test('when posting to collector', (t) => {
       method._post('[]', {}, (error) => {
         t.error(error)
         t.ok(sendMetrics.isDone())
-        t.end
+        t.end()
       })
     })
 
@@ -352,9 +352,26 @@ tap.test('when posting to collector', (t) => {
     })
 
     t.test('should default to gzip compression', (t) => {
-      const sendDeflatedMetrics = nock(URL)
+      const sendGzippedMetrics = nock(URL)
         .post(generate('metric_data', RUN_ID))
         .matchHeader('Content-Encoding', 'gzip')
+        .reply(200, { return_value: [] })
+
+      method._shouldCompress = () => true
+      method._post('[]', {}, (error) => {
+        t.error(error)
+
+        t.ok(sendGzippedMetrics.isDone())
+
+        t.end()
+      })
+    })
+
+    t.test('should use deflate compression when requested', (t) => {
+      method._agent.config.compressed_content_encoding = 'deflate'
+      const sendDeflatedMetrics = nock(URL)
+        .post(generate('metric_data', RUN_ID))
+        .matchHeader('Content-Encoding', 'deflate')
         .reply(200, { return_value: [] })
 
       method._shouldCompress = () => true

--- a/test/unit/collector/remote-method.test.js
+++ b/test/unit/collector/remote-method.test.js
@@ -196,8 +196,8 @@ tap.test('when calling a method on the collector', (t) => {
     const method = new RemoteMethod('test', BARE_AGENT, { host: 'localhost' })
     method._shouldCompress = () => true
     method._safeRequest = (options) => {
-      t.equal(options.body.readUInt8(0), 120)
-      t.equal(options.body.length, 14)
+      t.equal(options.body.readUInt8(0), 31)
+      t.equal(options.body.length, 26)
 
       t.end()
     }


### PR DESCRIPTION
## Proposed Release Notes

* Expose  `compressed_content_encoding` configuration and defaulted it to "gzip"

## Links

* Closes #1137 

## Details

This also makes the setting actually configurable instead of being
internally hard-coded to deflate