### PR TITLE
Stabilize mongo tests

### DIFF
--- a/test/versioned/mongodb-esm/bulk.tap.mjs
+++ b/test/versioned/mongodb-esm/bulk.tap.mjs
@@ -8,6 +8,7 @@ import semver from 'semver'
 import { test } from './collection-common.mjs'
 import helper from '../../lib/agent_helper.js'
 import { pkgVersion } from './common.cjs'
+import { STATEMENT_PREFIX } from './common.cjs'
 
 // see test/versioned/mongodb/common.js
 if (semver.satisfies(pkgVersion, '>=3.2.4 <4.1.4')) {
@@ -46,7 +47,7 @@ if (semver.satisfies(pkgVersion, '>=3.2.4 <4.1.4')) {
           t.error(err)
           verify(
             null,
-            ['Datastore/statement/MongoDB/esmTestCollection/unorderedBulk/batch', 'Callback: done'],
+            [`${STATEMENT_PREFIX}/unorderedBulk/batch`, 'Callback: done'],
             ['unorderedBulk']
           )
         })
@@ -75,11 +76,7 @@ if (semver.satisfies(pkgVersion, '>=3.2.4 <4.1.4')) {
 
         bulk.execute(function done(err) {
           t.error(err)
-          verify(
-            null,
-            ['Datastore/statement/MongoDB/esmTestCollection/orderedBulk/batch', 'Callback: done'],
-            ['orderedBulk']
-          )
+          verify(null, [`${STATEMENT_PREFIX}/orderedBulk/batch`, 'Callback: done'], ['orderedBulk'])
         })
       }
     )

--- a/test/versioned/mongodb-esm/collection-common.mjs
+++ b/test/versioned/mongodb-esm/collection-common.mjs
@@ -12,7 +12,7 @@ let METRIC_HOST_PORT = null
 const MONGO_SEGMENT_RE = common.MONGO_SEGMENT_RE
 const TRANSACTION_NAME = common.TRANSACTION_NAME
 const DB_NAME = common.DB_NAME
