### PR TITLE
Fixed issue where `grpc.record_errors` was not taken into consideration for client gRPC errors.

### DIFF
--- a/lib/instrumentation/grpc-js/grpc.js
+++ b/lib/instrumentation/grpc-js/grpc.js
@@ -78,9 +78,7 @@ function wrapStart(shim, original) {
         segment.addAttribute('grpc.statusCode', code)
         segment.addAttribute('grpc.statusText', details)
 
-        // Java captures client errors based on status code
-        // but has specific gRPC configuration to turn off
-        if (code !== 0) {
+        if (code !== 0 && shim.agent.config.grpc.record_errors) {
           // this is currently just creating an error from the details string
           shim.agent.errors.add(segment.transaction, details)
         }

--- a/test/versioned/grpc/client-bidi-streaming.tap.js
+++ b/test/versioned/grpc/client-bidi-streaming.tap.js
@@ -10,6 +10,7 @@ const helper = require('../../lib/agent_helper')
 const { ERR_CODE, ERR_MSG } = require('./constants')
 
 const {
+  assertError,
   assertExternalSegment,
   assertMetricsNotExisting,
   makeBidiStreamingRequest,
@@ -27,7 +28,7 @@ tap.test('gRPC Client: Bidi Streaming', (t) => {
   let grpc
 
   t.beforeEach(async () => {
-    agent = helper.instrumentMockedAgent({ grpc: { record_errors: false } })
+    agent = helper.instrumentMockedAgent()
     grpc = require('@grpc/grpc-js')
     const data = await createServer(grpc)
     proto = data.proto
@@ -140,37 +141,40 @@ tap.test('gRPC Client: Bidi Streaming', (t) => {
     }
   )
 
-  t.test('should record errors in a bidi stream transaction', (t) => {
-    const expectedStatusText = ERR_MSG
-    const expectedStatusCode = ERR_CODE
-    helper.runInTransaction(agent, 'web', async (tx) => {
-      tx.name = 'clientTransaction'
-      agent.on('transactionFinished', (transaction) => {
-        if (transaction.name === 'clientTransaction') {
-          // Make sure we're in the client and not server transaction
-          t.equal(agent.errors.traceAggregator.errors.length, 1, 'should record a single error')
-          const error = agent.errors.traceAggregator.errors[0][2]
-          t.equal(error, expectedStatusText, 'should have the error message')
-          assertExternalSegment({
-            t,
-            tx: transaction,
-            fnName: 'SayErrorBidiStream',
-            expectedStatusText,
-            expectedStatusCode
-          })
-          t.end()
+  const errorsEnabled = [true, false]
+  errorsEnabled.forEach((enabled) => {
+    t.test(`should ${enabled ? '' : 'not '}record errors in a transaction`, (t) => {
+      const expectedStatusText = ERR_MSG
+      const expectedStatusCode = ERR_CODE
+      agent.config.grpc.record_errors = enabled
+      helper.runInTransaction(agent, 'web', async (tx) => {
+        tx.name = 'clientTransaction'
+        agent.on('transactionFinished', (transaction) => {
+          if (transaction.name === 'clientTransaction') {
+            assertError({
+              t,
+              transaction,
+              errors: agent.errors,
+              expectErrors: enabled,
+              expectedStatusCode,
+              expectedStatusText,
+              fnName: 'SayErrorBidiStream',
+              clientError: true
+            })
+            t.end()
+          }
+        })
+
+        try {
+          const payload = [{ name: 'server-error' }]
+          await makeBidiStreamingRequest({ client, fnName: 'sayErrorBidiStream', payload })
+        } catch (err) {
+          t.ok(err, 'should get an error')
+          t.equal(err.code, expectedStatusCode, 'should get the right status code')
+          t.equal(err.details, expectedStatusText, 'should get the correct error message')
+          tx.end()
         }
       })
-
-      try {
-        const payload = [{ name: 'server-error' }]
-        await makeBidiStreamingRequest({ client, fnName: 'sayErrorBidiStream', payload })
-      } catch (err) {
-        t.ok(err, 'should get an error')
-        t.equal(err.code, expectedStatusCode, 'should get the right status code')
-        t.equal(err.details, expectedStatusText, 'should get the correct error message')
-        tx.end()
-      }
     })
   })
 })

--- a/test/versioned/grpc/client-streaming.tap.js
+++ b/test/versioned/grpc/client-streaming.tap.js
@@ -10,6 +10,7 @@ const helper = require('../../lib/agent_helper')
 const { ERR_CODE, ERR_MSG, HALT_CODE, HALT_SERVER_ERR_MSG } = require('./constants')
 
 const {
+  assertError,
   assertExternalSegment,
   assertMetricsNotExisting,
   makeClientStreamingRequest,
@@ -27,7 +28,7 @@ tap.test('gRPC Client: Client Streaming', (t) => {
   let grpc
 
   t.beforeEach(async () => {
-    agent = helper.instrumentMockedAgent({ grpc: { record_errors: false } })
+    agent = helper.instrumentMockedAgent()
     grpc = require('@grpc/grpc-js')
     const data = await createServer(grpc)
     proto = data.proto
@@ -125,77 +126,85 @@ tap.test('gRPC Client: Client Streaming', (t) => {
     t.end()
   })
 
-  t.test('should record errors in a transaction', (t) => {
-    const expectedStatusText = ERR_MSG
-    const expectedStatusCode = ERR_CODE
-    helper.runInTransaction(agent, 'web', async (tx) => {
-      tx.name = 'clientTransaction'
-      agent.on('transactionFinished', (transaction) => {
-        if (transaction.name === 'clientTransaction') {
-          // Make sure we're in the client and not server transaction
-          t.equal(agent.errors.traceAggregator.errors.length, 1, 'should record a single error')
-          const error = agent.errors.traceAggregator.errors[0][2]
-          t.equal(error, expectedStatusText, 'should have the error message')
-          assertExternalSegment({
-            t,
-            tx: transaction,
-            fnName: 'SayErrorClientStream',
-            expectedStatusText,
-            expectedStatusCode
-          })
-          t.end()
-        }
-      })
-
-      try {
-        const payload = [{ oh: 'noes' }]
-        await makeClientStreamingRequest({ client, fnName: 'sayErrorClientStream', payload })
-      } catch (err) {
-        t.ok(err, 'should get an error')
-        t.equal(err.code, expectedStatusCode, 'should get the right status code')
-        t.equal(err.details, expectedStatusText, 'should get the correct error message')
-        tx.end()
-      }
-    })
-  })
-
-  t.test('should record errors in a transaction when server sends error mid stream', (t) => {
-    const expectedStatusText = HALT_SERVER_ERR_MSG
-    const expectedStatusCode = HALT_CODE
-    helper.runInTransaction(agent, 'web', async (tx) => {
-      tx.name = 'clientTransaction'
-      agent.on('transactionFinished', (transaction) => {
-        if (transaction.name === 'clientTransaction') {
-          // Make sure we're in the client and not server transaction
-          t.equal(agent.errors.traceAggregator.errors.length, 1, 'should record a single error')
-          const error = agent.errors.traceAggregator.errors[0][2]
-          t.equal(error, expectedStatusText, 'should have the error message')
-          assertExternalSegment({
-            t,
-            tx: transaction,
-            fnName: 'SayErrorClientStream',
-            expectedStatusText,
-            expectedStatusCode
-          })
-          t.end()
-        }
-      })
-
-      try {
-        const payload = [{ name: 'error' }]
-        await makeClientStreamingRequest({
-          client,
-          fnName: 'sayErrorClientStream',
-          payload,
-          endStream: false
+  const errorsEnabled = [true, false]
+  errorsEnabled.forEach((enabled) => {
+    t.test(`should ${enabled ? '' : 'not '}record errors in a transaction`, (t) => {
+      const expectedStatusText = ERR_MSG
+      const expectedStatusCode = ERR_CODE
+      agent.config.grpc.record_errors = enabled
+      helper.runInTransaction(agent, 'web', async (tx) => {
+        tx.name = 'clientTransaction'
+        agent.on('transactionFinished', (transaction) => {
+          if (transaction.name === 'clientTransaction') {
+            assertError({
+              t,
+              transaction,
+              errors: agent.errors,
+              expectErrors: enabled,
+              expectedStatusCode,
+              expectedStatusText,
+              fnName: 'SayErrorClientStream',
+              clientError: true
+            })
+            t.end()
+          }
         })
-      } catch (err) {
-        t.ok(err, 'should get an error')
-        t.equal(err.code, expectedStatusCode, 'should get the right status code')
-        t.equal(err.details, expectedStatusText, 'should get the correct error message')
-        tx.end()
-      }
+
+        try {
+          const payload = [{ oh: 'noes' }]
+          await makeClientStreamingRequest({ client, fnName: 'sayErrorClientStream', payload })
+        } catch (err) {
+          t.ok(err, 'should get an error')
+          t.equal(err.code, expectedStatusCode, 'should get the right status code')
+          t.equal(err.details, expectedStatusText, 'should get the correct error message')
+          tx.end()
+        }
+      })
     })
+
+    t.test(
+      `should ${
+        enabled ? '' : 'not '
+      }record errors in a transaction when server sends error mid stream`,
+      (t) => {
+        const expectedStatusText = HALT_SERVER_ERR_MSG
+        const expectedStatusCode = HALT_CODE
+        agent.config.grpc.record_errors = enabled
+        helper.runInTransaction(agent, 'web', async (tx) => {
+          tx.name = 'clientTransaction'
+          agent.on('transactionFinished', (transaction) => {
+            if (transaction.name === 'clientTransaction') {
+              assertError({
+                t,
+                transaction,
+                errors: agent.errors,
+                expectErrors: enabled,
+                expectedStatusCode,
+                expectedStatusText,
+                fnName: 'SayErrorClientStream',
+                clientError: true
+              })
+              t.end()
+            }
+          })
+
+          try {
+            const payload = [{ name: 'error' }]
+            await makeClientStreamingRequest({
+              client,
+              fnName: 'sayErrorClientStream',
+              payload,
+              endStream: false
+            })
+          } catch (err) {
+            t.ok(err, 'should get an error')
+            t.equal(err.code, expectedStatusCode, 'should get the right status code')
+            t.equal(err.details, expectedStatusText, 'should get the correct error message')
+            tx.end()
+          }
+        })
+      }
+    )
   })
 
   t.test('should bind callback to the proper transaction context', (t) => {

--- a/test/versioned/grpc/client-unary.tap.js
+++ b/test/versioned/grpc/client-unary.tap.js
@@ -10,6 +10,7 @@ const helper = require('../../lib/agent_helper')
 const { ERR_CODE, ERR_MSG } = require('./constants')
 
 const {
+  assertError,
   assertExternalSegment,
   assertMetricsNotExisting,
   makeUnaryRequest,
@@ -27,7 +28,7 @@ tap.test('gRPC Client: Unary Requests', (t) => {
   let grpc
 
   t.beforeEach(async () => {
-    agent = helper.instrumentMockedAgent({ grpc: { record_errors: false } })
+    agent = helper.instrumentMockedAgent()
     grpc = require('@grpc/grpc-js')
     const data = await createServer(grpc)
     proto = data.proto
@@ -114,37 +115,40 @@ tap.test('gRPC Client: Unary Requests', (t) => {
     t.end()
   })
 
-  t.test('should record errors in a transaction', (t) => {
-    const expectedStatusText = ERR_MSG
-    const expectedStatusCode = ERR_CODE
-    helper.runInTransaction(agent, 'web', async (tx) => {
-      tx.name = 'clientTransaction'
-      agent.on('transactionFinished', (transaction) => {
-        if (transaction.name === 'clientTransaction') {
-          // Make sure we're in the client and not server transaction
-          t.equal(agent.errors.traceAggregator.errors.length, 1, 'should record a single error')
-          const error = agent.errors.traceAggregator.errors[0][2]
-          t.equal(error, expectedStatusText, 'should have the error message')
-          assertExternalSegment({
-            t,
-            tx: transaction,
-            fnName: 'SayError',
-            expectedStatusText,
-            expectedStatusCode
-          })
-          t.end()
+  const errorsEnabled = [true, false]
+  errorsEnabled.forEach((enabled) => {
+    t.test(`should ${enabled ? '' : 'not '}record errors in a transaction`, (t) => {
+      const expectedStatusText = ERR_MSG
+      const expectedStatusCode = ERR_CODE
+      agent.config.grpc.record_errors = enabled
+      helper.runInTransaction(agent, 'web', async (tx) => {
+        tx.name = 'clientTransaction'
+        agent.on('transactionFinished', (transaction) => {
+          if (transaction.name === 'clientTransaction') {
+            assertError({
+              t,
+              transaction,
+              errors: agent.errors,
+              expectErrors: enabled,
+              expectedStatusCode,
+              expectedStatusText,
+              fnName: 'SayError',
+              clientError: true
+            })
+            t.end()
+          }
+        })
+
+        try {
+          const payload = { oh: 'noes' }
+          await makeUnaryRequest({ client, fnName: 'sayError', payload })
+        } catch (err) {
+          t.ok(err, 'should get an error')
+          t.equal(err.code, expectedStatusCode, 'should get the right status code')
+          t.equal(err.details, expectedStatusText, 'should get the correct error message')
+          tx.end()
         }
       })
-
-      try {
-        const payload = { oh: 'noes' }
-        await makeUnaryRequest({ client, fnName: 'sayError', payload })
-      } catch (err) {
-        t.ok(err, 'should get an error')
-        t.equal(err.code, expectedStatusCode, 'should get the right status code')
-        t.equal(err.details, expectedStatusText, 'should get the correct error message')
-        tx.end()
-      }
     })
   })
 

--- a/test/versioned/grpc/server-bidi-streaming.tap.js
+++ b/test/versioned/grpc/server-bidi-streaming.tap.js
@@ -16,6 +16,7 @@ const {
   createServer,
   getClient,
   getServerTransactionName,
+  assertError,
   assertServerTransaction,
   assertServerMetrics,
   assertDistributedTracing
@@ -128,69 +129,42 @@ tap.test('gRPC Server: Bidi Streaming', (t) => {
     t.end()
   })
 
-  t.test('should record errors if `grpc.record_errors` is enabled', async (t) => {
-    let transaction
-    agent.on('transactionFinished', (tx) => {
-      if (tx.name === getServerTransactionName('SayErrorBidiStream')) {
-        transaction = tx
+  const errorsEnabled = [true, false]
+  errorsEnabled.forEach((enabled) => {
+    t.test(
+      `should ${enabled ? '' : 'not '}record errors if 'grpc.record_errors' is ${
+        enabled ? 'enabled' : 'disabled'
+      }`,
+      async (t) => {
+        agent.config.grpc.record_errors = enabled
+        const expectedStatusCode = ERR_CODE
+        const expectedStatusText = ERR_SERVER_MSG
+        let transaction
+        agent.on('transactionFinished', (tx) => {
+          if (tx.name === getServerTransactionName('SayErrorBidiStream')) {
+            transaction = tx
+          }
+        })
+
+        try {
+          const payload = [{ name: 'server-error' }]
+          await makeBidiStreamingRequest({ client, fnName: 'sayErrorBidiStream', payload })
+        } catch (err) {
+          // err tested in client tests
+        }
+
+        assertError({
+          t,
+          transaction,
+          errors: agent.errors,
+          agentMetrics: agent.metrics._metrics,
+          expectErrors: enabled,
+          expectedStatusCode,
+          expectedStatusText,
+          fnName: 'SayErrorBidiStream'
+        })
+        t.end()
       }
-    })
-
-    try {
-      const payload = [{ name: 'server-error' }]
-      await makeBidiStreamingRequest({ client, fnName: 'sayErrorBidiStream', payload })
-    } catch (err) {
-      // err tested in client tests
-    }
-    t.ok(transaction, 'transaction exists')
-    t.equal(agent.errors.traceAggregator.errors.length, 1, 'should record a single error')
-    const error = agent.errors.traceAggregator.errors[0][2]
-    t.equal(error, ERR_SERVER_MSG, 'should have the error message')
-    assertServerTransaction({
-      t,
-      transaction,
-      fnName: 'SayErrorBidiStream',
-      expectedStatusCode: ERR_CODE
-    })
-    assertServerMetrics({
-      t,
-      agentMetrics: agent.metrics._metrics,
-      fnName: 'SayErrorBidiStream',
-      expectedStatusCode: ERR_CODE
-    })
-    t.end()
-  })
-
-  t.test('should not record errors if `grpc.record_errors` is disabled', async (t) => {
-    agent.config.grpc.record_errors = false
-
-    let transaction
-    agent.on('transactionFinished', (tx) => {
-      if (tx.name === getServerTransactionName('SayErrorBidiStream')) {
-        transaction = tx
-      }
-    })
-
-    try {
-      const payload = [{ name: 'server-error' }]
-      await makeBidiStreamingRequest({ client, fnName: 'sayErrorBidiStream', payload })
-    } catch (err) {
-      // err tested in client tests
-    }
-    t.ok(transaction, 'transaction exists')
-    t.equal(agent.errors.traceAggregator.errors.length, 0, 'should not record any errors')
-    assertServerTransaction({
-      t,
-      transaction,
-      fnName: 'SayErrorBidiStream',
-      expectedStatusCode: ERR_CODE
-    })
-    assertServerMetrics({
-      t,
-      agentMetrics: agent.metrics._metrics,
-      fnName: 'SayErrorBidiStream',
-      expectedStatusCode: ERR_CODE
-    })
-    t.end()
+    )
   })
 })

--- a/test/versioned/grpc/server-client-streaming.tap.js
+++ b/test/versioned/grpc/server-client-streaming.tap.js
@@ -16,6 +16,7 @@ const {
   createServer,
   getClient,
   getServerTransactionName,
+  assertError,
   assertServerTransaction,
   assertServerMetrics,
   assertDistributedTracing
@@ -132,37 +133,43 @@ tap.test('gRPC Server: Client Streaming', (t) => {
     t.end()
   })
 
-  t.test('should record errors if `grpc.record_errors` is enabled', async (t) => {
-    let transaction
-    agent.on('transactionFinished', (tx) => {
-      if (tx.name === getServerTransactionName('SayErrorClientStream')) {
-        transaction = tx
-      }
-    })
+  const errorsEnabled = [true, false]
+  errorsEnabled.forEach((enabled) => {
+    t.test(
+      `should ${enabled ? '' : 'not '}record errors if 'grpc.record_errors' is ${
+        enabled ? 'enabled' : 'disabled'
+      }`,
+      async (t) => {
+        const expectedStatusCode = ERR_CODE
+        const expectedStatusText = ERR_SERVER_MSG
+        agent.config.grpc.record_errors = enabled
+        let transaction
+        agent.on('transactionFinished', (tx) => {
+          if (tx.name === getServerTransactionName('SayErrorClientStream')) {
+            transaction = tx
+          }
+        })
 
-    try {
-      const payload = [{ oh: 'noes' }]
-      await makeClientStreamingRequest({ client, fnName: 'sayErrorClientStream', payload })
-    } catch (err) {
-      // err tested in client tests
-    }
-    t.ok(transaction, 'transaction exists')
-    t.equal(agent.errors.traceAggregator.errors.length, 1, 'should record a single error')
-    const error = agent.errors.traceAggregator.errors[0][2]
-    t.equal(error, ERR_SERVER_MSG, 'should have the error message')
-    assertServerTransaction({
-      t,
-      transaction,
-      fnName: 'SayErrorClientStream',
-      expectedStatusCode: ERR_CODE
-    })
-    assertServerMetrics({
-      t,
-      agentMetrics: agent.metrics._metrics,
-      fnName: 'SayErrorClientStream',
-      expectedStatusCode: ERR_CODE
-    })
-    t.end()
+        try {
+          const payload = [{ oh: 'noes' }]
+          await makeClientStreamingRequest({ client, fnName: 'sayErrorClientStream', payload })
+        } catch (err) {
+          // err tested in client tests
+        }
+
+        assertError({
+          t,
+          transaction,
+          errors: agent.errors,
+          agentMetrics: agent.metrics._metrics,
+          expectErrors: enabled,
+          expectedStatusCode,
+          expectedStatusText,
+          fnName: 'SayErrorClientStream'
+        })
+        t.end()
+      }
+    )
   })
 
   t.test('should not record errors if `grpc.record_errors` is disabled', async (t) => {

--- a/test/versioned/grpc/server-streaming.tap.js
+++ b/test/versioned/grpc/server-streaming.tap.js
@@ -16,6 +16,7 @@ const {
   createServer,
   getClient,
   getServerTransactionName,
+  assertError,
   assertServerTransaction,
   assertServerMetrics,
   assertDistributedTracing
@@ -127,69 +128,42 @@ tap.test('gRPC Server: Server Streaming', (t) => {
     t.end()
   })
 
-  t.test('should record errors if `grpc.record_errors` is enabled', async (t) => {
-    let transaction
-    agent.on('transactionFinished', (tx) => {
-      if (tx.name === getServerTransactionName('SayErrorServerStream')) {
-        transaction = tx
+  const errorsEnabled = [true, false]
+  errorsEnabled.forEach((enabled) => {
+    t.test(
+      `should ${enabled ? '' : 'not '}record errors if 'grpc.record_errors' is ${
+        enabled ? 'enabled' : 'disabled'
+      }`,
+      async (t) => {
+        const expectedStatusCode = ERR_CODE
+        const expectedStatusText = ERR_SERVER_MSG
+        agent.config.grpc.record_errors = enabled
+        let transaction
+        agent.on('transactionFinished', (tx) => {
+          if (tx.name === getServerTransactionName('SayErrorServerStream')) {
+            transaction = tx
+          }
+        })
+
+        try {
+          const payload = { name: ['noes'] }
+          await makeServerStreamingRequest({ client, fnName: 'sayErrorServerStream', payload })
+        } catch (err) {
+          // err tested in client tests
+        }
+
+        assertError({
+          t,
+          transaction,
+          errors: agent.errors,
+          agentMetrics: agent.metrics._metrics,
+          expectErrors: enabled,
+          expectedStatusCode,
+          expectedStatusText,
+          fnName: 'SayErrorServerStream'
+        })
+        t.end()
       }
-    })
-
-    try {
-      const payload = { name: ['noes'] }
-      await makeServerStreamingRequest({ client, fnName: 'sayErrorServerStream', payload })
-    } catch (err) {
-      // err tested in client tests
-    }
-    t.ok(transaction, 'transaction exists')
-    t.equal(agent.errors.traceAggregator.errors.length, 1, 'should record a single error')
-    const error = agent.errors.traceAggregator.errors[0][2]
-    t.equal(error, ERR_SERVER_MSG, 'should have the error message')
-    assertServerTransaction({
-      t,
-      transaction,
-      fnName: 'SayErrorServerStream',
-      expectedStatusCode: ERR_CODE
-    })
-    assertServerMetrics({
-      t,
-      agentMetrics: agent.metrics._metrics,
-      fnName: 'SayErrorServerStream',
-      expectedStatusCode: ERR_CODE
-    })
-    t.end()
-  })
-
-  t.test('should not record errors if `grpc.record_errors` is disabled', async (t) => {
-    agent.config.grpc.record_errors = false
-
-    let transaction
-    agent.on('transactionFinished', (tx) => {
-      if (tx.name === getServerTransactionName('SayErrorServerStream')) {
-        transaction = tx
-      }
-    })
-
-    try {
-      const payload = { name: ['noes'] }
-      await makeServerStreamingRequest({ client, fnName: 'sayErrorServerStream', payload })
-    } catch (err) {
-      // err tested in client tests
-    }
-    t.ok(transaction, 'transaction exists')
-    t.equal(agent.errors.traceAggregator.errors.length, 0, 'should not record any errors')
-    assertServerTransaction({
-      t,
-      transaction,
-      fnName: 'SayErrorServerStream',
-      expectedStatusCode: ERR_CODE
-    })
-    assertServerMetrics({
-      t,
-      agentMetrics: agent.metrics._metrics,
-      fnName: 'SayErrorServerStream',
-      expectedStatusCode: ERR_CODE
-    })
-    t.end()
+    )
   })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated gRPC client instrumenation to respect `grpc.record_errors` when deciding to log errors on gRPC client requests.

## Links
Closes #1343

## Details

