### PR TITLE
NEWRELIC-7174: (prisma) add a binary target to the schema

### DIFF
--- a/test/versioned/prisma/prisma/schema.prisma
+++ b/test/versioned/prisma/prisma/schema.prisma
@@ -1,6 +1,7 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["tracing"]
+  binaryTargets   = ["native"]
 }
 
 datasource db {


### PR DESCRIPTION
Trying to fix the prisma test run on `main`.