### PR TITLE
fix troubleshooting template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Troubleshooting
+    url:  https://github.com/newrelic/node-newrelic/blob/main/README.md#support
+    about: Check out the README for troubleshooting directions

--- a/.github/ISSUE_TEMPLATE/troubleshooting.md
+++ b/.github/ISSUE_TEMPLATE/troubleshooting.md
@@ -1,5 +1,0 @@
-<!-- ⚠️⚠️STOP⚠️⚠️ -- PLEASE READ! -->
-
-We use GitHub to track feature requests and bug reports. Please **do not** submit issues for questions about how to configure, use features, troubleshoot, or best practices for using New Relic software.
-
-See the README.md support section in this repository for more details on self-service troubleshooting tooling, links to our comprehensive documentation, and how to get further support.


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
I noticed during a grooming session we have a troubleshooting.md that was never getting referenced.  I looked at how we handle this in other repos and updated it to be like [apollo plugin](https://github.com/newrelic/newrelic-node-apollo-server-plugin/blob/main/.github/ISSUE_TEMPLATE/config.yml)
