### PR TITLE
NEWRELIC-6379: (config) enable otlp_endpoint config item

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -53,6 +53,13 @@ defaultConfig.definition = () => ({
    */
   host: '',
   /**
+   * Endpoint to send OpenTelemetry spans to.
+   *
+   * This should be automatically deduced from your region and other
+   * settings, but if desired, you can override it.
+   */
+  otlp_endpoint: '',
+  /**
    * The port on which the collector proxy will be listening.
    *
    * You shouldn't need to change this.

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1298,12 +1298,19 @@ Config.prototype._canonicalize = function _canonicalize() {
   const level = this.logging.level
   this.logging.level = logAliases[level] || level
 
+  const region = parseKey(this.license_key)
   if (this.host === '') {
-    const region = parseKey(this.license_key)
     if (region) {
-      this.host = 'collector.' + region + '.nr-data.net'
+      this.host = `collector.${region}.nr-data.net`
     } else {
       this.host = 'collector.newrelic.com'
+    }
+  }
+  if (this.otlp_endpoint === '') {
+    if (region) {
+      this.otlp_endpoint = `otlp.${region}.nr-data.net`
+    } else {
+      this.otlp_endpoint = 'otlp.nr-data.net'
     }
   }
 

--- a/test/unit/config/config-env.test.js
+++ b/test/unit/config/config-env.test.js
@@ -115,6 +115,14 @@ tap.test('when overriding configuration values via environment variables', (t) =
     })
   })
 
+  t.test('should default OTel host if nothing to parse in the license key', (t) => {
+    idempotentEnv({ NEW_RELIC_LICENSE_KEY: 'hambulance' }, (tc) => {
+      t.ok(tc.otlp_endpoint)
+      t.equal(tc.otlp_endpoint, 'otlp.nr-data.net')
+      t.end()
+    })
+  })
+
   t.test('should parse the region off the license key for OTel', (t) => {
     idempotentEnv({ NEW_RELIC_LICENSE_KEY: 'eu01xxhambulance' }, (tc) => {
       t.ok(tc.otlp_endpoint)

--- a/test/unit/config/config-env.test.js
+++ b/test/unit/config/config-env.test.js
@@ -115,6 +115,25 @@ tap.test('when overriding configuration values via environment variables', (t) =
     })
   })
 
+  t.test('should parse the region off the license key for OTel', (t) => {
+    idempotentEnv({ NEW_RELIC_LICENSE_KEY: 'eu01xxhambulance' }, (tc) => {
+      t.ok(tc.otlp_endpoint)
+      t.equal(tc.otlp_endpoint, 'otlp.eu01.nr-data.net')
+      t.end()
+    })
+  })
+
+  t.test('should take an explicit OTel endpoint over the license key parsed host', (t) => {
+    idempotentEnv({ NEW_RELIC_LICENSE_KEY: 'eu01xxhambulance' }, function () {
+      idempotentEnv({ NEW_RELIC_OTLP_ENDPOINT: 'localhost' }, (tc) => {
+        t.ok(tc.otlp_endpoint)
+        t.equal(tc.otlp_endpoint, 'localhost')
+
+        t.end()
+      })
+    })
+  })
+
   t.test('should pick up on feature flags set via environment variables', (t) => {
     const ffNamePrefix = 'NEW_RELIC_FEATURE_FLAG_'
     const awaitFeatureFlag = ffNamePrefix + 'AWAIT_SUPPORT'


### PR DESCRIPTION
## Proposed Release Notes


## Links

* NEWRELIC-6379

## Details

The agent seems like the right place to have this sort of logic, similar to the logic for hitting the ordinary NR collector endpoint.

