### PR TITLE
skip running versioned tests with c8 when not --major

### DIFF
--- a/bin/run-versioned-tests.sh
+++ b/bin/run-versioned-tests.sh
@@ -23,6 +23,17 @@ else
   )
 fi
 
+# C8 runs out of heap when running against
+# patch/minor flag.  We will just skip it
+# and figure out another way to get coverage
+# when running on main branch. 
+if [[ $VERSIONED_MODE == '--major' ]];
+then
+  C8="c8 -o ./coverage/verisoned"
+else 
+  C8=""
+fi
+
 export AGENT_PATH=`pwd`
 
 # Runner will default to CPU count if not specified.
@@ -37,7 +48,7 @@ fi
 
 if [[ "${NPM7}" = 1 ]];
 then
-  time c8 -o ./coverage/versioned ./node_modules/.bin/versioned-tests $VERSIONED_MODE -i 2 --all --strict --samples $SAMPLES $JOBS_ARGS ${directories[@]}
+  time $C8 ./node_modules/.bin/versioned-tests $VERSIONED_MODE -i 2 --all --strict --samples $SAMPLES $JOBS_ARGS ${directories[@]}
 else
-  time c8 -o ./coverage/versioned ./node_modules/.bin/versioned-tests $VERSIONED_MODE -i 2 --strict --samples $SAMPLES $JOBS_ARGS ${directories[@]}
+  time $C8 ./node_modules/.bin/versioned-tests $VERSIONED_MODE -i 2 --strict --samples $SAMPLES $JOBS_ARGS ${directories[@]}
 fi


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
I merged #1371 and the CI on main failed with

```sh
<--- Last few GCs --->

[54885:0x150028000]   767040 ms: Mark-sweep 4043.2 (4138.5) -> 4036.7 (4138.4) MB, 1502.2 / 0.0 ms  (average mu = 0.109, current mu = 0.015) allocation failure; scavenge might not succeed
[54885:0x150028000]   768543 ms: Mark-sweep 4045.7 (4143.6) -> 4040.5 (4142.4) MB, 1488.7 / 0.0 ms  (average mu = 0.061, current mu = 0.009) allocation failure; scavenge might not succeed


<--- JS stacktrace --->

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
 1: 0x100e1bedc node::Abort() [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
 2: 0x100e1c064 node::ModifyCodeGenerationFromStrings(v8::Local<v8::Context>, v8::Local<v8::Value>, bool) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
 3: 0x100f6ec98 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
 4: 0x101119894 v8::internal::EmbedderStackStateScope::EmbedderStackStateScope(v8::internal::Heap*, v8::internal::EmbedderStackStateScope::Origin, cppgc::EmbedderStackState) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
 5: 0x10111d49c v8::internal::Heap::CollectSharedGarbage(v8::internal::GarbageCollectionReason) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
 6: 0x10111a490 v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector, v8::internal::GarbageCollectionReason, char const*, v8::GCCallbackFlags) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
 7: 0x1011178e8 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
 8: 0x10110c620 v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
 9: 0x10110ce50 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
10: 0x1010f2568 v8::internal::Factory::AllocateRaw(int, v8::internal::AllocationType, v8::internal::AllocationAlignment) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
11: 0x1010ec0f0 v8::internal::MaybeHandle<v8::internal::SeqOneByteString> v8::internal::FactoryBase<v8::internal::Factory>::NewRawStringWithMap<v8::internal::SeqOneByteString>(int, v8::internal::Map, v8::internal::AllocationType) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
12: 0x1010f4b24 v8::internal::Factory::NewStringFromUtf8(v8::base::Vector<char const> const&, v8::internal::AllocationType) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
13: 0x100f90db8 v8::String::NewFromUtf8(v8::Isolate*, char const*, v8::NewStringType, int) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
14: 0x100eceb94 node::StringBytes::Encode(v8::Isolate*, char const*, unsigned long, node::encoding, v8::Local<v8::Value>*) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
15: 0x100e00a84 void node::Buffer::(anonymous namespace)::StringSlice<(node::encoding)1>(v8::FunctionCallbackInfo<v8::Value> const&) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
16: 0x100fdf4d0 v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
17: 0x100fdefcc v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, v8::internal::BuiltinArguments) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
18: 0x100fde7f8 v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
19: 0x1017d118c Builtins_CEntry_Return1_DontSaveFPRegs_ArgvOnStack_BuiltinExit [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
20: 0x105e577f4
21: 0x105e5e5ec
22: 0x105eda7c8
23: 0x105ed73f4
24: 0x10175c198 Builtins_InterpreterEntryTrampoline [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
25: 0x10175c198 Builtins_InterpreterEntryTrampoline [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
26: 0x10175c198 Builtins_InterpreterEntryTrampoline [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
27: 0x10175c198 Builtins_InterpreterEntryTrampoline [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
28: 0x10175c198 Builtins_InterpreterEntryTrampoline [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
29: 0x10175c198 Builtins_InterpreterEntryTrampoline [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
30: 0x10175c198 Builtins_InterpreterEntryTrampoline [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
31: 0x10175c198 Builtins_InterpreterEntryTrampoline [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
32: 0x10175c198 Builtins_InterpreterEntryTrampoline [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
33: 0x10175a4d0 Builtins_JSEntryTrampoline [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
34: 0x10175a164 Builtins_JSEntry [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
35: 0x10109b164 v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
36: 0x10109a698 v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>, int, v8::internal::Handle<v8::internal::Object>*) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
37: 0x100f8abd8 v8::Function::Call(v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
38: 0x100d693a0 node::InternalMakeCallback(node::Environment*, v8::Local<v8::Object>, v8::Local<v8::Object>, v8::Local<v8::Function>, int, v8::Local<v8::Value>*, node::async_context) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
39: 0x100d7e32c node::AsyncWrap::MakeCallback(v8::Local<v8::Function>, int, v8::Local<v8::Value>*) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
40: 0x100ec2c10 node::(anonymous namespace)::ProcessWrap::OnExit(uv_process_s*, long long, int) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
41: 0x1017425c0 uv__chld [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
42: 0x101743c98 uv__signal_event [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
43: 0x10174c844 uv__io_poll [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
44: 0x10173ac94 uv_run [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
45: 0x100d69ccc node::SpinEventLoop(node::Environment*) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
46: 0x100e56a30 node::NodeMainInstance::Run(int*, node::Environment*) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
47: 0x100e56708 node::NodeMainInstance::Run() [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
48: 0x100def1d4 node::Start(int, char**) [/Users/revans/.nvm/versions/node/v18.6.0/bin/node]
49: 0x105c0908c
./bin/run-versioned-tests.sh: line 43: 54885 Abort trap: 6           c8 -o ./coverage/versioned ./node_modules/.bin/versioned-tests $VERSIONED_MODE -i 2 --all --strict --samples $SAMPLES $JOBS_ARGS ${directories[@]}
12:14
``

So my plan of trending all coverage on branches and main will have to change slightly.  I think to get versioned coverage on main we will schedule a nightly run but that's for another ticket.  This PR will just only run versioned tests with c8 when --major is specified which is the default in PRs.
