### PR TITLE
removes log forwarding from example config as it has been made GA

### DIFF
--- a/newrelic.js
+++ b/newrelic.js
@@ -28,14 +28,6 @@ exports.config = {
    * attributes include/exclude lists.
    */
   allow_all_headers: true,
-  application_logging: {
-    forwarding: {
-      /**
-       * Toggles whether the agent gathers log records for sending to New Relic.
-       */
-      enabled: true
-    }
-  },
   attributes: {
     /**
      * Prefix of attributes to exclude from all destinations. Allows * as wildcard


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Removed `application_logging.forwarding.enabled` stanza from sample config as the feature is Generally Available.

## Links

## Details
I noticed this was still being set even after making log forwarding GA.
