### PR TITLE
NR-57994 add manual way to invoke main coverage

### DIFF
--- a/.github/workflows/versioned-coverage.yml
+++ b/.github/workflows/versioned-coverage.yml
@@ -7,6 +7,7 @@
 name: Gather Versioned Test Coverage
 
 on:
+  workflow_dispatch:
   schedule:
     - cron:  '0 9 * * 1-5'
 


### PR DESCRIPTION
## Proposed Release Notes

## Links

## Details
Just in case we need to manually sync the versioned code coverage from main, adds the correct github hook to facilitate manually generating main versioned test coverage