### PR TITLE
NEWRELIC-4459: added noticeError example

### DIFF
--- a/api.js
+++ b/api.js
@@ -390,6 +390,17 @@ API.prototype.addCustomSpanAttribute = function addCustomSpanAttribute(key, valu
  * `Error` or one of its subtypes, but the API will handle strings and objects
  * that have an attached `.message` or `.stack` property.
  *
+ * An example of using this function is
+ *
+ *    try {
+ *      performSomeTask();
+ *    } catch (err) {
+ *      newrelic.noticeError(
+ *        err,
+ *        {extraInformation: "error already handled in the application"}
+ *      );
+ *    }
+ *
  * NOTE: Errors that are recorded using this method do _not_ obey the
  * `ignore_status_codes` configuration.
  *


### PR DESCRIPTION
## Proposed Release Notes

* added `noticeError` example for our API docs

## Links 

* Closes NEWRELIC-4459

## Details

Just a quick example using a simple extra attribute. Need to also update docs-website to either point to or to replicate this example.