### PR TITLE
CLM: Handle binding functions

### DIFF
--- a/lib/util/code-level-metrics.js
+++ b/lib/util/code-level-metrics.js
@@ -56,7 +56,7 @@ clmUtils.addCLMAttributes = function addCLMAttributes(fn, segment) {
     const { lineNumber, method, file: filePath, column } = funcInfo(fn)
     const fnName = setFunctionName(method)
 
-    if (isValidLength(fnName, 255) && isValidLength(filePath, 255)) {
+    if (isValidLength(fnName, 255) && filePath && isValidLength(filePath, 255)) {
       segment.addAttribute('code.filepath', filePath)
       segment.addAttribute('code.function', fnName)
       // both line numbers and columns start at 0 in v8, add 1 to reflect js code

--- a/test/unit/util/code-level-metrics.test.js
+++ b/test/unit/util/code-level-metrics.test.js
@@ -107,6 +107,18 @@ tap.test('CLM Meta', (t) => {
     t.end()
   })
 
+  t.test('should not add CLM attrs when filePath is null', (t) => {
+    function fn() {}
+    t.comment(
+      'This is testing Express router.route which binds a function thus breaking any function metadata'
+    )
+    const boundFn = fn.bind(null)
+    boundFn[symbols.clm] = true
+    addCLMAttributes(boundFn, segmentStub)
+    t.notOk(segmentStub.addAttribute.callCount)
+    t.end()
+  })
+
   t.test('should not return code attributes if function name > 255', (t) => {
     const fnName = longString(256)
     const fn = new Function(`return function ${fnName}() {}`)()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added a check to the code level metrics utility to ensure filePath was set before adding the `code.*` attributes.

## Links

## Details
I discovered this crash thus getting into the catch when running with an express app and code level metrics.  It turns out when you bind a function it loses all the function metadata thus making our lookup useless. You can see where this occurs in the [express router.route](https://github.com/expressjs/express/blob/master/lib/router/index.js#L509).  
