### PR TITLE
defaults: raise custom events limit to 30k

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -699,7 +699,7 @@ exports.config = () => ({
      *
      * @env NEW_RELIC_CUSTOM_INSIGHTS_EVENTS_MAX_SAMPLES_STORED
      */
-    max_samples_stored: 1000
+    max_samples_stored: 30000
   },
   /**
    * This is used to configure properties about the user's host name.


### PR DESCRIPTION
## Proposed Release Notes

* Increased the default limit of custom events from 1,000 to 30,000. 

## Links

* Closes https://issues.newrelic.com/browse/NR-54396

## Details

* Funny, the spec said we were at 10k, but that old limit is clearly just 1k.
