### PR TITLE
Node 18 restify tests

### DIFF
--- a/test/versioned/restify/restify-post-7/package.json
+++ b/test/versioned/restify/restify-post-7/package.json
@@ -21,6 +21,25 @@
         "transaction-naming.tap.js",
         "with-express.tap.js"
       ]
+    },
+    {
+      "engines": {
+        "node": ">=18"
+      },
+      "dependencies": {
+        "restify": ">=10.0.0",
+        "express": "4.16",
+        "restify-errors": "6.1"
+      },
+      "files": [
+        "capture-params.tap.js",
+        "ignoring.tap.js",
+        "restify.tap.js",
+        "rum.tap.js",
+        "router.tap.js",
+        "transaction-naming.tap.js",
+        "with-express.tap.js"
+      ]
     }
   ],
   "dependencies": {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added a new test stanza to run restify >=10 on Node 18.

## Links
Closes NR-33669

## Details
On versions 14 and 16, restify 10 was already getting run

```sh
Folder: restify-post-7
	 * restify(4): 7.7.0, 8.6.1, 9.0.0, 10.0.0
	 * express(1): 4.16
	 * restify-errors(1): 6.1.1
```

However, due to issues with restify 9 on Node 18 we had to skip it.  Now we can unleash it again for Node 18 🎉
