### PR TITLE
NEWRELIC-6167 Update `getBrowserTimingHeader` to inject Browser Agent regardless of transaction availability

### DIFF
--- a/api.js
+++ b/api.js
@@ -717,8 +717,7 @@ function validateContext(config) {
  * option `hasToRemoveScriptWrapper` it can send back only the script content
  * without the `<script>` wrapper. Useful for React component based frontend.
  *
- * This method must be called _during_ a transaction, and must be called every
- * time you want to generate the headers.
+ * This method must be called every time you want to generate the headers.
  *
  * Do *not* reuse the headers between users, or even between requests.
  *

--- a/api.js
+++ b/api.js
@@ -644,7 +644,7 @@ function _generateRUMHeader(options = {}, metadata, loader) {
  * information to generate our Browser Agent script tag
  *
  * @param {object} config agent configuration settings
- * @returns {object} object containing validation results: { isValidContext: boolean, failureIdx?: number, quietMode?: boolean}
+ * @returns {{ isValidContext: boolean, failureIdx?: number, quietMode?: boolean}} object containing validation results
  */
 function validateContext(config) {
   /*

--- a/test/unit/rum.test.js
+++ b/test/unit/rum.test.js
@@ -49,6 +49,16 @@ describe('the RUM API', function () {
     api.getBrowserTimingHeader().should.equal('<!-- NREUM: (0) -->')
   })
 
+  it('should issue a warning outside a transaction by default', function () {
+    api.getBrowserTimingHeader().should.equal('<!-- NREUM: (1) -->')
+  })
+
+  it('should issue a warning outside a transaction and allowTransactionlessInjection is false', function () {
+    api
+      .getBrowserTimingHeader({ allowTransactionlessInjection: false })
+      .should.equal('<!-- NREUM: (1) -->')
+  })
+
   it('should issue a warning if the transaction was ignored', function () {
     helper.runInTransaction(agent, function (tx) {
       tx.ignore = true
@@ -139,8 +149,8 @@ describe('the RUM API', function () {
     })
   })
 
-  it('should get the browser agent script when outside a transaction', function () {
-    const timingHeader = api.getBrowserTimingHeader()
+  it('should get the browser agent script when outside a transaction and allowTransactionlessInjection is true', function () {
+    const timingHeader = api.getBrowserTimingHeader({ allowTransactionlessInjection: true })
     timingHeader
       .startsWith(
         `<script type=\'text/javascript\'>window.NREUM||(NREUM={});NREUM.info = {"licenseKey":1234,"applicationID":12345,`

--- a/test/unit/rum.test.js
+++ b/test/unit/rum.test.js
@@ -49,10 +49,6 @@ describe('the RUM API', function () {
     api.getBrowserTimingHeader().should.equal('<!-- NREUM: (0) -->')
   })
 
-  it('should issue a warning outside a transaction', function () {
-    api.getBrowserTimingHeader().should.equal('<!-- NREUM: (1) -->')
-  })
-
   it('should issue a warning if the transaction was ignored', function () {
     helper.runInTransaction(agent, function (tx) {
       tx.ignore = true
@@ -141,6 +137,16 @@ describe('the RUM API', function () {
         .should.equal(true)
       timingHeader.endsWith(`}; function() {}</script>`).should.equal(true)
     })
+  })
+
+  it('should get the browser agent script when outside a transaction', function () {
+    const timingHeader = api.getBrowserTimingHeader()
+    timingHeader
+      .startsWith(
+        `<script type=\'text/javascript\'>window.NREUM||(NREUM={});NREUM.info = {"licenseKey":1234,"applicationID":12345,`
+      )
+      .should.equal(true)
+    timingHeader.endsWith(`}; function() {}</script>`).should.equal(true)
   })
 
   it('should get browser agent script with wrapping tag and add nonce attribute to script if passed in options', function () {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
* Update `getBrowserTimingHeader` to allow Browser Agent to be generated even when not in a Transaction by adding `allowTransactionlessInjection` to function options. `allowTransactionlessInjection` is a boolean option, and when set to `true`, will allow injection of the Browser Agent when not in a transaction. Note that if you are using this option, you may need to wait until the Node agent has established a connection before calling `getBrowserTimingHeader`. To wait until the agent is connected, you can add the following check to your code: 
```js
if (!newrelic.agent.collector.isConnected()) {
  await new Promise((resolve) => {
    newrelic.agent.on('connected', resolve)
  })
}
```

## Links
Closes https://github.com/newrelic/newrelic-node-nextjs/issues/99

## Details
This has been a source of pain for users in a SSR/SSG applications, where they may not necessarily have an active transaction when injecting the Browser Agent. Before this change, in these scenarios the Browser Agent would just not be injected, and users would have to fall back to the Copy/Paste method, which is hard to maintain over time. After this change, the Browser Agent will be injected, but will be missing the transaction related information. It's also worth noting that in this situation, users won't be able to do custom attribute forwarding, as it's reliant on transaction state.
