### PR TITLE
Release v9.1.0 Redux

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
 ### v9.1.0 (2022-09-22)
 
-* Added experimental ECAMScript Module(ESM) loader to support instrumentation of CommonJS packages in ESM applications.
-  * [ESM Loaders](https://nodejs.org/api/esm.html#loaders) are marked as experimental, which may break the New Relic Node.js ESM loader.
-  * ESM loader only supports versions of Node.js >= `16.12.0`.
+* Added [experimental loader](https://nodejs.org/api/esm.html#loaders) to support instrumentation of CommonJS packages in ECMAScript Module(ESM) applications.
+  * It only supports versions of Node.js >= `16.12.0`.
+  * It is subject to change due to its experimental stability.
 
 * Enhanced supportability metrics for ESM support.
   * Added new metrics to track usage of ESM loader(`Supportability/Features/ESM/Loader` and `Supportability/Features/ESM/UnsupportedLoader`).


### PR DESCRIPTION
### Proposed Release Notes

* Added [experimental loader](https://nodejs.org/api/esm.html#loaders) to support instrumentation of CommonJS packages in ECMAScript Module(ESM) applications.
  * It only supports versions of Node.js >= `16.12.0`.
  * It is subject to change due to its experimental stability.

* Enhanced supportability metrics for ESM support.
  * Added new metrics to track usage of ESM loader(`Supportability/Features/ESM/Loader` and `Supportability/Features/ESM/UnsupportedLoader`).
  * Updated instrumentation map to include an optional "friendly name" for tracking metrics.

* Enabled re-throwing ESM import errors of `newrelic.js` so that the user is informed to rename it to `newrelic.cjs`

* Fixed an issue with mongodb instrumentation where IPv6 address([::1]) was not getting mapped to localhost when setting the host attribute on the segment.

* Added a test ESM loader to properly mock out agent in versioned tests.

* Added ESM versioned tests for: `express`, `pg`, `mongodb`, and `@grpc/grpc-js`.

## Links

* PR: https://github.com/newrelic/node-newrelic/pull/1359
* PR: https://github.com/newrelic/node-newrelic/pull/1360
* PR: https://github.com/newrelic/node-newrelic/pull/1358
* PR: https://github.com/newrelic/node-newrelic/pull/1354
* PR: https://github.com/newrelic/node-newrelic/pull/1355
* PR: https://github.com/newrelic/node-newrelic/pull/1356
* PR: https://github.com/newrelic/node-newrelic/pull/1351
* PR: https://github.com/newrelic/node-newrelic/pull/1353
* PR: https://github.com/newrelic/node-newrelic/pull/1349
* PR: https://github.com/newrelic/node-newrelic/pull/1350
* PR: https://github.com/newrelic/node-newrelic/pull/1352
* PR: https://github.com/newrelic/node-newrelic/pull/1347
* PR: https://github.com/newrelic/node-newrelic/pull/1348

## Details

