### PR TITLE
Add collecting sql traces for Prisma

### DIFF
--- a/lib/instrumentation/@prisma/client.js
+++ b/lib/instrumentation/@prisma/client.js
@@ -11,6 +11,9 @@ const logger = require('../../logger').child({ component: 'prisma' })
 const parseSql = require('../../db/query-parsers/sql')
 // Note: runCommandRaw is another raw command but it is mongo which we cannot parse as sql
 const RAW_COMMANDS = ['executeRaw', 'queryRaw']
+// total hack but we need a way to know in query parser if it is raw sql or just a prisma model call
+// prefix prisma model calls with this variable
+const MODEL_CALL = '[NR_PRISMA]'
 
 const semver = require('semver')
 
@@ -82,30 +85,18 @@ function extractQueryArgs(args, pkgVersion) {
 
 /**
  * Extracts either the raw query or the client method.
- * If raw sql it will be returned as a formatted string of `users.executeRaw(select)`
  *
  * @param {Array} args arguments to a prisma operation
- * @param pkgVersion
- * @returns {string} formatted string of <collection>.<operation>
+ * @param {string} pkgVersion prisma version
+ * @returns {string} raw query string or [NR_MODEL]<collection>.<operation>
  */
 function retrieveQuery(args, pkgVersion) {
   if (Array.isArray(args)) {
     const action = args[0].action
     if (RAW_COMMANDS.includes(action)) {
-      const query = extractQueryArgs(args, pkgVersion)
-      const parsedQuery = parseSql(query)
-
-      let collection = ''
-      if (parsedQuery.collection) {
-        // Collection could be something like "public"."User", but what
-        // we want here is the second part, the table name.
-        const [part1, part2] = parsedQuery.collection.split('.')
-        collection = part2 || part1
-      }
-
-      return `${collection}.${action}(${parsedQuery.operation})`
+      return extractQueryArgs(args, pkgVersion)
     }
-    return args[0].clientMethod
+    return `${MODEL_CALL}${args[0].clientMethod}`
   }
 }
 
@@ -113,16 +104,20 @@ function retrieveQuery(args, pkgVersion) {
  * Parses formatted string to extract the collection and operation.
  * In case of executeRaw the string is created above in `retrieveQuery`
  *
- * @param {string} str formatted string of <collection>.<operation>
- * @returns {object} { collection, operation }
+ * @param {string} query raw query string or [NR_MODEL]<collection>.<operation>
+ * @returns {object} { collection, operation, query }
  */
-function queryParser(str) {
-  const [collection, operation] = str.split('.')
-
-  return {
-    collection,
-    operation
+function queryParser(query) {
+  if (query.startsWith(MODEL_CALL)) {
+    query = query.replace(MODEL_CALL, '')
+    const [collection, operation] = query.split('.')
+    return {
+      collection,
+      operation,
+      query
+    }
   }
+  return parseSql(query)
 }
 
 /**

--- a/lib/instrumentation/@prisma/client.js
+++ b/lib/instrumentation/@prisma/client.js
@@ -11,9 +11,8 @@ const logger = require('../../logger').child({ component: 'prisma' })
 const parseSql = require('../../db/query-parsers/sql')
 // Note: runCommandRaw is another raw command but it is mongo which we cannot parse as sql
 const RAW_COMMANDS = ['executeRaw', 'queryRaw']
-// total hack but we need a way to know in query parser if it is raw sql or just a prisma model call
-// prefix prisma model calls with this variable
-const MODEL_CALL = '[NR_PRISMA]'
+// indicator that this is a prisma model call and not raw query/statement
+const MODEL_CALL = Symbol('modelCall')
 
 const semver = require('semver')
 
@@ -96,7 +95,13 @@ function retrieveQuery(args, pkgVersion) {
     if (RAW_COMMANDS.includes(action)) {
       return extractQueryArgs(args, pkgVersion)
     }
-    return `${MODEL_CALL}${args[0].clientMethod}`
+
+    // cast to string obj to attach symbol
+    // this is done to tell query parser that we need to split string
+    // to extract contents
+    const clientMethod = new String(args[0].clientMethod)
+    clientMethod[MODEL_CALL] = true
+    return clientMethod
   }
 }
 
@@ -108,13 +113,13 @@ function retrieveQuery(args, pkgVersion) {
  * @returns {object} { collection, operation, query }
  */
 function queryParser(query) {
-  if (query.startsWith(MODEL_CALL)) {
-    query = query.replace(MODEL_CALL, '')
+  if (query[MODEL_CALL]) {
     const [collection, operation] = query.split('.')
     return {
       collection,
       operation,
-      query
+      // this is a String object, need to parse to string literal
+      query: query.toString()
     }
   }
   return parseSql(query)

--- a/lib/instrumentation/@prisma/client.js
+++ b/lib/instrumentation/@prisma/client.js
@@ -130,16 +130,12 @@ function queryParser(query) {
  */
 function extractPrismaConfig(client, pkgVersion) {
   if (semver.gte(pkgVersion, '4.11.0')) {
-    return new Promise((resolve, reject) => {
-      try {
-        const config = client._engine.library.getConfig({
-          datamodel: client._engine.datamodel,
-          ignoreEnvVarErrors: true
-        })
-        resolve(config)
-      } catch (err) {
-        reject(err)
-      }
+    // wait for the library promise to resolve before getting the config
+    return client._engine.libraryInstantiationPromise.then(() => {
+      return client._engine.library.getConfig({
+        datamodel: client._engine.datamodel,
+        ignoreEnvVarErrors: true
+      })
     })
   }
   return client._engine.getConfig()

--- a/lib/instrumentation/@prisma/client.js
+++ b/lib/instrumentation/@prisma/client.js
@@ -5,14 +5,12 @@
 
 'use strict'
 
-const { prismaConnection } = require('../../symbols')
+const { prismaConnection, prismaModelCall } = require('../../symbols')
 const { URL } = require('url')
 const logger = require('../../logger').child({ component: 'prisma' })
 const parseSql = require('../../db/query-parsers/sql')
 // Note: runCommandRaw is another raw command but it is mongo which we cannot parse as sql
 const RAW_COMMANDS = ['executeRaw', 'queryRaw']
-// indicator that this is a prisma model call and not raw query/statement
-const MODEL_CALL = Symbol('modelCall')
 
 const semver = require('semver')
 
@@ -87,7 +85,7 @@ function extractQueryArgs(args, pkgVersion) {
  *
  * @param {Array} args arguments to a prisma operation
  * @param {string} pkgVersion prisma version
- * @returns {string} raw query string or [NR_MODEL]<collection>.<operation>
+ * @returns {string} query raw query string or model call <collection>.<operation>
  */
 function retrieveQuery(args, pkgVersion) {
   if (Array.isArray(args)) {
@@ -100,7 +98,7 @@ function retrieveQuery(args, pkgVersion) {
     // this is done to tell query parser that we need to split string
     // to extract contents
     const clientMethod = new String(args[0].clientMethod)
-    clientMethod[MODEL_CALL] = true
+    clientMethod[prismaModelCall] = true
     return clientMethod
   }
 }
@@ -109,11 +107,11 @@ function retrieveQuery(args, pkgVersion) {
  * Parses formatted string to extract the collection and operation.
  * In case of executeRaw the string is created above in `retrieveQuery`
  *
- * @param {string} query raw query string or [NR_MODEL]<collection>.<operation>
+ * @param {string} query raw query string or model call <collection>.<operation>
  * @returns {object} { collection, operation, query }
  */
 function queryParser(query) {
-  if (query[MODEL_CALL]) {
+  if (query[prismaModelCall]) {
     const [collection, operation] = query.split('.')
     return {
       collection,

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -1443,7 +1443,7 @@ function isFunction(obj) {
  * @returns {bool} True if the object is a string, else false.
  */
 function isString(obj) {
-  return typeof obj === 'string'
+  return typeof obj === 'string' || obj instanceof String
 }
 
 /**

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -19,6 +19,7 @@ module.exports = {
   offTheRecord: Symbol('offTheRecord'),
   original: Symbol('original'),
   prismaConnection: Symbol('prismaConnection'),
+  prismaModelCall: Symbol('modelCall'),
   segment: Symbol('segment'),
   shim: Symbol('shim'),
   storeDatabase: Symbol('storeDatabase'),

--- a/test/unit/instrumentation/prisma-client.test.js
+++ b/test/unit/instrumentation/prisma-client.test.js
@@ -161,8 +161,8 @@ test('PrismaClient unit tests', (t) => {
       t.equal(children.length, 3, 'should have 3 segments')
       const [firstSegment, secondSegment, thirdSegment] = children
       t.equal(firstSegment.name, 'Datastore/statement/Prisma/user/create')
-      t.equal(secondSegment.name, 'Datastore/statement/Prisma/unit-test/executeRaw(select)')
-      t.equal(thirdSegment.name, 'Datastore/statement/Prisma/unit-test/executeRaw(select)')
+      t.equal(secondSegment.name, 'Datastore/statement/Prisma/unit-test/select')
+      t.equal(thirdSegment.name, 'Datastore/statement/Prisma/schema.unit-test/select')
       t.same(firstSegment.getAttributes(), {
         product: 'Prisma',
         host: 'my-host',
@@ -231,7 +231,7 @@ test('PrismaClient unit tests', (t) => {
       await client._executeRequest({ action: 'executeRaw' })
       const { children } = tx.trace.root
       const [firstSegment] = children
-      t.equal(firstSegment.name, 'Datastore/statement/Prisma/other/executeRaw(other)')
+      t.equal(firstSegment.name, 'Datastore/statement/Prisma/other/other')
       t.end()
     })
   })
@@ -261,7 +261,7 @@ test('PrismaClient unit tests', (t) => {
       const firstSegment = children[0]
       const secondSegment = children[1]
       t.equal(firstSegment.name, 'Datastore/statement/Prisma/user/create')
-      t.equal(secondSegment.name, 'Datastore/statement/Prisma/unit-test/executeRaw(select)')
+      t.equal(secondSegment.name, 'Datastore/statement/Prisma/unit-test/select')
       t.same(firstSegment.getAttributes(), {
         product: 'Prisma',
         host: 'my-host',

--- a/test/unit/instrumentation/prisma-client.test.js
+++ b/test/unit/instrumentation/prisma-client.test.js
@@ -42,7 +42,7 @@ test('PrismaClient unit tests', (t) => {
     Engine.prototype.getConfig = sinon.stub()
     let PrismaClient
     if (semver.gte(version, '4.11.0')) {
-      PrismaClient = function PrismaClient() {
+      PrismaClient = function () {
         const libraryInstantiationPromise = new Promise((resolve) => resolve())
         this._engine = {
           libraryInstantiationPromise
@@ -50,7 +50,7 @@ test('PrismaClient unit tests', (t) => {
         this._engine.library = new Engine()
       }
     } else {
-      PrismaClient = function PrismaClient() {
+      PrismaClient = function () {
         this._engine = new Engine()
       }
     }

--- a/test/unit/instrumentation/prisma-client.test.js
+++ b/test/unit/instrumentation/prisma-client.test.js
@@ -43,7 +43,10 @@ test('PrismaClient unit tests', (t) => {
     let PrismaClient
     if (semver.gte(version, '4.11.0')) {
       PrismaClient = function PrismaClient() {
-        this._engine = {}
+        const libraryInstantiationPromise = new Promise((resolve) => resolve())
+        this._engine = {
+          libraryInstantiationPromise
+        }
         this._engine.library = new Engine()
       }
     } else {
@@ -252,14 +255,17 @@ test('PrismaClient unit tests', (t) => {
 
     helper.runInTransaction(agent, async (tx) => {
       await client._executeRequest({ clientMethod: 'user.create', action: 'create' })
+      // need this here to work around the fact inContext is typically sync
+      // but we use it as async. In normal behavior you will have more async
+      // work happening to where it will apply the instance configuration to the active segment accordingly but in unit tests this is wonky
+      await new Promise((resolve) => resolve())
       await client._executeRequest({
         args: [['select test from unit-test;']],
         action: 'executeRaw'
       })
       const { children } = tx.trace.root
-      t.equal(children.length, 2, 'should have 2 segments')
-      const firstSegment = children[0]
-      const secondSegment = children[1]
+      t.equal(children.length, 2, 'should have 3 segments')
+      const [firstSegment, secondSegment] = children
       t.equal(firstSegment.name, 'Datastore/statement/Prisma/user/create')
       t.equal(secondSegment.name, 'Datastore/statement/Prisma/unit-test/select')
       t.same(firstSegment.getAttributes(), {
@@ -286,6 +292,10 @@ test('PrismaClient unit tests', (t) => {
 
     helper.runInTransaction(agent, async () => {
       await client._executeRequest({ clientMethod: 'user.create', action: 'create' })
+      // need this here to work around the fact inContext is typically sync
+      // but we use it as async. In normal behavior you will have more async
+      // work happening to where it will apply the instance configuration to the active segment accordingly but in unit tests this is wonky
+      await new Promise((resolve) => resolve())
       t.same(client[symbols.prismaConnection], {})
       t.end()
     })

--- a/test/unit/shim/shim.test.js
+++ b/test/unit/shim/shim.test.js
@@ -2442,6 +2442,7 @@ tap.test('Shim', function (t) {
     t.afterEach(afterEach)
     t.test('should detect if an item is a string', function (t) {
       t.ok(shim.isString('foobar'))
+      t.ok(shim.isString(new String('foobar')))
       t.notOk(shim.isString({}))
       t.notOk(shim.isString([]))
       t.notOk(shim.isString(arguments))

--- a/test/versioned/prisma/prisma.tap.js
+++ b/test/versioned/prisma/prisma.tap.js
@@ -6,42 +6,26 @@
 'use strict'
 const tap = require('tap')
 const helper = require('../../lib/agent_helper')
-const { DB, PRISMA } = require('../../../lib/metrics/names')
-const { assertSegments, findSegment } = require('../../lib/metrics_helper')
-const params = require('../../lib/params')
-const urltils = require('../../../lib/util/urltils')
-
+const { findSegment } = require('../../lib/metrics_helper')
+const { verify, verifySlowQueries, findMany, raw, rawUpdate } = require('./utils')
 const { initPrismaApp, getPostgresUrl } = require('./setup')
 const { upsertUsers } = require('./app')
 const seed = require('./prisma/seed')
 
-const findMany = `${PRISMA.STATEMENT}user/findMany`
-const update = `${PRISMA.STATEMENT}user/update`
-
-const expectedUpsertMetrics = {
-  [`${DB.ALL}`]: 4,
-  [`${DB.PREFIX}${DB.WEB}`]: 4,
-  [`${PRISMA.OPERATION}findMany`]: 2,
-  [`${PRISMA.STATEMENT}user/findMany`]: 2,
-  [`${PRISMA.OPERATION}update`]: 2,
-  [`${PRISMA.STATEMENT}user/update`]: 2,
-  [`${DB.PREFIX}${PRISMA.PREFIX}/${DB.WEB}`]: 4,
-  [`${DB.PREFIX}${PRISMA.PREFIX}/all`]: 4
-}
-
-tap.test('Basic run through prisma functionality', { timeout: 30 * 1000 }, async (t) => {
+tap.test('Basic run through prisma functionality', { timeout: 30 * 1000 }, (t) => {
+  t.autoend()
   let agent = null
   let PrismaClient = null
   let prisma = null
-  let host = null
+
+  t.before(async () => {
+    await initPrismaApp()
+  })
   t.beforeEach(async () => {
     process.env.DATABASE_URL = getPostgresUrl()
     agent = helper.instrumentMockedAgent()
     PrismaClient = require('@prisma/client').PrismaClient
     prisma = new PrismaClient()
-    host = urltils.isLocalhost(params.postgres_host)
-      ? agent.config.getHostnameSafe()
-      : params.postgrs_host
     await seed()
   })
 
@@ -52,50 +36,6 @@ tap.test('Basic run through prisma functionality', { timeout: 30 * 1000 }, async
     PrismaClient = null
     prisma = null
   })
-  await initPrismaApp()
-
-  function verifyMetrics(t) {
-    for (const [metricName, expectedCount] of Object.entries(expectedUpsertMetrics)) {
-      const metric = agent.metrics.getMetric(metricName)
-      t.equal(
-        metric.callCount,
-        expectedCount,
-        `should have counted ${metricName} ${expectedCount} times`
-      )
-    }
-  }
-
-  function verifyTraces(t, transaction) {
-    const trace = transaction.trace
-    t.ok(trace, 'trace should exist')
-    t.ok(trace.root, 'root element should exist')
-
-    assertSegments(trace.root, [findMany, update, update, findMany], { exact: true })
-    const findManySegment = findSegment(trace.root, findMany)
-    t.ok(findManySegment.timer.hrDuration, 'findMany segment should have ended')
-    const updateSegment = findSegment(trace.root, update)
-    t.ok(updateSegment.timer.hrDuration, 'update segment should have ended')
-    for (const segment of [findManySegment, updateSegment]) {
-      const attributes = segment.getAttributes()
-      const name = segment.name
-      t.equal(attributes.host, host, `host of segment ${name} should equal ${host}`)
-      t.equal(
-        attributes.database_name,
-        params.postgres_db,
-        `database name of segment ${name} should be ${params.postgres_db}`
-      )
-      t.equal(
-        attributes.port_path_or_id,
-        params.postgres_prisma_port.toString(),
-        `port of segment ${name} should be ${params.postgres_prisma_port}`
-      )
-    }
-  }
-
-  function verify(t, transaction) {
-    verifyMetrics(t)
-    verifyTraces(t, transaction)
-  }
 
   t.test('Metrics and traces are recorded with a transaction', (t) => {
     agent.config.datastore_tracer.instance_reporting.enabled = true
@@ -105,7 +45,7 @@ tap.test('Basic run through prisma functionality', { timeout: 30 * 1000 }, async
       const users = await upsertUsers(prisma)
       t.equal(users.length, 2, 'should get two users')
       tx.end()
-      verify(t, tx)
+      verify(t, agent, tx)
       t.end()
     })
   })
@@ -129,17 +69,8 @@ tap.test('Basic run through prisma functionality', { timeout: 30 * 1000 }, async
   })
 
   t.test('Raw queries should be recorded', async (t) => {
-    // Note that in raw queries we get the raw table name, which in
-    // this case is capitalised.
-    const queryRaw = `${PRISMA.STATEMENT}User/queryRaw(select)`
-
-    // We want to try the query two ways, both with and without
-    // namespacing the table, to make sure we always parse correctly
-    // and get the table.
     const queries = [
-      prisma.$queryRaw`SELECT * FROM "public"."User"`,
       prisma.$queryRaw`SELECT * FROM "User"`,
-      prisma.$queryRawUnsafe('SELECT * FROM "public"."User"'),
       prisma.$queryRawUnsafe('SELECT * FROM "User"')
     ]
     for (const query of queries) {
@@ -147,25 +78,16 @@ tap.test('Basic run through prisma functionality', { timeout: 30 * 1000 }, async
         const users = await query
         t.equal(users.length, 2, 'should get two users')
         tx.end()
-        const rawSegment = findSegment(tx.trace.root, queryRaw)
-        t.ok(rawSegment, `segment named ${queryRaw} should exist`)
+        const rawSegment = findSegment(tx.trace.root, raw)
+        t.ok(rawSegment, `segment named ${raw} should exist`)
       })
     }
     t.end()
   })
 
   t.test('Raw statements should be recorded', async (t) => {
-    // Note that in raw queries we get the raw table name, which in
-    // this case is capitalised.
-    const statementRaw = `${PRISMA.STATEMENT}User/executeRaw(update)`
-
-    // We want to try the query two ways, both with and without
-    // namespacing the table, to make sure we always parse correctly
-    // and get the table.
     const queries = [
-      prisma.$executeRaw`UPDATE "public"."User" SET "name"='New Relic was here'`,
       prisma.$executeRaw`UPDATE "User" SET "name"='New Relic was here'`,
-      prisma.$executeRawUnsafe('UPDATE "public"."User" SET "name"=\'New Relic was here\''),
       prisma.$executeRawUnsafe('UPDATE "User" SET "name"=\'New Relic was here\'')
     ]
     for (const query of queries) {
@@ -173,10 +95,45 @@ tap.test('Basic run through prisma functionality', { timeout: 30 * 1000 }, async
         const count = await query
         t.equal(count, 2, 'should modify two users')
         tx.end()
-        const rawSegment = findSegment(tx.trace.root, statementRaw)
-        t.ok(rawSegment, `segment named ${statementRaw} should exist`)
+        const rawSegment = findSegment(tx.trace.root, rawUpdate)
+        t.ok(rawSegment, `segment named ${rawUpdate} should exist`)
       })
     }
     t.end()
+  })
+
+  t.test('should add datastore instance params to slow query traces', (t) => {
+    // enable slow queries
+    agent.config.transaction_tracer.explain_threshold = 0
+    agent.config.transaction_tracer.record_sql = 'raw'
+    agent.config.slow_sql.enabled = true
+    helper.runInTransaction(agent, async (tx) => {
+      await prisma.$executeRaw`select * from pg_sleep(1);`
+      await upsertUsers(prisma)
+      tx.end()
+      verifySlowQueries(t, agent, ['select * from pg_sleep(1);', 'user.findMany', 'user.update'])
+      t.end()
+    })
+  })
+
+  t.test('should not add datastore instance params to slow query traces when disabled', (t) => {
+    // enable slow queries
+    agent.config.transaction_tracer.explain_threshold = 0
+    agent.config.transaction_tracer.record_sql = 'raw'
+    agent.config.slow_sql.enabled = true
+    // disable datastore instance
+    agent.config.datastore_tracer.instance_reporting.enabled = false
+    agent.config.datastore_tracer.database_name_reporting.enabled = false
+
+    helper.runInTransaction(agent, async (tx) => {
+      await prisma.$executeRaw`select * from User;`
+      tx.end()
+      const queryParams = agent.queries.samples.values().next().value
+      t.notOk(queryParams.host, 'should not have a host set')
+      t.notOk(queryParams.port_path_or_id, 'should not have a port set')
+      t.notOk(queryParams.database_name, 'should not have a database name set')
+
+      t.end()
+    })
   })
 })

--- a/test/versioned/prisma/prisma.tap.js
+++ b/test/versioned/prisma/prisma.tap.js
@@ -20,13 +20,13 @@ tap.test('Basic run through prisma functionality', { timeout: 30 * 1000 }, (t) =
 
   t.before(async () => {
     await initPrismaApp()
+    await seed()
   })
   t.beforeEach(async () => {
     process.env.DATABASE_URL = getPostgresUrl()
     agent = helper.instrumentMockedAgent()
     PrismaClient = require('@prisma/client').PrismaClient
     prisma = new PrismaClient()
-    await seed()
   })
 
   t.afterEach(async () => {

--- a/test/versioned/prisma/utils.js
+++ b/test/versioned/prisma/utils.js
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const utils = module.exports
+const { assertSegments, findSegment, getMetricHostName } = require('../../lib/metrics_helper')
+const { DB, PRISMA } = require('../../../lib/metrics/names')
+const params = require('../../lib/params')
+const expectedUpsertMetrics = {
+  [`${DB.ALL}`]: 4,
+  [`${DB.PREFIX}${DB.WEB}`]: 4,
+  [`${PRISMA.OPERATION}findMany`]: 2,
+  [`${PRISMA.STATEMENT}user/findMany`]: 2,
+  [`${PRISMA.OPERATION}update`]: 2,
+  [`${PRISMA.STATEMENT}user/update`]: 2,
+  [`${DB.PREFIX}${PRISMA.PREFIX}/${DB.WEB}`]: 4,
+  [`${DB.PREFIX}${PRISMA.PREFIX}/all`]: 4
+}
+const findMany = `${PRISMA.STATEMENT}user/findMany`
+utils.findMany = findMany
+const update = `${PRISMA.STATEMENT}user/update`
+// Note that in a raw query we get the raw table name, which in this
+// case is capitalized.
+const raw = `${PRISMA.STATEMENT}User/select`
+utils.raw = raw
+const rawUpdate = `${PRISMA.STATEMENT}User/update`
+utils.rawUpdate = rawUpdate
+
+/**
+ * Asserts all the expected datastore metrics for a given query
+ *
+ * @param {Object} t tap test instance
+ * @param {Object} agent mocked NR agent
+ */
+function verifyMetrics(t, agent) {
+  for (const [metricName, expectedCount] of Object.entries(expectedUpsertMetrics)) {
+    const metric = agent.metrics.getMetric(metricName)
+    t.equal(
+      metric.callCount,
+      expectedCount,
+      `should have counted ${metricName} ${expectedCount} times`
+    )
+  }
+}
+
+/**
+ * Asserts all relevant prisma segments and their associative datastore attributes.
+ * It also asserts that every segment has a hrDuration which means it has ended
+ *
+ * @param {Object} t tap test instance
+ * @param {Object} agent mocked NR agent
+ * @param {Object} transaction active NR transaction
+ */
+function verifyTraces(t, agent, transaction) {
+  const host = getMetricHostName(agent, params.postgres_host)
+  const trace = transaction.trace
+  t.ok(trace, 'trace should exist')
+  t.ok(trace.root, 'root element should exist')
+
+  assertSegments(trace.root, [findMany, update, update, findMany], { exact: true })
+  const findManySegment = findSegment(trace.root, findMany)
+  t.ok(findManySegment.timer.hrDuration, 'findMany segment should have ended')
+  const updateSegment = findSegment(trace.root, update)
+  t.ok(updateSegment.timer.hrDuration, 'update segment should have ended')
+  for (const segment of [findManySegment, updateSegment]) {
+    const attributes = segment.getAttributes()
+    const name = segment.name
+    t.equal(attributes.host, host, `host of segment ${name} should equal ${host}`)
+    t.equal(
+      attributes.database_name,
+      params.postgres_db,
+      `database name of segment ${name} should be ${params.postgres_db}`
+    )
+    t.equal(
+      attributes.port_path_or_id,
+      params.postgres_prisma_port.toString(),
+      `port of segment ${name} should be ${params.postgres_prisma_port}`
+    )
+  }
+}
+
+/**
+ * Gets the sql traces from the agent query trace aggregator.  It then asserts all their
+ * associative datastore attributes + backtrace.
+ *
+ * @param {Object} t tap test instance
+ * @param {Object} agent mocked NR agent
+ * @param {Number} [count=3] number of queries it expects in aggregator
+ */
+utils.verifySlowQueries = function verifySlowQueries(t, agent, queries = []) {
+  const metricHostName = getMetricHostName(agent, params.postgres_host)
+
+  t.equal(agent.queries.samples.size, queries.length, `should have ${queries.length} queries`)
+  let i = 0
+  for (const sample of agent.queries.samples.values()) {
+    t.equal(sample.trace.query, queries[i], 'Query name should be expected')
+    const queryParams = sample.getParams()
+
+    t.equal(queryParams.host, metricHostName, 'instance data should show up in slow query params')
+
+    t.equal(
+      queryParams.port_path_or_id,
+      String(params.postgres_prisma_port),
+      'instance data should show up in slow query params'
+    )
+
+    t.equal(
+      queryParams.database_name,
+      params.postgres_db,
+      'database name should show up in slow query params'
+    )
+
+    t.ok(queryParams.backtrace, 'params should contain a backtrace')
+    i++
+  }
+}
+
+/**
+ * Helper that verifies both metrics and relevant segments on trace
+ *
+ * @param {Object} t tap test instance
+ * @param {Object} agent mocked NR agent
+ * @param {Object} transaction active NR transaction
+ */
+utils.verify = function verify(t, agent, transaction) {
+  verifyMetrics(t, agent)
+  verifyTraces(t, agent, transaction)
+}

--- a/test/versioned/prisma/utils.js
+++ b/test/versioned/prisma/utils.js
@@ -97,6 +97,7 @@ utils.verifySlowQueries = function verifySlowQueries(t, agent, queries = []) {
   for (const sample of agent.queries.samples.values()) {
     t.equal(sample.trace.query, queries[i], 'Query name should be expected')
     const queryParams = sample.getParams()
+    console.log(queryParams)
 
     t.equal(queryParams.host, metricHostName, 'instance data should show up in slow query params')
 

--- a/test/versioned/prisma/utils.js
+++ b/test/versioned/prisma/utils.js
@@ -97,7 +97,6 @@ utils.verifySlowQueries = function verifySlowQueries(t, agent, queries = []) {
   for (const sample of agent.queries.samples.values()) {
     t.equal(sample.trace.query, queries[i], 'Query name should be expected')
     const queryParams = sample.getParams()
-    console.log(queryParams)
 
     t.equal(queryParams.host, metricHostName, 'instance data should show up in slow query params')
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated prisma instrumentation to support the capturing of SQL Traces.

## Links
Closes NEWRELIC-7174

## Details
I removed some logic that parsed that table from the database.  All of our other instrumentation keeps that in tact, so `schema.table` was parsed to `table` but is now back to `schema.table`.  Also in capturing sql traces for prisma model calls the query will just be `<model>.<action>` (i.e. users.findMany).  The more important thing in traces is the backtrace that will locate the line it exists for customers to identify it.