-const { connect, close } = common
+const { connect, close, COLLECTIONS } = common
 
 export {
   MONGO_SEGMENT_RE,
@@ -24,8 +24,6 @@ export {
   test,
   dropTestCollections
 }
-
-const COLLECTIONS = ['esmTestCollection', 'esmTestCollection2']
 
 function test({ suiteName, agent, t }, run) {
   t.test(suiteName, { timeout: 10000 }, function (t) {

--- a/test/versioned/mongodb-esm/collection-find.tap.mjs
+++ b/test/versioned/mongodb-esm/collection-find.tap.mjs
@@ -7,7 +7,7 @@ import semver from 'semver'
 import tap from 'tap'
 import { test } from './collection-common.mjs'
 import helper from '../../lib/agent_helper.js'
-import { pkgVersion } from './common.cjs'
+import { pkgVersion, STATEMENT_PREFIX } from './common.cjs'
 
 let findOpt = { returnOriginal: false }
 // 4.0.0 changed this opt https://github.com/mongodb/node-mongodb-native/pull/2803/files
@@ -38,11 +38,7 @@ tap.test('Collection(Find) Tests', (t) => {
           t.equal(data.value.a, 15)
           t.equal(data.value.i, 1)
           t.equal(data.ok, 1)
-          verify(
-            null,
-            ['Datastore/statement/MongoDB/esmTestCollection/findAndModify', 'Callback: done'],
-            ['findAndModify']
-          )
+          verify(null, [`${STATEMENT_PREFIX}/findAndModify`, 'Callback: done'], ['findAndModify'])
         }
       }
     )
@@ -54,11 +50,7 @@ tap.test('Collection(Find) Tests', (t) => {
           t.error(err)
           t.equal(data.value.i, 1)
           t.equal(data.ok, 1)
-          verify(
-            null,
-            ['Datastore/statement/MongoDB/esmTestCollection/findAndRemove', 'Callback: done'],
-            ['findAndRemove']
-          )
+          verify(null, [`${STATEMENT_PREFIX}/findAndRemove`, 'Callback: done'], ['findAndRemove'])
         })
       }
     )
@@ -68,11 +60,7 @@ tap.test('Collection(Find) Tests', (t) => {
     collection.findOne({ i: 15 }, function done(err, data) {
       t.error(err)
       t.equal(data.i, 15)
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/findOne', 'Callback: done'],
-        ['findOne']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/findOne`, 'Callback: done'], ['findOne'])
     })
   })
 
@@ -85,7 +73,7 @@ tap.test('Collection(Find) Tests', (t) => {
         t.equal(data.value.i, 15)
         verify(
           null,
-          ['Datastore/statement/MongoDB/esmTestCollection/findOneAndDelete', 'Callback: done'],
+          [`${STATEMENT_PREFIX}/findOneAndDelete`, 'Callback: done'],
           ['findOneAndDelete']
         )
       })
@@ -103,7 +91,7 @@ tap.test('Collection(Find) Tests', (t) => {
         t.equal(data.ok, 1)
         verify(
           null,
-          ['Datastore/statement/MongoDB/esmTestCollection/findOneAndReplace', 'Callback: done'],
+          [`${STATEMENT_PREFIX}/findOneAndReplace`, 'Callback: done'],
           ['findOneAndReplace']
         )
       }
@@ -121,7 +109,7 @@ tap.test('Collection(Find) Tests', (t) => {
         t.equal(data.ok, 1)
         verify(
           null,
-          ['Datastore/statement/MongoDB/esmTestCollection/findOneAndUpdate', 'Callback: done'],
+          [`${STATEMENT_PREFIX}/findOneAndUpdate`, 'Callback: done'],
           ['findOneAndUpdate']
         )
       }

--- a/test/versioned/mongodb-esm/collection-index.tap.mjs
+++ b/test/versioned/mongodb-esm/collection-index.tap.mjs
@@ -7,7 +7,7 @@ import semver from 'semver'
 import tap from 'tap'
 import { test, DB_NAME } from './collection-common.mjs'
 import helper from '../../lib/agent_helper.js'
-import { pkgVersion } from './common.cjs'
+import { pkgVersion, STATEMENT_PREFIX } from './common.cjs'
 
 tap.test('Collection(Index) Tests', (t) => {
   t.autoend()
@@ -24,11 +24,7 @@ tap.test('Collection(Index) Tests', (t) => {
     collection.createIndex('i', function onIndex(err, data) {
       t.error(err)
       t.equal(data, 'i_1')
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/createIndex', 'Callback: onIndex'],
-        ['createIndex']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/createIndex`, 'Callback: onIndex'], ['createIndex'])
     })
   })
 
@@ -41,9 +37,9 @@ tap.test('Collection(Index) Tests', (t) => {
         verify(
           null,
           [
-            'Datastore/statement/MongoDB/esmTestCollection/createIndex',
+            `${STATEMENT_PREFIX}/createIndex`,
             'Callback: onIndex',
-            'Datastore/statement/MongoDB/esmTestCollection/dropIndex',
+            `${STATEMENT_PREFIX}/dropIndex`,
             'Callback: done'
           ],
           ['createIndex', 'dropIndex']
@@ -71,11 +67,7 @@ tap.test('Collection(Index) Tests', (t) => {
       }
       t.same(result, expectedResult, 'should have expected results')
 
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/indexes', 'Callback: done'],
-        ['indexes']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/indexes`, 'Callback: done'], ['indexes'])
     })
   })
 
@@ -84,11 +76,7 @@ tap.test('Collection(Index) Tests', (t) => {
       t.error(err)
       t.equal(data, true)
 
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/indexExists', 'Callback: done'],
-        ['indexExists']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/indexExists`, 'Callback: done'], ['indexExists'])
     })
   })
 
@@ -101,7 +89,7 @@ tap.test('Collection(Index) Tests', (t) => {
 
         verify(
           null,
-          ['Datastore/statement/MongoDB/esmTestCollection/indexInformation', 'Callback: done'],
+          [`${STATEMENT_PREFIX}/indexInformation`, 'Callback: done'],
           ['indexInformation']
         )
       })
@@ -115,11 +103,7 @@ tap.test('Collection(Index) Tests', (t) => {
         collection.dropAllIndexes(function done(err, data) {
           t.error(err)
           t.equal(data, true)
-          verify(
-            null,
-            ['Datastore/statement/MongoDB/esmTestCollection/dropAllIndexes', 'Callback: done'],
-            ['dropAllIndexes']
-          )
+          verify(null, [`${STATEMENT_PREFIX}/dropAllIndexes`, 'Callback: done'], ['dropAllIndexes'])
         })
       }
     )
