### PR TITLE
NEWRELIC-5561 added code_level_metrics.enabled and defaulted it to false

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1198,6 +1198,16 @@ defaultConfig.definition = () => ({
     formatter: boolean,
     default: false,
     env: 'NEW_RELIC_IGNORE_SERVER_SIDE_CONFIG'
+  },
+
+  /**
+   * Toggles whether to capture code.* attributes on spans
+   */
+  code_level_metrics: {
+    enabled: {
+      formatter: boolean,
+      default: false
+    }
   }
 })
 

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -261,8 +261,13 @@ tap.test('with default properties', (t) => {
     t.end()
   })
 
-  t.test('should default to api.esm.custom_instrumentation_entrypoint to null', (t) => {
+  t.test('should default api.esm.custom_instrumentation_entrypoint to null', (t) => {
     t.equal(configuration.api.esm.custom_instrumentation_entrypoint, null)
+    t.end()
+  })
+
+  t.test('should default `code_level_metrics.enabled` to false', (t) => {
+    t.equal(configuration.code_level_metrics.enabled, false)
     t.end()
   })
 })

--- a/test/unit/config/config-env.test.js
+++ b/test/unit/config/config-env.test.js
@@ -654,4 +654,11 @@ tap.test('when overriding configuration values via environment variables', (t) =
       }
     )
   })
+
+  t.test('should pick up code_level_metrics.enabled', (t) => {
+    idempotentEnv({ NEW_RELIC_CODE_LEVEL_METRICS_ENABLED: 'true' }, function (tc) {
+      t.equal(tc.code_level_metrics.enabled, true)
+      t.end()
+    })
+  })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added configuration option to toggle Code Level Metrics: `code_level_metrics.enabled`.  
   * It defaults to false.
   * The environment variable is `NEW_RELIC_CODE_LEVEL_METRICS_ENABLED`.

## Links
Closes NEWRELIC-5561

## Details
