### PR TITLE
NR-57994 Requested changes for code coverage collection

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -120,7 +120,7 @@ jobs:
         files: lcov.info
         flags: versioned-tests-${{ matrix.node-version }}
 
-  async-local-context-tests:
+  async-local-context:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -41,6 +41,7 @@ jobs:
     - name: Post Unit Test Coverage
       uses: codecov/codecov-action@v3
       with:
+        fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./coverage/unit/
         files: lcov.info
@@ -50,6 +51,7 @@ jobs:
     - name: Post ESM Unit Test Coverage
       uses: codecov/codecov-action@v3
       with:
+        fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./coverage/esm-unit/
         files: lcov.info
@@ -77,6 +79,7 @@ jobs:
     - name: Post Integration Test Coverage
       uses: codecov/codecov-action@v3
       with:
+        fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./coverage/integration/
         files: lcov.info
@@ -115,6 +118,7 @@ jobs:
       uses: codecov/codecov-action@v3
       if: github.ref != 'refs/heads/main'
       with:
+        fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./coverage/versioned/
         files: lcov.info

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -54,9 +54,6 @@ jobs:
         directory: ./coverage/esm-unit/
         files: lcov.info
         flags: esm-unit-tests-${{ matrix.node-version }}
-    - name: Run Async Local Context Unit Tests
-      if: ${{ matrix.node-version != '14.x' }}
-      run: npm run unit:async-local
 
   integration:
     runs-on: ubuntu-latest
@@ -84,9 +81,6 @@ jobs:
         directory: ./coverage/integration/
         files: lcov.info
         flags: integration-tests-${{ matrix.node-version }}
-    - name: Run Async Local Context Integration Tests
-      if: ${{ matrix.node-version != '14.x' }}
-      run: npm run integration:async-local
 
   versioned:
     runs-on: ubuntu-latest
@@ -125,8 +119,29 @@ jobs:
         directory: ./coverage/versioned/
         files: lcov.info
         flags: versioned-tests-${{ matrix.node-version }}
+
+  async-local-context-tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install Dependencies
+      run: npm ci
+    - name: Run Async Local Context Unit Tests
+      run: npm run unit:async-local
+    - name: Run Docker Services
+      run: npm run services
+    - name: Run Async Local Context Integration Tests
+      run: npm run integration:async-local
     - name: Run Async Local Context Versioned Tests (Node 16+)
-      if: ${{ matrix.node-version != '14.x' }}
       run: TEST_CHILD_TIMEOUT=600000 npm run versioned:async-local
       env:
         VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -135,12 +135,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
       run: npm ci
-    - name: Run Async Local Context Unit Tests
-      run: npm run unit:async-local
     - name: Run Docker Services
       run: npm run services
-    - name: Run Async Local Context Integration Tests
-      run: npm run integration:async-local
     - name: Run Async Local Context Versioned Tests (Node 16+)
       run: TEST_CHILD_TIMEOUT=600000 npm run versioned:async-local
       env:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -41,7 +41,6 @@ jobs:
     - name: Post Unit Test Coverage
       uses: codecov/codecov-action@v3
       with:
-        fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./coverage/unit/
         files: lcov.info
@@ -51,7 +50,6 @@ jobs:
     - name: Post ESM Unit Test Coverage
       uses: codecov/codecov-action@v3
       with:
-        fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./coverage/esm-unit/
         files: lcov.info
@@ -79,7 +77,6 @@ jobs:
     - name: Post Integration Test Coverage
       uses: codecov/codecov-action@v3
       with:
-        fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./coverage/integration/
         files: lcov.info
@@ -118,7 +115,6 @@ jobs:
       uses: codecov/codecov-action@v3
       if: github.ref != 'refs/heads/main'
       with:
-        fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./coverage/versioned/
         files: lcov.info

--- a/.github/workflows/versioned-coverage.yml
+++ b/.github/workflows/versioned-coverage.yml
@@ -1,0 +1,49 @@
+# Daily workflow to gather coverage of our versioned tests from the `main` branch
+
+# Reason: We run the versioned tests on main with the `--minor` flag, which causes
+# c8 to OOM. So instead, we will have this daily job to scrape the coverage every
+# weekday until we can figure out the c8 issue
+
+name: Gather Versioned Test Coverage
+
+on:
+  schedule:
+    - cron:  '0 9 * * 1-5'
+
+jobs:
+  versioned:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install Dependencies
+      run: npm ci
+    - name: Run Docker Services
+      run: npm run services
+    - name: Run Versioned Tests (npm v6 / Node 12/14)
+      if: ${{ matrix.node-version == '14.x' }}
+      run: TEST_CHILD_TIMEOUT=600000 npm run versioned:npm6
+      env:
+        VERSIONED_MODE: --major
+        JOBS: 4 # 2 per CPU seems to be the sweet spot in GHA (July 2022)
+    - name: Run Versioned Tests (npm v7 / Node 16+)
+      if: ${{ matrix.node-version != '14.x' }}
+      run: TEST_CHILD_TIMEOUT=600000 npm run versioned:npm7
+      env:
+        VERSIONED_MODE: --major
+        JOBS: 4 # 2 per CPU seems to be the sweet spot in GHA (July 2022)
+    - name: Post Versioned Test Coverage
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        directory: ./coverage/versioned/
+        files: lcov.info
+        flags: versioned-tests-${{ matrix.node-version }}

--- a/.github/workflows/versioned-coverage.yml
+++ b/.github/workflows/versioned-coverage.yml
@@ -43,7 +43,6 @@ jobs:
     - name: Post Versioned Test Coverage
       uses: codecov/codecov-action@v3
       with:
-        fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./coverage/versioned/
         files: lcov.info

--- a/.github/workflows/versioned-coverage.yml
+++ b/.github/workflows/versioned-coverage.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Post Versioned Test Coverage
       uses: codecov/codecov-action@v3
       with:
+        fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./coverage/versioned/
         files: lcov.info


### PR DESCRIPTION
## Proposed Release Notes

## Links
Follow up from #1385 

## Details
There were a couple of late breaking requests for the original codecov implementation, so this PR addresses them
1. Move Async Local Context tests out into own GHA step, they're a bit flaky and having them lumped with the others means that re-runs take forever
2. Only run versioned tests on Async Local Context, as our integration/unit tests for Async Local Context are already dealt with by the original runs
3. Added a "cron" like job to run 4/5am eastern to gather coverage of versioned tests from the `main` branch, as we can only gather coverage for versioned tests with the `--major` flag due to c8 OOM'ing with the `--minor` flag