@@ -128,11 +112,7 @@ tap.test('Collection(Index) Tests', (t) => {
       collection.ensureIndex('i', function done(err, data) {
         t.error(err)
         t.equal(data, 'i_1')
-        verify(
-          null,
-          ['Datastore/statement/MongoDB/esmTestCollection/ensureIndex', 'Callback: done'],
-          ['ensureIndex']
-        )
+        verify(null, [`${STATEMENT_PREFIX}/ensureIndex`, 'Callback: done'], ['ensureIndex'])
       })
     })
 
@@ -141,11 +121,7 @@ tap.test('Collection(Index) Tests', (t) => {
         t.error(err)
         t.equal(data, true)
 
-        verify(
-          null,
-          ['Datastore/statement/MongoDB/esmTestCollection/reIndex', 'Callback: done'],
-          ['reIndex']
-        )
+        verify(null, [`${STATEMENT_PREFIX}/reIndex`, 'Callback: done'], ['reIndex'])
       })
     })
   }

--- a/test/versioned/mongodb-esm/collection-misc.tap.mjs
+++ b/test/versioned/mongodb-esm/collection-misc.tap.mjs
@@ -7,7 +7,7 @@ import semver from 'semver'
 import tap from 'tap'
 import { test, DB_NAME } from './collection-common.mjs'
 import helper from '../../lib/agent_helper.js'
