### PR TITLE
NEWRELIC-5885 Fix `/proc` file read error handling in system-info.js

### DIFF
--- a/lib/system-info.js
+++ b/lib/system-info.js
@@ -214,7 +214,7 @@ module.exports._getProcessorStats = async function getProcessorStats() {
 
     return processorStats
   } else if (platform.match(/linux/i)) {
-    const data = await readProc('/proc/cpuinfo')
+    const data = await getProcInfo('/proc/cpuinfo')
 
     return parseCpuInfo(data)
   }
@@ -237,7 +237,7 @@ module.exports._getMemoryStats = async function getMemoryStats() {
     const memory = await getSysctlValue(['hw.realmem'])
     return parseInt(memory, 10) / (1024 * 1024)
   } else if (platform.match(/linux/i)) {
-    const data = await readProc('/proc/meminfo')
+    const data = await getProcInfo('/proc/meminfo')
     return parseMemInfo(data)
   }
 
@@ -254,7 +254,7 @@ async function getKernelVersion() {
   if (platform.match(/darwin/i) || platform.match(/bsd/i)) {
     return await getSysctlValue(['kern.version'])
   } else if (platform.match(/linux/i)) {
-    return await readProc('/proc/version')
+    return await getProcInfo('/proc/version')
   }
 
   logger.debug('Unknown platform: %s; could not read kernel version', platform)
@@ -293,4 +293,19 @@ async function getSysctlValue(names = []) {
   }
 
   return returnValue
+}
+
+/**
+ * Helper method for getting /proc/* file information in Linux environments
+ *
+ * @param {string} procPath - the proc file to read
+ * @returns {*} null if the lookup fails, otherwise the proc file information
+ */
+async function getProcInfo(procPath) {
+  try {
+    return await readProc(procPath)
+  } catch (err) {
+    // swallow the error if reading fails, logging handled in readProc()
+    return null
+  }
 }

--- a/test/unit/system-info.test.js
+++ b/test/unit/system-info.test.js
@@ -207,6 +207,18 @@ tap.test('getProcessorStats - linux', (t) => {
     }
     t.same(results, expected, 'should return the expected results')
   })
+
+  t.test('should return null if readProc fails', async (t) => {
+    readProcFunction.yields(new Error('oops'))
+
+    const results = await systemInfo._getProcessorStats()
+    const expected = {
+      logical: null,
+      cores: null,
+      packages: null
+    }
+    t.same(results, expected, 'should return the expected results')
+  })
 })
 
 tap.test('getProcessorStats - unknown', (t) => {
@@ -358,6 +370,13 @@ tap.test('getMemoryStats - linux', (t) => {
 
     const results = await systemInfo._getMemoryStats()
     t.equal(results, 1837.953125)
+  })
+
+  t.test('should return null if readProc fails', async (t) => {
+    readProcFunction.yields(new Error('oops'))
+
+    const results = await systemInfo._getMemoryStats()
+    t.equal(results, null)
   })
 })
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
* Fixed system info gathering to prevent unhandled promise rejection when an error occurs reading `/proc` information.

## Links
Fixes #1462 / NEWRELIC-5885

## Details
Wrap usage of `readProc()` to swallow errors, restoring the original logic pre complexity reducing refactor. `readProc()` also handles the logging if an error does occur. Added unit tests to cover the exported functionality, but I feel like we should have a discussion about simplifying the unit testing by exporting more of the functions.