### PR TITLE
NEWRELIC-5072: add `grpc.ignore_status_codes` config option

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -936,6 +936,21 @@ defaultConfig.definition = () => ({
     record_errors: {
       formatter: boolean,
       default: true
+    },
+    /**
+     * List of gRPC error status codes the error tracer should disregard.
+     * Ignoring a status code means that the transaction is not renamed to
+     * match the code, and the request is not treated as an error by the error
+     * collector.
+     *
+     * NOTE: This configuration value has no effect on errors recorded using
+     * `noticeError()`.
+     *
+     * Defaults to no codes ignored.
+     */
+    ignore_status_codes: {
+      formatter: array,
+      default: []
     }
   },
   /**

--- a/lib/instrumentation/grpc-js/grpc.js
+++ b/lib/instrumentation/grpc-js/grpc.js
@@ -78,8 +78,10 @@ function wrapStart(shim, original) {
         segment.addAttribute('grpc.statusCode', code)
         segment.addAttribute('grpc.statusText', details)
 
-        if (code !== 0 && shim.agent.config.grpc.record_errors) {
-          // this is currently just creating an error from the details string
+        const agent = shim.agent
+        const config = agent.config
+
+        if (shouldTrackError(code, config)) {
           shim.agent.errors.add(segment.transaction, details)
         }
 
@@ -184,9 +186,10 @@ function wrapRegister(shim, original) {
 
     function instrumentEventListeners(stream, transaction) {
       const agent = shim.agent
+      const config = agent.config
       stream.call.once('callEnd', (statusCode) => {
         transaction.trace.attributes.addAttribute(DESTINATION, 'response.status', statusCode)
-        if (statusCode !== 0 && agent.config.grpc.record_errors) {
+        if (shouldTrackError(statusCode, config)) {
           const status = constants.Status[statusCode]
           const error = new Error(`gRPC status code ${statusCode}: ${status}`)
           agent.errors.add(transaction, error)
@@ -200,6 +203,14 @@ function wrapRegister(shim, original) {
       // client is streaming. https://issues.newrelic.com/browse/NEWRELIC-1460
     }
   }
+}
+
+function shouldTrackError(statusCode, config) {
+  return (
+    statusCode > 0 &&
+    config.grpc.record_errors &&
+    !config.grpc.ignore_status_codes.includes(statusCode)
+  )
 }
 
 module.exports = function instrument(shim) {

--- a/test/versioned/grpc-esm/client-unary.tap.mjs
+++ b/test/versioned/grpc-esm/client-unary.tap.mjs
@@ -123,12 +123,18 @@ tap.test('gRPC Client: Unary Requests', (t) => {
     t.end()
   })
 
-  const errorsEnabled = [true, false]
-  errorsEnabled.forEach((enabled) => {
-    t.test(`should ${enabled ? '' : 'not '}record errors in a transaction`, (t) => {
+  const grpcConfigs = [
+    { record_errors: true, ignore_status_codes: [], should: true },
+    { record_errors: false, ignore_status_codes: [], should: false },
+    { record_errors: true, ignore_status_codes: [9], should: false }
+  ]
+  grpcConfigs.forEach((config) => {
+    const should = config.should ? 'should' : 'should not'
+    const testName = `${should} record errors in a transaction when ignoring ${config.ignore_status_codes}`
+    t.test(testName, (t) => {
       const expectedStatusText = ERR_MSG
       const expectedStatusCode = ERR_CODE
-      agent.config.grpc.record_errors = enabled
+      agent.config.grpc.record_errors = config.should
       helper.runInTransaction(agent, 'web', async (tx) => {
         tx.name = 'clientTransaction'
         function transactionFinished(transaction) {
@@ -137,7 +143,7 @@ tap.test('gRPC Client: Unary Requests', (t) => {
               t,
               transaction,
               errors: agent.errors,
-              expectErrors: enabled,
+              expectErrors: config.should,
               expectedStatusCode,
               expectedStatusText,
               fnName: 'SayError',

--- a/test/versioned/grpc-esm/server-unary.tap.mjs
+++ b/test/versioned/grpc-esm/server-unary.tap.mjs
@@ -31,25 +31,6 @@ tap.test('gRPC Server: Unary Requests', (t) => {
   let proto
   let grpc
 
-  /*
-  t.beforeEach(async () => {
-    agent = helper.instrumentMockedAgent()
-    grpc = require('@grpc/grpc-js')
-    const data = await createServer(grpc)
-    proto = data.proto
-    server = data.server
-    client = getClient(grpc, proto)
-  })
-
-  t.afterEach(() => {
-    helper.unloadAgent(agent)
-    server.forceShutdown()
-    client.close()
-    grpc = null
-    proto = null
-  })
-  */
-
   t.before(async () => {
     agent = helper.instrumentMockedAgent()
     grpc = await import('@grpc/grpc-js')

--- a/test/versioned/grpc/client-server-streaming.tap.js
+++ b/test/versioned/grpc/client-server-streaming.tap.js
@@ -123,12 +123,18 @@ tap.test('gRPC Client: Server Streaming', (t) => {
     t.end()
   })
 
-  const errorsEnabled = [true, false]
-  errorsEnabled.forEach((enabled) => {
-    t.test(`should ${enabled ? '' : 'not '}record errors in a transaction`, (t) => {
+  const grpcConfigs = [
+    { record_errors: true, ignore_status_codes: [], should: true },
+    { record_errors: false, ignore_status_codes: [], should: false },
+    { record_errors: true, ignore_status_codes: [9], should: false }
+  ]
+  grpcConfigs.forEach((config) => {
+    const should = config.should ? 'should' : 'should not'
+    const testName = `${should} record errors in a transaction when ignoring ${config.ignore_status_codes}`
+    t.test(testName, (t) => {
       const expectedStatusText = ERR_MSG
       const expectedStatusCode = ERR_CODE
-      agent.config.grpc.record_errors = enabled
+      agent.config.grpc.record_errors = config.should
       helper.runInTransaction(agent, 'web', async (tx) => {
         tx.name = 'clientTransaction'
         agent.on('transactionFinished', (transaction) => {
@@ -137,7 +143,7 @@ tap.test('gRPC Client: Server Streaming', (t) => {
               t,
               transaction,
               errors: agent.errors,
-              expectErrors: enabled,
+              expectErrors: config.should,
               expectedStatusCode,
               expectedStatusText,
               fnName: 'SayErrorServerStream',

--- a/test/versioned/grpc/client-unary.tap.js
+++ b/test/versioned/grpc/client-unary.tap.js
@@ -115,12 +115,18 @@ tap.test('gRPC Client: Unary Requests', (t) => {
     t.end()
   })
 
-  const errorsEnabled = [true, false]
-  errorsEnabled.forEach((enabled) => {
-    t.test(`should ${enabled ? '' : 'not '}record errors in a transaction`, (t) => {
+  const grpcConfigs = [
+    { record_errors: true, ignore_status_codes: [], should: true },
+    { record_errors: false, ignore_status_codes: [], should: false },
+    { record_errors: true, ignore_status_codes: [9], should: false }
+  ]
+  grpcConfigs.forEach((config) => {
+    const should = config.should ? 'should' : 'should not'
+    const testName = `${should} record errors in a transaction when ignoring ${config.ignore_status_codes}`
+    t.test(testName, (t) => {
       const expectedStatusText = ERR_MSG
       const expectedStatusCode = ERR_CODE
-      agent.config.grpc.record_errors = enabled
+      agent.config.grpc.record_errors = config.should
       helper.runInTransaction(agent, 'web', async (tx) => {
         tx.name = 'clientTransaction'
         agent.on('transactionFinished', (transaction) => {
@@ -129,7 +135,7 @@ tap.test('gRPC Client: Unary Requests', (t) => {
               t,
               transaction,
               errors: agent.errors,
-              expectErrors: enabled,
+              expectErrors: config.should,
               expectedStatusCode,
               expectedStatusText,
               fnName: 'SayError',

--- a/test/versioned/grpc/server-streaming.tap.js
+++ b/test/versioned/grpc/server-streaming.tap.js
@@ -128,42 +128,43 @@ tap.test('gRPC Server: Server Streaming', (t) => {
     t.end()
   })
 
-  const errorsEnabled = [true, false]
-  errorsEnabled.forEach((enabled) => {
-    t.test(
-      `should ${enabled ? '' : 'not '}record errors if 'grpc.record_errors' is ${
-        enabled ? 'enabled' : 'disabled'
-      }`,
-      async (t) => {
-        const expectedStatusCode = ERR_CODE
-        const expectedStatusText = ERR_SERVER_MSG
-        agent.config.grpc.record_errors = enabled
-        let transaction
-        agent.on('transactionFinished', (tx) => {
-          if (tx.name === getServerTransactionName('SayErrorServerStream')) {
-            transaction = tx
-          }
-        })
-
-        try {
-          const payload = { name: ['noes'] }
-          await makeServerStreamingRequest({ client, fnName: 'sayErrorServerStream', payload })
-        } catch (err) {
-          // err tested in client tests
+  const grpcConfigs = [
+    { record_errors: true, ignore_status_codes: [], should: true },
+    { record_errors: false, ignore_status_codes: [], should: false },
+    { record_errors: true, ignore_status_codes: [9], should: false }
+  ]
+  grpcConfigs.forEach((config) => {
+    const should = config.should ? 'should' : 'should not'
+    const testName = `${should} record errors in a transaction when ignoring ${config.ignore_status_codes}`
+    t.test(testName, async (t) => {
+      const expectedStatusCode = ERR_CODE
+      const expectedStatusText = ERR_SERVER_MSG
+      agent.config.grpc.record_errors = config.should
+      let transaction
+      agent.on('transactionFinished', (tx) => {
+        if (tx.name === getServerTransactionName('SayErrorServerStream')) {
+          transaction = tx
         }
+      })
 
-        assertError({
-          t,
-          transaction,
-          errors: agent.errors,
-          agentMetrics: agent.metrics._metrics,
-          expectErrors: enabled,
-          expectedStatusCode,
-          expectedStatusText,
-          fnName: 'SayErrorServerStream'
-        })
-        t.end()
+      try {
+        const payload = { name: ['noes'] }
+        await makeServerStreamingRequest({ client, fnName: 'sayErrorServerStream', payload })
+      } catch (err) {
+        // err tested in client tests
       }
-    )
+
+      assertError({
+        t,
+        transaction,
+        errors: agent.errors,
+        agentMetrics: agent.metrics._metrics,
+        expectErrors: config.should,
+        expectedStatusCode,
+        expectedStatusText,
+        fnName: 'SayErrorServerStream'
+      })
+      t.end()
+    })
   })
 })

--- a/test/versioned/grpc/server-unary.tap.js
+++ b/test/versioned/grpc/server-unary.tap.js
@@ -136,45 +136,46 @@ tap.test('gRPC Server: Unary Requests', (t) => {
     t.end()
   })
 
-  const errorsEnabled = [true, false]
-  errorsEnabled.forEach((enabled) => {
-    t.test(
-      `should ${enabled ? '' : 'not '}record errors if 'grpc.record_errors' is ${
-        enabled ? 'enabled' : 'disabled'
-      }`,
-      async (t) => {
-        agent.config.grpc.record_errors = enabled
-        const expectedStatusCode = ERR_CODE
-        const expectedStatusText = ERR_SERVER_MSG
-        let transaction
-        agent.on('transactionFinished', (tx) => {
-          if (tx.name === getServerTransactionName('SayError')) {
-            transaction = tx
-          }
-        })
-
-        try {
-          await makeUnaryRequest({
-            client,
-            fnName: 'sayError',
-            payload: { oh: 'noes' }
-          })
-        } catch (err) {
-          // err tested in client tests
+  const grpcConfigs = [
+    { record_errors: true, ignore_status_codes: [], should: true },
+    { record_errors: false, ignore_status_codes: [], should: false },
+    { record_errors: true, ignore_status_codes: [9], should: false }
+  ]
+  grpcConfigs.forEach((config) => {
+    const should = config.should ? 'should' : 'should not'
+    const testName = `${should} record errors in a transaction when ignoring ${config.ignore_status_codes}`
+    t.test(testName, async (t) => {
+      agent.config.grpc.record_errors = config.should
+      const expectedStatusCode = ERR_CODE
+      const expectedStatusText = ERR_SERVER_MSG
+      let transaction
+      agent.on('transactionFinished', (tx) => {
+        if (tx.name === getServerTransactionName('SayError')) {
+          transaction = tx
         }
+      })
 
-        assertError({
-          t,
-          transaction,
-          errors: agent.errors,
-          agentMetrics: agent.metrics._metrics,
-          expectErrors: enabled,
-          expectedStatusCode,
-          expectedStatusText,
-          fnName: 'SayError'
+      try {
+        await makeUnaryRequest({
+          client,
+          fnName: 'sayError',
+          payload: { oh: 'noes' }
         })
-        t.end()
+      } catch (err) {
+        // err tested in client tests
       }
-    )
+
+      assertError({
+        t,
+        transaction,
+        errors: agent.errors,
+        agentMetrics: agent.metrics._metrics,
+        expectErrors: config.should,
+        expectedStatusCode,
+        expectedStatusText,
+        fnName: 'SayError'
+      })
+      t.end()
+    })
   })
 })


### PR DESCRIPTION
## Proposed Release Notes

* Added new configuration option: `grpc.ignore_status_codes`

## Links

* NEWRELIC-5072

## Details

* By default, this ignores nothing. In the future, we might decide to add some status codes to be ignored by default. A likely candidate seems status code 5: NOT FOUND.