-import { pkgVersion } from './common.cjs'
+import { pkgVersion, STATEMENT_PREFIX } from './common.cjs'
 
 function verifyAggregateData(t, data) {
   t.equal(data.length, 3, 'should have expected amount of results')
@@ -40,7 +40,7 @@ tap.test('Collection(Index) Tests', (t) => {
         verify(
           err,
           [
-            'Datastore/statement/MongoDB/esmTestCollection/aggregate',
+            `${STATEMENT_PREFIX}/aggregate`,
             'Datastore/statement/MongoDB/esmTestCollection/toArray'
           ],
           ['aggregate', 'toArray'],
@@ -64,7 +64,7 @@ tap.test('Collection(Index) Tests', (t) => {
         verify(
           null,
           [
-            'Datastore/statement/MongoDB/esmTestCollection/aggregate',
+            `${STATEMENT_PREFIX}/aggregate`,
             'Datastore/statement/MongoDB/esmTestCollection/toArray'
           ],
           ['aggregate', 'toArray'],
@@ -85,11 +85,7 @@ tap.test('Collection(Index) Tests', (t) => {
       t.error(err)
       t.equal(data.insertedCount, 1)
       t.equal(data.deletedCount, 30)
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/bulkWrite', 'Callback: onWrite'],
-        ['bulkWrite']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/bulkWrite`, 'Callback: onWrite'], ['bulkWrite'])
     }
   })
 
@@ -97,11 +93,7 @@ tap.test('Collection(Index) Tests', (t) => {
     collection.count(function onCount(err, data) {
       t.error(err)
       t.equal(data, 30)
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/count', 'Callback: onCount'],
-        ['count']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/count`, 'Callback: onCount'], ['count'])
     })
   })
 
@@ -109,11 +101,7 @@ tap.test('Collection(Index) Tests', (t) => {
     collection.distinct('mod10', function done(err, data) {
       t.error(err)
       t.same(data.sort(), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/distinct', 'Callback: done'],
-        ['distinct']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/distinct`, 'Callback: done'], ['distinct'])
     })
   })
 
@@ -121,11 +109,7 @@ tap.test('Collection(Index) Tests', (t) => {
     collection.drop(function done(err, data) {
       t.error(err)
       t.equal(data, true)
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/drop', 'Callback: done'],
-        ['drop']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/drop`, 'Callback: done'], ['drop'])
     })
   })
 
@@ -151,9 +135,9 @@ tap.test('Collection(Index) Tests', (t) => {
         verify(
           null,
           [
-            'Datastore/statement/MongoDB/esmTestCollection/ensureIndex',
+            `${STATEMENT_PREFIX}/ensureIndex`,
             'Callback: indexed',
-            'Datastore/statement/MongoDB/esmTestCollection/geoNear',
+            `${STATEMENT_PREFIX}/geoNear`,
             'Callback: done'
           ],
           ['ensureIndex', 'geoNear']
@@ -167,11 +151,7 @@ tap.test('Collection(Index) Tests', (t) => {
       t.error(err)
       t.notOk(data)
 
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/isCapped', 'Callback: done'],
-        ['isCapped']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/isCapped`, 'Callback: done'], ['isCapped'])
     })
   })
 
@@ -198,11 +178,7 @@ tap.test('Collection(Index) Tests', (t) => {
       data.sort((a, b) => a._id - b._id)
       t.same(data, expectedData)
 
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/mapReduce', 'Callback: done'],
-        ['mapReduce']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/mapReduce`, 'Callback: done'], ['mapReduce'])
     }
 
     /* eslint-disable */
@@ -229,11 +205,7 @@ tap.test('Collection(Index) Tests', (t) => {
         t.notOk(data, 'should have expected results')
       }
 
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/options', 'Callback: done'],
-        ['options']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/options`, 'Callback: done'], ['options'])
     })
   })
 
@@ -254,9 +226,9 @@ tap.test('Collection(Index) Tests', (t) => {
           verify(
             null,
             [
-              'Datastore/statement/MongoDB/esmTestCollection/parallelCollectionScan',
+              `${STATEMENT_PREFIX}/parallelCollectionScan`,
               'Callback: done',
-              'Datastore/statement/MongoDB/esmTestCollection/toArray',
+              `${STATEMENT_PREFIX}/toArray`,
               'Callback: toArray'
             ],
             ['parallelCollectionScan', 'toArray']
@@ -286,9 +258,9 @@ tap.test('Collection(Index) Tests', (t) => {
           verify(
             null,
             [
-              'Datastore/statement/MongoDB/esmTestCollection/ensureIndex',
+              `${STATEMENT_PREFIX}/ensureIndex`,
               'Callback: indexed',
-              'Datastore/statement/MongoDB/esmTestCollection/geoHaystackSearch',
+              `${STATEMENT_PREFIX}/geoHaystackSearch`,
               'Callback: done'
             ],
             ['ensureIndex', 'geoHaystackSearch']
@@ -314,11 +286,7 @@ tap.test('Collection(Index) Tests', (t) => {
           { mod10: 8, count: 3, total: 54 },
           { mod10: 9, count: 3, total: 57 }
         ])
-        verify(
-          null,
-          ['Datastore/statement/MongoDB/esmTestCollection/group', 'Callback: done'],
-          ['group']
-        )
+        verify(null, [`${STATEMENT_PREFIX}/group`, 'Callback: done'], ['group'])
       }
 
       function count(obj, prev) {
@@ -336,11 +304,7 @@ tap.test('Collection(Index) Tests', (t) => {
     collection.rename('esmTestCollection2', function done(err) {
       t.error(err)
 
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/rename', 'Callback: done'],
-        ['rename']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/rename`, 'Callback: done'], ['rename'])
     })
   })
 
@@ -351,11 +315,7 @@ tap.test('Collection(Index) Tests', (t) => {
       t.equal(data.count, 30)
       t.equal(data.ok, 1)
 
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/stats', 'Callback: done'],
-        ['stats']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/stats`, 'Callback: done'], ['stats'])
     })
   })
 })

--- a/test/versioned/mongodb-esm/collection-update.tap.mjs
+++ b/test/versioned/mongodb-esm/collection-update.tap.mjs
@@ -7,7 +7,7 @@ import semver from 'semver'
 import tap from 'tap'
 import { test } from './collection-common.mjs'
 import helper from '../../lib/agent_helper.js'
-import { pkgVersion } from './common.cjs'
+import { pkgVersion, STATEMENT_PREFIX } from './common.cjs'
 
 /**
  * The response from the methods in this file differ between versions
@@ -58,11 +58,7 @@ tap.test('Collection(Update) Tests', (t) => {
         count: 3,
         keyPrefix: 'deleted'
       })
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/deleteMany', 'Callback: done'],
-        ['deleteMany']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/deleteMany`, 'Callback: done'], ['deleteMany'])
     })
   })
 
