### PR TITLE
Address cognitive complexity in hapi instrumentation

### DIFF
--- a/lib/instrumentation/@hapi/hapi.js
+++ b/lib/instrumentation/@hapi/hapi.js
@@ -5,8 +5,6 @@
 
 'use strict'
 
-/* eslint sonarjs/cognitive-complexity: ["error", 68] -- TODO: https://issues.newrelic.com/browse/NEWRELIC-5252 */
-
 const record = require('../../metrics/recorders/generic')
 // This object defines all the events that we want to wrap extensions
 // for, as they are the only ones associated with requests.
@@ -66,6 +64,12 @@ function serverPostConstructor(shim) {
     return
   }
 
+  wrapProtoDecorate(shim, proto)
+  wrapProtoRoute(shim, proto)
+  wrapProtoExt(shim, proto)
+}
+
+function wrapProtoDecorate(shim, proto) {
   shim.wrap(proto, 'decorate', function wrapDecorate(shim, original) {
     return function wrappedDecorate(type) {
       // server.decorate also accepts 'request', 'toolkit', 'server' types,
@@ -99,7 +103,9 @@ function serverPostConstructor(shim) {
       return original.apply(this, args)
     }
   })
+}
 
+function wrapProtoRoute(shim, proto) {
   shim.wrap(proto, 'route', function wrapRoute(shim, original) {
     return function wrappedRoute() {
       const args = shim.argsToArray.apply(shim, arguments)
@@ -116,51 +122,53 @@ function serverPostConstructor(shim) {
           this.realm.modifiers.route.prefix) ||
         ''
 
-      _wrapRoute(shim, args[0])
+      _wrapRoute(shim, args[0], prefix)
 
       return original.apply(this, args)
-
-      function _wrapRoute(shim, route) {
-        const routePath = prefix + route.path
-        if (shim.isArray(route)) {
-          for (let i = 0; i < route.length; ++i) {
-            _wrapRoute(shim, route[i])
-          }
-          return
-        } else if (route.options) {
-          // v17 now prefers `options` property...
-          if (route.options.pre) {
-            // config objects can also contain multiple OTHER handlers in a `pre` array
-            route.options.pre = wrapPreHandlers(shim, route.options.pre, routePath)
-          }
-          if (route.options.handler) {
-            _wrapRouteHandler(shim, route.options, routePath)
-            return
-          }
-        } else if (route.config) {
-          // ... but `config` still works
-          if (route.config.pre) {
-            route.config.pre = wrapPreHandlers(shim, route.config.pre, routePath)
-          }
-          if (route.config.handler) {
-            _wrapRouteHandler(shim, route.config, routePath)
-            return
-          }
-        }
-        _wrapRouteHandler(shim, route, routePath)
-      }
-
-      function _wrapRouteHandler(shim, container, path) {
-        if (typeof container.handler !== 'function') {
-          return
-        }
-        shim.wrap(container, 'handler', function wrapHandler(shim, handler) {
-          return wrapRouteHandler(shim, handler, path)
-        })
-      }
     }
   })
+}
 
+function _wrapRoute(shim, route, prefix) {
+  const routePath = prefix + route.path
+  if (shim.isArray(route)) {
+    for (let i = 0; i < route.length; ++i) {
+      _wrapRoute(shim, route[i], prefix)
+    }
+    return
+  } else if (route.options) {
+    // v17 now prefers `options` property...
+    if (route.options.pre) {
+      // config objects can also contain multiple OTHER handlers in a `pre` array
+      route.options.pre = wrapPreHandlers(shim, route.options.pre, routePath)
+    }
+    if (route.options.handler) {
+      _wrapRouteHandler(shim, route.options, routePath)
+      return
+    }
+  } else if (route.config) {
+    // ... but `config` still works
+    if (route.config.pre) {
+      route.config.pre = wrapPreHandlers(shim, route.config.pre, routePath)
+    }
+    if (route.config.handler) {
+      _wrapRouteHandler(shim, route.config, routePath)
+      return
+    }
+  }
+  _wrapRouteHandler(shim, route, routePath)
+}
+
+function _wrapRouteHandler(shim, container, path) {
+  if (typeof container.handler !== 'function') {
+    return
+  }
+  shim.wrap(container, 'handler', function wrapHandler(shim, handler) {
+    return wrapRouteHandler(shim, handler, path)
+  })
+}
+
+function wrapProtoExt(shim, proto) {
   shim.wrap(proto, 'ext', function wrapExt(shim, original) {
     return function wrappedExt(event, method) {
       const args = shim.argsToArray.apply(shim, arguments)
@@ -208,15 +216,13 @@ function wrapRouteHandler(shim, handler, path) {
   return shim.recordMiddleware(handler, {
     route: path,
     req: function getReq(shim, fn, fnName, args) {
-      const request = args[0]
-      if (request && request.raw) {
-        return request.raw.req
-      }
+      const [request] = args
+      return request?.raw?.req
     },
     promise: true,
     params: function getParams(shim, fn, fnName, args) {
-      const req = args[0]
-      return req && req.params
+      const [req] = args
+      return req?.params
     }
   })
 }
@@ -230,9 +236,9 @@ function wrapMiddleware(shim, middleware, event) {
     route: event,
     type: event === 'onPreResponse' ? shim.ERRORWARE : shim.MIDDLEWARE,
     promise: true,
-    req: function getReq(shim, fn, fnName, args) {
-      const req = args[0]
-      return req && req.raw && req.raw.req
+    req: function getReq(_shim, _fn, _fnName, args) {
+      const [req] = args
+      return req?.raw?.req
     }
   })
 }

--- a/test/versioned/hapi/capture-params.tap.js
+++ b/test/versioned/hapi/capture-params.tap.js
@@ -152,7 +152,7 @@ function makeRequest(t, uri) {
   }
   request.get(params, function (err, res, body) {
     t.equal(res.statusCode, 200, 'nothing exploded')
-    t.deepEqual(body, { status: 'ok' }, 'got expected response')
+    t.same(body, { status: 'ok' }, 'got expected response')
     t.end()
   })
 }

--- a/test/versioned/hapi/ignoring.tap.js
+++ b/test/versioned/hapi/ignoring.tap.js
@@ -52,7 +52,7 @@ test('ignoring a Hapi route', function (t) {
     }
     request.get(params, function (error, res, body) {
       t.equal(res.statusCode, 400, 'got expected error')
-      t.deepEqual(body, { status: 'cartcartcart' }, 'got expected response')
+      t.same(body, { status: 'cartcartcart' }, 'got expected response')
     })
   })
 })

