### PR TITLE
Fixed transaction name finalization to properly copy the appropriate transaction name to baseSegment

### DIFF
--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -419,12 +419,12 @@ function finalizeNameFromUri(requestURL, statusCode) {
   this.url = urltils.scrub(requestURL)
   this.statusCode = statusCode
 
+  // Bob Notes
+  // I'm not sure why we try to finalize the name here when this just calls this.getFullName() when it tries
+  // to build this name in intrinstic attrs serialization method
+
   // Derive the name from the request URL.
-  const partialName = this._partialNameFromUri(requestURL, statusCode)
-  this._partialName = partialName.value
-  if (partialName.ignore) {
-    this.ignore = true
-  }
+  this.name = this.getFullName()
 
   // If a namestate stack exists, copy route parameters over to the trace.
   if (!this.nameState.isEmpty() && this.baseSegment) {
@@ -447,17 +447,6 @@ function finalizeNameFromUri(requestURL, statusCode) {
       }
     }, this)
   }
-
-  // Apply transaction name normalization rules (sent by server) to full name.
-  const fullName = TYPE_METRICS[this.type] + '/' + this._partialName
-  const normalized = this.agent.transactionNameNormalizer.normalize(fullName)
-  if (normalized.ignore) {
-    this.ignore = true
-  }
-  this.name = normalized.value
-
-  // 5. transaction segment term normalizer
-  this.name = this.agent.txSegmentNormalizer.normalize(this.name).value
 
   // Allow the API to explicitly set the ignored status.
   if (this.forceIgnore !== null) {
@@ -532,21 +521,18 @@ Transaction.prototype.finalizeName = function finalizeName(name) {
     return this.finalizeNameFromUri(this.url, this.statusCode)
   }
 
-  this._partialName = this.forceName || name || this._partialName
-  if (!this._partialName) {
+  // this may seem out of place but certain API methods
+  // set the _partialName directly so use that as a fallback
+  this._partialName = name || this._partialName
+
+  name = this.getFullName()
+
+  if (!name) {
     logger.debug('No name for transaction %s, not finalizing.', this.id)
     return
   }
 
-  const fullName = TYPE_METRICS[this.type] + '/' + this._partialName
-
-  // Transaction normalizers run on the full metric name, not the user facing
-  // transaction name.
-  const normalized = this.agent.transactionNameNormalizer.normalize(fullName)
-  if (normalized.ignore) {
-    this.ignore = true
-  }
-  this.name = normalized.value
+  this.name = name
 
   if (this.forceIgnore !== null) {
     this.ignore = this.forceIgnore
@@ -582,7 +568,11 @@ Transaction.prototype.finalizeName = function finalizeName(name) {
  */
 Transaction.prototype.getName = function getName() {
   if (this.isWeb() && this.url) {
-    return this._partialNameFromUri(this.url, this.statusCode).value
+    const finalName = this._partialNameFromUri(this.url, this.statusCode)
+    if (finalName.ignore) {
+      this.ignore = true
+    }
+    return finalName.value
   }
   return this._partialName
 }
@@ -600,8 +590,14 @@ Transaction.prototype.getFullName = function getFullName() {
   if (!name) {
     return null
   }
+
+  this._partialName = name
   const fullName = TYPE_METRICS[this.type] + '/' + name
-  return this.agent.transactionNameNormalizer.normalize(fullName).value
+  const finalName = this.agent.transactionNameNormalizer.normalize(fullName)
+  if (finalName.ignore) {
+    this.ignore = true
+  }
+  return finalName.value
 }
 
 /**

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -418,12 +418,6 @@ function finalizeNameFromUri(requestURL, statusCode) {
 
   this.url = urltils.scrub(requestURL)
   this.statusCode = statusCode
-
-  // Bob Notes
-  // I'm not sure why we try to finalize the name here when this just calls this.getFullName() when it tries
-  // to build this name in intrinstic attrs serialization method
-
-  // Derive the name from the request URL.
   this.name = this.getFullName()
 
   // If a namestate stack exists, copy route parameters over to the trace.

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -511,7 +511,7 @@ Transaction.prototype._markAsWeb = function _markAsWeb(rawURL) {
 Transaction.prototype.finalizeName = function finalizeName(name) {
   // If no name is given, and this is a web transaction with a url, then
   // finalize the name using the stored url.
-  if (name == null && this.type === 'web' && this.url) {
+  if (name == null && this.isWeb() && this.url) {
     return this.finalizeNameFromUri(this.url, this.statusCode)
   }
 
@@ -573,10 +573,14 @@ Transaction.prototype.getName = function getName() {
 
 Transaction.prototype.getFullName = function getFullName() {
   let name = null
+  // use value from `api.setTransaction`
   if (this.forceName) {
     name = this.forceName
+    // use value from previously finalized named
   } else if (this.name) {
     return this.name
+    // derive name from uri in web case
+    // or just use whatever was this._partialName
   } else {
     name = this.getName()
   }
@@ -591,6 +595,13 @@ Transaction.prototype.getFullName = function getFullName() {
   if (finalName.ignore) {
     this.ignore = true
   }
+
+  // apply transaction segment term normalizer
+  // only to web transactions
+  if (this.isWeb() && this.url) {
+    return this.agent.txSegmentNormalizer.normalize(finalName.value).value
+  }
+
   return finalName.value
 }
 

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -590,19 +590,21 @@ Transaction.prototype.getFullName = function getFullName() {
   }
 
   this._partialName = name
-  const fullName = TYPE_METRICS[this.type] + '/' + name
-  const finalName = this.agent.transactionNameNormalizer.normalize(fullName)
-  if (finalName.ignore) {
+  let fullName = TYPE_METRICS[this.type] + '/' + name
+  const normalized = this.agent.transactionNameNormalizer.normalize(fullName)
+  if (normalized.ignore) {
     this.ignore = true
   }
+
+  fullName = normalized.value
 
   // apply transaction segment term normalizer
   // only to web transactions
   if (this.isWeb() && this.url) {
-    return this.agent.txSegmentNormalizer.normalize(finalName.value).value
+    fullName = this.agent.txSegmentNormalizer.normalize(fullName).value
   }
 
-  return finalName.value
+  return fullName
 }
 
 /**

--- a/test/unit/transaction-naming.test.js
+++ b/test/unit/transaction-naming.test.js
@@ -5,150 +5,166 @@
 
 'use strict'
 
-// TODO: convert to normal tap style.
-// Below allows use of mocha DSL with tap runner.
-require('tap').mochaGlobals()
-
-const chai = require('chai')
-const expect = chai.expect
 const helper = require('../lib/agent_helper')
 const API = require('../../api')
+const { test } = require('tap')
 
-describe('Transaction naming:', function () {
+test('Transaction naming:', function (t) {
+  t.autoend()
   let agent
 
-  beforeEach(function () {
+  t.beforeEach(function () {
     agent = helper.loadMockedAgent()
   })
 
-  afterEach(function () {
+  t.afterEach(function () {
     helper.unloadAgent(agent)
   })
 
-  it('Transaction should be named /* without any other naming source', function (done) {
+  t.test('Transaction should be named /* without any other naming source', function (t) {
     helper.runInTransaction(agent, function (transaction) {
       transaction.finalizeNameFromUri('http://test.test.com/', 200)
-      expect(transaction.name).equal('WebTransaction/NormalizedUri/*')
-      done()
+      t.equal(transaction.name, 'WebTransaction/NormalizedUri/*')
+      t.equal(transaction.name, transaction.getFullName(), 'name should be equal to finalized name')
+      t.end()
     })
   })
 
-  it('Transaction should not be normalized when 404', function (done) {
+  t.test('Transaction should not be normalized when 404', function (t) {
     helper.runInTransaction(agent, function (transaction) {
       transaction.nameState.setName('Expressjs', 'GET', '/', null)
       transaction.finalizeNameFromUri('http://test.test.com/', 404)
-      expect(transaction.name).to.equal('WebTransaction/Expressjs/GET/(not found)')
-      done()
+      t.equal(transaction.name, 'WebTransaction/Expressjs/GET/(not found)')
+      t.equal(transaction.name, transaction.getFullName(), 'name should be equal to finalized name')
+      t.end()
     })
   })
 
-  it('Instrumentation should trump default naming', function (done) {
+  t.test('Instrumentation should trump default naming', function (t) {
     helper.runInTransaction(agent, function (transaction) {
       simulateInstrumentation(transaction)
       transaction.finalizeNameFromUri('http://test.test.com/', 200)
-      expect(transaction.name).equal('WebTransaction/Expressjs/GET//setByInstrumentation')
-      done()
+      t.equal(transaction.name, 'WebTransaction/Expressjs/GET//setByInstrumentation')
+      t.equal(transaction.name, transaction.getFullName(), 'name should be equal to finalized name')
+      t.end()
     })
   })
 
-  it('API naming should trump default naming', function (done) {
+  t.test('API naming should trump default naming', function (t) {
     const api = new API(agent)
     helper.runInTransaction(agent, function (transaction) {
       api.setTransactionName('override')
       transaction.finalizeNameFromUri('http://test.test.com/', 200)
-      expect(transaction.name).equal('WebTransaction/Custom/override')
-      done()
+      t.equal(transaction.name, 'WebTransaction/Custom/override')
+      t.equal(transaction.name, transaction.getFullName(), 'name should be equal to finalized name')
+      t.end()
     })
   })
 
-  it('API naming should trump instrumentation naming', function (done) {
+  t.test('API naming should trump instrumentation naming', function (t) {
     const api = new API(agent)
     helper.runInTransaction(agent, function (transaction) {
       simulateInstrumentation(transaction)
       api.setTransactionName('override')
       transaction.finalizeNameFromUri('http://test.test.com/', 200)
-      expect(transaction.name).equal('WebTransaction/Custom/override')
-      done()
+      t.equal(transaction.name, 'WebTransaction/Custom/override')
+      t.equal(transaction.name, transaction.getFullName(), 'name should be equal to finalized name')
+      t.end()
     })
   })
 
-  it('API naming should trump instrumentation naming (order should not matter)', function (done) {
+  t.test('API naming should trump instrumentation naming (order should not matter)', function (t) {
     const api = new API(agent)
     helper.runInTransaction(agent, function (transaction) {
       api.setTransactionName('override')
       simulateInstrumentation(transaction)
       transaction.finalizeNameFromUri('http://test.test.com/', 200)
-      expect(transaction.name).equal('WebTransaction/Custom/override')
-      done()
+      t.equal(transaction.name, 'WebTransaction/Custom/override')
+      t.equal(transaction.name, transaction.getFullName(), 'name should be equal to finalized name')
+      t.end()
     })
   })
 
-  it('API should trump 404', function (done) {
+  t.test('API should trump 404', function (t) {
     const api = new API(agent)
     helper.runInTransaction(agent, function (transaction) {
       api.setTransactionName('override')
       simulateInstrumentation(transaction)
       transaction.finalizeNameFromUri('http://test.test.com/', 404)
-      expect(transaction.name).equal('WebTransaction/Custom/override')
-      done()
+      t.equal(transaction.name, 'WebTransaction/Custom/override')
+      t.equal(transaction.name, transaction.getFullName(), 'name should be equal to finalized name')
+      t.end()
     })
   })
 
-  it('Custom naming rules should trump default naming', function (done) {
+  t.test('Custom naming rules should trump default naming', function (t) {
     agent.userNormalizer.addSimple(/\//, '/test-transaction')
     helper.runInTransaction(agent, function (transaction) {
       transaction.finalizeNameFromUri('http://test.test.com/', 200)
-      expect(transaction.name).equal('WebTransaction/NormalizedUri/test-transaction')
-      done()
+      t.equal(transaction.name, 'WebTransaction/NormalizedUri/test-transaction')
+      t.equal(transaction.name, transaction.getFullName(), 'name should be equal to finalized name')
+      t.end()
     })
   })
 
-  it('Server sent naming rules should be applied when user specified rules are set', function (done) {
-    agent.urlNormalizer.addSimple(/\d+/, '*')
-    agent.userNormalizer.addSimple(/123/, 'abc')
-    helper.runInTransaction(agent, function (transaction) {
-      transaction.finalizeNameFromUri('http://test.test.com/123/456', 200)
-      expect(transaction.name).equal('WebTransaction/NormalizedUri/abc/*')
-      done()
-    })
-  })
+  t.test(
+    'Server sent naming rules should be applied when user specified rules are set',
+    function (t) {
+      agent.urlNormalizer.addSimple(/\d+/, '*')
+      agent.userNormalizer.addSimple(/123/, 'abc')
+      helper.runInTransaction(agent, function (transaction) {
+        transaction.finalizeNameFromUri('http://test.test.com/123/456', 200)
+        t.equal(transaction.name, 'WebTransaction/NormalizedUri/abc/*')
+        t.equal(
+          transaction.name,
+          transaction.getFullName(),
+          'name should be equal to finalized name'
+        )
+        t.end()
+      })
+    }
+  )
 
-  it('Custom naming rules should be cleaned up', function (done) {
+  t.test('Custom naming rules should be cleaned up', function (t) {
     agent.userNormalizer.addSimple(/\//, 'test-transaction')
     helper.runInTransaction(agent, function (transaction) {
       transaction.finalizeNameFromUri('http://test.test.com/', 200)
-      expect(transaction.name).equal('WebTransaction/NormalizedUri/test-transaction')
-      done()
+      t.equal(transaction.name, 'WebTransaction/NormalizedUri/test-transaction')
+      t.equal(transaction.name, transaction.getFullName(), 'name should be equal to finalized name')
+      t.end()
     })
   })
 
-  it('Custom naming rules should trump instrumentation naming', function (done) {
+  t.test('Custom naming rules should trump instrumentation naming', function (t) {
     agent.userNormalizer.addSimple(/\//, '/test-transaction')
     helper.runInTransaction(agent, function (transaction) {
       simulateInstrumentation(transaction)
       transaction.finalizeNameFromUri('http://test.test.com/', 200)
-      expect(transaction.name).equal('WebTransaction/NormalizedUri/test-transaction')
-      done()
+      t.equal(transaction.name, 'WebTransaction/NormalizedUri/test-transaction')
+      t.equal(transaction.name, transaction.getFullName(), 'name should be equal to finalized name')
+      t.end()
     })
   })
 
-  it('Custom naming rules should trump API calls', function (done) {
+  t.test('API calls should trump Custom naming rules', function (t) {
     agent.userNormalizer.addSimple(/\//, '/test-transaction')
     const api = new API(agent)
     helper.runInTransaction(agent, function (transaction) {
       api.setTransactionName('override')
       transaction.finalizeNameFromUri('http://test.test.com/', 200)
-      expect(transaction.name).equal('WebTransaction/NormalizedUri/test-transaction')
-      done()
+      t.equal(transaction.name, 'WebTransaction/Custom/override')
+      t.equal(transaction.name, transaction.getFullName(), 'name should be equal to finalized name')
+      t.end()
     })
   })
 
-  it('Custom naming rules should trump 404', function (done) {
+  t.test('Custom naming rules should trump 404', function (t) {
     agent.userNormalizer.addSimple(/\//, '/test-transaction')
     helper.runInTransaction(agent, function (transaction) {
       transaction.finalizeNameFromUri('http://test.test.com/', 404)
-      expect(transaction.name).equal('WebTransaction/NormalizedUri/test-transaction')
-      done()
+      t.equal(transaction.name, 'WebTransaction/NormalizedUri/test-transaction')
+      t.equal(transaction.name, transaction.getFullName(), 'name should be equal to finalized name')
+      t.end()
     })
   })
 })

--- a/test/unit/transaction.test.js
+++ b/test/unit/transaction.test.js
@@ -410,7 +410,7 @@ describe('Transaction', function () {
         trans.forceName = url
         trans.url = url
         agent.txSegmentNormalizer.load([
-          { prefix: 'WebTransaction/NormalizedUri', terms: ['explicit', 'lyrics'] }
+          { prefix: 'WebTransaction/NormalizedUri', terms: ['test', 'string'] }
         ])
         trans.finalizeNameFromUri(url, 200)
         expect(trans.name).to.equal('WebTransaction/NormalizedUri/test/*/string/*')

--- a/test/unit/transaction.test.js
+++ b/test/unit/transaction.test.js
@@ -404,6 +404,17 @@ describe('Transaction', function () {
         trans.finalizeNameFromUri('/test/string?do=thing&another=thing', 501)
         expect(trans.statusCode).equal(501)
       })
+
+      it('should update value from segment normalizer rules', function () {
+        const url = 'NormalizedUri/test/explicit/string/lyrics'
+        trans.forceName = url
+        trans.url = url
+        agent.txSegmentNormalizer.load([
+          { prefix: 'WebTransaction/NormalizedUri', terms: ['explicit', 'lyrics'] }
+        ])
+        trans.finalizeNameFromUri(url, 200)
+        expect(trans.name).to.equal('WebTransaction/NormalizedUri/test/*/string/*')
+      })
     })
 
     describe('with a custom partial name set', function () {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed transaction name finalization to properly copy the appropriate transaction name to root segment.

## Links
Closes https://issues.newrelic.com/browse/NEWRELIC-3089

## Details
A customer reported not being able to find transactions that were displaying as the transaction.name attribute on base span/segments.  After digging I realized it was because they had both custom naming rules and using the `setTransactionName` API to name transactions.  Our transaction finalization logic to copy the transaction name to the root segment was broken.  It favored custom naming rules over API based transaction naming.  I was able to determine a mismatch in logic around transaction name resolution and adding transactions to intrinsic events.  The latter was relying on transaction.getFullName() to extract name which as you can see [here](https://github.com/newrelic/node-newrelic/blob/main/lib/transaction/index.js#L592) favors forceName(aka using setTransactionName to name transaction).  I just updated the finalizeName and finalizeNameFromUri to use that as well.  It broke some tests but it was clear the transaction-naming tests were wrong, specifically the one that said `Custom naming rules should trump API calls`.  If you simply added the `t.equal(transaction.name, transaction.getFullName())`, it would fail which meant that custom naming rules do not trump API and in fact in the API docs it says the latter

 > Give the current transaction a custom name. Overrides any New Relic naming rules set in configuration or from New Relic's servers.

This bug has probably existed for a while and never caught or people never cared because the net was just that the root segment/span would have a `transaction.name` attribute to a transaction that was never reported to collector.