@@ -75,11 +71,7 @@ tap.test('Collection(Update) Tests', (t) => {
         count: 1,
         keyPrefix: 'deleted'
       })
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/deleteOne', 'Callback: done'],
-        ['deleteOne']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/deleteOne`, 'Callback: done'], ['deleteOne'])
     })
   })
 
@@ -98,11 +90,7 @@ tap.test('Collection(Update) Tests', (t) => {
         }
       })
 
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/insert', 'Callback: done'],
-        ['insert']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/insert`, 'Callback: done'], ['insert'])
     })
   })
 
@@ -122,11 +110,7 @@ tap.test('Collection(Update) Tests', (t) => {
         }
       })
 
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/insertMany', 'Callback: done'],
-        ['insertMany']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/insertMany`, 'Callback: done'], ['insertMany'])
     })
   })
 
@@ -144,11 +128,7 @@ tap.test('Collection(Update) Tests', (t) => {
         }
       })
 
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/insertOne', 'Callback: done'],
-        ['insertOne']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/insertOne`, 'Callback: done'], ['insertOne'])
     })
   })
 
@@ -162,11 +142,7 @@ tap.test('Collection(Update) Tests', (t) => {
         keyPrefix: 'deleted'
       })
 
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/remove', 'Callback: done'],
-        ['remove']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/remove`, 'Callback: done'], ['remove'])
     })
   })
 
@@ -188,11 +164,7 @@ tap.test('Collection(Update) Tests', (t) => {
         }
       })
 
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/replaceOne', 'Callback: done'],
-        ['replaceOne']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/replaceOne`, 'Callback: done'], ['replaceOne'])
     })
   })
 
@@ -202,11 +174,7 @@ tap.test('Collection(Update) Tests', (t) => {
         t.error(err)
         t.same(data.result, { ok: 1, n: 1 })
 
-        verify(
-          null,
-          ['Datastore/statement/MongoDB/esmTestCollection/save', 'Callback: done'],
-          ['save']
-        )
+        verify(null, [`${STATEMENT_PREFIX}/save`, 'Callback: done'], ['save'])
       })
     })
   }
@@ -229,11 +197,7 @@ tap.test('Collection(Update) Tests', (t) => {
         }
       })
 
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/update', 'Callback: done'],
-        ['update']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/update`, 'Callback: done'], ['update'])
     })
   })
 
@@ -255,11 +219,7 @@ tap.test('Collection(Update) Tests', (t) => {
         }
       })
 
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/updateMany', 'Callback: done'],
-        ['updateMany']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/updateMany`, 'Callback: done'], ['updateMany'])
     })
   })
 
@@ -281,11 +241,7 @@ tap.test('Collection(Update) Tests', (t) => {
         }
       })
 
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/updateOne', 'Callback: done'],
-        ['updateOne']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/updateOne`, 'Callback: done'], ['updateOne'])
     })
   })
 })

--- a/test/versioned/mongodb-esm/common.cjs
+++ b/test/versioned/mongodb-esm/common.cjs
@@ -14,10 +14,14 @@ const urltils = require('../../../lib/util/urltils')
 const MONGO_SEGMENT_RE = /^Datastore\/.*?\/MongoDB/
 const TRANSACTION_NAME = 'mongo test'
 const DB_NAME = 'integration'
+const COLLECTIONS = ['esmTestCollection', 'esmTestCollection2']
+const STATEMENT_PREFIX = `Datastore/statement/MongoDB/${COLLECTIONS[0]}`
 
 exports.MONGO_SEGMENT_RE = MONGO_SEGMENT_RE
 exports.TRANSACTION_NAME = TRANSACTION_NAME
 exports.DB_NAME = DB_NAME
+exports.COLLECTIONS = COLLECTIONS
+exports.STATEMENT_PREFIX = STATEMENT_PREFIX
 
 // Check package versions to decide which connect function to use below
 exports.connect = function connect() {

--- a/test/versioned/mongodb-esm/cursor.tap.mjs
+++ b/test/versioned/mongodb-esm/cursor.tap.mjs
@@ -15,7 +15,7 @@ import {
   TRANSACTION_NAME
 } from './collection-common.mjs'
 import helper from '../../lib/agent_helper.js'
-import { pkgVersion } from './common.cjs'
+import { pkgVersion, STATEMENT_PREFIX } from './common.cjs'
 
 tap.test('Cursor Tests', (t) => {
   t.autoend()
@@ -33,11 +33,7 @@ tap.test('Cursor Tests', (t) => {
     collection.find({}).count(function onCount(err, data) {
       t.notOk(err, 'should not error')
       t.equal(data, 30, 'should have correct result')
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/count', 'Callback: onCount'],
-        ['count']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/count`, 'Callback: onCount'], ['count'])
     })
   })
 
