### PR TITLE
NEWRELIC-5370 Update versioned tests to support restify@9.0.0

### DIFF
--- a/test/versioned/restify/restify-post-7/restify.tap.js
+++ b/test/versioned/restify/restify-post-7/restify.tap.js
@@ -41,9 +41,10 @@ tap.test('Restify', (t) => {
       t.ok(isFramework, 'should indicate that restify is a framework')
     })
 
-    server.get('/hello/:name', function sayHello(req, res) {
+    server.get('/hello/:name', function sayHello(req, res, next) {
       t.ok(agent.getTransaction(), 'transaction should be available in handler')
       res.send('hello ' + req.params.name)
+      next()
     })
 
     server.listen(0, function () {
@@ -80,9 +81,10 @@ tap.test('Restify', (t) => {
         const server = restify.createServer({ key: key, certificate: certificate })
         t.teardown(() => server.close())
 
-        server.get('/hello/:name', function sayHello(req, res) {
+        server.get('/hello/:name', function sayHello(req, res, next) {
           t.ok(agent.getTransaction(), 'transaction should be available in handler')
           res.send('hello ' + req.params.name)
+          next()
         })
 
         server.listen(0, function () {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
* Update our versioned tests to support Restify 9.0.0

## Links
Closes NEWRELIC-5370
[Release Notes](https://github.com/restify/node-restify/releases/tag/v9.0.0)
[Migration Guide](https://github.com/restify/node-restify/blob/master/docs/guides/8to9guide.md)
[Re-Routing with next() removal](https://github.com/restify/node-restify/pull/1847)

## Details
Two major changes that effected our tests
1. If using a callback for definitions, the function signature MUST have req, res, and next (arity 3)
2. Using `next('my-route')` to perform re-routing is no longer supported and has been removed