### PR TITLE
Preserving GCP IDs that come in as numbers

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -22,6 +22,7 @@ code, the source code can be found at [https://github.com/newrelic/node-newrelic
 * [@tyriar/fibonacci-heap](#tyriarfibonacci-heap)
 * [concat-stream](#concat-stream)
 * [https-proxy-agent](#https-proxy-agent)
+* [json-bigint](#json-bigint)
 * [json-stringify-safe](#json-stringify-safe)
 * [readable-stream](#readable-stream)
 * [semver](#semver)
@@ -1200,6 +1201,34 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
+### json-bigint
+
+This product includes source derived from [json-bigint](https://github.com/sidorares/json-bigint) ([v1.0.0](https://github.com/sidorares/json-bigint/tree/v1.0.0)), distributed under the [MIT License](https://github.com/sidorares/json-bigint/blob/v1.0.0/LICENSE):
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2013 Andrey Sidorov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 ```
 
 ### json-stringify-safe

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -18,7 +18,7 @@ module.exports.clearCache = function clearGCPCache() {
 const enquoteGcpIds = (str) => {
   // If JS receives a very long number, it'll lose precision in being converted to scientific notation
   // This matters for GCP id, which is delivered as an unquoted number
-  const regex = /(id|"id"|\\"id\\"):\s?(\d+)/
+  const regex = /(id|"id"|\\"id\\"):\s?(\d+),/
   const matchId = str.match(regex)
   if (!matchId) {
     return str

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -15,6 +15,25 @@ module.exports.clearCache = function clearGCPCache() {
   resultDict = null
 }
 
+const enquoteGcpIds = (str) => {
+  // If JS receives a very long number, it'll lose precision in being converted to scientific notation
+  // This matters for GCP id, which is delivered as an unquoted number
+  const regex = /(id|"id"|\\"id\\"):\s?(\d+)/
+  const matchId = str.match(regex)
+  if (!matchId) {
+    return str
+  }
+  // replacement method depends on how quotes are escaped
+  // in a real response they probably aren't, but in local testing they need to be.
+  let newStr = str
+  if (matchId[1] === `id` || matchId[1] === `"id"`) {
+    newStr = str.replace(matchId[2], `"${matchId[2]}"`)
+  } else if (matchId[1] === '\\"id\\"') {
+    newStr = str.replace(matchId[2], `\\"${matchId[2]}\\"`)
+  }
+  return newStr
+}
+
 function fetchGCPInfo(agent, callback) {
   if (!agent.config.utilization || !agent.config.utilization.detect_gcp) {
     return setImmediate(callback, null)
@@ -37,9 +56,13 @@ function fetchGCPInfo(agent, callback) {
       if (err) {
         return callback(err)
       }
-
+      data = enquoteGcpIds(data)
       try {
         data = JSON.parse(data)
+        if (typeof data === 'string') {
+          // parse again if still a string; primarily for large int test
+          data = JSON.parse(data)
+        }
       } catch (e) {
         logger.debug(e, 'Failed to parse GCP metadata.')
         data = null

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -8,30 +8,12 @@
 const logger = require('../logger.js').child({ component: 'gcp-info' })
 const common = require('./common')
 const NAMES = require('../metrics/names.js')
+const JSONbig = require('json-bigint')({ useNativeBigInt: true })
 let resultDict = null
 
 module.exports = fetchGCPInfo
 module.exports.clearCache = function clearGCPCache() {
   resultDict = null
-}
-
-const enquoteGcpIds = (str) => {
-  // If JS receives a very long number, it'll lose precision in being converted to scientific notation
-  // This matters for GCP id, which is delivered as an unquoted number
-  const regex = /(id|"id"|\\"id\\"):\s?(\d+),/
-  const matchId = str.match(regex)
-  if (!matchId) {
-    return str
-  }
-  // replacement method depends on how quotes are escaped
-  // in a real response they probably aren't, but in local testing they need to be.
-  let newStr = str
-  if (matchId[1] === `id` || matchId[1] === `"id"`) {
-    newStr = str.replace(matchId[2], `"${matchId[2]}"`)
-  } else if (matchId[1] === '\\"id\\"') {
-    newStr = str.replace(matchId[2], `\\"${matchId[2]}\\"`)
-  }
-  return newStr
 }
 
 function fetchGCPInfo(agent, callback) {
@@ -56,12 +38,15 @@ function fetchGCPInfo(agent, callback) {
       if (err) {
         return callback(err)
       }
-      data = enquoteGcpIds(data)
       try {
-        data = JSON.parse(data)
+        data = JSONbig.parse(data)
+        // if the incoming string was escaped, we have to double-parse
         if (typeof data === 'string') {
           // parse again if still a string; primarily for large int test
-          data = JSON.parse(data)
+          data = JSONbig.parse(data)
+        }
+        if (typeof data.id !== 'string') {
+          data.id = data.id.toString()
         }
       } catch (e) {
         logger.debug(e, 'Failed to parse GCP metadata.')

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -40,11 +40,6 @@ function fetchGCPInfo(agent, callback) {
       }
       try {
         data = JSONbig.parse(data)
-        // if the incoming string was escaped, we have to double-parse
-        if (typeof data === 'string') {
-          // parse again if still a string; primarily for large int test
-          data = JSONbig.parse(data)
-        }
         if (typeof data.id !== 'string') {
           data.id = data.id.toString()
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@tyriar/fibonacci-heap": "^2.0.7",
         "concat-stream": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
+        "json-bigint": "^1.0.0",
         "json-stringify-safe": "^5.0.0",
         "readable-stream": "^3.6.0",
         "semver": "^5.3.0",
@@ -4258,6 +4259,14 @@
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
       "dev": true
     },
+    "node_modules/bignumber.js": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -8022,6 +8031,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -17321,6 +17338,11 @@
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
       "dev": true
     },
+    "bignumber.js": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig=="
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -20095,6 +20117,14 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
+    },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
     },
     "json-buffer": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
     "@tyriar/fibonacci-heap": "^2.0.7",
     "concat-stream": "^2.0.0",
     "https-proxy-agent": "^5.0.0",
+    "json-bigint": "^1.0.0",
     "json-stringify-safe": "^5.0.0",
     "readable-stream": "^3.6.0",
     "semver": "^5.3.0",

--- a/test/integration/pricing/system-info.tap.js
+++ b/test/integration/pricing/system-info.tap.js
@@ -122,7 +122,7 @@ test('pricing system-info gcp', function (t) {
     .get('/computeMetadata/v1/instance/')
     .query({ recursive: true })
     .reply(200, {
-      id: '3161347020215157000',
+      id: '3161347020215157123',
       machineType: 'projects/492690098729/machineTypes/custom-1-1024',
       name: 'aef-default-20170501t160547-7gh8',
       zone: 'projects/492690098729/zones/us-central1-c'
@@ -143,7 +143,7 @@ test('pricing system-info gcp', function (t) {
 
   fetchSystemInfo(agent, function fetchSystemInfoCb(err, systemInfo) {
     const expectedData = {
-      id: '3161347020215157000',
+      id: '3161347020215157123',
       machineType: 'custom-1-1024',
       name: 'aef-default-20170501t160547-7gh8',
       zone: 'us-central1-c'

--- a/test/integration/pricing/vendor-info-tests.js
+++ b/test/integration/pricing/vendor-info-tests.js
@@ -9,6 +9,7 @@ const path = require('path')
 const nock = require('nock')
 const fs = require('fs')
 const helper = require('../../lib/agent_helper')
+const JSONbig = require('json-bigint')({ useNativeBigInt: true })
 
 module.exports = function (t, vendor) {
   const testFile = path.resolve(
@@ -30,7 +31,7 @@ module.exports = function (t, vendor) {
       return
     }
 
-    const cases = JSON.parse(data)
+    const cases = JSONbig.parse(data)
 
     t.autoend()
     t.ok(cases.length > 0, 'should have tests to run')
@@ -71,7 +72,7 @@ function makeTest(testCase, vendor, getInfo) {
       if (responseData.timeout) {
         redirection = redirection.delay(timeout)
       }
-      redirection.reply(200, JSON.stringify(responseData.response || ''))
+      redirection.reply(200, JSONbig.stringify(responseData.response || ''))
     }
 
     // This may be messy but AWS makes an extra call to get an auth token

--- a/test/lib/cross_agent_tests/utilization/utilization_json.json
+++ b/test/lib/cross_agent_tests/utilization/utilization_json.json
@@ -183,7 +183,7 @@
     "input_hostname": "myotherhost",
     "input_full_hostname": "myotherhost.com",
     "input_ip_address": ["1.2.3.4"],
-    "input_gcp_id": "3161347020215157000",
+    "input_gcp_id": "3161347020215157123",
     "input_gcp_type": "projects/492690098729/machineTypes/custom-1-1024",
     "input_gcp_name": "aef-default-20170501t160547-7gh8",
     "input_gcp_zone": "projects/492690098729/zones/us-central1-c",
@@ -196,7 +196,7 @@
       "ip_address": ["1.2.3.4"],
       "vendors": {
         "gcp": {
-          "id": "3161347020215157000",
+          "id": "3161347020215157123",
           "machineType": "custom-1-1024",
           "name": "aef-default-20170501t160547-7gh8",
           "zone": "us-central1-c"
@@ -211,7 +211,7 @@
     "input_hostname": "myotherhost",
     "input_full_hostname": "myotherhost.com",
     "input_ip_address": ["1.2.3.4"],
-    "input_gcp_id": "3161347020215157000",
+    "input_gcp_id": "3161347020215157123",
     "input_gcp_type": "projects/492690098729/machineTypes/custom-1-1024",
     "input_gcp_name": null,
     "input_gcp_zone": "projects/492690098729/zones/us-central1-c",

--- a/test/lib/cross_agent_tests/utilization_vendor_specific/gcp.json
+++ b/test/lib/cross_agent_tests/utilization_vendor_specific/gcp.json
@@ -284,5 +284,22 @@
         "zone": "us-central1-c"
       }
     }
+  },
+  {
+    "testname": "Handle numeric-only instance id - escaped string",
+    "uri": {
+      "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
+        "response": "{\"id\": 3161347020215157123, \"machineType\":\"projects/1234567890/machineTypes/custom-1-1024\",\"name\":\"aef-default-20170501t160547-7gh8\",\"zone\":\"projects/1234567890/zones/us-central1-c\"}",
+        "timeout": false
+      }
+    },
+    "expected_vendors_hash": {
+      "gcp": {
+        "id": "3161347020215157123",
+        "machineType": "custom-1-1024",
+        "name": "aef-default-20170501t160547-7gh8",
+        "zone": "us-central1-c"
+      }
+    }
   }
 ]

--- a/test/lib/cross_agent_tests/utilization_vendor_specific/gcp.json
+++ b/test/lib/cross_agent_tests/utilization_vendor_specific/gcp.json
@@ -24,7 +24,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": "3161347020215157123",
+          "id": 3161347020215157123,
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "aef-default-20170501t160547-7gh8",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -46,7 +46,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": "3161347020215157123",
+          "id": 3161347020215157123,
           "machineType": "<script>lol</script>",
           "name": "aef-default-20170501t160547-7gh8",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -66,7 +66,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": "3161347020215157123",
+          "id": 3161347020215157123,
           "machineType": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
           "name": "aef-default-20170501t160547-7gh8",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -126,7 +126,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": "3161347020215157123",
+          "id": 3161347020215157123,
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "aef-default-20170501t160547-7gh8",
           "zone": "<script>lol</script>"
@@ -146,7 +146,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": "3161347020215157123",
+          "id": 3161347020215157123,
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "aef-default-20170501t160547-7gh8",
           "zone": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
@@ -166,7 +166,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": "3161347020215157123",
+          "id": 3161347020215157123,
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "<script>lol</script>",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -186,7 +186,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": "3161347020215157123",
+          "id": 3161347020215157123,
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -206,7 +206,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": "3161347020215157123",
+          "id": 3161347020215157123,
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "滈 橀槶澉 鞻饙騴 鱙鷭黂 甗糲 紁羑 嗂 蛶觢豥 餤駰鬳 釂鱞鸄",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -228,7 +228,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": "3161347020215157123",
+          "id": 3161347020215157123,
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "滈 橀槶澉 鞻饙騴 鱙鷭黂 甗糲, 紁羑 嗂 蛶觢豥 餤駰鬳 釂鱞鸄",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -248,7 +248,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": "3161347020215157123",
+          "id": 3161347020215157123,
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "Bang!",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -268,7 +268,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": "3161347020215157123",
+          "id": 3161347020215157123,
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "a-b_c.3... and/or 503 867-5309",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -281,23 +281,6 @@
         "id": "3161347020215157123",
         "machineType": "custom-1-1024",
         "name": "a-b_c.3... and/or 503 867-5309",
-        "zone": "us-central1-c"
-      }
-    }
-  },
-  {
-    "testname": "Handle numeric-only instance id - escaped string",
-    "uri": {
-      "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
-        "response": "{\"id\": 3161347020215157123, \"machineType\":\"projects/1234567890/machineTypes/custom-1-1024\",\"name\":\"aef-default-20170501t160547-7gh8\",\"zone\":\"projects/1234567890/zones/us-central1-c\"}",
-        "timeout": false
-      }
-    },
-    "expected_vendors_hash": {
-      "gcp": {
-        "id": "3161347020215157123",
-        "machineType": "custom-1-1024",
-        "name": "aef-default-20170501t160547-7gh8",
         "zone": "us-central1-c"
       }
     }

--- a/test/lib/cross_agent_tests/utilization_vendor_specific/gcp.json
+++ b/test/lib/cross_agent_tests/utilization_vendor_specific/gcp.json
@@ -24,7 +24,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": 3161347020215157000,
+          "id": "3161347020215157123",
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "aef-default-20170501t160547-7gh8",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -34,7 +34,7 @@
     },
     "expected_vendors_hash": {
       "gcp": {
-        "id": "3161347020215157000",
+        "id": "3161347020215157123",
         "machineType": "custom-1-1024",
         "name": "aef-default-20170501t160547-7gh8",
         "zone": "us-central1-c"
@@ -46,7 +46,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": 3161347020215157000,
+          "id": "3161347020215157123",
           "machineType": "<script>lol</script>",
           "name": "aef-default-20170501t160547-7gh8",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -66,7 +66,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": 3161347020215157000,
+          "id": "3161347020215157123",
           "machineType": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
           "name": "aef-default-20170501t160547-7gh8",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -126,7 +126,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": 3161347020215157000,
+          "id": "3161347020215157123",
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "aef-default-20170501t160547-7gh8",
           "zone": "<script>lol</script>"
@@ -146,7 +146,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": 3161347020215157000,
+          "id": "3161347020215157123",
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "aef-default-20170501t160547-7gh8",
           "zone": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
@@ -166,7 +166,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": 3161347020215157000,
+          "id": "3161347020215157123",
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "<script>lol</script>",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -186,7 +186,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": 3161347020215157000,
+          "id": "3161347020215157123",
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -206,7 +206,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": 3161347020215157000,
+          "id": "3161347020215157123",
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "滈 橀槶澉 鞻饙騴 鱙鷭黂 甗糲 紁羑 嗂 蛶觢豥 餤駰鬳 釂鱞鸄",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -216,7 +216,7 @@
     },
     "expected_vendors_hash": {
       "gcp": {
-        "id": "3161347020215157000",
+        "id": "3161347020215157123",
         "machineType": "custom-1-1024",
         "name": "滈 橀槶澉 鞻饙騴 鱙鷭黂 甗糲 紁羑 嗂 蛶觢豥 餤駰鬳 釂鱞鸄",
         "zone": "us-central1-c"
@@ -228,7 +228,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": 3161347020215157000,
+          "id": "3161347020215157123",
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "滈 橀槶澉 鞻饙騴 鱙鷭黂 甗糲, 紁羑 嗂 蛶觢豥 餤駰鬳 釂鱞鸄",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -248,7 +248,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": 3161347020215157000,
+          "id": "3161347020215157123",
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "Bang!",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -268,7 +268,7 @@
     "uri": {
       "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true": {
         "response": {
-          "id": 3161347020215157000,
+          "id": "3161347020215157123",
           "machineType": "projects/492690098729/machineTypes/custom-1-1024",
           "name": "a-b_c.3... and/or 503 867-5309",
           "zone": "projects/492690098729/zones/us-central1-c"
@@ -278,7 +278,7 @@
     },
     "expected_vendors_hash": {
       "gcp": {
-        "id": "3161347020215157000",
+        "id": "3161347020215157123",
         "machineType": "custom-1-1024",
         "name": "a-b_c.3... and/or 503 867-5309",
         "zone": "us-central1-c"

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Tue Dec 20 2022 12:00:46 GMT-0500 (Eastern Standard Time)",
+  "lastUpdated": "Mon Jan 23 2023 16:01:56 GMT-0500 (Eastern Standard Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -134,6 +134,19 @@
       "publisher": "Nathan Rajlich",
       "email": "nathan@tootallnate.net",
       "url": "http://n8.io/"
+    },
+    "json-bigint@1.0.0": {
+      "name": "json-bigint",
+      "version": "1.0.0",
+      "range": "^1.0.0",
+      "licenses": "MIT",
+      "repoUrl": "https://github.com/sidorares/json-bigint",
+      "versionedRepoUrl": "https://github.com/sidorares/json-bigint/tree/v1.0.0",
+      "licenseFile": "node_modules/json-bigint/LICENSE",
+      "licenseUrl": "https://github.com/sidorares/json-bigint/blob/v1.0.0/LICENSE",
+      "licenseTextSource": "file",
+      "publisher": "Andrey Sidorov",
+      "email": "sidorares@yandex.ru"
     },
     "json-stringify-safe@5.0.1": {
       "name": "json-stringify-safe",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

Added safety check to enquote GCP IDs the platform reports as numbers. These numbers can be long enough that JS converts them to scientific notation, losing precision. Updated cross-agent test fixtures to expose this, with a new test case for this issue. Closes NR-80407

## Links
https://issues.newrelic.com/browse/NR-80407

## Details
