### PR TITLE
Fix handling ipv6 localhost alias for mongodb instrumentation

### DIFF
--- a/lib/instrumentation/mongodb/v4-mongo.js
+++ b/lib/instrumentation/mongodb/v4-mongo.js
@@ -45,7 +45,7 @@ function cmdStartedHandler(shim, evnt) {
       if (hosts && hosts.length && hosts[0].socketPath) {
         port = hosts[0].socketPath
       }
-    } else if (['127.0.0.1', '[::1]'].includes(host)) {
+    } else if (['127.0.0.1', '::1', '[::1]'].includes(host)) {
       host = 'localhost'
     }
 

--- a/lib/instrumentation/mongodb/v4-mongo.js
+++ b/lib/instrumentation/mongodb/v4-mongo.js
@@ -45,7 +45,7 @@ function cmdStartedHandler(shim, evnt) {
       if (hosts && hosts.length && hosts[0].socketPath) {
         port = hosts[0].socketPath
       }
-    } else if (['127.0.0.1', '::1'].includes(host)) {
+    } else if (['127.0.0.1', '[::1]'].includes(host)) {
       host = 'localhost'
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated the alias for localhost in mongodb instrumentation when dealing with IPv6 addresses.

## Links

## Details
In #1288 we added support for IPv6 address parsing.  At that time `::1` was the the localhost alias.  However mongodb just released 4.10.0 and [IPv6 host connection fix](https://jira.mongodb.org/browse/NODE-4621) broke our tests.  I'm debating on if I should add the `::1` back to the list but I removed and ran `npm run versioned:minor mongodb` and had 0 failing tests.
