### PR TITLE
fix: update normalizeHeaders to gracefully handle no headers

### DIFF
--- a/lib/serverless/api-gateway.js
+++ b/lib/serverless/api-gateway.js
@@ -59,7 +59,8 @@ function normalizeQueryStringParameters(event) {
 }
 
 /**
- * normalizes headers either from multi value headers or normal headers to a
+ * Normalizes both request and response headers,
+ * either from Multi Value headers or "normal" headers to a
  * lowercase key map with comma separated string
  *
  * @param {object} event The event with headers to normalize
@@ -67,8 +68,14 @@ function normalizeQueryStringParameters(event) {
  * @returns {Object<string, string>} The normalized headers map
  */
 function normalizeHeaders(event, lowerCaseKey = false) {
+  const headers = event.multiValueHeaders ?? event.headers
+
+  if (!headers) {
+    return
+  }
+
   return Object.fromEntries(
-    Object.entries(event.multiValueHeaders ?? event.headers).map(([headerKey, headerValue]) => {
+    Object.entries(headers).map(([headerKey, headerValue]) => {
       const newKey = lowerCaseKey ? headerKey.toLowerCase() : headerKey
 
       if (Array.isArray(headerValue)) {

--- a/test/unit/serverless/aws-lambda.test.js
+++ b/test/unit/serverless/aws-lambda.test.js
@@ -420,6 +420,30 @@ tap.test('AwsLambda.patchLambdaHandler', (t) => {
       }
     })
 
+    t.test('should work when responding without headers', (t) => {
+      agent.on('transactionFinished', confirmAgentAttribute)
+
+      const apiGatewayProxyEvent = lambdaSampleEvents.apiGatewayProxyEvent
+
+      const wrappedHandler = awsLambda.patchLambdaHandler((event, context, callback) => {
+        callback(null, {
+          isBase64Encoded: false,
+          statusCode: 200,
+          body: 'worked'
+        })
+      })
+
+      wrappedHandler(apiGatewayProxyEvent, stubContext, stubCallback)
+
+      function confirmAgentAttribute(transaction) {
+        const agentAttributes = transaction.trace.attributes.get(ATTR_DEST.TRANS_EVENT)
+
+        t.equal(agentAttributes['http.statusCode'], '200')
+
+        t.end()
+      }
+    })
+
     t.test('should detect event type', (t) => {
       agent.on('transactionFinished', confirmAgentAttribute)
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
* Fixed error with Lambda/ALB serverless instrumentation when no response headers were included

## Links
Fixes #1503 / NEWRELIC-6805

## Details
When we updated to support multivalue headers/query params in #1489, we overlooked the scenario where there are no headers at all (which is possible with the response case), which caused the `Object.entries()` call to throw. Now, we'll first check to see if we have any headers at all to normalize, if not, then exit early.