--- a/test/versioned/hapi/render.tap.js
+++ b/test/versioned/hapi/render.tap.js
@@ -50,7 +50,7 @@ tap.test('agent instrumentation of Hapi', function (t) {
         t.error(error, 'should not fail to make request')
 
         t.ok(/application\/json/.test(response.headers['content-type']), 'got correct content type')
-        t.deepEqual(JSON.parse(body), { yep: true }, 'response survived')
+        t.same(JSON.parse(body), { yep: true }, 'response survived')
 
         let stats
 

--- a/test/versioned/hapi/router.tap.js
+++ b/test/versioned/hapi/router.tap.js
@@ -54,7 +54,7 @@ tap.test('Hapi router introspection', function (t) {
       }
       request.get(params, function (error, res, body) {
         t.equal(res.statusCode, 200, 'nothing exploded')
-        t.deepEqual(body, { status: 'ok' }, 'got expected response')
+        t.same(body, { status: 'ok' }, 'got expected response')
         t.end()
       })
     })
@@ -84,7 +84,7 @@ tap.test('Hapi router introspection', function (t) {
       }
       request.get(params, function (error, res, body) {
         t.equal(res.statusCode, 200, 'nothing exploded')
-        t.deepEqual(body, { status: 'ok' }, 'got expected response')
+        t.same(body, { status: 'ok' }, 'got expected response')
         t.end()
       })
     })
@@ -111,7 +111,7 @@ tap.test('Hapi router introspection', function (t) {
       }
       request.get(params, function (error, res, body) {
         t.equal(res.statusCode, 200, 'nothing exploded')
-        t.deepEqual(body, { status: 'ok' }, 'got expected response')
+        t.same(body, { status: 'ok' }, 'got expected response')
         t.end()
       })
     })
@@ -161,7 +161,7 @@ tap.test('Hapi router introspection', function (t) {
       }
       request.get(params, function (error, res, body) {
         t.equal(res.statusCode, 200, 'nothing exploded')
-        t.deepEqual(body, { status: 'ok' }, 'got expected response')
+        t.same(body, { status: 'ok' }, 'got expected response')
         t.end()
       })
     })
@@ -193,7 +193,7 @@ tap.test('Hapi router introspection', function (t) {
       }
       request.get(params, function (error, res, body) {
         t.equal(res.statusCode, 200, 'nothing exploded')
-        t.deepEqual(body, { status: 'ok' }, 'got expected response')
+        t.same(body, { status: 'ok' }, 'got expected response')
         t.end()
       })
     })
@@ -242,7 +242,7 @@ tap.test('Hapi router introspection', function (t) {
       }
       request.post(params, function (error, res, body) {
         t.equal(res.statusCode, 200, 'nothing exploded')
-        t.deepEqual(body, { status: 'ok' }, 'got expected response')
+        t.same(body, { status: 'ok' }, 'got expected response')
         t.end()
       })
     })
@@ -265,7 +265,7 @@ tap.test('Hapi router introspection', function (t) {
       }
       request.get(params, function (error, res, body) {
         t.equal(res.statusCode, 404, 'nonexistent route was not found')
-        t.deepEqual(
+        t.same(
           body,
           { statusCode: 404, error: 'Not Found', message: 'Not Found' },
           'got expected response'
@@ -278,8 +278,8 @@ tap.test('Hapi router introspection', function (t) {
   t.test('using shared `pre` config option', function (t) {
     agent.on('transactionFinished', (transaction) => {
       t.equal(
-        'WebTransaction/Hapi/GET//first/{firstId}/second/{secondId}/data',
         transaction.name,
+        'WebTransaction/Hapi/GET//first/{firstId}/second/{secondId}/data',
         'transaction is named correctly'
       )
     })
@@ -362,7 +362,7 @@ tap.test('Hapi router introspection', function (t) {
       }
       request.get(params, function (error, res, body) {
         t.equal(res.statusCode, 200, 'nothing exploded')
-        t.deepEqual(body, { success: 'TRUE' }, 'got expected response')
+        t.same(body, { success: 'TRUE' }, 'got expected response')
         t.end()
       })
     })

--- a/test/versioned/hapi/vhost.tap.js
+++ b/test/versioned/hapi/vhost.tap.js
@@ -78,7 +78,7 @@ tap.test('Hapi vhost support', function (t) {
       }
       request.get(params, function (error, res, body) {
         t.equal(res.statusCode, 200, 'nothing exploded')
-        t.deepEqual(body, { status: 'ok' }, 'got expected response')
+        t.same(body, { status: 'ok' }, 'got expected response')
         t.end()
       })
     })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links
Closes NEWRELIC-5285

## Details
The versioned tests were still using deprecated methods like `deepEqual` so I fixed this.  The hapi instrumentation complexity was resolved by moving all functions to be at the root of file and pass in proper context.
