### PR TITLE
Fix esm loader to work in Node < 18

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
-  "**/*.js": [
+  "**/*.{cjs,mjs,js}": [
     "eslint --fix"
   ]
 }

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1767,7 +1767,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ### @newrelic/test-utilities
 
-This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v7.0.0](https://github.com/newrelic/node-test-utilities/tree/v7.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v7.0.0/LICENSE):
+This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v7.1.0](https://github.com/newrelic/node-test-utilities/tree/v7.1.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v7.1.0/LICENSE):
 
 ```
                                  Apache License

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1767,7 +1767,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ### @newrelic/test-utilities
 
-This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v7.1.0](https://github.com/newrelic/node-test-utilities/tree/v7.1.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v7.1.0/LICENSE):
+This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v7.1.1](https://github.com/newrelic/node-test-utilities/tree/v7.1.1)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v7.1.1/LICENSE):
 
 ```
                                  Apache License

--- a/esm-loader.mjs
+++ b/esm-loader.mjs
@@ -28,7 +28,7 @@ const logger = loggingModule.child({ component: 'esm-loader' })
  */
 export async function resolve(specifier, context, nextResolve) {
   if (!newrelic.agent) {
-    return nextResolve(specifier)
+    return nextResolve(specifier, context, nextResolve)
   }
 
   /**
@@ -37,7 +37,7 @@ export async function resolve(specifier, context, nextResolve) {
    * package type (commonjs/module/builtin) without
    * duplicating the logic of the Node.js hook
    */
-  const resolvedModule = await nextResolve(specifier)
+  const resolvedModule = await nextResolve(specifier, context, nextResolve)
   const instrumentationName = shimmer.getInstrumentationNameFromModuleName(specifier)
   const instrumentationDefinition = shimmer.registeredInstrumentations[instrumentationName]
 

--- a/esm-loader.mjs
+++ b/esm-loader.mjs
@@ -6,6 +6,8 @@
 import newrelic from './index.js'
 import shimmer from './lib/shimmer.js'
 import loggingModule from './lib/logger.js'
+import semver from 'semver'
+const isSupportedVersion = () => semver.gte(process.version, 'v16.12.0')
 
 const logger = loggingModule.child({ component: 'esm-loader' })
 
@@ -27,7 +29,7 @@ const logger = loggingModule.child({ component: 'esm-loader' })
  * @returns {Promise} Promise object representing the resolution of a given specifier
  */
 export async function resolve(specifier, context, nextResolve) {
-  if (!newrelic.agent) {
+  if (!newrelic.agent || !isSupportedVersion()) {
     return nextResolve(specifier, context, nextResolve)
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@newrelic/eslint-config": "^0.0.3",
         "@newrelic/newrelic-oss-cli": "^0.1.2",
         "@newrelic/proxy": "^2.0.0",
-        "@newrelic/test-utilities": "^7.0.0",
+        "@newrelic/test-utilities": "^7.1.1",
         "@octokit/rest": "^18.0.15",
         "@slack/bolt": "^3.7.0",
         "ajv": "^6.12.6",
@@ -900,9 +900,9 @@
       }
     },
     "node_modules/@newrelic/test-utilities": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-7.0.0.tgz",
-      "integrity": "sha512-TZ+fw8P20T1tkdK7ZyQJ4zXq02UrhhDl5qPgXwgMJRG+acY+hqMF+qOBa58sp+5lNlztbRgkkC90xAeEEaWbcw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-7.1.1.tgz",
+      "integrity": "sha512-Q5dFqz87jfSHTF7gtoJJYSzmxMtIXHOasHaZHphA38f5EAda3GwlJmc3UveT6nXkj+5vCYF9Z84hOI8ZnNQdwQ==",
       "dev": true,
       "dependencies": {
         "async": "^3.2.3",
@@ -14461,9 +14461,9 @@
       "requires": {}
     },
     "@newrelic/test-utilities": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-7.0.0.tgz",
-      "integrity": "sha512-TZ+fw8P20T1tkdK7ZyQJ4zXq02UrhhDl5qPgXwgMJRG+acY+hqMF+qOBa58sp+5lNlztbRgkkC90xAeEEaWbcw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-7.1.1.tgz",
+      "integrity": "sha512-Q5dFqz87jfSHTF7gtoJJYSzmxMtIXHOasHaZHphA38f5EAda3GwlJmc3UveT6nXkj+5vCYF9Z84hOI8ZnNQdwQ==",
       "dev": true,
       "requires": {
         "async": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "@newrelic/eslint-config": "^0.0.3",
     "@newrelic/newrelic-oss-cli": "^0.1.2",
     "@newrelic/proxy": "^2.0.0",
-    "@newrelic/test-utilities": "^7.0.0",
+    "@newrelic/test-utilities": "^7.1.1",
     "@octokit/rest": "^18.0.15",
     "@slack/bolt": "^3.7.0",
     "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "test": "npm run integration && npm run unit && npm run unit:esm",
     "third-party-updates": "oss third-party manifest --includeOptDeps && oss third-party notices --includeOptDeps && git add THIRD_PARTY_NOTICES.md third_party_manifest.json",
     "unit": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/unit\\/.*\\.test\\.js)$' --timeout=180 --no-coverage --reporter classic",
-    "unit:esm": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/unit\\/.*\\.test\\.mjs)$' --timeout=180 --no-coverage --reporter classic --node-arg=--loader=testdouble",
+    "unit:esm": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^test\\/unit\\/.*\\.test\\.mjs)$' --timeout=180 --no-coverage --reporter classic --node-arg=--experimental-loader=testdouble",
     "update-cross-agent-tests": "./bin/update-cats.sh",
     "versioned-tests": "./bin/run-versioned-tests.sh",
     "update-changelog-version": "node ./bin/update-changelog-version",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Fri Sep 09 2022 11:24:41 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Fri Sep 16 2022 10:44:06 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -213,15 +213,15 @@
       "email": "nathan@tootallnate.net",
       "url": "http://n8.io/"
     },
-    "@newrelic/test-utilities@7.0.0": {
+    "@newrelic/test-utilities@7.1.0": {
       "name": "@newrelic/test-utilities",
-      "version": "7.0.0",
+      "version": "7.1.0",
       "range": "^7.0.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-test-utilities",
-      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v7.0.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v7.1.0",
       "licenseFile": "node_modules/@newrelic/test-utilities/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v7.0.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v7.1.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Fri Sep 16 2022 10:44:06 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Fri Sep 16 2022 10:55:21 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -213,15 +213,15 @@
       "email": "nathan@tootallnate.net",
       "url": "http://n8.io/"
     },
-    "@newrelic/test-utilities@7.1.0": {
+    "@newrelic/test-utilities@7.1.1": {
       "name": "@newrelic/test-utilities",
-      "version": "7.1.0",
-      "range": "^7.0.0",
+      "version": "7.1.1",
+      "range": "^7.1.1",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-test-utilities",
-      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v7.1.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v7.1.1",
       "licenseFile": "node_modules/@newrelic/test-utilities/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v7.1.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v7.1.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated ESM loader to pass in all arguments to parent resolve methods.

## Links
Closes NEWRELIC-3588

## Details
It was found during tests of node 14 and 16 that our ESM loader would not work.  Due to the experimental nature of the loader API this fix will add support for Node 16.12.0+.  We do not intend to support any versions less than that with the ESM loader because the resolve hook point does not return format for a given module.  We rely on it to update the path in shimmer for cjs instrumentation.  It's technically not needed right now because we don't support any ES module instrumentation but when we do this will be a requirement.
