### PR TITLE
CLM support for all middleware 

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -9241,7 +9241,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ### @contrast/fn-inspect
 
-This product includes source derived from [@contrast/fn-inspect](https://github.com/Contrast-Security-Inc/node-fn-inspect) ([v3.2.0](https://github.com/Contrast-Security-Inc/node-fn-inspect/tree/v3.2.0)), distributed under the [MIT License](https://github.com/Contrast-Security-Inc/node-fn-inspect/blob/v3.2.0/LICENSE):
+This product includes source derived from [@contrast/fn-inspect](https://github.com/Contrast-Security-Inc/node-fn-inspect) ([v3.3.0](https://github.com/Contrast-Security-Inc/node-fn-inspect/tree/v3.3.0)), distributed under the [MIT License](https://github.com/Contrast-Security-Inc/node-fn-inspect/blob/v3.3.0/LICENSE):
 
 ```
 Copyright 2022 Contrast Security, Inc

--- a/lib/instrumentation/director.js
+++ b/lib/instrumentation/director.js
@@ -17,6 +17,7 @@ module.exports = function initialize(agent, director, moduleName, shim) {
   shim.wrapMiddlewareMounter(proto, methods, {
     route: shim.SECOND,
     wrapper: function wrapMiddleware(shim, middleware, name, path) {
+      debugger
       return shim.recordMiddleware(middleware, {
         route: path,
         req: function getReq() {

--- a/lib/instrumentation/director.js
+++ b/lib/instrumentation/director.js
@@ -17,7 +17,6 @@ module.exports = function initialize(agent, director, moduleName, shim) {
   shim.wrapMiddlewareMounter(proto, methods, {
     route: shim.SECOND,
     wrapper: function wrapMiddleware(shim, middleware, name, path) {
-      debugger
       return shim.recordMiddleware(middleware, {
         route: path,
         req: function getReq() {

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -14,6 +14,7 @@ const path = require('path')
 const specs = require('./specs')
 const util = require('util')
 const symbols = require('../symbols')
+const maybeAddCLMAttributes = require('../util/code-level-metrics')
 
 // Some modules do terrible things, like change the prototype of functions. To
 // avoid crashing things we'll use a cached copy of apply everywhere.
@@ -863,6 +864,7 @@ function record(nodule, properties, recordNamer) {
       )
 
       const segment = shouldCreateSegment ? _rawCreateSegment(shim, segDesc) : parent
+      maybeAddCLMAttributes(fn, segment)
 
       return _doRecord.call(this, segment, args, segDesc, shouldCreateSegment)
     }

--- a/lib/shim/webframework-shim.js
+++ b/lib/shim/webframework-shim.js
@@ -689,7 +689,7 @@ function _defaultResponsePredicate() {
  * @param {Function} middleware function to apply clm symbol
  */
 function assignCLMSymbol(shim, middleware) {
-  if (shim.isFunction(middleware) && shim?.agent?.config?.code_level_metrics?.enabled) {
+  if (shim.isFunction(middleware) && shim.agent.config.code_level_metrics.enabled) {
     middleware[symbols.clm] = true
   }
 }

--- a/lib/shim/webframework-shim.js
+++ b/lib/shim/webframework-shim.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-/* eslint sonarjs/cognitive-complexity: ["error", 69] -- TODO: https://issues.newrelic.com/browse/NEWRELIC-5252 */
+/* eslint sonarjs/cognitive-complexity: ["error", 70] -- TODO: https://issues.newrelic.com/browse/NEWRELIC-5252 */
 
 const genericRecorder = require('../metrics/recorders/generic')
 const logger = require('../logger.js').child({ component: 'WebFrameworkShim' })
@@ -735,6 +735,10 @@ function _recordMiddleware(shim, middleware, spec) {
   const isErrorWare = spec.type === MIDDLEWARE_TYPE_NAMES.ERRORWARE
   const getReq = shim.isFunction(spec.req) ? spec.req : _makeGetReq(shim, spec.req)
 
+  if (shim?.agent?.config?.code_level_metrics?.enabled) {
+    middleware[symbols.clm] = true
+  }
+
   return shim.record(
     middleware,
     spec.promise ? middlewareWithPromiseRecorder : middlewareWithCallbackRecorder
@@ -1102,7 +1106,7 @@ function _isError(shim, err) {
  *   The spec object the values are coming from
  */
 function _copyExpectedSpecParameters(destination, source) {
-  const keys = ['matchArity']
+  const keys = ['matchArity', 'clm']
 
   for (let i = 0; i < keys.length; ++i) {
     const key = keys[i]

--- a/lib/shim/webframework-shim.js
+++ b/lib/shim/webframework-shim.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-/* eslint sonarjs/cognitive-complexity: ["error", 70] -- TODO: https://issues.newrelic.com/browse/NEWRELIC-5252 */
+/* eslint sonarjs/cognitive-complexity: ["error", 69] -- TODO: https://issues.newrelic.com/browse/NEWRELIC-5252 */
 
 const genericRecorder = require('../metrics/recorders/generic')
 const logger = require('../logger.js').child({ component: 'WebFrameworkShim' })
@@ -678,6 +678,23 @@ function _defaultResponsePredicate() {
 }
 
 /**
+ * Attaches a flag on function indicating that
+ * CLM attributes need to be associated with the middleware
+ * span during record
+ *
+ * Note: director instrumentation will crash as middleware is a string. Its instrumentation
+ * is relying on a wrapper and the string value is just to appease all the shim code
+ *
+ * @param {Shim} shim instance of shim
+ * @param {Function} middleware function to apply clm symbol
+ */
+function assignCLMSymbol(shim, middleware) {
+  if (shim.isFunction(middleware) && shim?.agent?.config?.code_level_metrics?.enabled) {
+    middleware[symbols.clm] = true
+  }
+}
+
+/**
  * Wraps the given function in a middleware recorder function.
  *
  * @private
@@ -735,9 +752,7 @@ function _recordMiddleware(shim, middleware, spec) {
   const isErrorWare = spec.type === MIDDLEWARE_TYPE_NAMES.ERRORWARE
   const getReq = shim.isFunction(spec.req) ? spec.req : _makeGetReq(shim, spec.req)
 
-  if (shim?.agent?.config?.code_level_metrics?.enabled) {
-    middleware[symbols.clm] = true
-  }
+  assignCLMSymbol(shim, middleware)
 
   return shim.record(
     middleware,
@@ -1106,7 +1121,7 @@ function _isError(shim, err) {
  *   The spec object the values are coming from
  */
 function _copyExpectedSpecParameters(destination, source) {
-  const keys = ['matchArity', 'clm']
+  const keys = ['matchArity']
 
   for (let i = 0; i < keys.length; ++i) {
     const key = keys[i]

--- a/lib/shim/webframework-shim.js
+++ b/lib/shim/webframework-shim.js
@@ -682,8 +682,8 @@ function _defaultResponsePredicate() {
  * CLM attributes need to be associated with the middleware
  * span during record
  *
- * Note: director instrumentation will crash as middleware is a string. Its instrumentation
- * is relying on a wrapper and the string value is just to appease all the shim code
+ * Note: director middleware instrumentation passes in a string as the "function" so we have to check if the middleware is actually a function
+ * to avoid crashing.
  *
  * @param {Shim} shim instance of shim
  * @param {Function} middleware function to apply clm symbol

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -7,6 +7,7 @@
 
 module.exports = {
   cache: Symbol('cache'),
+  clm: Symbol('codeLevelMetrics'),
   context: Symbol('context'),
   databaseName: Symbol('databaseName'),
   disableDT: Symbol('Disable distributed tracing'), // description for backwards compatibility

--- a/lib/util/code-level-metrics.js
+++ b/lib/util/code-level-metrics.js
@@ -42,8 +42,10 @@ module.exports = function addCLMAttributes(fn, segment) {
     if (isValidLength(fnName, 255) && isValidLength(filePath, 255)) {
       segment.addAttribute('code.filepath', filePath)
       segment.addAttribute('code.function', fnName)
-      segment.addAttribute('code.lineno', lineNumber + 1) // line numbers start at 0 in v8 so we have to add 1 to reflect js code
-      segment.addAttribute('code.column', column)
+      // both line numbers and columns start at 0 in v8, add 1 to reflect js code
+      // See: https://v8.github.io/api/head/classv8_1_1Function.html#a87bc63f97a9a39f83051570519fc63c2
+      segment.addAttribute('code.lineno', lineNumber + 1)
+      segment.addAttribute('code.column', column + 1)
     }
   } catch (err) {
     logger.infoOnce({ err }, 'Not using v8 function inspector, falling back to function name')

--- a/lib/util/code-level-metrics.js
+++ b/lib/util/code-level-metrics.js
@@ -6,6 +6,7 @@
 'use strict'
 const logger = require('../logger').child({ component: 'code-level-metrics' })
 const { isValidLength } = require('./byte-limit')
+const symbols = require('../symbols')
 
 /**
  * Uses function name if truthy
@@ -19,33 +20,37 @@ function setFunctionName(name) {
 }
 
 /**
- * Helper to retrieve Code Level Metrics(CLM)
- * properties from a function reference.
+ * Helper used to assign Code Level Metrics(CLM)
+ * to an active segment.
+ *
+ * spec states if function or filepath are > 255, do not assign
+ * CLM attrs
  *
  * @param {Function} fn function reference
- * @returns {object} CLM properties
+ * @param {TraceSegment} segment active segment to attach code.* attrs
  */
-module.exports = function getCLMMeta(fn) {
+module.exports = function addCLMAttributes(fn, segment) {
+  if (!fn[symbols.clm]) {
+    return
+  }
+
   try {
     const { funcInfo } = require('@contrast/fn-inspect')
-    const { lineNumber, method, file: filePath } = funcInfo(fn)
+    const { lineNumber, method, file: filePath, column } = funcInfo(fn)
     const fnName = setFunctionName(method)
 
     if (isValidLength(fnName, 255) && isValidLength(filePath, 255)) {
-      return {
-        'code.filepath': filePath,
-        'code.function': fnName,
-        'code.lineno': lineNumber + 1 // line numbers start at 0 in v8 so we have to add 1 to reflect js code
-      }
+      segment.addAttribute('code.filepath', filePath)
+      segment.addAttribute('code.function', fnName)
+      segment.addAttribute('code.lineno', lineNumber + 1) // line numbers start at 0 in v8 so we have to add 1 to reflect js code
+      segment.addAttribute('code.column', column)
     }
   } catch (err) {
     logger.infoOnce({ err }, 'Not using v8 function inspector, falling back to function name')
     const fnName = setFunctionName(fn.name)
 
     if (isValidLength(fnName, 255)) {
-      return {
-        'code.function': fnName
-      }
+      segment.addAttribute('code.function', fnName)
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "npm": ">=6.0.0"
       },
       "optionalDependencies": {
-        "@contrast/fn-inspect": "^3.2.0",
+        "@contrast/fn-inspect": "^3.3.0",
         "@newrelic/native-metrics": "^9.0.0"
       }
     },
@@ -511,9 +511,9 @@
       }
     },
     "node_modules/@contrast/fn-inspect": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@contrast/fn-inspect/-/fn-inspect-3.2.0.tgz",
-      "integrity": "sha512-VDk7BVT9J7Jfmo2oW8tEfHreLqNx8ebcJE4aSGwvHd6Pfq7ql09vv45KmVvUM2EM1D8U0IFqQxHrVBGaKEJx1A==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/fn-inspect/-/fn-inspect-3.3.0.tgz",
+      "integrity": "sha512-iulijoAuhfamXZNWsEy4ORNd8TxqD6aKeMiukDpWSwuRJ3sB+4lOmY2DkP2WwlBpYMmh3k4/7LHP2I925Y2xKQ==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -14332,9 +14332,9 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
     "@contrast/fn-inspect": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@contrast/fn-inspect/-/fn-inspect-3.2.0.tgz",
-      "integrity": "sha512-VDk7BVT9J7Jfmo2oW8tEfHreLqNx8ebcJE4aSGwvHd6Pfq7ql09vv45KmVvUM2EM1D8U0IFqQxHrVBGaKEJx1A==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/fn-inspect/-/fn-inspect-3.3.0.tgz",
+      "integrity": "sha512-iulijoAuhfamXZNWsEy4ORNd8TxqD6aKeMiukDpWSwuRJ3sB+4lOmY2DkP2WwlBpYMmh3k4/7LHP2I925Y2xKQ==",
       "optional": true,
       "requires": {
         "nan": "^2.16.0",

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
   },
   "optionalDependencies": {
     "@newrelic/native-metrics": "^9.0.0",
-    "@contrast/fn-inspect": "^3.2.0"
+    "@contrast/fn-inspect": "^3.3.0"
   },
   "devDependencies": {
     "@newrelic/eslint-config": "^0.2.0",

--- a/test/unit/util/code-level-metrics.test.js
+++ b/test/unit/util/code-level-metrics.test.js
@@ -50,7 +50,7 @@ tap.test('CLM Meta', (t) => {
       'code.filepath': __filename,
       'code.function': 'testFunction',
       'code.lineno': 46,
-      'code.column': 25
+      'code.column': 26
     })
     t.end()
   })
@@ -63,7 +63,7 @@ tap.test('CLM Meta', (t) => {
       'code.filepath': __filename,
       'code.function': 'testFunction',
       'code.lineno': 59,
-      'code.column': 34
+      'code.column': 35
     })
     t.end()
   })
@@ -77,7 +77,7 @@ tap.test('CLM Meta', (t) => {
         'code.filepath': helperPath,
         'code.function': 'testFunction',
         'code.lineno': 11,
-        'code.column': 39
+        'code.column': 40
       })
       t.end()
     }
@@ -90,7 +90,7 @@ tap.test('CLM Meta', (t) => {
       'code.filepath': helperPath,
       'code.function': '(anonymous)',
       'code.lineno': 9,
-      'code.column': 26
+      'code.column': 27
     })
     t.end()
   })
@@ -102,7 +102,7 @@ tap.test('CLM Meta', (t) => {
       'code.filepath': helperPath,
       'code.function': '(anonymous)',
       'code.lineno': 10,
-      'code.column': 18
+      'code.column': 19
     })
     t.end()
   })

--- a/test/unit/util/code-level-metrics.test.js
+++ b/test/unit/util/code-level-metrics.test.js
@@ -6,11 +6,20 @@
 'use strict'
 
 const tap = require('tap')
-const getCLMMeta = require('../../../lib/util/code-level-metrics')
+const addCLMAttributes = require('../../../lib/util/code-level-metrics')
 const { anon, arrow, named } = require('../../lib/clm-helper')
 const path = require('path')
 const helperPath = path.resolve(`${__dirname}/../../lib/clm-helper.js`)
 const sinon = require('sinon')
+const symbols = require('../../../lib/symbols')
+tap.Test.prototype.addAssert('clmAttrs', 2, function clmAttrs(segmentStub, expectedAttrs) {
+  const attrs = segmentStub.addAttribute.args
+  const attrsObj = attrs.reduce((obj, [key, value]) => {
+    obj[key] = value
+    return obj
+  }, {})
+  this.same(attrsObj, expectedAttrs, 'CLM attrs should match')
+})
 
 /**
  * Helper to generate a long string
@@ -25,25 +34,36 @@ function longString(len) {
 
 tap.test('CLM Meta', (t) => {
   t.autoend()
+  let segmentStub
+
+  t.beforeEach(() => {
+    segmentStub = {
+      addAttribute: sinon.stub()
+    }
+  })
 
   t.test('should return function name as code.function from function reference', (t) => {
     function testFunction() {}
-    const meta = getCLMMeta(testFunction)
-    t.same(meta, {
+    testFunction[symbols.clm] = true
+    addCLMAttributes(testFunction, segmentStub)
+    t.clmAttrs(segmentStub, {
       'code.filepath': __filename,
       'code.function': 'testFunction',
-      'code.lineno': 30
+      'code.lineno': 46,
+      'code.column': 25
     })
     t.end()
   })
 
   t.test('should return variable name as code.function from function reference', (t) => {
     const testFunction = function () {}
-    const meta = getCLMMeta(testFunction)
-    t.same(meta, {
+    testFunction[symbols.clm] = true
+    addCLMAttributes(testFunction, segmentStub)
+    t.clmAttrs(segmentStub, {
       'code.filepath': __filename,
       'code.function': 'testFunction',
-      'code.lineno': 41
+      'code.lineno': 59,
+      'code.column': 34
     })
     t.end()
   })
@@ -51,32 +71,38 @@ tap.test('CLM Meta', (t) => {
   t.test(
     'should return function name not variable name as code.function from function reference',
     (t) => {
-      const meta = getCLMMeta(named)
-      t.same(meta, {
+      named[symbols.clm] = true
+      addCLMAttributes(named, segmentStub)
+      t.clmAttrs(segmentStub, {
         'code.filepath': helperPath,
         'code.function': 'testFunction',
-        'code.lineno': 11
+        'code.lineno': 11,
+        'code.column': 39
       })
       t.end()
     }
   )
 
   t.test('should return (anonymous) as code.function from (anonymous) function reference', (t) => {
-    const meta = getCLMMeta(anon)
-    t.same(meta, {
+    anon[symbols.clm] = true
+    addCLMAttributes(anon, segmentStub)
+    t.clmAttrs(segmentStub, {
       'code.filepath': helperPath,
       'code.function': '(anonymous)',
-      'code.lineno': 9
+      'code.lineno': 9,
+      'code.column': 26
     })
     t.end()
   })
 
   t.test('should return (anonymous) as code.function from arrow function reference', (t) => {
-    const meta = getCLMMeta(arrow)
-    t.same(meta, {
+    arrow[symbols.clm] = true
+    addCLMAttributes(arrow, segmentStub)
+    t.clmAttrs(segmentStub, {
       'code.filepath': helperPath,
       'code.function': '(anonymous)',
-      'code.lineno': 10
+      'code.lineno': 10,
+      'code.column': 18
     })
     t.end()
   })
@@ -84,8 +110,9 @@ tap.test('CLM Meta', (t) => {
   t.test('should not return code attributes if function name > 255', (t) => {
     const fnName = longString(256)
     const fn = new Function(`return function ${fnName}() {}`)()
-    const meta = getCLMMeta(fn)
-    t.notOk(meta)
+    fn[symbols.clm] = true
+    addCLMAttributes(fn, segmentStub)
+    t.notOk(segmentStub.addAttribute.callCount)
     t.end()
   })
 
@@ -101,11 +128,20 @@ tap.test('CLM Meta', (t) => {
       fnInspector.funcInfo.restore()
     })
 
+    t.test('should not try to get function metadata if clm symbol does not exist', (t) => {
+      addCLMAttributes(() => {}, segmentStub)
+      t.notOk(fnInspector.funcInfo.callCount, 'should not call funcInfo')
+      t.notOk(segmentStub.addAttribute.callCount, 'should not call segment.addAttribute')
+      t.end()
+    })
+
     t.test('should not return code attributes if filepath > 255', (t) => {
       const longPath = longString(300)
       fnInspector.funcInfo.returns({ lineNumber: 1, method: 'unitTest', file: longPath })
-      const meta = getCLMMeta(() => {})
-      t.notOk(meta)
+      const fn = () => {}
+      fn[symbols.clm] = true
+      addCLMAttributes(fn, segmentStub)
+      t.notOk(segmentStub.addAttribute.callCount)
       t.end()
     })
 
@@ -113,20 +149,21 @@ tap.test('CLM Meta', (t) => {
       const err = new Error('failed to get function meta')
       fnInspector.funcInfo.throws(err)
       function test() {}
-      const meta = getCLMMeta(test)
-      t.same(meta, {
-        'code.function': 'test'
-      })
+      test[symbols.clm] = true
+      addCLMAttributes(test, segmentStub)
+      t.equal(segmentStub.addAttribute.callCount, 1)
+      t.same(segmentStub.addAttribute.args[0], ['code.function', 'test'])
       t.end()
     })
 
     t.test('should not return code attributes if function name is > 255', (t) => {
       const fnName = longString(256)
       const fn = new Function(`return function ${fnName}() {}`)()
+      fn[symbols.clm] = true
       const err = new Error('oh noes, not again')
       fnInspector.funcInfo.throws(err)
-      const meta = getCLMMeta(fn)
-      t.notOk(meta)
+      addCLMAttributes(fn, segmentStub)
+      t.notOk(segmentStub.addAttribute.callCount)
       t.end()
     })
   })

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,18 +1,18 @@
 {
-  "lastUpdated": "Tue Nov 29 2022 12:01:49 GMT-0500 (Eastern Standard Time)",
+  "lastUpdated": "Wed Nov 30 2022 17:29:44 GMT-0500 (Eastern Standard Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
   "optionalDependencies": {
-    "@contrast/fn-inspect@3.2.0": {
+    "@contrast/fn-inspect@3.3.0": {
       "name": "@contrast/fn-inspect",
-      "version": "3.2.0",
-      "range": "^3.2.0",
+      "version": "3.3.0",
+      "range": "^3.3.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/Contrast-Security-Inc/node-fn-inspect",
-      "versionedRepoUrl": "https://github.com/Contrast-Security-Inc/node-fn-inspect/tree/v3.2.0",
+      "versionedRepoUrl": "https://github.com/Contrast-Security-Inc/node-fn-inspect/tree/v3.3.0",
       "licenseFile": "node_modules/@contrast/fn-inspect/LICENSE",
-      "licenseUrl": "https://github.com/Contrast-Security-Inc/node-fn-inspect/blob/v3.2.0/LICENSE",
+      "licenseUrl": "https://github.com/Contrast-Security-Inc/node-fn-inspect/blob/v3.3.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Contrast Security"
     },


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Attached code level metrics attributes to middleware spans when `config.code_level_metrics.enabled` is true.

## Links
Closes NEWRELIC-5564

## Details
This code will solve all the web frameworks we want to attach CLM metrics for.  Basically any instrumentation that uses `shim.recordMiddleware` will flag the middleware function as CLM available. Then when the middleware function actually gets called it will get the function metadata and add it as attributes on the segment.

I only added versioned tests assertions for express but this will work for all other frameworks and we have tickets to add those corresponding tests.  To verify this doesn't break instrumentation you can run

```sh
NEW_RELIC_CODE_LEVEL_METRICS_ENABLED=true npm run versioned
```

Note: There will be 1 failure(express/segments) as there's a test assuming that clm is disabled.