### PR TITLE
NEWRELIC-5572 added helper to retrieve CLM meta from a function reference

### DIFF
--- a/lib/util/code-level-metrics.js
+++ b/lib/util/code-level-metrics.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/**
+ * Helper to retrive Code Level Metrics(CLM)
+ * properties from a function reference.
+ *
+ * Currently this only will return code.function,
+ * more will be added later behind a feature flag
+ *
+ * @param {Function} fn function reference
+ * @returns {object} CLM properties
+ */
+module.exports = function getCLMMeta(fn) {
+  return {
+    'code.function': fn?.name || 'anonymous'
+  }
+}

--- a/test/unit/util/code-level-metrics.test.js
+++ b/test/unit/util/code-level-metrics.test.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const getCLMMeta = require('../../../lib/util/code-level-metrics')
+
+tap.test('CLM Meta', (t) => {
+  t.autoend()
+
+  t.test('should return function name as code.function from function reference', (t) => {
+    function testFunction() {}
+    const meta = getCLMMeta(testFunction)
+    t.same(meta, {
+      'code.function': 'testFunction'
+    })
+    t.end()
+  })
+
+  t.test('should return variable name as code.function from function reference', (t) => {
+    const testFunction = function () {}
+    const meta = getCLMMeta(testFunction)
+    t.same(meta, {
+      'code.function': 'testFunction'
+    })
+    t.end()
+  })
+
+  t.test(
+    'should return function name not variable name as code.function from function reference',
+    (t) => {
+      const testFunction = function realFunction() {}
+      const meta = getCLMMeta(testFunction)
+      t.same(meta, {
+        'code.function': 'realFunction'
+      })
+      t.end()
+    }
+  )
+
+  t.test('should return anonymous as code.function from anonymous function reference', (t) => {
+    const meta = getCLMMeta(function () {})
+    t.same(meta, {
+      'code.function': 'anonymous'
+    })
+    t.end()
+  })
+
+  t.test('should return anonymous as code.function from arrow function reference', (t) => {
+    const meta = getCLMMeta(() => {})
+    t.same(meta, {
+      'code.function': 'anonymous'
+    })
+    t.end()
+  })
+})


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added a utility to retrieve Code Level Metrics(CLM) metadata from a function reference.

## Links
Closes NEWRELIC-5572

## Details
This is the basic utility. The plan is layer on more from the v8 stack trace API and put behind a feature flag until we can measure the perf impact with OATS.
