### PR TITLE
Add new tracking type instrumentation 

### DIFF
--- a/lib/collector/facts.js
+++ b/lib/collector/facts.js
@@ -9,12 +9,6 @@ const fetchSystemInfo = require('../system-info')
 const logger = require('../logger').child({ component: 'facts' })
 const os = require('os')
 const parseLabels = require('../util/label-parser')
-const NAMES = require('../metrics/names')
-
-// For now static and tentative list of which logging libraries we
-// want to track. Later might come up with a better way of populating
-// this list.
-const LOG_LIBRARIES = ['winston', 'bunyan', 'pino', 'loglevel', 'npmlog', 'fancy-log']
 
 module.exports = facts
 
@@ -37,8 +31,6 @@ async function facts(agent, callback) {
 
   systemInfo = systemInfo || Object.create(null)
   environment = environment || []
-
-  countSupportabilityForLogLibraries(environment, agent)
 
   const hostname = agent.config.getHostnameSafe()
   const results = {
@@ -147,24 +139,4 @@ function getIdentifierOverride(appNames) {
     // NOTE: The concat is necessary to prevent sort from happening in-place.
     appNames.concat([]).sort().join(',')
   ].join(':')
-}
-
-/**
- * This function searches the computed environment for the presence of
- * some popular logging libraries. If present, it increments the
- * corresponding supportability metrics.
- *
- * @param {Array} environment the environment computed by
- * @param {object} agent the New Relic agent
- */
-function countSupportabilityForLogLibraries(environment, agent) {
-  const packages = environment.find((elt) => elt[0] === 'Packages')[1]
-  packages.forEach((pkg) => {
-    pkg = JSON.parse(pkg)[0]
-    if (LOG_LIBRARIES.includes(pkg)) {
-      agent.metrics
-        .getOrCreateMetric(`${NAMES.SUPPORTABILITY.NODEJS_DEPENDENCIES}/${pkg}`)
-        .incrementCallCount()
-    }
-  })
 }

--- a/lib/instrumentations.js
+++ b/lib/instrumentations.js
@@ -38,6 +38,21 @@ module.exports = function instrumentations() {
     'undici': { type: MODULE_TYPE.TRANSACTION },
     '@hapi/vision': { type: MODULE_TYPE.WEB_FRAMEWORK },
     'when': { module: './instrumentation/when' },
-    'winston': { type: MODULE_TYPE.GENERIC }
+    'winston': { type: MODULE_TYPE.GENERIC },
+    /**
+     * The modules below are listed here purely to take
+     * advantage of the Supportability/Features/onRequire/<module>
+     * metrics for libraries we want to track for some reason or another.
+     * The big uses cases are:
+     *  Logging libraries we want to instrument in the future
+     *  Libraries that have OpenTelemetry instrumentation we want to register
+     *  or have already registered.
+     */
+    'loglevel': { type: MODULE_TYPE.TRACKING },
+    'npmlog': { type: MODULE_TYPE.TRACKING },
+    'fancy-log': { type: MODULE_TYPE.TRACKING },
+    '@prisma/client': { type: MODULE_TYPE.TRACKING },
+    '@nestjs/core': { type: MODULE_TYPE.TRACKING },
+    'knex': { type: MODULE_TYPE.TRACKING }
   }
 }

