### PR TITLE
fix prisma instrumentation

### DIFF
--- a/lib/instrumentation/@prisma/client.js
+++ b/lib/instrumentation/@prisma/client.js
@@ -12,6 +12,8 @@ const parseSql = require('../../db/query-parsers/sql')
 // Note: runCommandRaw is another raw command but it is mongo which we cannot parse as sql
 const RAW_COMMANDS = ['executeRaw', 'queryRaw']
 
+const semver = require('semver')
+
 /**
  * Extracts the connection url from env var or the .value prop
  * Very similar to this helper: https://github.com/prisma/prisma/blob/main/packages/internals/src/utils/parseEnvValue.ts
@@ -50,18 +52,54 @@ function parseConnectionString(provider, datasource) {
 }
 
 /**
+ * Extracts the raw query string from the appropriate location within the function args.
+ * In 4.11.0 prisma refactored code and args are an array on .args, whereas before they
+ * were an object on .args.
+ *
+ * @param {Array} args args passed to the prisma function
+ * @param {string} pkgVersion prisma version
+ * @returns {string} raw query string
+ */
+function extractQueryArgs(args, pkgVersion) {
+  let query = ''
+  try {
+    if (semver.gte(pkgVersion, '4.11.0')) {
+      query = args[0].args[0][0]
+    } else {
+      query = args[0].args.query
+    }
+  } catch (err) {
+    logger.error('Failed to extract query from raw query: %s', err.message)
+  }
+
+  return query
+}
+
+/**
  * Extracts either the raw query or the client method.
- * If raw sql it will be returned as a formatted string of `$executeRaw(select).users`
+ * If raw sql it will be returned as a formatted string of `users.executeRaw(select)`
  *
  * @param {Array} args arguments to a prisma operation
+ * @param pkgVersion
  * @returns {string} formatted string of <collection>.<operation>
  */
