### PR TITLE
feat: prisma instrumentation support

### DIFF
--- a/lib/instrumentation/@prisma/client.js
+++ b/lib/instrumentation/@prisma/client.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+/**
+ * Instruments the `prisma/client` module, function that is
+ * passed to `onRequire` when instantiating instrumentation.
+ *
+ * @param {object} _agent - NewRelic agent
+ * @param {object} prismaClient - The prismaClient library definition
+ * @param prisma
+ * @param Prisma
+ * @param {string} _moduleName - String representation of require/import path
+ * @param {object} shim - shim for instrumentation
+ */
+module.exports = function initialize(_agent, prisma, _moduleName, shim) {
+  shim.setDatastore(shim.PRISMA)
+  shim.setParser(queryParser)
+
+  if (!shim.isWrapped(prisma, 'PrismaClient')) {
+    shim.wrapReturn(prisma, 'PrismaClient', (shim, fn, fnName, client) => {
+      clientPostConstructor.call(client, shim)
+    })
+  }
+
+  function clientPostConstructor(shim) {
+    // Do not know the way testing recordOperation
+    // shim.recordOperation(this, ['$connect', '$disconnect'], { callback: shim.LAST })
+    shim.recordQuery(this, '_request', prismaClientQueryWrapper)
+  }
+}
+
+function queryParser(method) {
+  const [model, action] = method.split('.')
+
+  return {
+    collection: model,
+    operation: action
+  }
+}
+function prismaClientQueryWrapper(shim, _, __, queryArgs) {
+  return {
+    callback: shim.LAST,
+    promise: true,
+    query: queryArgs[0].clientMethod
+  }
+}

--- a/lib/instrumentations.js
+++ b/lib/instrumentations.js
@@ -51,7 +51,7 @@ module.exports = function instrumentations() {
     'loglevel': { type: MODULE_TYPE.TRACKING },
     'npmlog': { type: MODULE_TYPE.TRACKING },
     'fancy-log': { type: MODULE_TYPE.TRACKING },
-    '@prisma/client': { type: MODULE_TYPE.TRACKING },
+    '@prisma/client': { type: MODULE_TYPE.DATASTORE },
     '@nestjs/core': { type: MODULE_TYPE.TRACKING },
     'knex': { type: MODULE_TYPE.TRACKING }
   }

--- a/lib/metrics/names.js
+++ b/lib/metrics/names.js
@@ -298,6 +298,13 @@ const LOGGING = {
   LOCAL_DECORATING: `${SUPPORTABILITY.LOGGING}/LocalDecorating/${NODEJS.PREFIX}`
 }
 
+const PRISMA = {
+  PREFIX: 'Prisma',
+  STATEMENT: DB.STATEMENT + '/Prisma/',
+  OPERATION: DB.OPERATION + '/Prisma/',
+  INSTANCE: DB.INSTANCE + '/Prisma/'
+}
+
 module.exports = {
   ACTION_DELIMITER: '/',
   ALL: ALL,
@@ -345,5 +352,6 @@ module.exports = {
   URI: 'Uri',
   UTILIZATION: UTILIZATION,
   VIEW: VIEW,
-  WEB: WEB
+  WEB: WEB,
+  PRISMA: PRISMA
 }

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -37,7 +37,8 @@ const DATASTORE_NAMES = {
   MYSQL: 'MySQL',
   NEPTUNE: 'Neptune',
   POSTGRES: 'Postgres',
-  REDIS: 'Redis'
+  REDIS: 'Redis',
+  PRISMA: 'Prisma'
 }
 
 /**


### PR DESCRIPTION

## Proposed Release Notes

## Links

## Details

It changes @prisma/client module type from TRACKING to DATASTORE so the operations are visible on newrelic transactions and database. 
It wraps the PrismaClient _request, the function communicates with Prisma engines to run queries, to record query. I could not find a way to get host parameters. 