### PR TITLE
fixed prisma versioned tests to properly work across all supported versions

### DIFF
--- a/test/versioned/prisma/package.json
+++ b/test/versioned/prisma/package.json
@@ -19,6 +19,8 @@
       ]
     }
   ],
-  "dependencies": {
+  "prisma": {
+    "schema": "./prisma/schema.prisma",
+    "seed": "node ./prisma/seed.js"
   }
 }

--- a/test/versioned/prisma/prisma.tap.js
+++ b/test/versioned/prisma/prisma.tap.js
@@ -10,7 +10,6 @@ const { findSegment } = require('../../lib/metrics_helper')
 const { verify, verifySlowQueries, findMany, raw, rawUpdate } = require('./utils')
 const { initPrismaApp, getPostgresUrl } = require('./setup')
 const { upsertUsers } = require('./app')
-const seed = require('./prisma/seed')
 
 tap.test('Basic run through prisma functionality', { timeout: 30 * 1000 }, (t) => {
   t.autoend()
@@ -20,8 +19,8 @@ tap.test('Basic run through prisma functionality', { timeout: 30 * 1000 }, (t) =
 
   t.before(async () => {
     await initPrismaApp()
-    await seed()
   })
+
   t.beforeEach(async () => {
     process.env.DATABASE_URL = getPostgresUrl()
     agent = helper.instrumentMockedAgent()

--- a/test/versioned/prisma/prisma/schema.prisma
+++ b/test/versioned/prisma/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["tracing"]
-  binaryTargets   = ["native"]
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {

--- a/test/versioned/prisma/prisma/seed.js
+++ b/test/versioned/prisma/prisma/seed.js
@@ -33,4 +33,15 @@ async function seed() {
   await prisma.$disconnect()
 }
 
-module.exports = seed
+seed()
+  .then(async () => {
+    await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    // eslint-disable-next-line no-console
+    console.error(e)
+
+    await prisma.$disconnect()
+
+    throw e
+  })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
It seems like just adding the `debian-openssl-3.0.x` didn't fix issue. Instead you had to add the schema/seed as npm scripts.  You can see [here](https://github.com/bizob2828/node-newrelic/actions/runs/4348134972) that the versioned tests pass in all versions

<img width="989" alt="screenshot 2023-03-06 at 4 43 29 PM" src="https://user-images.githubusercontent.com/1874937/223239532-26066cfd-e1f4-4b4b-bc4e-3d01e0da3636.png">