-function retrieveQuery(args) {
+function retrieveQuery(args, pkgVersion) {
   if (Array.isArray(args)) {
     const action = args[0].action
     if (RAW_COMMANDS.includes(action)) {
-      const parsedQuery = parseSql(args[0]?.args?.query)
-      return `${action}(${parsedQuery.operation}).${parsedQuery.collection}`
+      const query = extractQueryArgs(args, pkgVersion)
+      const parsedQuery = parseSql(query)
+      console.log(parsedQuery)
+
+      let collection = ''
+      if (parsedQuery.collection) {
+        // Collection could be something like "public"."User", but what
+        // we want here is the second part, the table name.
+        const [part1, part2] = parsedQuery.collection.split('.')
+        collection = part2 || part1
+      }
+
+      return `${collection}.${action}(${parsedQuery.operation})`
     }
     return args[0].clientMethod
   }
@@ -84,6 +122,31 @@ function queryParser(str) {
 }
 
 /**
+ * Extracts the prisma connection information from the engine. In pre 4.11.0 this existed
+ * on a different object and was also a promise.
+ *
+ * @param {object} client prisma client instance
+ * @param {string} pkgVersion prisma version
+ * @returns {Promise} returns prisma connection configuration
+ */
+function extractPrismaConfig(client, pkgVersion) {
+  if (semver.gte(pkgVersion, '4.11.0')) {
+    return new Promise((resolve, reject) => {
+      try {
+        const config = client._engine.library.getConfig({
+          datamodel: client._engine.datamodel,
+          ignoreEnvVarErrors: true
+        })
+        resolve(config)
+      } catch (err) {
+        reject(err)
+      }
+    })
+  }
+  return client._engine.getConfig()
+}
+
+/**
  * Instruments the `@prisma/client` module, function that is
  * passed to `onRequire` when instantiating instrumentation.
  *
@@ -93,6 +156,7 @@ function queryParser(str) {
  * @param {object} shim New Relic shim
  */
 module.exports = async function initialize(_agent, prisma, _moduleName, shim) {
+  const pkgVersion = shim.require('./package.json').version
   shim.setDatastore(shim.PRISMA)
   shim.setParser(queryParser)
 
@@ -104,14 +168,15 @@ module.exports = async function initialize(_agent, prisma, _moduleName, shim) {
 
       return {
         promise: true,
-        query: retrieveQuery(args),
+        query: retrieveQuery(args, pkgVersion),
         /**
          * Adds the relevant host, port, database_name parameters
          * to the active segment
          */
-        inContext() {
+        inContext: async function inContext() {
           if (!client[prismaConnection]) {
-            client._engine.getConfig().then((prismaConfig) => {
+            try {
+              const prismaConfig = await extractPrismaConfig(client, pkgVersion)
               const activeDatasource = prismaConfig?.datasources[0]
               const dbParams = parseConnectionString(
                 activeDatasource?.provider,
@@ -119,7 +184,10 @@ module.exports = async function initialize(_agent, prisma, _moduleName, shim) {
               )
               shim.captureInstanceAttributes(dbParams.host, dbParams.port, dbParams.dbName)
               client[prismaConnection] = dbParams
-            })
+            } catch (err) {
+              logger.error('Failed to retrieve prisma config in %s: %s', pkgVersion, err.message)
+              client[prismaConnection] = {}
+            }
           } else {
             shim.captureInstanceAttributes(
               client[prismaConnection].host,

--- a/lib/instrumentation/@prisma/client.js
+++ b/lib/instrumentation/@prisma/client.js
@@ -89,7 +89,6 @@ function retrieveQuery(args, pkgVersion) {
     if (RAW_COMMANDS.includes(action)) {
       const query = extractQueryArgs(args, pkgVersion)
       const parsedQuery = parseSql(query)
-      console.log(parsedQuery)
 
       let collection = ''
       if (parsedQuery.collection) {
@@ -157,6 +156,14 @@ function extractPrismaConfig(client, pkgVersion) {
  */
 module.exports = async function initialize(_agent, prisma, _moduleName, shim) {
   const pkgVersion = shim.require('./package.json').version
+  if (semver.lt(pkgVersion, '4.0.0')) {
+    logger.warn(
+      'Skipping instrumentation of @prisma/client.  Minimum supported version of library is 4.0.0, actual version %s',
+      pkgVersion
+    )
+    return
+  }
+
   shim.setDatastore(shim.PRISMA)
   shim.setParser(queryParser)
 

--- a/test/unit/instrumentation/prisma-client.test.js
+++ b/test/unit/instrumentation/prisma-client.test.js
@@ -11,6 +11,7 @@ const helper = require('../../lib/agent_helper')
 const DatastoreShim = require('../../../lib/shim/datastore-shim.js')
 const symbols = require('../../../lib/symbols')
 const sinon = require('sinon')
+const semver = require('semver')
 
 let agent = null
 let initialize = null
@@ -27,19 +28,28 @@ test('PrismaClient unit tests', (t) => {
     agent = helper.instrumentMockedAgent()
     initialize = require('../../../lib/instrumentation/@prisma/client')
     shim = new DatastoreShim(agent, 'prisma')
+    sinon.stub(shim, 'require')
+    shim.require.returns({ version: '4.0.0' })
   })
 
   t.afterEach(function () {
     helper.unloadAgent(agent)
   })
 
-  function getMockModule() {
+  function getMockModule(version = '4.0.0') {
     function Engine() {}
 
     Engine.prototype.getConfig = sinon.stub()
-
-    function PrismaClient() {
-      this._engine = new Engine()
+    let PrismaClient
+    if (semver.gte(version, '4.11.0')) {
+      PrismaClient = function PrismaClient() {
+        this._engine = {}
+        this._engine.library = new Engine()
+      }
+    } else {
+      PrismaClient = function PrismaClient() {
+        this._engine = new Engine()
+      }
     }
 
     PrismaClient.prototype._executeRequest = sinon.stub().resolves()
@@ -143,12 +153,16 @@ test('PrismaClient unit tests', (t) => {
         args: { query: 'select test from unit-test;' },
         action: 'executeRaw'
       })
+      await client._executeRequest({
+        args: { query: 'select test from schema.unit-test;' },
+        action: 'executeRaw'
+      })
       const { children } = tx.trace.root
-      t.equal(children.length, 2, 'should have 2 segments')
-      const firstSegment = children[0]
-      const secondSegment = children[1]
+      t.equal(children.length, 3, 'should have 3 segments')
+      const [firstSegment, secondSegment, thirdSegment] = children
       t.equal(firstSegment.name, 'Datastore/statement/Prisma/user/create')
-      t.equal(secondSegment.name, 'Datastore/statement/Prisma/executeRaw(select)/unit-test')
+      t.equal(secondSegment.name, 'Datastore/statement/Prisma/unit-test/executeRaw(select)')
+      t.equal(thirdSegment.name, 'Datastore/statement/Prisma/unit-test/executeRaw(select)')
       t.same(firstSegment.getAttributes(), {
         product: 'Prisma',
         host: 'my-host',
@@ -177,6 +191,98 @@ test('PrismaClient unit tests', (t) => {
         }
       ]
     })
+
+    helper.runInTransaction(agent, async () => {
+      await client._executeRequest({ clientMethod: 'user.create', action: 'create' })
+      t.same(client[symbols.prismaConnection], {})
+      t.end()
+    })
+  })
+
+  t.test('should not set connection params if it fails to retrieve config', (t) => {
+    const MockPrismaClient = getMockModule()
+    const prisma = { PrismaClient: MockPrismaClient }
+
+    initialize(agent, prisma, '@prisma/client', shim)
+    const client = new prisma.PrismaClient()
+    const err = new Error('i failed')
+    client._engine.getConfig.rejects(err)
+
+    helper.runInTransaction(agent, async () => {
+      await client._executeRequest({ clientMethod: 'user.create', action: 'create' })
+      t.same(client[symbols.prismaConnection], {})
+      t.end()
+    })
+  })
+
+  t.test('should not crash if it fails to extract query from call', (t) => {
+    const MockPrismaClient = getMockModule()
+    const prisma = { PrismaClient: MockPrismaClient }
+
+    initialize(agent, prisma, '@prisma/client', shim)
+    const client = new prisma.PrismaClient()
+    client._engine.getConfig.resolves({
+      datasources: [
+        { provider: 'postgres', url: { value: 'postgresql://postgres:prisma@my-host:5436/db' } }
+      ]
+    })
+
+    helper.runInTransaction(agent, async (tx) => {
+      await client._executeRequest({ action: 'executeRaw' })
+      const { children } = tx.trace.root
+      const [firstSegment] = children
+      t.equal(firstSegment.name, 'Datastore/statement/Prisma/other/executeRaw(other)')
+      t.end()
+    })
+  })
+
+  t.test('should work on 4.11.0', (t) => {
+    const version = '4.11.0'
+    const MockPrismaClient = getMockModule(version)
+    const prisma = { PrismaClient: MockPrismaClient }
+
+    shim.require.returns({ version })
+    initialize(agent, prisma, '@prisma/client', shim)
+    const client = new prisma.PrismaClient()
+    client._engine.library.getConfig.returns({
+      datasources: [
+        { provider: 'postgres', url: { value: 'postgresql://postgres:prisma@my-host:5436/db' } }
+      ]
+    })
+
+    helper.runInTransaction(agent, async (tx) => {
+      await client._executeRequest({ clientMethod: 'user.create', action: 'create' })
+      await client._executeRequest({
+        args: [['select test from unit-test;']],
+        action: 'executeRaw'
+      })
+      const { children } = tx.trace.root
+      t.equal(children.length, 2, 'should have 2 segments')
+      const firstSegment = children[0]
+      const secondSegment = children[1]
+      t.equal(firstSegment.name, 'Datastore/statement/Prisma/user/create')
+      t.equal(secondSegment.name, 'Datastore/statement/Prisma/unit-test/executeRaw(select)')
+      t.same(firstSegment.getAttributes(), {
+        product: 'Prisma',
+        host: 'my-host',
+        port_path_or_id: '5436',
+        database_name: 'db'
+      })
+      t.same(firstSegment.getAttributes(), secondSegment.getAttributes())
+      t.end()
+    })
+  })
+
+  t.test('should not set connection params in 4.11.0+ if it fails to retrieve config', (t) => {
+    const version = '4.11.0'
+    const MockPrismaClient = getMockModule(version)
+    const prisma = { PrismaClient: MockPrismaClient }
+
+    shim.require.returns({ version })
+    initialize(agent, prisma, '@prisma/client', shim)
+    const client = new prisma.PrismaClient()
+    const err = new Error('i failed')
+    client._engine.library.getConfig.throws(err)
 
     helper.runInTransaction(agent, async () => {
       await client._executeRequest({ clientMethod: 'user.create', action: 'create' })

--- a/test/unit/instrumentation/prisma-client.test.js
+++ b/test/unit/instrumentation/prisma-client.test.js
@@ -290,4 +290,15 @@ test('PrismaClient unit tests', (t) => {
       t.end()
     })
   })
+
+  t.test('should not instrument prisma/client on versions less than 4.0.0', (t) => {
+    const MockPrismaClient = getMockModule()
+    const prisma = { PrismaClient: MockPrismaClient }
+
+    shim.require.returns({ version: '3.8.0' })
+    initialize(agent, prisma, '@prisma/client', shim)
+    const client = new prisma.PrismaClient()
+    t.notOk(shim.isWrapped(client._executeRequest), 'should not instrument @prisma/client')
+    t.end()
+  })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links
Closes NEWRELIC-7171

## Details
 * updated prisma instrumentation to work with version 4.11.0.  
 * I also added more defensive code to avoid future crashes with instrumentation if prisma internals change.
 * lock down min version of instrumentation to 4.0.0

Tested this with #1522 from 4.0.0 to 4.11.0

```sh
 ✓ prisma (100) 8m
===============================================================
Versions executed

Folder: prisma
	 * @prisma/client(10): 4.0.0, 4.1.1, 4.2.1, 4.4.0, 4.5.0, 4.6.1, 4.8.1, 4.9.0, 4.10.1, 4.11.0
	 * prisma(10): 4.0.0, 4.1.1, 4.2.1, 4.4.0, 4.5.0, 4.6.1, 4.8.1, 4.9.0, 4.10.1, 4.11.0
===============================================================
PASS

real	8m33.275s
user	4m52.602s
sys	1m20.720s
      513.27 real       292.60 user        80.72 sys
```

