### PR TITLE
NR-69739  Reintroduced throttled reading of dependency tree

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -10,6 +10,7 @@ const { fsPromises } = require('./util/unwrapped-core')
 const os = require('os')
 const logger = require('./logger').child({ component: 'environment' })
 const stringify = require('json-stringify-safe')
+const asyncEachLimit = require('./util/async-each-limit')
 const DISPATCHER_VERSION = 'Dispatcher Version'
 
 // As of 1.7.0 you can no longer dynamically link v8
@@ -72,7 +73,7 @@ async function listPackages(root, packages = []) {
 
   try {
     const dirs = await fsPromises.readdir(root)
-    await Promise.all(dirs.map(forEachDir))
+    await asyncEachLimit(dirs, forEachDir, 2)
     _log('Done listing packages in %s', root)
   } catch (err) {
     logger.trace(err, 'Could not list packages in %s (probably not an error)', root)
@@ -122,7 +123,7 @@ async function listDependencies(root, children = [], visited = Object.create(nul
 
   try {
     const dirs = await fsPromises.readdir(root)
-    await Promise.all(dirs.map(forEachEntry))
+    await asyncEachLimit(dirs, forEachEntry, 2)
     _log('Done listing dependencies in %s', root)
   } catch (err) {
     logger.trace(err, 'Could not read directories in %s (probably not an error)', root)
@@ -232,7 +233,7 @@ function getGlobalPackages() {
  * package appears at most once, with all the versions joined into a
  * comma-delimited list.
  *
- * @param packages
+ * @param {Array} packages list of packages to process
  * @returns {Array.<string[]>} Sorted list of [name, version] pairs.
  */
 function flattenVersions(packages) {
@@ -308,15 +309,18 @@ async function getOtherPackages() {
   }
   _log('Looking for other packages in %j', paths)
 
-  const pathPromises = paths.map((nodePath) => {
-    if (nodePath[0] !== '/') {
-      nodePath = path.resolve(process.cwd(), nodePath)
-    }
-    _log('Getting other packages from %s', nodePath)
-    return getPackages(nodePath)
-  })
+  const otherPackages = await asyncEachLimit(
+    paths,
+    (nodePath) => {
+      if (nodePath[0] !== '/') {
+        nodePath = path.resolve(process.cwd(), nodePath)
+      }
+      _log('Getting other packages from %s', nodePath)
+      return getPackages(nodePath)
+    },
+    2
+  )
 
-  const otherPackages = await Promise.all(pathPromises)
   otherPackages.forEach((pkg) => {
     other.packages.push.apply(other.packages, pkg.packages)
     other.dependencies.push.apply(other.dependencies, pkg.dependencies)
@@ -470,7 +474,7 @@ async function refresh() {
  * Refreshes settings and returns the settings object.
  *
  * @private
- * @returns {Promise}
+ * @returns {Promise} the updated/refreshed settings
  */
 async function getJSON() {
   _log('Getting environment JSON')

--- a/lib/util/async-each-limit.js
+++ b/lib/util/async-each-limit.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/**
+ * Helper method for limiting number of concurrent async executions to a certain limit
+ * Native replacement for async.eachLimit, fixes https://issues.newrelic.com/browse/NR-69739
+ *
+ * Shamelessly ripped off from https://github.com/nodejs/help/issues/2192#issuecomment-533730280
+ * and https://timtech.blog/posts/limiting-async-operations-promise-concurrency-javascript/
+ *
+ * @param {Array} items Array to iterate over
+ * @param {Function} fn the callback from Array.map you would normally write that contains an async operation
+ * @param {number} limit the maximum allowed concurrent invocations of `fn`
+ */
+async function eachLimit(items, fn, limit) {
+  const results = []
+
+  while (items.length) {
+    const resolved = await Promise.all(items.splice(0, limit).map(fn))
+    results.push(...resolved)
+  }
+
+  return results
+}
+
+module.exports = eachLimit

--- a/test/unit/util/async-each-limit.test.js
+++ b/test/unit/util/async-each-limit.test.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { test } = require('tap')
+const sinon = require('sinon')
+const eachLimit = require('../../../lib/util/async-each-limit')
+
+test('eachLimit', async (t) => {
+  t.autoend()
+
+  t.test('should limit concurrent executions', async (t) => {
+    t.autoend()
+
+    let firstPromiseResolve
+    let secondPromiseResolve
+    let thirdPromiseResolve
+
+    const access = sinon
+      .stub()
+      .onCall(0)
+      .returns(
+        new Promise((resolve) => {
+          firstPromiseResolve = resolve
+        })
+      )
+      .onCall(1)
+      .returns(
+        new Promise((resolve) => {
+          secondPromiseResolve = resolve
+        })
+      )
+      .onCall(2)
+      .returns(
+        new Promise((resolve) => {
+          thirdPromiseResolve = resolve
+        })
+      )
+
+    const items = ['foo.json', 'bar.json', 'baz.json']
+    const mapper = async (file) => {
+      try {
+        await access(file)
+        return true
+      } catch (err) {
+        return false
+      }
+    }
+
+    const promise = eachLimit(items, mapper, 2)
+
+    t.equal(access.callCount, 2, 'should have called two promises')
+    t.ok(access.calledWith('foo.json'), 'should have called the first promise')
+    t.ok(access.calledWith('bar.json'), 'should have called the second promise')
+    t.notOk(access.calledWith('baz.json'), 'should not have called the third promise yet')
+
+    firstPromiseResolve()
+    t.notOk(access.calledWith('baz.json'), 'should still not have called the third promise')
+
+    secondPromiseResolve()
+    thirdPromiseResolve()
+
+    const results = await promise
+
+    t.equal(access.callCount, 3, 'should have called three promises')
+    t.ok(access.calledWith('baz.json'), 'should have called the third promise')
+    t.same(results, [true, true, true], 'should return the correct results')
+  })
+})


### PR DESCRIPTION
## Proposed Release Notes
* Reintroduced throttled reading of dependency tree at startup to prevent EMFILE issues

## Links
Closes NR-69739

## Details
In [9.0.1](https://github.com/newrelic/node-newrelic/pull/1325/files#diff-24984142d58a41889c987b60103bcd93653f3551f71f6cdf22b5762e885c9cd6L86), we removed the async library as a dependency because as a group we did not like how confusing it was to read. An unfortunate side effect is that we removed throttling the dependency lookups at start-up. This meant that customers could run into EMFILE issues, as shown in the GTSE attached to the JIRA ticket mentioned above.

I also did some JSDoc cleanup in the environment file while I was in there