### PR TITLE
Re-adds minami as a dev dependency.

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -53,6 +53,7 @@ code, the source code can be found at [https://github.com/newrelic/node-newrelic
 * [jsdoc](#jsdoc)
 * [lint-staged](#lint-staged)
 * [memcached](#memcached)
+* [minami](#minami)
 * [nock](#nock)
 * [prettier](#prettier)
 * [proxyquire](#proxyquire)
@@ -2611,6 +2612,75 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+```
+
+### minami
+
+This product includes source derived from [minami](https://github.com/Nijikokun/minami) ([v1.2.3](https://github.com/Nijikokun/minami/tree/v1.2.3)), distributed under the [Apache-2.0 License](https://github.com/Nijikokun/minami/blob/v1.2.3/LICENSE):
+
+```
+# License
+
+Minami is free software, licensed under the Apache License, Version 2.0 (the
+"License"). Commercial and non-commercial use are permitted in compliance with
+the License.
+
+Copyright (c) 2014-2015 Nijiko Yonskai <nijikokun@gmail.com> and the
+[contributors to Minami](https://github.com/Nijikokun/minami/graphs/contributors).
+All rights reserved.
+
+You may obtain a copy of the License at:
+http://www.apache.org/licenses/LICENSE-2.0
+
+In addition, a copy of the License is included with this distribution.
+
+As stated in Section 7, "Disclaimer of Warranty," of the License:
+
+> Licensor provides the Work (and each Contributor provides its Contributions)
+> on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+> express or implied, including, without limitation, any warranties or
+> conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+> PARTICULAR PURPOSE. You are solely responsible for determining the
+> appropriateness of using or redistributing the Work and assume any risks
+> associated with Your exercise of permissions under this License.
+
+The source code for JSDoc 3 is available at:
+https://github.com/Nijikokun/minami
+
+# Third-Party Software
+
+Minami includes or depends upon the following third-party software, either in
+whole or in part. Each third-party software package is provided under its own
+license.
+
+## JSDoc 3
+
+JSDoc 3 is free software, licensed under the Apache License, Version 2.0 (the
+"License"). Commercial and non-commercial use are permitted in compliance with
+the License.
+
+Copyright (c) 2011-2015 Michael Mathews <micmath@gmail.com> and the
+[contributors to JSDoc](https://github.com/jsdoc3/jsdoc/graphs/contributors).
+All rights reserved.
+
+You may obtain a copy of the License at:
+http://www.apache.org/licenses/LICENSE-2.0
+
+In addition, a copy of the License is included with this distribution.
+
+As stated in Section 7, "Disclaimer of Warranty," of the License:
+
+> Licensor provides the Work (and each Contributor provides its Contributions)
+> on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+> express or implied, including, without limitation, any warranties or
+> conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+> PARTICULAR PURPOSE. You are solely responsible for determining the
+> appropriateness of using or redistributing the Work and assume any risks
+> associated with Your exercise of permissions under this License.
+
+The source code for JSDoc 3 is available at:
+https://github.com/jsdoc3/jsdoc
+
 ```
 
 ### nock

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "jsdoc": "^3.6.3",
         "lint-staged": "^11.0.0",
         "memcached": ">=0.2.8",
+        "minami": "^1.2.3",
         "nock": "11.8.0",
         "prettier": "^2.3.2",
         "proxyquire": "^1.8.0",
@@ -8706,6 +8707,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/minami": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/minami/-/minami-1.2.3.tgz",
+      "integrity": "sha512-3f2QqqbUC1usVux0FkQMFYB73yd9JIxmHSn1dWQacizL6hOUaNu6mA3KxZ9SfiCc4qgcgq+5XP59+hP7URa1Dw==",
+      "dev": true
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -20428,6 +20435,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
+    },
+    "minami": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/minami/-/minami-1.2.3.tgz",
+      "integrity": "sha512-3f2QqqbUC1usVux0FkQMFYB73yd9JIxmHSn1dWQacizL6hOUaNu6mA3KxZ9SfiCc4qgcgq+5XP59+hP7URa1Dw==",
       "dev": true
     },
     "minimatch": {

--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
     "jsdoc": "^3.6.3",
     "lint-staged": "^11.0.0",
     "memcached": ">=0.2.8",
+    "minami": "^1.2.3",
     "nock": "11.8.0",
     "prettier": "^2.3.2",
     "proxyquire": "^1.8.0",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,8 +1,23 @@
 {
-  "lastUpdated": "Mon Aug 15 2022 10:14:46 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Thu Aug 18 2022 15:05:09 GMT-0700 (Pacific Daylight Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
+  "optionalDependencies": {
+    "@newrelic/native-metrics@9.0.0": {
+      "name": "@newrelic/native-metrics",
+      "version": "9.0.0",
+      "range": "^9.0.0",
+      "licenses": "Apache-2.0",
+      "repoUrl": "https://github.com/newrelic/node-native-metrics",
+      "versionedRepoUrl": "https://github.com/newrelic/node-native-metrics/tree/v9.0.0",
+      "licenseFile": "node_modules/@newrelic/native-metrics/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-native-metrics/blob/v9.0.0/LICENSE",
+      "licenseTextSource": "file",
+      "publisher": "New Relic Node.js agent team",
+      "email": "nodejs@newrelic.com"
+    }
+  },
   "includeDev": true,
   "dependencies": {
     "@grpc/grpc-js@1.6.9": {
@@ -461,6 +476,19 @@
       "licenseTextSource": "file",
       "publisher": "Arnout Kazemier"
     },
+    "minami@1.2.3": {
+      "name": "minami",
+      "version": "1.2.3",
+      "range": "^1.2.3",
+      "licenses": "Apache-2.0",
+      "repoUrl": "https://github.com/Nijikokun/minami",
+      "versionedRepoUrl": "https://github.com/Nijikokun/minami/tree/v1.2.3",
+      "licenseFile": "node_modules/minami/LICENSE",
+      "licenseUrl": "https://github.com/Nijikokun/minami/blob/v1.2.3/LICENSE",
+      "licenseTextSource": "file",
+      "publisher": "Nijiko Yonskai",
+      "email": "nijikokun@gmail.com"
+    },
     "nock@11.8.0": {
       "name": "nock",
       "version": "11.8.0",
@@ -601,21 +629,6 @@
       "licenseFile": "node_modules/when/LICENSE.txt",
       "licenseUrl": "https://github.com/cujojs/when/blob/v3.7.8/LICENSE.txt",
       "licenseTextSource": "file"
-    }
-  },
-  "optionalDependencies": {
-    "@newrelic/native-metrics@9.0.0": {
-      "name": "@newrelic/native-metrics",
-      "version": "9.0.0",
-      "range": "^9.0.0",
-      "licenses": "Apache-2.0",
-      "repoUrl": "https://github.com/newrelic/node-native-metrics",
-      "versionedRepoUrl": "https://github.com/newrelic/node-native-metrics/tree/v9.0.0",
-      "licenseFile": "node_modules/@newrelic/native-metrics/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-native-metrics/blob/v9.0.0/LICENSE",
-      "licenseTextSource": "file",
-      "publisher": "New Relic Node.js agent team",
-      "email": "nodejs@newrelic.com"
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Fixed public jsdoc generation.

  Added`minami` back as a dev dependency for use with `jsdoc-conf.js`.

## Links

* https://github.com/newrelic/node-newrelic/pull/1316

## Details

`minami` is referenced by jsdoc-conf as a template. This was accidentally removed in the cleanup PR: https://github.com/newrelic/node-newrelic/pull/1316.
