### PR TITLE
Capture (and decorate/forward) logs emitted via console.log

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1185,6 +1185,15 @@ defaultConfig.definition = () => ({
         formatter: boolean,
         default: false
       }
+    },
+    capture_console: {
+      /**
+       * Toggles whether the agent will capture any logs written to console.log, console.warn, etc
+       */
+      enabled: {
+        formatter: boolean,
+        default: false
+      }
     }
   },
   /**

--- a/lib/instrumentation/core/console.js
+++ b/lib/instrumentation/core/console.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const util = require('util')
+
+const {
+  isApplicationLoggingEnabled,
+  isLogForwardingEnabled,
+  isLocalDecoratingEnabled,
+  isMetricsEnabled,
+  incrementLoggingLinesMetrics,
+  truncate
+} = require('../../util/application-logging')
+
+function consoleCaptureEnabled(agent) {
+  const config = agent.config
+  const logForwarding = isLogForwardingEnabled(config, agent)
+  const localDecoration = isLocalDecoratingEnabled(config)
+  const metrics = isMetricsEnabled(config)
+  const enabled =
+    isApplicationLoggingEnabled(config) &&
+    config.application_logging.capture_console.enabled &&
+    (logForwarding || localDecoration || metrics)
+  return enabled
+    ? {
+        logForwarding,
+        localDecoration,
+        metrics
+      }
+    : false
+}
+
+function logLevelFromFunction(methodName) {
+  return methodName === 'log' || methodName === 'dir' ? 'info' : methodName
+}
+
+function formatMessage(methodName, args) {
+  return truncate(
+    methodName === 'dir' ? util.inspect.apply(util, args) : util.format.apply(util, args)
+  )
+}
+
+function initialize(agent, nodule, name, shim) {
+  if (!nodule) {
+    return false
+  }
+  const logConfig = consoleCaptureEnabled(agent)
+  if (!logConfig) {
+    shim.logger.debug('Application logging not enabled. Not instrumenting console logging.')
+    return
+  }
+
+  shim.wrap(
+    nodule,
+    ['log', 'dir', 'info', 'debug', 'warn', 'error'],
+    function wrapLog(_shim, origLog, methodName) {
+      return function wrappedLog() {
+        const args = shim.argsToArray.apply(shim, arguments)
+
+        const logLevel = logLevelFromFunction(methodName)
+        if (logConfig.metrics) {
+          incrementLoggingLinesMetrics(logLevel, agent.metrics)
+        }
+
+        let message = formatMessage(methodName, args)
+
+        if (logConfig.localDecoration) {
+          message = message + agent.getNRLinkingMetadata()
+          return origLog.apply(this, [message])
+        } else if (logConfig.logForwarding) {
+          const metadata = agent.getLinkingMetadata(true)
+          agent.logs.add({
+            message,
+            timestamp: Date.now(),
+            level: logLevel,
+            ...metadata
+          })
+        }
+        return origLog.apply(this, args)
+      }
+    }
+  )
+}
+
+module.exports = initialize

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -23,6 +23,10 @@ const CORE_INSTRUMENTATION = {
     type: MODULE_TYPE.GENERIC,
     file: 'child_process.js'
   },
+  console: {
+    type: MODULE_TYPE.GENERIC,
+    file: 'console.js'
+  },
   crypto: {
     type: MODULE_TYPE.GENERIC,
     file: 'crypto.js'

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -256,6 +256,9 @@ tap.test('with default properties', (t) => {
       },
       local_decorating: {
         enabled: false
+      },
+      capture_console: {
+        enabled: false
       }
     })
     t.end()

--- a/test/unit/config/config-env.test.js
+++ b/test/unit/config/config-env.test.js
@@ -595,7 +595,8 @@ tap.test('when overriding configuration values via environment variables', (t) =
       NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED: 'true',
       NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED: '12345',
       NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED: 'false',
-      NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED: 'true'
+      NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED: 'true',
+      NEW_RELIC_APPLICATION_LOGGING_CAPTURE_CONSOLE: 'true'
     }
     idempotentEnv(config, function (tc) {
       t.strictSame(tc.application_logging, {
@@ -609,6 +610,9 @@ tap.test('when overriding configuration values via environment variables', (t) =
         },
         local_decorating: {
           enabled: true
+        },
+        capture_console: {
+          enabled: false
         }
       })
       t.end()

--- a/test/unit/instrumentation/core/console.test.js
+++ b/test/unit/instrumentation/core/console.test.js
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/* eslint-disable no-console */
+
+const tap = require('tap')
+const test = tap.test
+
+const helper = require('../../../lib/agent_helper')
+const Shim = require('../../../../lib/shim/shim.js')
+const { validateLogLine } = require('../../../lib/logging-helper')
+
+tap.Test.prototype.addAssert('validateAnnotations', 2, validateLogLine)
+
+test('Console', (t) => {
+  t.autoend()
+
+  let agent = null
+  let initialize
+  let shim
+  let origMethods
+  let logs
+
+  t.before(() => {
+    initialize = require('../../../../lib/instrumentation/core/console')
+  })
+  t.beforeEach((t) => {
+    origMethods = {}
+    logs = { debug: [], log: [], dir: [], info: [], warn: [], error: [] }
+    // stub console functions to avoid littering stdout/stderr for this test
+    Object.keys(logs).forEach((m) => {
+      origMethods[m] = console[m]
+      console[m] = function () {
+        logs[m].push(Array.from(arguments))
+      }
+    })
+    helper.temporarilyOverrideTapUncaughtBehavior(tap, t)
+
+    agent = helper.instrumentMockedAgent()
+    shim = new Shim(agent, 'console')
+  })
+
+  t.afterEach(() => {
+    helper.unloadAgent(agent)
+    // replace stubs
+    Object.entries(origMethods).forEach(([m, func]) => {
+      console[m] = func
+    })
+  })
+
+  t.test('should not instrument any functions by default', (t) => {
+    t.doesNotThrow(() => {
+      initialize(agent, null, 'console', shim)
+    })
+    t.end()
+  })
+  t.test('should not instrument if config is not explicitly set to capture console logs', (t) => {
+    const origLog = console.log
+
+    initialize(agent, console, 'console', shim)
+    t.equal(console.log, origLog, 'console.log remains as-is')
+
+    t.end()
+  })
+  t.test('should instrument each method if config is set to capture console logs', (t) => {
+    const logMethods = ['log', 'info', 'debug', 'warn', 'error'].reduce(
+      (m, acc) => Object.assign(acc, { [m]: console[m] }),
+      {}
+    )
+    agent.config.application_logging.capture_console.enabled = true
+
+    initialize(agent, console, 'console', shim)
+    Object.entries(logMethods).forEach(([method, origFunc]) => {
+      t.not(console[method], origFunc, `console.${method} replaced`)
+    })
+
+    t.end()
+  })
+  t.test('adds appropriate logs to accumulator', (t) => {
+    agent.config.application_logging.capture_console.enabled = true
+    initialize(agent, console, 'console', shim)
+
+    helper.runInTransaction(agent, 'test', (transaction) => {
+      console.debug('msg 1')
+      console.log('msg 2')
+      console.info('msg 3')
+      console.warn('msg 4')
+      console.error('msg 5')
+      console.dir({ a: { b: { c: { d: { e: 'too deep' } } } } }, { depth: 3 })
+      transaction.end()
+      const logEvents = agent.logs.getEvents()
+      t.ok(logEvents.find((evt) => evt.level === 'debug' && evt.message === 'msg 1'))
+      t.ok(logEvents.find((evt) => evt.level === 'info' && evt.message === 'msg 2'))
+      t.ok(logEvents.find((evt) => evt.level === 'info' && evt.message === 'msg 3'))
+      t.ok(logEvents.find((evt) => evt.level === 'warn' && evt.message === 'msg 4'))
+      t.ok(logEvents.find((evt) => evt.level === 'error' && evt.message === 'msg 5'))
+      t.ok(
+        logEvents.find((evt) => evt.level === 'info' && evt.message.indexOf('{ d: [Object] }') > 0)
+      )
+
+      logEvents.forEach((evt) => {
+        t.hasProps(
+          evt,
+          ['timestamp', 'entity.name', 'entity.type', 'hostname', 'trace.id', 'span.id'],
+          'has all expected properties'
+        )
+      })
+
+      t.end()
+    })
+  })
+
+  t.test('adds linking data when local decoration enabled', (t) => {
+    agent.config.application_logging.capture_console.enabled = true
+    agent.config.application_logging.local_decorating.enabled = true
+    agent.config.application_logging.forwarding.enabled = false
+    initialize(agent, console, 'console', shim)
+
+    helper.runInTransaction(agent, 'test', (transaction) => {
+      console.debug('msg 1')
+      console.log('msg 2')
+      console.info('msg 3')
+      console.warn('msg 4')
+      console.error('msg 5')
+      console.dir({ msg: 'msg 6' })
+      transaction.end()
+      const logEvents = agent.logs.getEvents()
+      t.ok(logEvents.length === 0, 'no logs collected in agent')
+      Object.entries(logs).forEach(([level, [l]]) => {
+        t.match(l, /msg \d.* NR-LINKING/, `has embedded linking data (${level})`)
+      })
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
Some applictions (or libraries) may use console.log/warn/error/etc as a "poor-man's logging frameowrk". Ideally, New Relic application logging could gather these and forward (or decroate) them for aggregating in New Relic.

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

Optionally (via config) capture and forward (or decorate) logs emitted via `console.log` and friends to New Relic

## Links

## Details

This PR adds instrumentation to the core `console` object such that the various logging-related methods (`console.log`, `console.dir`, `console.debug`, `console.info`, `console.warn` and `console.error`) can be captured and forwarded to New Relic's application log aggregation. This feature is off by default and requires a configuration value be set to turn this on: `application_logging.capture_console.enabled`
