### PR TITLE
Added plumbing for ESM instrumentation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,17 @@ module.exports = {
   ignorePatterns: ['test/versioned-external'],
   overrides: [
     {
+      files: ['**/*.mjs'],
+      parserOptions: {
+        ecmaVersion: '2020'
+      },
+      rules: {
+        // TODO: remove this when we decide on how to address
+        // here: https://issues.newrelic.com/browse/NEWRELIC-3321
+        'node/no-unsupported-features/es-syntax': 'off'
+      }
+    },
+    {
       files: ['newrelic.js'],
       rules: {
         'header/header': ['off']

--- a/esm-loader.mjs
+++ b/esm-loader.mjs
@@ -10,7 +10,16 @@ import NAMES from './lib/metrics/names.js'
 import semver from 'semver'
 
 const isSupportedVersion = () => semver.gte(process.version, 'v16.12.0')
+// This check will prevent resolve hooks executing from within this file
+// If I do `import('foo')` in here it'll hit the resolve hook multiple times
+const isFromEsmLoader = (context) =>
+  context && context.parentURL && context.parentURL.includes('newrelic/esm-loader.mjs')
+
 const logger = loggingModule.child({ component: 'esm-loader' })
+// exporting for testing purposes
+export const registeredSpecifiers = new Map()
+
+const esmShimPath = new URL('./lib/esm-shim.mjs', import.meta.url)
 
 if (newrelic.agent) {
   addESMSupportabilityMetrics(newrelic.agent)
@@ -24,17 +33,14 @@ if (newrelic.agent) {
  *
  * Docs: https://nodejs.org/api/esm.html#resolvespecifier-context-nextresolve
  *
- * @param {string} specifier
- *        String identifier in an import statement or import() expression
- * @param {object} context
- *        Metadata about the specifier, including url of the parent module and any import assertions
+ * @param {string} specifier string identifier in an import statement or import() expression
+ * @param {object} context metadata about the specifier, including url of the parent module and any import assertions
  *        Optional argument that only needs to be passed when changed
- * @param {Function} nextResolve
- *        The Node.js default resolve hook
+ * @param {Function} nextResolve The subsequent resolve hook in the chain, or the Node.js default resolve hook after the last user-supplied resolve hook
  * @returns {Promise} Promise object representing the resolution of a given specifier
  */
 export async function resolve(specifier, context, nextResolve) {
-  if (!newrelic.agent || !isSupportedVersion()) {
+  if (!newrelic.agent || !isSupportedVersion() || isFromEsmLoader(context)) {
     return nextResolve(specifier, context, nextResolve)
   }
 
@@ -45,18 +51,19 @@ export async function resolve(specifier, context, nextResolve) {
    * duplicating the logic of the Node.js hook
    */
   const resolvedModule = await nextResolve(specifier, context, nextResolve)
+  const { url, format } = resolvedModule
   const instrumentationName = shimmer.getInstrumentationNameFromModuleName(specifier)
   const instrumentationDefinition = shimmer.registeredInstrumentations[instrumentationName]
 
   if (instrumentationDefinition) {
-    logger.debug(`Instrumentation exists for ${specifier}`)
+    logger.debug(`Instrumentation exists for ${specifier} ${format} package.`)
 
-    if (resolvedModule.format === 'commonjs') {
+    if (format === 'commonjs') {
       // ES Modules translate import statements into fully qualified filepaths, so we create a copy of our instrumentation under this filepath
       const instrumentationDefinitionCopy = Object.assign({}, instrumentationDefinition)
 
       // Stripping the prefix is necessary because the code downstream gets this url without it
-      instrumentationDefinitionCopy.moduleName = resolvedModule.url.replace('file://', '')
+      instrumentationDefinitionCopy.moduleName = url.replace('file://', '')
 
       // Added to keep our Supportability metrics from exploding/including customer info via full filepath
       instrumentationDefinitionCopy.specifier = specifier
@@ -66,12 +73,70 @@ export async function resolve(specifier, context, nextResolve) {
       logger.debug(
         `Registered CommonJS instrumentation for ${specifier} under ${instrumentationDefinitionCopy.moduleName}`
       )
+    } else if (format === 'module') {
+      registeredSpecifiers.set(url, specifier)
+      const modifiedUrl = new URL(url)
+      // add a query param to the resolved url so the load hook below knows
+      // to rewrite and wrap the source code
+      modifiedUrl.searchParams.set('hasNrInstrumentation', 'true')
+      resolvedModule.url = modifiedUrl.href
     } else {
-      logger.debug(`${specifier} is not a CommonJS module, skipping for now`)
+      logger.debug(`${specifier} is not a CommonJS nor ESM package, skipping for now.`)
     }
   }
 
   return resolvedModule
+}
+
+/**
+ * Hook chain responsible for determining how a URL should be interpreted, retrieved, and parsed.
+ *
+ * Our loader has to be the last user-supplied loader if chaining is happening,
+ * as we rely on `nextLoad` being the default Node.js resolve hook to load the ESM.
+ *
+ * Docs: https://nodejs.org/dist/latest-v18.x/docs/api/esm.html#loadurl-context-nextload
+ *
+ * @param {string} url the URL returned by the resolve chain
+ * @param {object} context metadata about the url, including conditions, format and import assertions
+ * @param {Function} nextLoad the subsequent load hook in the chain, or the Node.js default load hook after the last user-supplied load hook
+ * @returns {Promise} Promise object representing the resolution of a given specifier
+ */
+export async function load(url, context, nextLoad) {
+  if (!newrelic.agent || !isSupportedVersion()) {
+    return nextLoad(url, context, nextLoad)
+  }
+
+  let parsedUrl
+
+  try {
+    parsedUrl = new URL(url)
+  } catch (err) {
+    logger.error('Unable to parse url: %s, msg: %s', url, err.message)
+    return nextLoad(url, context, nextLoad)
+  }
+
+  const hasNrInstrumentation = parsedUrl.searchParams.get('hasNrInstrumentation')
+
+  if (!hasNrInstrumentation) {
+    return nextLoad(url, context, nextLoad)
+  }
+
+  /**
+   * undo the work we did in the resolve hook above
+   * so we can properly rewrite source and not get in an infinite loop
+   */
+  parsedUrl.searchParams.delete('hasNrInstrumentation')
+
+  const originalUrl = parsedUrl.href
+  const specifier = registeredSpecifiers.get(originalUrl)
+  const rewrittenSource = await wrapEsmSource(originalUrl, specifier)
+  logger.debug(`Registered module instrumentation for ${specifier}.`)
+
+  return {
+    format: 'module',
+    source: rewrittenSource,
+    shortCircuit: true
+  }
 }
 
 /**
@@ -81,7 +146,7 @@ export async function resolve(specifier, context, nextResolve) {
  *        instantiation of the New Relic agent
  * @returns {void}
  */
-export function addESMSupportabilityMetrics(agent) {
+function addESMSupportabilityMetrics(agent) {
   if (isSupportedVersion()) {
     agent.metrics.getOrCreateMetric(NAMES.FEATURES.ESM.LOADER).incrementCallCount()
   } else {
@@ -91,4 +156,38 @@ export function addESMSupportabilityMetrics(agent) {
     )
     agent.metrics.getOrCreateMetric(NAMES.FEATURES.ESM.UNSUPPORTED_LOADER).incrementCallCount()
   }
+}
+
+/**
+ * Rewrites the source code of a ES module we want to instrument.
+ * This is done by injecting the ESM shim which proxies every property on the exported
+ * module and registers the module with shimmer so instrumentation can be registered properly.
+ *
+ * @param {string} url the URL returned by the resolve chain
+ * @param {string} specifier string identifier in an import statement or import() expression
+ * @returns {string} source code rewritten to wrap with our esm-shim
+ */
+async function wrapEsmSource(url, specifier) {
+  const pkg = await import(url)
+  const props = Object.keys(pkg)
+  const trimmedUrl = url.replace('file://', '')
+
+  return `
+    import wrapModule from '${esmShimPath.href}'
+    import * as _originalModule from '${url}'
+    // lets have as little code in here as possible and push most to
+    // a helper function or class
+    const _wrappedModule = wrapModule(_originalModule, '${specifier}', '${trimmedUrl}')
+    // Generate matching exports
+    ${props
+      .map((propName) => {
+        const propertyExportSource = `
+    let _${propName} = _wrappedModule.${propName}
+    // this allows for dynamically mapping to ${propName}
+    export { _${propName} as ${propName} }`
+
+        return propertyExportSource
+      })
+      .join('\n')}
+  `
 }

--- a/lib/esm-shim.mjs
+++ b/lib/esm-shim.mjs
@@ -16,12 +16,18 @@ export default function wrapModule(module, moduleName, resolvedPath) {
     set: (target, key, val) => {
       return (proxiedProps[key] = val)
     },
+    /**
+     * This is normally not allowed.
+     *  We have some things that define property, unsure if at the module level.
+     * Ideally, we can get away from doing this sort of thing at all in the future
+     * in a post AsyncLocalStorage world, etc.
+     * If we never do at the module level, perhaps we can not define this or defer upstream
+     *
+     * @param target
+     * @param key
+     * @param descriptor
+     */
     defineProperty: (target, key, descriptor) => {
-      // This is normally not allowed.
-      // We have some things that define property, unsure if at the module level.
-      // Ideally, we can get away from doing this sort of thing at all in the future
-      // in a post AsyncLocalStorage world, etc.
-      // If we never do at the module level, perhaps we can not define this or defer upstream
       return Object.defineProperty(proxiedProps, key, descriptor)
     }
   })

--- a/lib/esm-shim.mjs
+++ b/lib/esm-shim.mjs
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import shimmer from './shimmer.js'
+import newrelic from '../index.js'
+const { agent } = newrelic
+
+export default function wrapModule(module, moduleName, resolvedPath) {
+  const proxiedProps = Object.assign(Object.create(null), module)
+  const proxiedModule = new Proxy(module, {
+    get: (target, key) => {
+      return proxiedProps[key] || target[key]
+    },
+    set: (target, key, val) => {
+      return (proxiedProps[key] = val)
+    },
+    defineProperty: (target, key, descriptor) => {
+      // This is normally not allowed.
+      // We have some things that define property, unsure if at the module level.
+      // Ideally, we can get away from doing this sort of thing at all in the future
+      // in a post AsyncLocalStorage world, etc.
+      // If we never do at the module level, perhaps we can not define this or defer upstream
+      return Object.defineProperty(proxiedProps, key, descriptor)
+    }
+  })
+
+  return shimmer.instrumentPostLoad(agent, proxiedModule, moduleName, resolvedPath, true)
+}

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -467,12 +467,12 @@ const shimmer = (module.exports = {
     return instrumentation
   },
 
-  instrumentPostLoad(agent, module, moduleName, resolvedName) {
+  instrumentPostLoad(agent, module, moduleName, resolvedName, returnModule = false) {
     const result = _postLoad(agent, module, moduleName, resolvedName)
     // This is to not break the public API
     // previously it would just call instrumentation
     // and not check the result
-    return !!result.__NR_instrumented
+    return returnModule ? result : !!result.__NR_instrumented
   }
 })
 

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -7,23 +7,10 @@
 module.exports = {
   plugins: ['disable'],
   processor: 'disable/disable',
-  parserOptions: {
-    ecmaVersion: '2020'
-  },
   settings: {
     'disable/plugins': ['jsdoc']
   },
   env: {
     mocha: true
-  },
-  overrides: [
-    {
-      files: ['*.mjs'],
-      rules: {
-        // TODO: remove this when we decide on how to address
-        // here: https://issues.newrelic.com/browse/NEWRELIC-3321
-        'node/no-unsupported-features/es-syntax': 'off'
-      }
-    }
-  ]
+  }
 }

--- a/test/lib/esm-helpers.mjs
+++ b/test/lib/esm-helpers.mjs
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as url from 'url'
+import semver from 'semver'
+const helpers = Object.create(null)
+
+helpers.__dirname = function __dirname(cwd) {
+  return url.fileURLToPath(new URL('.', cwd))
+}
+
+helpers.supportedLoaderVersion = function supportedLoaderVersion() {
+  return semver.gte(process.version, 'v16.12.0')
+}
+
+export default helpers

--- a/test/lib/test-mod-instrumentation.js
+++ b/test/lib/test-mod-instrumentation.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+// NOTE: This signature is different that traditional instrumentation as
+// I am not passing in the agent, shim, etc like it is done in shimmer
+// See: https://github.com/newrelic/node-newrelic/blob/main/lib/shimmer.js#L564
+module.exports = function initialize(shim, testMod) {
+  shim.wrap(testMod.default, 'testMethod', function wrapTestMethod(shim, orig) {
+    return function wrappedTestMethod() {
+      const result = orig.apply(this, arguments)
+      return `${result} that we have instrumented.`
+    }
+  })
+
+  shim.wrap(testMod, 'namedMethod', function wrapNamedMethod(shim, orig) {
+    return function wrappedNamedMethod() {
+      const result = orig.apply(this, arguments)
+      return `${result} that we have instrumented.`
+    }
+  })
+}

--- a/test/lib/test-mod.mjs
+++ b/test/lib/test-mod.mjs
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const testMod = Object.create(null)
+testMod.testMethod = function testMethod() {
+  return 'this is a test method'
+}
+
+export default testMod
+export const namedMethod = function namedMethod() {
+  return 'this is a named method'
+}

--- a/test/unit/esm-instrumentation.test.mjs
+++ b/test/unit/esm-instrumentation.test.mjs
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import tap from 'tap'
+import sinon from 'sinon'
+import path from 'node:path'
+import * as td from 'testdouble'
+import shimmer from '../../lib/shimmer.js'
+import helper from '../lib/agent_helper.js'
+import esmHelpers from '../lib/esm-helpers.mjs'
+import { default as testModInstrumentation } from '../lib/test-mod-instrumentation.js'
+const __dirname = esmHelpers.__dirname(import.meta.url)
+const TEST_MOD_FILE_PATH = path.resolve(`${__dirname}../lib/test-mod.mjs`)
+const MOD_URL = `file://${TEST_MOD_FILE_PATH}`
+shimmer.registerInstrumentation({
+  moduleName: 'test-mod',
+  type: 'generic',
+  onRequire: testModInstrumentation
+})
+
+tap.test('Instrument ESM', { skip: !esmHelpers.supportedLoaderVersion() }, async (t) => {
+  const fakeAgent = helper.loadMockedAgent()
+  await td.replaceEsm('../../index.js', {}, { agent: fakeAgent })
+  const loader = await import('../../esm-loader.mjs')
+  loader.registeredSpecifiers.set(MOD_URL, 'test-mod')
+  const data = await loader.load(`${MOD_URL}?hasNrInstrumentation=true`, {}, sinon.stub())
+  const mod = await import(
+    `data:application/javascript;base64,${Buffer.from(data.source).toString('base64')}`
+  )
+  const result = mod.default.testMethod()
+  t.ok(result.endsWith('that we have instrumented.'), 'should instrument methods on default export')
+  const namedMethodResult = mod.namedMethod()
+  t.ok(namedMethodResult.endsWith('that we have instrumented.'), 'should instrument named exports')
+})

--- a/test/unit/esm-loader.test.mjs
+++ b/test/unit/esm-loader.test.mjs
@@ -232,22 +232,16 @@ tap.test('ES Module Loader', { skip: !esmHelpers.supportedLoaderVersion() }, (t)
     const expectedSource = `
     import wrapModule from 'file://${ESM_SHIM_FILE_PATH}'
     import * as _originalModule from '${MOD_URL}'
-    // lets have as little code in here as possible and push most to
-    // a helper function or class
     const _wrappedModule = wrapModule(_originalModule, 'test-mod', '${TEST_MOD_FILE_PATH}')
-    // Generate matching exports
     
     let _default = _wrappedModule.default
-    // this allows for dynamically mapping to default
     export { _default as default }
 
     let _namedMethod = _wrappedModule.namedMethod
-    // this allows for dynamically mapping to namedMethod
     export { _namedMethod as namedMethod }
   `
     t.equal(data.source, expectedSource, 'should rewrite source accordingly')
     t.equal(data.format, 'module', 'should be of format module')
-    t.ok(data.shortCircuit, 'should apply shortcuit to load hook')
   })
 
   t.test('should call next load if imported url lacks `hasNrInstrumentation`', async (t) => {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Implemented load hook in ESM loader to provide ability to instrument ESM packages.

## Links
Closes NEWRELIC-3768

## Details
As you can see our approach to providing the plumbing for instrumenting ESM packages is to rewrite the source code in the load hook to wrap all exported functions in a proxy.  I was able to prove this out by adding a test ESM package and basic instrumentation.
