### PR TITLE
Drop async lib from environment unit test

### DIFF
--- a/test/unit/environment.test.js
+++ b/test/unit/environment.test.js
@@ -257,8 +257,8 @@ describe('the environment scraper', function () {
 
   describe('with symlinks', function () {
     const nmod = path.resolve(__dirname, '../helpers/node_modules')
-    const makeDir = async (dirp, mkdirDb) => {
-      const code = await fs
+    const makeDir = (dirp) => {
+      return fs
         .mkdir(dirp)
         .then(() => null)
         .catch((err) => {
@@ -267,11 +267,6 @@ describe('the environment scraper', function () {
           }
           return null
         })
-      // vestigial--mkdirDb is the async callback, invisibly appended to arguments when apply is used
-      if (mkdirDb) {
-        return mkdirDb(code)
-      }
-      return code
     }
     const makePackage = async (pkg, dep) => {
       const dir = path.join(nmod, pkg)

--- a/test/unit/environment.test.js
+++ b/test/unit/environment.test.js
@@ -258,15 +258,14 @@ describe('the environment scraper', function () {
   describe('with symlinks', function () {
     const nmod = path.resolve(__dirname, '../helpers/node_modules')
     const makeDir = (dirp) => {
-      return fs
-        .mkdir(dirp)
-        .then(() => null)
-        .catch((err) => {
-          if (err.code !== 'EEXIST') {
-            return err
-          }
-          return null
-        })
+      try {
+        return fs.mkdir(dirp)
+      } catch (err) {
+        if (err.code !== 'EEXIST') {
+          return err
+        }
+        return null
+      }
     }
     const makePackage = async (pkg, dep) => {
       const dir = path.join(nmod, pkg)


### PR DESCRIPTION
Replaced async lib with async functions
Replaced fs with fs/promises
Replaced rimraf with fs/promises

Signed-off-by: mrickard <maurice@mauricerickard.com>

## Proposed Release Notes
In environment unit test: 
* Replaced async lib with async functions
* Replaced fs with fs/promises
* Replaced rimraf with fs/promises

## Links
https://issues.newrelic.com/browse/NR-39257

## Details
