### PR TITLE
NEWRELIC-5277 refactored buildConfig to be less complex, addressed all jsdoc warnings within file

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -5,8 +5,6 @@
 
 'use strict'
 
-/* eslint sonarjs/cognitive-complexity: ["error", 17] -- TODO: https://issues.newrelic.com/browse/NEWRELIC-5252*/
-
 const defaultConfig = module.exports
 const { array, int, float, boolean, object, objectList, allowList } = require('./formatters')
 
@@ -20,6 +18,8 @@ const { array, int, float, boolean, object, objectList, allowList } = require('.
  * an override if the env var does not follow our standard convention.  We should not have
  * to add any more overrides as all new configuration values should follow the convention of
  * `NEW_RELIC_PATH_TO_CONFIG_KEY`
+ *
+ * @returns {object} configuration definition
  */
 defaultConfig.definition = () => ({
   newrelic_home: {
@@ -438,7 +438,7 @@ defaultConfig.definition = () => ({
      * This flag dictates whether the agent attempts to read files
      * to get info about the container the process is running in.
      *
-     * @env NEW_RELIC_UTILIZATION_DETECT_DOCKER
+     * env NEW_RELIC_UTILIZATION_DETECT_DOCKER
      */
     detect_docker: {
       formatter: boolean,
@@ -547,7 +547,7 @@ defaultConfig.definition = () => ({
      * slow trace aggregator if no slow transactions have been recorded for the
      * last 5 harvest cycles, restarting the aggregation process.
      *
-     * @env NEW_RELIC_TRACER_TOP_N
+     * env NEW_RELIC_TRACER_TOP_N
      */
     top_n: {
       formatter: int,
@@ -604,7 +604,7 @@ defaultConfig.definition = () => ({
      *
      * By default, socket.io long-polling is ignored.
      *
-     * @env NEW_RELIC_IGNORING_RULES
+     * env NEW_RELIC_IGNORING_RULES
      */
     ignore: {
       formatter: array,
@@ -762,7 +762,7 @@ defaultConfig.definition = () => ({
        * Prefix of attributes to exclude in transaction events.
        * Allows * as wildcard at end.
        *
-       * @env NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_EXCLUDE
+       * env NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_EXCLUDE
        */
       exclude: {
         formatter: array,
@@ -772,7 +772,7 @@ defaultConfig.definition = () => ({
        * Prefix of attributes to include in transaction events.
        * Allows * as wildcard at end.
        *
-       * @env NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_INCLUDE
+       * env NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_INCLUDE
        */
       include: {
         formatter: array,
@@ -895,7 +895,7 @@ defaultConfig.definition = () => ({
      * Sets the maximum number of slow query samples that will be collected in a
      * single harvest cycle.
      *
-     * @env NEW_RELIC_MAX_SQL_SAMPLES
+     * env NEW_RELIC_MAX_SQL_SAMPLES
      */
     max_samples: {
       formatter: int,
@@ -906,9 +906,11 @@ defaultConfig.definition = () => ({
   /**
    * Controls behavior of datastore instance metrics.
    *
+   * @property {object} instance_reporting container around enabling flag
    * @property {boolean} [instance_reporting.enabled=true]
    *  Enables reporting the host and port/path/id of database servers. Default
    *  is `true`.
+   * @property {object} database_name_reporting container around enabling flag
    * @property {boolean} [database_name_reporting.enabled=true]
    *  Enables reporting of database/schema names. Default is `true`.
    */
@@ -1076,6 +1078,7 @@ defaultConfig.definition = () => ({
   /**
    * Controls behavior of message broker tracing.
    *
+   * @property {object} segment_parameters property around enabling flag
    * @property {boolean} [segment_parameters.enabled=true]
    *  Enables reporting parameters on message broker segments.
    */
@@ -1189,7 +1192,7 @@ defaultConfig.definition = () => ({
    * disallow the use of New Relic's server-side configuration for agents.
    * To do so, set this to true.
    *
-   * @env NEW_RELIC_IGNORE_SERVER_SIDE_CONFIG
+   * env NEW_RELIC_IGNORE_SERVER_SIDE_CONFIG
    */
   ignore_server_configuration: {
     formatter: boolean,
@@ -1200,6 +1203,8 @@ defaultConfig.definition = () => ({
 
 /**
  * Creates a new default config
+ *
+ * @returns {object} default configuration object
  */
 defaultConfig.config = () => {
   const config = Object.create(null)
@@ -1223,18 +1228,11 @@ function buildConfig(definition, config, paths = [], objectKeys = 1) {
     const type = typeof value
     keysSeen++
     if (type === 'string') {
-      if (paths.length) {
-        setNestedKey(conf, [...paths, key], value)
-      } else {
-        conf[key] = value
-      }
+      assignConfigValue({ config: conf, key, value, paths })
     } else if (type === 'object') {
       if (value.hasOwnProperty('default')) {
-        if (paths.length) {
-          setNestedKey(conf, [...paths, key], value.default)
-        } else {
-          conf[key] = value.default
-        }
+        assignConfigValue({ config: conf, key, value: value.default, paths })
+        // add the current leaf node key to the paths and recurse through function again
       } else {
         const { length } = Object.keys(value)
         paths.push(key)
@@ -1249,6 +1247,24 @@ function buildConfig(definition, config, paths = [], objectKeys = 1) {
   // to properly derive env vars of future leaf nodes
   if (keysSeen === objectKeys) {
     paths.pop()
+  }
+}
+
+/**
+ * Assigns a value to a configuration option. In the case of a nested key
+ * it will properly build the structure leading to the value
+ *
+ * @param {object} params args to fn
+ * @param {object} params.config object that is used to construct the agent config
+ * @param {string} params.key name of the configuration option
+ * @param {string} params.value value the configuration option
+ * @param {Array} [params.paths=[]] an array to capture the leaf node keys to properly assign defaults for nested objects
+ */
+function assignConfigValue({ config, key, value, paths }) {
+  if (paths.length) {
+    setNestedKey(config, [...paths, key], value)
+  } else {
+    config[key] = value
   }
 }
 

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1232,8 +1232,8 @@ function buildConfig(definition, config, paths = [], objectKeys = 1) {
     } else if (type === 'object') {
       if (value.hasOwnProperty('default')) {
         assignConfigValue({ config: conf, key, value: value.default, paths })
-        // add the current leaf node key to the paths and recurse through function again
       } else {
+        // add the current leaf node key to the paths and recurse through function again
         const { length } = Object.keys(value)
         paths.push(key)
         buildConfig(definition[key], conf, paths, length)


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links
Closes NEWRELIC-5277

## Details
I extracted common logic in build config to a single assignConfigValue function. Since I was in here I addressed all the jsdoc linting warnings too.

