### PR TITLE
restore shortCircuit on load hook to prevent crash in loader

### DIFF
--- a/esm-loader.mjs
+++ b/esm-loader.mjs
@@ -134,7 +134,8 @@ export async function load(url, context, nextLoad) {
 
   return {
     format: 'module',
-    source: rewrittenSource
+    source: rewrittenSource,
+    shortCircuit: true
   }
 }
 

--- a/test/unit/esm-loader.test.mjs
+++ b/test/unit/esm-loader.test.mjs
@@ -242,6 +242,7 @@ tap.test('ES Module Loader', { skip: !esmHelpers.supportedLoaderVersion() }, (t)
   `
     t.equal(data.source, expectedSource, 'should rewrite source accordingly')
     t.equal(data.format, 'module', 'should be of format module')
+    t.ok(data.shortCircuit, 'should set shortCircuit to true to properly return load hook')
   })
 
   t.test('should call next load if imported url lacks `hasNrInstrumentation`', async (t) => {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
I hit an issue when trying to use the new hook to instrument ESM which does not exist in the unit tests because it doesn't actually rely on the `--experimental-loader` hook.  If we had versioned tests at the time I change this it would've caught the bug.  

```sh
Error [ERR_LOADER_CHAIN_INCOMPLETE]: "newrelic/esm-loader.mjs 'load'" did not call the next hook in its chain and did not explicitly signal a short circuit. If this is intentional, include `shortCircuit: true` in the hook's return.
```