@@ -50,11 +46,7 @@ tap.test('Cursor Tests', (t) => {
       } else {
         t.ok(data.hasOwnProperty('queryPlanner'), 'should have correct response')
       }
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/explain', 'Callback: onExplain'],
-        ['explain']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/explain`, 'Callback: onExplain'], ['explain'])
     })
   })
 
@@ -63,11 +55,7 @@ tap.test('Cursor Tests', (t) => {
       collection.find({}).nextObject(function onNextObject(err, data) {
         t.notOk(err)
         t.equal(data.i, 0)
-        verify(
-          null,
-          ['Datastore/statement/MongoDB/esmTestCollection/nextObject', 'Callback: onNextObject'],
-          ['nextObject']
-        )
+        verify(null, [`${STATEMENT_PREFIX}/nextObject`, 'Callback: onNextObject'], ['nextObject'])
       })
     })
   }
@@ -76,11 +64,7 @@ tap.test('Cursor Tests', (t) => {
     collection.find({}).next(function onNext(err, data) {
       t.notOk(err)
       t.equal(data.i, 0)
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/next', 'Callback: onNext'],
-        ['next']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/next`, 'Callback: onNext'], ['next'])
     })
   })
 
@@ -88,11 +72,7 @@ tap.test('Cursor Tests', (t) => {
     collection.find({}).toArray(function onToArray(err, data) {
       t.notOk(err)
       t.equal(data[0].i, 0)
-      verify(
-        null,
-        ['Datastore/statement/MongoDB/esmTestCollection/toArray', 'Callback: onToArray'],
-        ['toArray']
-      )
+      verify(null, [`${STATEMENT_PREFIX}/toArray`, 'Callback: onToArray'], ['toArray'])
     })
   })
 

--- a/test/versioned/mongodb-esm/db.tap.mjs
+++ b/test/versioned/mongodb-esm/db.tap.mjs
@@ -7,13 +7,20 @@ import semver from 'semver'
 import tap from 'tap'
 import { dropTestCollections } from './collection-common.mjs'
 import helper from '../../lib/agent_helper.js'
-import { pkgVersion, getHostName, getPort, connect, close, DB_NAME } from './common.cjs'
+import {
+  pkgVersion,
+  getHostName,
+  getPort,
+  connect,
+  close,
+  DB_NAME,
+  COLLECTIONS
+} from './common.cjs'
 import params from '../../lib/params.js'
 
 let MONGO_HOST = null
 let MONGO_PORT = null
 const BAD_MONGO_COMMANDS = ['collection']
