### PR TITLE
removed set-output as it is deprecated

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -35,7 +35,7 @@ jobs:
         git config user.email gh-actions-${GITHUB_ACTOR}@github.com
     - name: Get Created Tag
       id: get_tag
-      run: echo "::set-output name=latest_tag::$(cat package.json | jq .version)"
+      run: echo "latest_tag=$(cat package.json | jq .version)" >> $GITHUB_OUTPUT
     - name: Update system configuration pages
       run: node ./bin/update-system-config-pages.js --version ${{ steps.get_tag.outputs.latest_tag }} --staging-key ${{ secrets.NEW_RELIC_API_KEY_STAGING }} --prod-key ${{ secrets.NEW_RELIC_API_KEY_PRODUCTION }}
     - name: Publish API Docs

--- a/.github/workflows/release-creation.yml
+++ b/.github/workflows/release-creation.yml
@@ -62,7 +62,7 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
     - name: Get Created Tag
       id: get_tag
-      run: echo "::set-output name=latest_tag::$(git describe --tags --abbrev=0)"
+      run: echo "latest_tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
     - name: Create GitHub Release
       run: node ./agent-repo/bin/create-github-release.js --tag ${{ steps.get_tag.outputs.latest_tag }} --repo ${{ github.repository }} --changelog ${{ inputs.changelog_file }}
       env:


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Details
Updated a few workflows that relied on set-output, an action that is now deprecated in GHA.
