### PR TITLE
DO NOT MERGE - set transaction_tracer.record_sql default to obfuscated

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -573,7 +573,7 @@ defaultConfig.definition = () => ({
      */
     record_sql: {
       formatter: allowList.bind(null, ['off', 'obfuscated', 'raw']),
-      default: 'off',
+      default: 'obfuscated',
       env: 'NEW_RELIC_RECORD_SQL'
     },
 

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -163,8 +163,8 @@ tap.test('with default properties', (t) => {
     t.end()
   })
 
-  t.test('should not record by default sql', (t) => {
-    t.equal(configuration.transaction_tracer.record_sql, 'off')
+  t.test('should obfsucate sql by default', (t) => {
+    t.equal(configuration.transaction_tracer.record_sql, 'obfuscated')
     t.end()
   })
 

--- a/test/unit/config/config-server-side.test.js
+++ b/test/unit/config/config-server-side.test.js
@@ -174,10 +174,10 @@ tap.test('when receiving server-side configuration', (t) => {
   })
 
   t.test('should not configure record_sql', (t) => {
-    t.equal(config.transaction_tracer.record_sql, 'off')
+    t.equal(config.transaction_tracer.record_sql, 'obfuscated')
 
     config.onConnect({ 'transaction_tracer.record_sql': 'raw' })
-    t.equal(config.transaction_tracer.record_sql, 'off')
+    t.equal(config.transaction_tracer.record_sql, 'obfuscated')
 
     t.end()
   })


### PR DESCRIPTION
…s with all other agents. In fact this PR was lost in the shuffle from GHE to GitHub.com https://source.datanerd.us/NodeJS-agent/nodejs_agent/pull/1982/files

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * **BREAKING** - Updated the default of `config.transaction_tracer.record_sql` from `off` to `obfuscated`.  

## Links

## Details
I noticed this when I was working on prisma instrumentation, and did some spelunkeing.  I found this [PR](https://source.datanerd.us/NodeJS-agent/nodejs_agent/pull/1982), that got lost during the move from GHE to GitHub.com back in April of 2020.  The change gets up compliant with the agent spec.  However, this change is breaking.  I just wanted to open the PR and assign label so we can talk about it.  We may want to let this sit until we release our next semver major v10.  