-const COLLECTIONS = ['esmTestCollection', 'testColl', 'testColl2']
 
 tap.test('Db tests', (t) => {
   t.autoend()
@@ -137,7 +144,7 @@ tap.test('Db tests', (t) => {
   if (semver.satisfies(pkgVersion, '<4')) {
     t.test('collection', (t) => {
       dbTest({ t, agent, mongodb }, function collectionTest(t, db, verify) {
-        db.collection('esmTestCollection', function gotCollection(err, collection) {
+        db.collection(COLLECTIONS[0], function gotCollection(err, collection) {
           t.error(err, 'should not have error')
           t.ok(collection, 'collection is not null')
           verify(['Datastore/operation/MongoDB/collection', 'Callback: gotCollection'])
@@ -178,11 +185,11 @@ tap.test('Db tests', (t) => {
 
   t.test('createCollection', (t) => {
     dbTest({ t, agent, mongodb, dropCollections: true }, function collectionTest(t, db, verify) {
-      db.createCollection('esmTestCollection', function gotCollection(err, collection) {
+      db.createCollection(COLLECTIONS[0], function gotCollection(err, collection) {
         t.error(err, 'should not have error')
         t.equal(
           collection.collectionName || collection.s.name,
-          'esmTestCollection',
+          COLLECTIONS[0],
           'new collection should have the right name'
         )
         verify(['Datastore/operation/MongoDB/createCollection', 'Callback: gotCollection'])
@@ -192,7 +199,7 @@ tap.test('Db tests', (t) => {
 
   t.test('createIndex', (t) => {
     dbTest({ t, agent, mongodb }, function collectionTest(t, db, verify) {
-      db.createIndex('esmTestCollection', 'foo', function createdIndex(err, result) {
+      db.createIndex(COLLECTIONS[0], 'foo', function createdIndex(err, result) {
         t.error(err, 'should not have error')
         t.equal(result, 'foo_1', 'should have the right result')
         verify(['Datastore/operation/MongoDB/createIndex', 'Callback: createdIndex'])
@@ -202,10 +209,10 @@ tap.test('Db tests', (t) => {
 
   t.test('dropCollection', (t) => {
     dbTest({ t, agent, mongodb }, function collectionTest(t, db, verify) {
-      db.createCollection('esmTestCollection', function gotCollection(err) {
+      db.createCollection(COLLECTIONS[0], function gotCollection(err) {
         t.error(err, 'should not have error getting collection')
 
-        db.dropCollection('esmTestCollection', function droppedCollection(err, result) {
+        db.dropCollection(COLLECTIONS[0], function droppedCollection(err, result) {
           t.error(err, 'should not have error dropping collection')
           t.ok(result === true, 'result should be boolean true')
           verify([
@@ -232,7 +239,7 @@ tap.test('Db tests', (t) => {
   if (semver.satisfies(pkgVersion, '<4')) {
     t.test('ensureIndex', (t) => {
       dbTest({ t, agent, mongodb }, function collectionTest(t, db, verify) {
-        db.ensureIndex('esmTestCollection', 'foo', function ensuredIndex(err, result) {
+        db.ensureIndex(COLLECTIONS[0], 'foo', function ensuredIndex(err, result) {
           t.error(err, 'should not have error')
           t.equal(result, 'foo_1')
           verify(['Datastore/operation/MongoDB/ensureIndex', 'Callback: ensuredIndex'])
@@ -242,9 +249,9 @@ tap.test('Db tests', (t) => {
 
     t.test('indexInformation', (t) => {
       dbTest({ t, agent, mongodb }, function collectionTest(t, db, verify) {
-        db.ensureIndex('esmTestCollection', 'foo', function ensuredIndex(err) {
+        db.ensureIndex(COLLECTIONS[0], 'foo', function ensuredIndex(err) {
           t.error(err, 'ensureIndex should not have error')
-          db.indexInformation('esmTestCollection', function gotInfo(err2, result) {
+          db.indexInformation(COLLECTIONS[0], function gotInfo(err2, result) {
             t.error(err2, 'indexInformation should not have error')
             t.same(
               result,
@@ -264,9 +271,9 @@ tap.test('Db tests', (t) => {
   } else {
     t.test('indexInformation', (t) => {
       dbTest({ t, agent, mongodb }, function collectionTest(t, db, verify) {
-        db.createIndex('esmTestCollection', 'foo', function createdIndex(err) {
+        db.createIndex(COLLECTIONS[0], 'foo', function createdIndex(err) {
           t.error(err, 'createIndex should not have error')
-          db.indexInformation('esmTestCollection', function gotInfo(err2, result) {
+          db.indexInformation(COLLECTIONS[0], function gotInfo(err2, result) {
             t.error(err2, 'indexInformation should not have error')
             t.same(
               result,
@@ -287,11 +294,11 @@ tap.test('Db tests', (t) => {
 
   t.test('renameCollection', (t) => {
     dbTest({ t, agent, mongodb }, function collectionTest(t, db, verify) {
-      db.createCollection('testColl', function gotCollection(err) {
+      db.createCollection(COLLECTIONS[0], function gotCollection(err) {
         t.error(err, 'should not have error getting collection')
-        db.renameCollection('testColl', 'testColl2', function renamedCollection(err2) {
+        db.renameCollection(COLLECTIONS[0], COLLECTIONS[1], function renamedCollection(err2) {
           t.error(err2, 'should not have error renaming collection')
-          db.dropCollection('testColl2', function droppedCollection(err3) {
+          db.dropCollection(COLLECTIONS[1], function droppedCollection(err3) {
             t.error(err3)
             verify([
               'Datastore/operation/MongoDB/createCollection',


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
We have had instability with versioned tests for a few days.  I think it is related to the db.tap tests sharing collection names between ESM and CJS.  This PR updates the esm tests to use a centralized constant only used in esm to avoid this collision.
