### PR TITLE
add name to callback function in shim runInContext

### DIFF
--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -348,7 +348,7 @@ Shim.prototype[symbols.unwrap] = unwrapAll
  *    segment = shim.createSegment(seg.name, seg.recorder, seg.parent)
  *  }
  *  ```
- * @property {object.<string, *>} $cache
+ * @property {Object<string, *>} $cache
  *  Adds the value as an extra parameter to all specs in the same context as the
  *  cache. If the current context is a function, the cache will be recreated on
  *  each invocation of the function. This value can be useful for passing a
@@ -1300,7 +1300,7 @@ function applySegment(func, segment, full, context, args, inContextCB) {
   const contextManager = this._contextManager
   const prevSegment = contextManager.getContext()
 
-  return contextManager.runInContext(segment, () => {
+  return contextManager.runInContext(segment, function runInContextCb() {
     if (full) {
       segment.start()
     }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
This is a slight tweak but important when profiling the agent.  We are trying to determine why async local storage uses more CPU than legacy/promise context manager and this function is in the hot path and currently an anonymous arrow function. It makes it difficult to easily identify this when looking at flame graphs, heap dumps, etc. 
