### PR TITLE
Add expected boolean to noticeError

### DIFF
--- a/lib/errors/error-collector.js
+++ b/lib/errors/error-collector.js
@@ -276,8 +276,9 @@ class ErrorCollector {
    * @param {?Transaction}  transaction  Transaction associated with the error.
    * @param {*} error The error passed into `API#noticeError()`
    * @param {object} customAttributes custom attributes to add to the error
+   * @param {boolean} expected Is the error expected?
    */
-  addUserError(transaction, error, customAttributes) {
+  addUserError(transaction, error, customAttributes, expected) {
     if (!error) {
       return
     }
@@ -289,7 +290,7 @@ class ErrorCollector {
     }
 
     const timestamp = Date.now()
-    const exception = new Exception({ error, timestamp, customAttributes })
+    const exception = new Exception({ error, timestamp, customAttributes, expected })
 
     if (transaction) {
       transaction.addUserError(exception)

--- a/lib/errors/error-collector.js
+++ b/lib/errors/error-collector.js
@@ -114,19 +114,27 @@ class ErrorCollector {
    *
    * @param {Transaction} transaction the collected exception's transaction
    * @param {number} collectedErrors the number of errors we've successfully .collect()-ed
-   * @returns {number} the new number of errors successfully .collect()-ed
+   * @param {number} expectedErrors the number of errors marked as expected in noticeError
+   * @returns {Array.<number>} the updated [collectedErrors, expectedErrors] numbers post-processing
    */
-  _processUserErrors(transaction, collectedErrors) {
+  _processUserErrors(transaction, collectedErrors, expectedErrors) {
     if (transaction.userErrors.length) {
       for (let i = 0; i < transaction.userErrors.length; i++) {
         const exception = transaction.userErrors[i]
         if (this.collect(transaction, exception)) {
           ++collectedErrors
+          // if we could collect it, then check if expected
+          if (
+            urltils.isExpectedError(this.config, transaction.statusCode) ||
+            errorHelper.isExpectedException(transaction, exception, this.config, urltils)
+          ) {
+            ++expectedErrors
+          }
         }
       }
     }
 
-    return collectedErrors
+    return [collectedErrors, expectedErrors]
   }
 
   /**
@@ -145,7 +153,7 @@ class ErrorCollector {
         // if we could collect it, then check if expected
         if (
           urltils.isExpectedError(this.config, transaction.statusCode) ||
-          errorHelper.isExpectedException(transaction, exception.error, this.config, urltils)
+          errorHelper.isExpectedException(transaction, exception, this.config, urltils)
         ) {
           ++expectedErrors
         }
@@ -196,7 +204,11 @@ class ErrorCollector {
 
     // errors from noticeError are currently exempt from
     // ignore and exclude rules
-    collectedErrors = this._processUserErrors(transaction, collectedErrors)
+    ;[collectedErrors, expectedErrors] = this._processUserErrors(
+      transaction,
+      collectedErrors,
+      expectedErrors
+    )
 
     const isErroredTransaction = urltils.isError(this.config, transaction.statusCode)
     const isIgnoredErrorStatusCode = urltils.isIgnoredError(this.config, transaction.statusCode)

--- a/lib/errors/helper.js
+++ b/lib/errors/helper.js
@@ -34,12 +34,18 @@ module.exports = {
     )
   },
   isExpectedException: function isExpectedException(transaction, exception, config, urltils) {
-    const { type, message } = this.extractErrorInformation(transaction, exception, config, urltils)
+    // this is getting JUST the exception.error
+    const { type, message } = this.extractErrorInformation(
+      transaction,
+      exception.error,
+      config,
+      urltils
+    )
 
     return (
+      exception._expected ||
       this.isExpectedErrorClass(config, type) ||
-      this.isExpectedErrorMessage(config, type, message) ||
-      exception._expected
+      this.isExpectedErrorMessage(config, type, message)
     )
   },
 

--- a/lib/errors/helper.js
+++ b/lib/errors/helper.js
@@ -37,7 +37,9 @@ module.exports = {
     const { type, message } = this.extractErrorInformation(transaction, exception, config, urltils)
 
     return (
-      this.isExpectedErrorClass(config, type) || this.isExpectedErrorMessage(config, type, message)
+      this.isExpectedErrorClass(config, type) ||
+      this.isExpectedErrorMessage(config, type, message) ||
+      exception._expected
     )
   },
 

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -19,11 +19,12 @@ const Transaction = require('../transaction')
 const ERROR_EXPECTED_PATH = 'error.expected'
 
 class Exception {
-  constructor({ error, timestamp, customAttributes, agentAttributes }) {
+  constructor({ error, timestamp, customAttributes, agentAttributes, expected }) {
     this.error = error
     this.timestamp = timestamp || 0
     this.customAttributes = customAttributes || {}
     this.agentAttributes = agentAttributes || {}
+    this._expected = expected
   }
 
   getErrorDetails(config) {
@@ -34,7 +35,7 @@ class Exception {
   }
 
   isExpected(config, { type, message }) {
-    if (!this._expected) {
+    if (typeof this._expected === 'undefined') {
       this._expected =
         errorHelper.isExpectedErrorClass(config, type) ||
         errorHelper.isExpectedErrorMessage(config, type, message)
@@ -103,13 +104,8 @@ function createError(transaction, exception, config) {
 
   params.stack_trace = maybeAddStackTrace(exception, config)
 
-  params.intrinsics[ERROR_EXPECTED_PATH] = errorHelper.isExpected(
-    type,
-    message,
-    transaction,
-    config,
-    urltils
-  )
+  params.intrinsics[ERROR_EXPECTED_PATH] =
+    exception._expected || errorHelper.isExpected(type, message, transaction, config, urltils)
 
   return [0, name, message, type, params]
 }

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -860,7 +860,7 @@ Transaction.prototype.hasOnlyExpectedErrors = function hasOnlyExpectedErrors() {
     const exception = this.exceptions[i]
     // this exception is neither expected nor ignored
     const isUnexpected = !(
-      errorHelper.isExpectedException(this, exception.error, this.agent.config, urltils) ||
+      errorHelper.isExpectedException(this, exception, this.agent.config, urltils) ||
       errorHelper.shouldIgnoreError(this, exception.error, this.agent.config)
     )
     if (isUnexpected) {

--- a/test/unit/errors/error-collector.test.js
+++ b/test/unit/errors/error-collector.test.js
@@ -1755,7 +1755,7 @@ tap.test('Errors', (t) => {
 
             t.equal(Object.keys(customAttributes).length, 2)
             t.ok(customAttributes.c)
-            t.equal(attributes['error.expected'], true) // is false
+            t.equal(attributes['error.expected'], true)
             t.equal(Object.keys(agentAttributes).length, 0)
             t.end()
           }

--- a/test/unit/errors/error-collector.test.js
+++ b/test/unit/errors/error-collector.test.js
@@ -512,8 +512,6 @@ tap.test('Errors', (t) => {
         }
       )
 
-      // ///////////////////////
-
       t.test('should ignore errors if related transaction is ignored', (t) => {
         const transaction = createTransaction(agent, 500)
         transaction.ignore = true
@@ -1721,13 +1719,13 @@ tap.test('Errors', (t) => {
         })
         t.test('unexpected noticeError should default to expected: false', (t) => {
           const error = new Error('another noticed error')
-          api.noticeError(error, null, false)
+          api.noticeError(error)
 
           const attributes = getFirstEventIntrinsicAttributes(aggregator, t)
           t.equal(attributes['error.expected'], false)
           t.end()
         })
-        t.test('noticeError true should be definable without customAttributes', (t) => {
+        t.test('noticeError expected:true should be definable without customAttributes', (t) => {
           const error = new Error('yet another noticed expected error')
           api.noticeError(error, true)
 
@@ -1735,7 +1733,7 @@ tap.test('Errors', (t) => {
           t.equal(attributes['error.expected'], true)
           t.end()
         })
-        t.test('noticeError false should be definable without customAttributes', (t) => {
+        t.test('noticeError expected:false should be definable without customAttributes', (t) => {
           const error = new Error('yet another noticed unexpected error')
           api.noticeError(error, false)
 
@@ -1762,10 +1760,6 @@ tap.test('Errors', (t) => {
             t.end()
           }
         )
-
-        // / local expected:false should override global expected:true
-        // / local expected:true should override global expected:false
-
         t.end()
       })
       t.end()

--- a/test/unit/errors/error-collector.test.js
+++ b/test/unit/errors/error-collector.test.js
@@ -469,7 +469,6 @@ tap.test('Errors', (t) => {
         t.end()
       })
 
-      // ////////////////////
       t.test(
         'should generate transaction error metric for unexpected error via noticeError',
         (t) => {
@@ -508,7 +507,7 @@ tap.test('Errors', (t) => {
 
           const metric = agent.metrics.getMetric('Errors/WebTransaction/TestJS/path')
 
-          t.equal(metric.callCount, 0)
+          t.notOk(metric)
           t.end()
         }
       )

--- a/test/unit/errors/error-collector.test.js
+++ b/test/unit/errors/error-collector.test.js
@@ -289,7 +289,7 @@ tap.test('Errors', (t) => {
       t.end()
     })
 
-    t.test('should not gather appliction errors if it is switched off by user config', (t) => {
+    t.test('should not gather application errors if it is switched off by user config', (t) => {
       const error = new Error('this error will never be seen')
       agent.config.error_collector.enabled = false
 
@@ -1169,7 +1169,7 @@ tap.test('Errors', (t) => {
 
     t.test('should not generate expected error metric for ignored errors', (t) => {
       agent.config.error_collector.expected_classes = ['Error']
-      agent.config.error_collector.ignore_classes = ['Error'] // takes prescedence
+      agent.config.error_collector.ignore_classes = ['Error'] // takes precedence
       const transaction = createTransaction(agent, 200)
 
       errorCollector.add(transaction, new Error('error1'))

--- a/test/unit/errors/expected.test.js
+++ b/test/unit/errors/expected.test.js
@@ -20,7 +20,7 @@ const errorHelper = require('../../../lib/errors/helper')
 const expect = chai.expect
 
 describe('Expected Errors', function () {
-  describe('when expeced configuration is present', function () {
+  describe('when expected configuration is present', function () {
     let agent
 
     beforeEach(function () {

--- a/test/unit/errors/expected.test.js
+++ b/test/unit/errors/expected.test.js
@@ -247,7 +247,8 @@ describe('Expected Errors', function () {
     it('should not increment error metric call counts, bg transaction', function () {
       helper.runInTransaction(agent, function (tx) {
         agent.config.error_collector.expected_messages = { Error: ['except this error'] }
-        const exception = new Error('except this error')
+        const error = new Error('except this error')
+        const exception = new Exception({ error })
         const result = errorHelper.isExpectedException(tx, exception, agent.config, urltils)
 
         expect(result).equals(true)

--- a/test/unit/errors/expected.test.js
+++ b/test/unit/errors/expected.test.js
@@ -16,6 +16,7 @@ const chai = require('chai')
 const should = require('chai').should()
 const urltils = require('../../../lib/util/urltils')
 const errorHelper = require('../../../lib/errors/helper')
+const API = require('../../../api')
 
 const expect = chai.expect
 
@@ -125,6 +126,19 @@ describe('Expected Errors', function () {
         expect(errorExpected[0]['error.expected']).equals(true)
 
         done()
+      })
+    })
+
+    it('expected errors raised via noticeError should not increment apdex frustrating', function () {
+      helper.runInTransaction(agent, function (tx) {
+        const api = new API(agent)
+        api.noticeError(new Error('we expected something to go wrong'), {}, true)
+        const apdexStats = tx.metrics.getOrCreateApdexMetric(NAMES.APDEX)
+        tx._setApdex(NAMES.APDEX, 1, 1)
+        const json = apdexStats.toJSON()
+        tx.end()
+        // no errors in the frustrating column
+        expect(json[2]).equals(0)
       })
     })
 


### PR DESCRIPTION
## Proposed Release Notes
 * Added ability to mark errors as expected when using `newrelic.noticeError`.

## Links
https://issues.newrelic.com/browse/NEWRELIC-7045

## Details
Closes NEWRELIC-7045
