### PR TITLE
NEWRELIC-6211: (winston) also instrument winston.loggers.add

### DIFF
--- a/lib/instrumentation/winston.js
+++ b/lib/instrumentation/winston.js
@@ -26,29 +26,63 @@ module.exports = function instrument(agent, winston, _, shim) {
     return
   }
 
+  createModuleUsageMetric('winston', agent.metrics)
+
   shim.wrap(winston, 'createLogger', function wrapCreate(shim, createLogger) {
-    return function createWrappedLogger() {
+    return function wrappedCreateLogger() {
       const args = shim.argsToArray.apply(shim, arguments)
       const opts = args[0] || {}
       if (isStream(opts)) {
         return createLogger.apply(this, args)
       }
-
-      createModuleUsageMetric('winston', agent.metrics)
-
-      if (isLocalDecoratingEnabled(config) || isMetricsEnabled(config)) {
-        registerFormatter({ opts, agent, winston })
-      }
-
-      const winstonLogger = createLogger.apply(this, args)
-
-      if (isLogForwardingEnabled(config, agent)) {
-        winstonLogger.add(new NrTransport({ agent }))
-      }
-
-      return winstonLogger
+      return performInstrumentation({
+        obj: this,
+        args,
+        opts,
+        agent,
+        winston,
+        registerLogger: createLogger
+      })
     }
   })
+
+  shim.wrap(winston.loggers, 'add', function wrapAdd(shim, add) {
+    return function wrappedAdd() {
+      const args = shim.argsToArray.apply(shim, arguments)
+      const id = args[0]
+      const opts = args[1] || {}
+      // add does nothing if the logger has already been added, so we
+      // have to do the same nothingness here.
+      const alreadyAdded = this.loggers.has(id)
+      if (alreadyAdded || isStream(opts)) {
+        return add.apply(this, args)
+      }
+      return performInstrumentation({
+        obj: this,
+        args,
+        opts,
+        agent,
+        winston,
+        registerLogger: add
+      })
+    }
+  })
+}
+
+function performInstrumentation({ obj, args, opts, agent, winston, registerLogger }) {
+  const config = agent.config
+
+  if (isLocalDecoratingEnabled(config) || isMetricsEnabled(config)) {
+    registerFormatter({ opts, agent, winston })
+  }
+
+  const winstonLogger = registerLogger.apply(obj, args)
+
+  if (isLogForwardingEnabled(config, agent)) {
+    winstonLogger.add(new NrTransport({ agent }))
+  }
+
+  return winstonLogger
 }
 
 /**

--- a/lib/instrumentation/winston.js
+++ b/lib/instrumentation/winston.js
@@ -26,8 +26,6 @@ module.exports = function instrument(agent, winston, _, shim) {
     return
   }
 
-  createModuleUsageMetric('winston', agent.metrics)
-
   shim.wrap(winston, 'createLogger', function wrapCreate(shim, createLogger) {
     return function wrappedCreateLogger() {
       const args = shim.argsToArray.apply(shim, arguments)
@@ -71,6 +69,8 @@ module.exports = function instrument(agent, winston, _, shim) {
 
 function performInstrumentation({ obj, args, opts, agent, winston, registerLogger }) {
   const config = agent.config
+
+  createModuleUsageMetric('winston', agent.metrics)
 
   if (isLocalDecoratingEnabled(config) || isMetricsEnabled(config)) {
     registerFormatter({ opts, agent, winston })

--- a/test/versioned/winston/winston.tap.js
+++ b/test/versioned/winston/winston.tap.js
@@ -86,13 +86,12 @@ tap.test('winston instrumentation', (t) => {
   t.test('logging enabled', (t) => {
     setup({ application_logging: { enabled: true } })
 
-    // Add two loggers with two different methods, should still be
-    // just one call count for the whole library.
+    // If we add two loggers, that counts as two instrumenations.
     winston.createLogger({})
     winston.loggers.add('local', {})
 
     const metric = agent.metrics.getMetric(LOGGING.LIBS.WINSTON)
-    t.equal(metric.callCount, 1, 'should create external module metric')
+    t.equal(metric.callCount, 2, 'should create external module metric')
     t.end()
   })
 


### PR DESCRIPTION
There is a different part of the Winston API that our current instrumentation simply misses. It's possible to create a logger by directly calling `createLogger`, but it's also possible to add new loggers to the list of loggers by doing `winston.loggers.add` with almost the same syntax.

This factors out a bit of the logic so that both methods of creating winston loggers are instrumented.

## Proposed Release Notes

* Instrumented `winston.loggers.add` so it works like `winston.createLogger`.

## Links

* Closes NEWRELIC-6211