### PR TITLE
update actions that are using deprecated node 12

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -11,9 +11,9 @@ jobs:
         node-version: [lts/*]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
@@ -29,9 +29,9 @@ jobs:
         node-version: [14.x, 16.x, 18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
@@ -49,9 +49,9 @@ jobs:
         node-version: [14.x, 16.x, 18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
@@ -69,9 +69,9 @@ jobs:
         node-version: [14.x, 16.x, 18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
@@ -101,9 +101,9 @@ jobs:
         node-version: [16.x, 18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
@@ -121,9 +121,9 @@ jobs:
         node-version: [16.x, 18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
@@ -143,9 +143,9 @@ jobs:
         node-version: [16.x, 18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies

--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -9,9 +9,9 @@ jobs:
   checking-pending-prs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: lts/*
     - name: Install Dependencies

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -24,7 +24,7 @@ jobs:
         # it needs the full history to perform this merge.
         fetch-depth: 0
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -23,14 +23,14 @@ jobs:
 
     steps:
     # Check out caller repo
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # check out agent repo to agent-repo for the bin folders
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: newrelic/node-newrelic
         path: agent-repo
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     # Only need to install deps in agent-repo because of the bin scripts

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -12,9 +12,9 @@ jobs:
         node-version: [lts/*]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1 # https://github.com/actions/setup-node
+      uses: actions/setup-node@v3 # https://github.com/actions/setup-node
       with:
         node-version: ${{ matrix.node-version }}
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release-creation.yml
+++ b/.github/workflows/release-creation.yml
@@ -30,14 +30,14 @@ jobs:
 
     steps:
     # Check out caller repo
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # check out agent repo to agent-repo for the bin folders
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: newrelic/node-newrelic
         path: agent-repo
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -22,7 +22,7 @@ jobs:
             return data.data && data.data.default_branch === context.ref.split('/').slice(-1)[0]
       - name: Checkout Self
         if: ${{ steps.default-branch.outputs.result == 'true' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run Repolinter
         if: ${{ steps.default-branch.outputs.result == 'true' }}
         uses: newrelic/repolinter-action@v1

--- a/.github/workflows/smoke-test-workflow.yml
+++ b/.github/workflows/smoke-test-workflow.yml
@@ -19,9 +19,9 @@ jobs:
         node-version: [14.x, 16.x, 18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies

--- a/.github/workflows/test-specific.yml
+++ b/.github/workflows/test-specific.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v3
       ref: ${{ github.event.inputs.branch }}
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
I just happen to notice this while waiting for the [agent to be released](https://github.com/newrelic/node-newrelic/actions/runs/3315379709).

Github actions removed [Node 12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) as a runner.  This PR fixes all instances that rely on Node.js 12.
