### PR TITLE
NEWRELIC-5290 refactored timers instrumentation to make easier to rea…

### DIFF
--- a/lib/instrumentation/core/timers.js
+++ b/lib/instrumentation/core/timers.js
@@ -5,73 +5,114 @@
 
 'use strict'
 
-/* eslint sonarjs/cognitive-complexity: ["error", 16] -- TODO: https://issues.newrelic.com/browse/NEWRELIC-5252 */
-
 const symbols = require('../../symbols')
+const Timers = require('timers')
 
 module.exports = initialize
 
-function initialize(agent, timers, moduleName, shim) {
-  if (!agent.config.feature_flag.async_local_context) {
+function initialize(agent, timers, _moduleName, shim) {
+  const isAsyncLocalContext = agent.config.feature_flag.async_local_context
+
+  if (!isAsyncLocalContext) {
     instrumentProcessMethods(shim, process)
+    instrumentSetImmediate(shim, [timers, global])
   }
 
-  instrumentTimerMethods(timers)
+  instrumentTimerMethods(shim, [timers, global])
+}
 
-  // If we need to instrument separate references to timers on the global object,
-  // do that now.
-  if (!shim.isWrapped(global.setTimeout)) {
-    instrumentTimerMethods(global)
-  }
-
-  function instrumentTimerMethods(nodule) {
-    const asynchronizers = ['setTimeout', 'setInterval']
-
-    shim.record(nodule, asynchronizers, recordAsynchronizers)
-
-    if (!agent.config.feature_flag.async_local_context) {
-      // We don't want to create segments for setImmediate calls, as the
-      // object allocation may incur too much overhead in some situations
-      shim.wrap(nodule, 'setImmediate', wrapSetImmediate)
+/**
+ * Sets up instrumentation for setImmediate on both timers and global.
+ *
+ * We do not want to create segments for setImmediate calls,
+ * as the object allocation may incur too much overhead in some situations
+ *
+ * @param {Shim} shim instance of shim
+ * @param {Array<Timers,global>} pkgs array with references to timers and global
+ */
+function instrumentSetImmediate(shim, pkgs) {
+  pkgs.forEach((nodule) => {
+    if (shim.isWrapped(nodule.setImmediate)) {
+      return
     }
 
-    shim.wrap(nodule, 'clearTimeout', wrapClearTimeout)
-
-    makeWrappedPromisifyCompatible(shim, nodule)
-  }
-
-  function wrapSetImmediate(shim, fn) {
-    return function wrappedSetImmediate() {
-      const segment = shim.getActiveSegment()
-      if (!segment) {
-        return fn.apply(this, arguments)
-      }
-
-      const args = shim.argsToArray.apply(shim, arguments, segment)
-      shim.bindSegment(args, shim.FIRST)
-
-      return fn.apply(this, args)
-    }
-  }
-
-  function wrapClearTimeout(shim, fn) {
-    return function wrappedClearTimeout(timer) {
-      if (timer && timer._onTimeout) {
-        const segment = timer._onTimeout[symbols.segment]
-        if (segment && !segment.opaque) {
-          segment.ignore = true
+    shim.wrap(nodule, 'setImmediate', function wrapSetImmediate(shim, fn) {
+      return function wrappedSetImmediate() {
+        const segment = shim.getActiveSegment()
+        if (!segment) {
+          return fn.apply(this, arguments)
         }
+
+        const args = shim.argsToArray.apply(shim, arguments, segment)
+        shim.bindSegment(args, shim.FIRST)
+
+        return fn.apply(this, args)
       }
+    })
 
-      return fn.apply(this, arguments)
+    copySymbols(shim, nodule, 'setImmediate')
+  })
+}
+
+/**
+ * Sets up instrumentation for setTimeout, setInterval and clearTimeout
+ * on timers and global.
+ *
+ * @param {Shim} shim instance of shim
+ * @param {Array<Timers,global>} pkgs array with references to timers and global
+ */
+function instrumentTimerMethods(shim, pkgs) {
+  pkgs.forEach((nodule) => {
+    if (shim.isWrapped(nodule.setTimeout)) {
+      return
     }
-  }
 
-  function recordAsynchronizers(shim, fn, name) {
-    return { name: 'timers.' + name, callback: shim.FIRST }
+    const asynchronizers = ['setTimeout', 'setInterval']
+    shim.record(nodule, asynchronizers, recordAsynchronizers)
+    shim.wrap(nodule, 'clearTimeout', wrapClearTimeout)
+    makeWrappedPromisifyCompatible(shim, nodule)
+  })
+}
+
+/**
+ * Ignores the segment when clearTimeout is called
+ *
+ * @param {Shim} _shim instance of shim
+ * @param {Function} fn clearTimeout
+ * @returns {Function} wrapped clearTimeout
+ */
+function wrapClearTimeout(_shim, fn) {
+  return function wrappedClearTimeout(timer) {
+    if (timer && timer._onTimeout) {
+      const segment = timer._onTimeout[symbols.segment]
+      if (segment && !segment.opaque) {
+        segment.ignore = true
+      }
+    }
+
+    return fn.apply(this, arguments)
   }
 }
 
+/**
+ * Defines the spec for setTimeout and setInterval
+ *
+ * @param {Shim} shim instance of shim
+ * @param {Function} _fn original function
+ * @param {string} name name of function
+ * @returns {object} spec defining how to instrument
+ */
+function recordAsynchronizers(shim, _fn, name) {
+  return { name: 'timers.' + name, callback: shim.FIRST }
+}
+
+/**
+ * Instruments core process methods: nextTick, _nextDomainTick, _tickDomainCallback
+ * Note: This does not get registered when the context manager is async local
+ *
+ * @param {Shim} shim instance of shim
+ * @param {process} process global process object
+ */
 function instrumentProcessMethods(shim, process) {
   const processMethods = ['nextTick', '_nextDomainTick', '_tickDomainCallback']
 
@@ -96,21 +137,27 @@ function instrumentProcessMethods(shim, process) {
   })
 }
 
-function makeWrappedPromisifyCompatible(shim, timers) {
-  const originalSetTimeout = shim.getOriginal(timers.setTimeout)
-  Object.getOwnPropertySymbols(originalSetTimeout).forEach((symbol) => {
-    timers.setTimeout[symbol] = originalSetTimeout[symbol]
-  })
+/**
+ * Copies the symbols from original setTimeout and setInterval onto the wrapped functions
+ *
+ * @param {Shim} shim instance of shim
+ * @param {Timers} nodule Timers class
+ */
+function makeWrappedPromisifyCompatible(shim, nodule) {
+  copySymbols(shim, nodule, 'setTimeout')
+  copySymbols(shim, nodule, 'setInterval')
+}
 
-  const originalSetInterval = shim.getOriginal(timers.setInterval)
-  Object.getOwnPropertySymbols(originalSetInterval).forEach((symbol) => {
-    timers.setInterval[symbol] = originalSetInterval[symbol]
+/**
+ * Helper to copy symbols from original function to wrapped one
+ *
+ * @param {Shim} shim instance of shim
+ * @param {Timers} nodule Timers class
+ * @param {string} name name of function
+ */
+function copySymbols(shim, nodule, name) {
+  const originalFunction = shim.getOriginal(nodule[name])
+  Object.getOwnPropertySymbols(originalFunction).forEach((symbol) => {
+    nodule[name][symbol] = originalFunction[symbol]
   })
-
-  if (!shim.agent.config.feature_flag.async_local_context) {
-    const originalSetImmediate = shim.getOriginal(timers.setImmediate)
-    Object.getOwnPropertySymbols(originalSetImmediate).forEach((symbol) => {
-      timers.setImmediate[symbol] = originalSetImmediate[symbol]
-    })
-  }
 }


### PR DESCRIPTION
…son about. I broke out the setImmediate instrumentation into its own function and also created a helper for moving symbosl from original to wrapped

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links
closes NEWRELIC-5290

## Details
I consolidated all the logic that gets skipped when async local context manager is enabled into its own branch.  Before the registration was scattered between 3 functions.  I also simplified instrumenting on both timers and global namespace. I also added and fixed all jsdoc linting violations