### PR TITLE
NEWRELIC-5286 refactored redis v4 instrumentation to be less complex by extracting functions as standalone instead of inline functions

### DIFF
--- a/lib/instrumentation/@node-redis/client.js
+++ b/lib/instrumentation/@node-redis/client.js
@@ -3,61 +3,70 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint sonarjs/cognitive-complexity: ["error", 20] -- TODO: https://issues.newrelic.com/browse/NEWRELIC-5252 */
-
 'use strict'
 const CLIENT_COMMANDS = ['select', 'quit', 'SELECT', 'QUIT']
+const opts = Symbol('clientOptions')
 
-module.exports = function initialize(agent, redis, moduleName, shim) {
+module.exports = function initialize(_agent, redis, _moduleName, shim) {
   shim.setDatastore(shim.REDIS)
   const COMMANDS = Object.keys(shim.require('dist/lib/client/commands.js').default)
   const CMDS_TO_INSTRUMENT = [...COMMANDS, ...CLIENT_COMMANDS]
   shim.wrap(redis, 'createClient', function wrapCreateClient(shim, original) {
     return function wrappedCreateClient() {
       const client = original.apply(this, arguments)
-      const clientOptions = getRedisParams(client.options)
-      CMDS_TO_INSTRUMENT.forEach((cmd) => {
-        shim.recordOperation(client, cmd, function wrapCommand(shim, fn, fnName, args) {
-          const [key, value] = args
-          const parameters = Object.assign({}, clientOptions)
-          // If selecting a database, subsequent commands
-          // will be using said database, update the clientOptions
-          // but not the current parameters(feature parity with v3)
-          if (cmd.toLowerCase() === 'select') {
-            clientOptions.database_name = key
-          }
-          if (agent.config.attributes.enabled) {
-            if (key) {
-              parameters.key = JSON.stringify(key)
-            }
-            if (value) {
-              parameters.value = JSON.stringify(value)
-            }
-          }
-
-          return {
-            name: (cmd && cmd.toLowerCase()) || 'other',
-            parameters,
-            promise: true
-          }
-        })
-      })
-
+      client[opts] = getRedisParams(client.options)
+      CMDS_TO_INSTRUMENT.forEach(instrumentClientCommand.bind(null, shim, client))
       return client
     }
   })
+}
 
-  /**
-   * Extracts the datastore parameters from the client options
-   *
-   * @param {object} opts client.options
-   * @returns {object} params
-   */
-  function getRedisParams(opts) {
-    return {
-      host: (opts.socket && opts.socket.host) || 'localhost',
-      port_path_or_id: (opts.socket && (opts.socket.path || opts.socket.port)) || '6379',
-      database_name: opts.database || 0
+/**
+ * Instruments a given command on the client by calling `shim.recordOperation`
+ *
+ * @param {Shim} shim shim instance
+ * @param {object} client redis client instance
+ * @param {string} cmd command to instrument
+ */
+function instrumentClientCommand(shim, client, cmd) {
+  const { agent } = shim
+
+  shim.recordOperation(client, cmd, function wrapCommand(_shim, _fn, _fnName, args) {
+    const [key, value] = args
+    const parameters = Object.assign({}, client[opts])
+    // If selecting a database, subsequent commands
+    // will be using said database, update the clientOptions
+    // but not the current parameters(feature parity with v3)
+    if (cmd.toLowerCase() === 'select') {
+      client[opts].database_name = key
     }
+    if (agent.config.attributes.enabled) {
+      if (key) {
+        parameters.key = JSON.stringify(key)
+      }
+      if (value) {
+        parameters.value = JSON.stringify(value)
+      }
+    }
+
+    return {
+      name: (cmd && cmd.toLowerCase()) || 'other',
+      parameters,
+      promise: true
+    }
+  })
+}
+
+/**
+ * Extracts the datastore parameters from the client options
+ *
+ * @param {object} clientOpts client.options
+ * @returns {object} params
+ */
+function getRedisParams(clientOpts) {
+  return {
+    host: clientOpts?.socket?.host || 'localhost',
+    port_path_or_id: clientOpts?.socket?.path || clientOpts?.socket?.port || '6379',
+    database_name: clientOpts.database || 0
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links
Closes NEWRELIC-5286

## Details
This was a very minimal refactor. It was simple as lifting inline functions into standalone and binding things accordingly.  I made a slight tweak by also putting the params needed for a datasource on the client instance as a symbol.
