### PR TITLE
moved the async local versioned test to nightly job to cut down on runtimes of PR/main CI

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -114,29 +114,6 @@ jobs:
         name: versioned-tests-${{ matrix.node-version }}
         path: ./coverage/versioned/lcov.info
 
-  async-local-context:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [16.x, 18.x]
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install Dependencies
-      run: npm ci
-    - name: Run Docker Services
-      run: npm run services
-    - name: Run Async Local Context Versioned Tests (Node 16+)
-      run: TEST_CHILD_TIMEOUT=600000 npm run versioned:async-local
-      env:
-        VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}
-        JOBS: 4 # 2 per CPU seems to be the sweet spot in GHA (July 2022)
-
   codecov:
     needs: [unit, integration, versioned]
     runs-on: ubuntu-latest

--- a/.github/workflows/versioned-coverage.yml
+++ b/.github/workflows/versioned-coverage.yml
@@ -12,6 +12,29 @@ on:
     - cron:  '0 9 * * 1-5'
 
 jobs:
+  async-local-context:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install Dependencies
+      run: npm ci
+    - name: Run Docker Services
+      run: npm run services
+    - name: Run Async Local Context Versioned Tests (Node 16+)
+      run: TEST_CHILD_TIMEOUT=600000 npm run versioned:async-local
+      env:
+        VERSIONED_MODE: --major 
+        JOBS: 4 # 2 per CPU seems to be the sweet spot in GHA (July 2022)
+
   versioned:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
We discussed this in planning.  The async local versioned tests haven't caught anything.  It is safe to run these less frequently to boost the CI time on PRs and main runs.  I filed a [ticket](https://issues.newrelic.com/browse/NEWRELIC-7153) to move this to CI as the default in v10 when we drop the legacy context manager.