--- a/lib/metrics/names.js
+++ b/lib/metrics/names.js
@@ -23,7 +23,6 @@ const SUPPORTABILITY = {
   TRANSACTION_API: 'Supportability/API/Transaction',
   UTILIZATION: 'Supportability/utilization',
   DEPENDENCIES: 'Supportability/InstalledDependencies',
-  NODEJS_DEPENDENCIES: 'Supportability/InstalledDependencies/Nodejs',
   NODEJS: 'Supportability/Nodejs',
   REGISTRATION: 'Supportability/Registration',
   EVENT_HARVEST: 'Supportability/EventHarvest',

--- a/lib/shim/constants.js
+++ b/lib/shim/constants.js
@@ -32,5 +32,11 @@ exports.MODULE_TYPE = {
   TRANSACTION: 'transaction',
 
   /** Web server framework module, such as Express or Restify. */
-  WEB_FRAMEWORK: 'web-framework'
+  WEB_FRAMEWORK: 'web-framework',
+
+  /**
+   * Used to load supportability metrics on installed verisions of packages
+   * that the Node.js agent does not instrument(i.e. - otel instrumentation or top logging libraries)
+   */
+  TRACKING: 'tracking'
 }

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -530,6 +530,13 @@ function instrumentPostLoad(agent, nodule, moduleName, resolvedName) {
     NAMES.FEATURES.INSTRUMENTATION.ON_REQUIRE
   )
 
+  // Tracking instrumentation is only used to add the supportability metrics
+  // that occur directly above this.  No reason to attempt to load instrumentation
+  // as it does not exist.
+  if (instrumentation.type === MODULE_TYPE.TRACKING) {
+    return nodule
+  }
+
   try {
     if (instrumentation.onRequire(shim, nodule, moduleName) !== false) {
       nodule = shim.getExport(nodule)
@@ -580,7 +587,6 @@ function _firstPartyInstrumentation(agent, fileName, shim, nodule, moduleName) {
 
 function _postLoad(agent, nodule, name, resolvedName) {
   const instrumentation = shimmer.getInstrumentationNameFromModuleName(name)
-
   const registeredInstrumentation = shimmer.registeredInstrumentations[instrumentation]
   const hasPostLoadInstrumentation =
     registeredInstrumentation && registeredInstrumentation.onRequire
@@ -596,7 +602,6 @@ function _postLoad(agent, nodule, name, resolvedName) {
 
 function _onResolveFileName(agent, requiredNameOrPath, resolvedFilepath) {
   const instrumentation = shimmer.getInstrumentationNameFromModuleName(requiredNameOrPath)
-
   const registeredInstrumentation = shimmer.registeredInstrumentations[instrumentation]
   const hasResolvedFileInstrumentation =
     registeredInstrumentation && registeredInstrumentation.onResolved

--- a/test/integration/module-loading/module-loading.tap.js
+++ b/test/integration/module-loading/module-loading.tap.js
@@ -11,12 +11,11 @@ const path = require('path')
 const helper = require('../../lib/agent_helper')
 const shimmer = require('../../../lib/shimmer')
 const symbols = require('../../../lib/symbols')
+const { FEATURES } = require('../../../lib/metrics/names')
 
 const CUSTOM_MODULE_PATH = './node_modules/customTestPackage'
-const EXPECTED_RESOLVED_METRIC_NAME =
-  'Supportability/Features/Instrumentation/OnResolved/./node_modules/customTestPackage'
-const EXPECTED_REQUIRE_METRIC_NAME =
-  'Supportability/Features/Instrumentation/OnRequire/./node_modules/customTestPackage'
+const EXPECTED_RESOLVED_METRIC_NAME = `${FEATURES.INSTRUMENTATION.ON_RESOLVED}/${CUSTOM_MODULE_PATH}`
+const EXPECTED_REQUIRE_METRIC_NAME = `${FEATURES.INSTRUMENTATION.ON_REQUIRE}/${CUSTOM_MODULE_PATH}`
 
 tap.test('Should properly track module paths to enable shim.require()', function (t) {
   t.autoend()
@@ -47,6 +46,32 @@ tap.test('Should properly track module paths to enable shim.require()', function
   const shimLoadedCustom = shim.require('custom')
   t.ok(shimLoadedCustom, 'shim.require() should load module')
   t.equal(shimLoadedCustom.name, 'customFunction', 'Should grab correct module')
+})
+
+tap.test('should only log supportability metric for tracking type instrumentation', function (t) {
+  t.autoend()
+
+  let agent = helper.instrumentMockedAgent()
+
+  t.teardown(() => {
+    helper.unloadAgent(agent)
+    agent = null
+  })
+
+  const PKG = `${FEATURES.INSTRUMENTATION.ON_REQUIRE}/@prisma/client`
+  const PKG_VERSION = `${FEATURES.INSTRUMENTATION.ON_REQUIRE}/@prisma/client/Version/3`
+
+  // eslint-disable-next-line node/no-extraneous-require
+  const prisma = require('@prisma/client')
+  const prismaOnRequiredMetric = agent.metrics._metrics.unscoped[PKG]
+  t.equal(prismaOnRequiredMetric.callCount, 1, `should record ${PKG}`)
+  const prismaVersionMetric = agent.metrics._metrics.unscoped[PKG_VERSION]
+  t.equal(prismaVersionMetric.callCount, 1, `should record ${PKG_VERSION}`)
+  t.notOk(
+    prisma[symbols.instrumented],
+    'should not try to instrument a package that is of type tracking'
+  )
+  t.end()
 })
 
 tap.test('shim.require() should play well with multiple test runs', (t) => {

--- a/test/integration/module-loading/node_modules/@prisma/client/index.js
+++ b/test/integration/module-loading/node_modules/@prisma/client/index.js
@@ -1,0 +1,3 @@
+module.exports = () => {
+  console.log('hello  wolrd')
+}

--- a/test/integration/module-loading/node_modules/@prisma/client/package.json
+++ b/test/integration/module-loading/node_modules/@prisma/client/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@prisma/client",
+  "version": "3.0.0",
+  "main": "index.js",
+  "engines": {
+    "node": ">=12"
+  }
+}

--- a/test/unit/facts.test.js
+++ b/test/unit/facts.test.js
@@ -20,8 +20,6 @@ const facts = proxyquire('../../lib/collector/facts', {
     child: sinon.stub().callsFake(() => loggerMock)
   }
 })
-const NAMES = require('../../lib/metrics/names')
-
 const sysInfo = require('../../lib/system-info')
 const utilTests = require('../lib/cross_agent_tests/utilization/utilization_json')
 const bootIdTests = require('../lib/cross_agent_tests/utilization/boot_id')
@@ -758,60 +756,6 @@ tap.test('display_host', { timeout: 20000 }, (t) => {
     facts(agent, function getFacts(factsed) {
       os.networkInterfaces = originalNI
       t.equal(factsed.display_host, 'UNKNOWN_BOX')
-      t.end()
-    })
-  })
-})
-
-tap.test('log metrics for common logging libraries', (t) => {
-  t.autoend()
-
-  const logPackages = ['winston', 'bunyan']
-  const otherPackages = ['express', 'indium']
-  const packages = logPackages.concat(otherPackages)
-  let agent = null
-
-  t.beforeEach(() => {
-    loggerMock.debug.reset()
-    const config = {
-      app_name: [...APP_NAMES]
-    }
-    agent = helper.loadMockedAgent(Object.assign(config, DISABLE_ALL_DETECTIONS))
-    // fake getJSON for testing
-    sinon.stub(agent.environment, 'getJSON')
-    agent.environment.getJSON.resolves([
-      [
-        'Packages',
-        packages.map((lib) => {
-          return `["${lib}","0.0.0"]`
-        })
-      ]
-    ])
-  })
-
-  t.afterEach(() => {
-    agent.environment.getJSON.restore()
-    helper.unloadAgent(agent)
-  })
-
-  t.test('logs metrics for common logging libraries', (t) => {
-    facts(agent, function getFacts() {
-      // doesn't matter what gets returned because we only care what was logged
-      // wait for harvest cycle
-
-      // check metrics
-      for (const lib of logPackages) {
-        const metric = agent.metrics.getOrCreateMetric(
-          `${NAMES.SUPPORTABILITY.NODEJS_DEPENDENCIES}/${lib}`
-        )
-        t.equal(metric.callCount, 1, `${lib} should have logged`)
-      }
-      for (const lib of otherPackages) {
-        const metric = agent.metrics.getOrCreateMetric(
-          `${NAMES.SUPPORTABILITY.NODEJS_DEPENDENCIES}/${lib}`
-        )
-        t.equal(metric.callCount, 0, `${lib} should not have logged`)
-      }
       t.end()
     })
   })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Add a new tracking type of instrumentation.  This will be responsible for logging `Supportability/Features/Instrumentation/OnResolved/<pkg>` and `Supportability/Features/Instrumentation/OnResolved/<pkg>/Version/<version>` metrics when packages are required.

## Links
Closes NEWRELIC-6384

## Details
I plan on updating angler to start collecting these new metrics.  These new metrics will be used to track how many customers are requiring packages that have otel instrumentation but also logging libraries to properly track usage.  The previous metrics for logging were loaded when a dependency existed in the package.json.  
