### PR TITLE
code-level-metrics: fix invocation of infoOnce

### DIFF
--- a/lib/util/code-level-metrics.js
+++ b/lib/util/code-level-metrics.js
@@ -65,7 +65,11 @@ clmUtils.addCLMAttributes = function addCLMAttributes(fn, segment) {
       segment.addAttribute('code.column', column + 1)
     }
   } catch (err) {
-    logger.infoOnce({ err }, 'Not using v8 function inspector, falling back to function name')
+    logger.infoOnce(
+      'clm:function-inspector',
+      { err },
+      'Not using v8 function inspector, falling back to function name'
+    )
     const fnName = setFunctionName(fn.name)
 
     if (isValidLength(fnName, 255)) {


### PR DESCRIPTION
The *Once family of logging functions need a key to know what to only report once. This string key should be the first parameter.

https://github.com/newrelic/node-newrelic/blob/df3e611c578ab2227f0ace2a8996c5a2d7137762/lib/util/logger.js#L118
