### PR TITLE
NEWRELIC-4484 NEWRELIC-4485: implement API for enqueing logs and metrics

### DIFF
--- a/lib/instrumentation/bunyan.js
+++ b/lib/instrumentation/bunyan.js
@@ -11,18 +11,9 @@ const {
   isLocalDecoratingEnabled,
   isMetricsEnabled,
   createModuleUsageMetric,
-  incrementLoggingLinesMetrics
+  incrementLoggingLinesMetrics,
+  truncate
 } = require('../util/application-logging')
-
-const MAX_LENGTH = 1021
-const OUTPUT_LENGTH = 1024
-const truncate = (str) => {
-  if (str && str.length > OUTPUT_LENGTH) {
-    return str.substring(0, MAX_LENGTH) + '...'
-  }
-
-  return str
-}
 
 const logger = require('../logger').child({ component: 'bunyan' })
 

--- a/test/unit/api/api-record-log-events.test.js
+++ b/test/unit/api/api-record-log-events.test.js
@@ -31,25 +31,10 @@ tap.test('Agent API - recordCustomEvent', (t) => {
 
   t.test('can handle a singular log message', (t) => {
     const now = Date.now()
-    const stack = `Error
-      at REPL53:1:1
-      at Script.runInThisContext (node:vm:129:12)
-      at REPLServer.defaultEval (node:repl:572:29)
-      at bound (node:domain:433:15)
-      at REPLServer.runBound [as eval] (node:domain:444:12)
-      at REPLServer.onLine (node:repl:902:10)
-      at REPLServer.emit (node:events:525:35)
-      at REPLServer.emit (node:domain:489:12)
-      at [_onLine] [as _onLine] (node:internal/readline/interface:425:12)
-      at [_line] [as _line] (node:internal/readline/interface:886:18)`
-
+    const error = new Error('testing error')
     api.recordLogEvent({
       message,
-      error: {
-        message: 'REPL is unhappy',
-        stack: stack,
-        class: 'Error'
-      }
+      error
     })
 
     const logMessage = popTopLogMessage(agent)

--- a/test/unit/api/api-record-log-events.test.js
+++ b/test/unit/api/api-record-log-events.test.js
@@ -31,9 +31,26 @@ tap.test('Agent API - recordCustomEvent', (t) => {
 
   t.test('can handle a singular log message', (t) => {
     const now = Date.now()
-    t.doesNotThrow(() => {
-      api.recordLogEvent({ message })
-    }, 'does not throw when logging a single message')
+    const stack = `Error
+      at REPL53:1:1
+      at Script.runInThisContext (node:vm:129:12)
+      at REPLServer.defaultEval (node:repl:572:29)
+      at bound (node:domain:433:15)
+      at REPLServer.runBound [as eval] (node:domain:444:12)
+      at REPLServer.onLine (node:repl:902:10)
+      at REPLServer.emit (node:events:525:35)
+      at REPLServer.emit (node:domain:489:12)
+      at [_onLine] [as _onLine] (node:internal/readline/interface:425:12)
+      at [_line] [as _line] (node:internal/readline/interface:886:18)`
+
+    api.recordLogEvent({
+      message,
+      error: {
+        message: 'REPL is unhappy',
+        stack: stack,
+        class: 'Error'
+      }
+    })
 
     const logMessage = popTopLogMessage(agent)
     t.ok(logMessage, 'we have a log message')
@@ -43,6 +60,9 @@ tap.test('Agent API - recordCustomEvent', (t) => {
     t.ok(logMessage.hostname, 'a hostname was set')
     t.notOk(logMessage['trace.id'], 'it does not have a trace id')
     t.notOk(logMessage['span.id'], 'it does not have a span id')
+    t.equal(logMessage['error.message'], 'REPL is unhappy', 'it has the right error.message')
+    t.equal(logMessage['error.stack'], stack, 'it has the right error.stack')
+    t.equal(logMessage['error.class'], 'Error', 'it has the right error.class')
 
     const lineMetric = agent.metrics.getMetric(LOGGING.LINES)
     t.ok(lineMetric, 'line logging metric exists')
@@ -60,18 +80,19 @@ tap.test('Agent API - recordCustomEvent', (t) => {
   })
 
   t.test('adds the proper linking data in a transaction', (t) => {
-    const now = Date.now()
+    const birthday = 365515200000
+    const birth = 'a new jordi is here'
 
     helper.runInTransaction(agent, 'logging-api-test', (tx) => {
-      api.recordLogEvent({ message, level: 'info' })
+      api.recordLogEvent({ message: birth, timestamp: birthday, level: 'info' })
       tx.end()
     })
     const logMessage = popTopLogMessage(agent)
 
     t.ok(logMessage, 'we have a log message')
-    t.equal(logMessage.message, message, 'it has the right log message')
+    t.equal(logMessage.message, birth, 'it has the right log message')
     t.equal(logMessage.level, 'info', 'it has `info` severity')
-    t.ok(logMessage.timestamp >= now, 'its timestamp is current')
+    t.equal(logMessage.timestamp, birthday, 'its timestamp is correct')
     t.ok(logMessage.hostname, 'a hostname was set')
     t.ok(logMessage['trace.id'], 'it has a trace id')
     t.ok(logMessage['span.id'], 'it has a spand id')

--- a/test/unit/api/api-record-log-events.test.js
+++ b/test/unit/api/api-record-log-events.test.js
@@ -80,6 +80,7 @@ tap.test('Agent API - recordCustomEvent', (t) => {
   })
 
   t.test('adds the proper linking data in a transaction', (t) => {
+    agent.config.entity_guid = 'api-guid'
     const birthday = 365515200000
     const birth = 'a new jordi is here'
 
@@ -95,7 +96,10 @@ tap.test('Agent API - recordCustomEvent', (t) => {
     t.equal(logMessage.timestamp, birthday, 'its timestamp is correct')
     t.ok(logMessage.hostname, 'a hostname was set')
     t.ok(logMessage['trace.id'], 'it has a trace id')
-    t.ok(logMessage['span.id'], 'it has a spand id')
+    t.ok(logMessage['span.id'], 'it has a span id')
+    t.ok(logMessage['entity.type'], 'it has an entity type')
+    t.ok(logMessage['entity.name'], 'it has an entity name')
+    t.equal(logMessage['entity.guid'], 'api-guid', 'it has the right entity guid')
 
     const lineMetric = agent.metrics.getMetric(LOGGING.LINES)
     t.ok(lineMetric, 'line logging metric exists')

--- a/test/unit/api/api-record-log-events.test.js
+++ b/test/unit/api/api-record-log-events.test.js
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const helper = require('../../lib/agent_helper.js')
+const API = require('../../../api.js')
+const { SUPPORTABILITY, LOGGING } = require('../../../lib/metrics/names')
+const API_METRIC = SUPPORTABILITY.API + '/recordLogEvent'
+
+tap.test('Agent API - recordCustomEvent', (t) => {
+  t.autoend()
+
+  let agent = null
+  let api = null
+  const message = 'just logging a log in the logger'
+
+  t.beforeEach(() => {
+    agent = helper.loadMockedAgent()
+    api = new API(agent)
+  })
+
+  t.afterEach(() => {
+    helper.unloadAgent(agent)
+    agent = null
+    api = null
+  })
+
+  t.test('can handle a singular log message', (t) => {
+    const now = Date.now()
+    t.doesNotThrow(() => {
+      api.recordLogEvent({ message })
+    }, 'does not throw when logging a single message')
+
+    const logMessage = popTopLogMessage(agent)
+    t.ok(logMessage, 'we have a log message')
+    t.equal(logMessage.message, message, 'it has the right log message')
+    t.equal(logMessage.level, 'UNKNOWN', 'it has UNKNOWN severity')
+    t.ok(logMessage.timestamp >= now, 'its timestamp is current')
+    t.ok(logMessage.hostname, 'a hostname was set')
+    t.notOk(logMessage['trace.id'], 'it does not have a trace id')
+    t.notOk(logMessage['span.id'], 'it does not have a span id')
+
+    const lineMetric = agent.metrics.getMetric(LOGGING.LINES)
+    t.ok(lineMetric, 'line logging metric exists')
+    t.equal(lineMetric.callCount, 1, 'ensure a single log line was counted')
+
+    const unknownLevelMetric = agent.metrics.getMetric(LOGGING.LEVELS.UNKNOWN)
+    t.ok(unknownLevelMetric, 'unknown level logging metric exists')
+    t.equal(unknownLevelMetric.callCount, 1, 'ensure a single log line was counted')
+
+    const apiMetric = agent.metrics.getMetric(API_METRIC)
+    t.ok(apiMetric, 'API logging metric exists')
+    t.equal(apiMetric.callCount, 1, 'ensure one API call was counted')
+
+    t.end()
+  })
+
+  t.test('adds the proper linking data in a transaction', (t) => {
+    const now = Date.now()
+
+    helper.runInTransaction(agent, 'logging-api-test', (tx) => {
+      api.recordLogEvent({ message, level: 'info' })
+      tx.end()
+    })
+    const logMessage = popTopLogMessage(agent)
+
+    t.ok(logMessage, 'we have a log message')
+    t.equal(logMessage.message, message, 'it has the right log message')
+    t.equal(logMessage.level, 'info', 'it has `info` severity')
+    t.ok(logMessage.timestamp >= now, 'its timestamp is current')
+    t.ok(logMessage.hostname, 'a hostname was set')
+    t.ok(logMessage['trace.id'], 'it has a trace id')
+    t.ok(logMessage['span.id'], 'it has a spand id')
+
+    const lineMetric = agent.metrics.getMetric(LOGGING.LINES)
+    t.ok(lineMetric, 'line logging metric exists')
+    t.equal(lineMetric.callCount, 1, 'ensure a single log line was counted')
+
+    const infoLevelMetric = agent.metrics.getMetric(LOGGING.LEVELS.INFO)
+    t.ok(infoLevelMetric, 'info level logging metric exists')
+    t.equal(infoLevelMetric.callCount, 1, 'ensure a single log line was counted')
+
+    const apiMetric = agent.metrics.getMetric(API_METRIC)
+    t.ok(apiMetric, 'API logging metric exists')
+    t.equal(apiMetric.callCount, 1, 'ensure one API call was counted')
+
+    t.end()
+  })
+
+  t.test('does not collect logs when high security mode is on', (t) => {
+    // We need to go through all of the config logic, as HSM disables
+    // log forwarding as one of its configs, can't just directly set
+    // the HSM config after the agent has been created.
+    helper.unloadAgent(agent)
+    agent = helper.loadMockedAgent({ high_security: true })
+    api = new API(agent)
+
+    api.recordLogEvent({ message })
+
+    const logs = getLogMessages(agent)
+    t.equal(logs.length, 0, 'no log messages in queue')
+
+    const apiMetric = agent.metrics.getMetric(API_METRIC)
+    t.ok(apiMetric, 'API logging metric exists anyway')
+    t.equal(apiMetric.callCount, 1, 'ensure one API call was counted anyway')
+
+    t.end()
+  })
+
+  t.test('does not collect logs when log forwarding is disabled in the config', (t) => {
+    agent.config.application_logging.forwarding.enabled = false
+    api.recordLogEvent({ message })
+
+    const logs = getLogMessages(agent)
+    t.equal(logs.length, 0, 'no log messages in queue')
+
+    const apiMetric = agent.metrics.getMetric(API_METRIC)
+    t.ok(apiMetric, 'API logging metric exists anyway')
+    t.equal(apiMetric.callCount, 1, 'ensure one API call was counted anyway')
+
+    t.end()
+  })
+
+  t.test('it does not collect logs if the user sends a malformed message', (t) => {
+    t.doesNotThrow(() => {
+      api.recordLogEvent(message)
+    }, 'no erroring out if passing in a string instead of an object')
+
+    t.doesNotThrow(() => {
+      api.recordLogEvent({ msg: message })
+    }, 'no erroring out if passing in an object missing a "message" attribute')
+
+    const logs = getLogMessages(agent)
+    t.equal(logs.length, 0, 'no log messages in queue')
+
+    const apiMetric = agent.metrics.getMetric(API_METRIC)
+    t.ok(apiMetric, 'API logging metric exists anyway')
+    t.equal(apiMetric.callCount, 2, 'ensure two API calls were counted anyway')
+
+    t.end()
+  })
+
+  t.test('log line metrics are not collected if the setting is disabled', (t) => {
+    agent.config.application_logging.metrics.enabled = false
+    api.recordLogEvent({ message })
+
+    const logMessage = popTopLogMessage(agent)
+    t.ok(logMessage, 'we have a log message')
+
+    const lineMetric = agent.metrics.getMetric(LOGGING.LINES)
+    t.notOk(lineMetric, 'line logging metric does not exist')
+
+    const unknownLevelMetric = agent.metrics.getMetric(LOGGING.LEVELS.UNKNOWN)
+    t.notOk(unknownLevelMetric, 'unknown level logging metric does not exist')
+
+    const apiMetric = agent.metrics.getMetric(API_METRIC)
+    t.ok(apiMetric, 'but API logging metric does exist')
+    t.equal(apiMetric.callCount, 1, 'and one API call was counted anyway')
+    t.end()
+  })
+})
+
+function popTopLogMessage(agent) {
+  return getLogMessages(agent).pop()
+}
+
+function getLogMessages(agent) {
+  return agent.logs.events.toArray()
+}

--- a/test/unit/api/api-record-log-events.test.js
+++ b/test/unit/api/api-record-log-events.test.js
@@ -45,8 +45,8 @@ tap.test('Agent API - recordCustomEvent', (t) => {
     t.ok(logMessage.hostname, 'a hostname was set')
     t.notOk(logMessage['trace.id'], 'it does not have a trace id')
     t.notOk(logMessage['span.id'], 'it does not have a span id')
-    t.equal(logMessage['error.message'], 'REPL is unhappy', 'it has the right error.message')
-    t.equal(logMessage['error.stack'], stack, 'it has the right error.stack')
+    t.equal(logMessage['error.message'], 'testing error', 'it has the right error.message')
+    t.equal(logMessage['error.stack'], error.stack, 'it has the right error.stack')
     t.equal(logMessage['error.class'], 'Error', 'it has the right error.class')
 
     const lineMetric = agent.metrics.getMetric(LOGGING.LINES)

--- a/test/unit/api/stub.test.js
+++ b/test/unit/api/stub.test.js
@@ -8,7 +8,7 @@
 const tap = require('tap')
 const API = require('../../../stub_api')
 
-const EXPECTED_API_COUNT = 29
+const EXPECTED_API_COUNT = 30
 
 tap.test('Agent API - Stubbed Agent API', (t) => {
   t.autoend()


### PR DESCRIPTION
Some tests also added.

## Proposed Release Notes

* Added an API for enqueuing application logs for forwarding 
```js
newrelic.recordLogEvent({ message: 'hello world', level: 'info' })`
```

**Note**: If you are including a serialized error make sure it is on the `error` key of message: 
```js
const error = new Error('testing errors'); 
newrelic.recordLogEvent({ message: 'error example', level: 'error', error })
```

## Links
closes NEWRELIC-4484
closes NEWRELIC-4485

## Details

* This should behave identically as normal application log forwarding with respect to configuration and metrics. A new metric has been added that counts the number of times this API function is called.