### PR TITLE
 added setUserID api method

### DIFF
--- a/api.js
+++ b/api.js
@@ -28,6 +28,7 @@ const ATTR_DEST = require('./lib/config/attribute-filter').DESTINATIONS
 const MODULE_TYPE = require('./lib/shim/constants').MODULE_TYPE
 const NAMES = require('./lib/metrics/names')
 const obfuscate = require('./lib/util/sql/obfuscate')
+const { DESTINATIONS } = require('./lib/config/attribute-filter')
 
 /*
  *
@@ -1692,6 +1693,30 @@ API.prototype.obfuscateSql = function obfuscateSql(sql, dialect) {
   metric.incrementCallCount()
 
   return obfuscate(sql, dialect)
+}
+
+/**
+ * Assigns `enduser.id` attribute on transaction and trace events. It will also
+ * assign the attribute to errors if they occur within a transaction.
+ *
+ * @param {string} id a unique identifier used to set the `enduser.id` attribute
+ */
+API.prototype.setUserID = function setUserID(id) {
+  const metric = this.agent.metrics.getOrCreateMetric(NAMES.SUPPORTABILITY.API + '/setUserID')
+  metric.incrementCallCount()
+
+  if (!id) {
+    logger.warn('User Id is empty, not assign to transaction and/or errors')
+    return
+  }
+
+  const transaction = this.agent.tracer.getTransaction()
+  if (!transaction) {
+    logger.warn('No transaction found when trying to assign User Id to transaction')
+    return
+  }
+
+  transaction.trace.attributes.addAttribute(DESTINATIONS.TRANS_COMMON, 'enduser.id', id)
 }
 
 /**

--- a/api.js
+++ b/api.js
@@ -1705,14 +1705,12 @@ API.prototype.setUserID = function setUserID(id) {
   const metric = this.agent.metrics.getOrCreateMetric(NAMES.SUPPORTABILITY.API + '/setUserID')
   metric.incrementCallCount()
 
-  if (!id) {
-    logger.warn('User Id is empty, not assign to transaction and/or errors')
-    return
-  }
-
   const transaction = this.agent.tracer.getTransaction()
-  if (!transaction) {
-    logger.warn('No transaction found when trying to assign User Id to transaction')
+
+  if (!(id && transaction)) {
+    logger.warn(
+      'User id is empty or not in a transaction, not assigning `enduser.id` attribute to transaction events, trace events, and/or errors.'
+    )
     return
   }
 

--- a/test/unit/api/api-set-user-id.test.js
+++ b/test/unit/api/api-set-user-id.test.js
@@ -51,6 +51,8 @@ tap.test('Agent API = set user id', (t) => {
       t.equal(loggerMock.warn.callCount, 0, 'should not log warnings when setUserID succeeds')
       const attrs = tx.trace.attributes.get(DESTINATIONS.TRANS_EVENT)
       t.equal(attrs['enduser.id'], id, 'should set enduser.id attribute on transaction')
+      const traceAttrs = tx.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
+      t.equal(traceAttrs['enduser.id'], id, 'should set enduser.id attribute on transaction')
       t.end()
     })
   })

--- a/test/unit/api/api-set-user-id.test.js
+++ b/test/unit/api/api-set-user-id.test.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+const loggerMock = require('../mocks/logger')()
+
+const helper = require('../../lib/agent_helper')
+const API = proxyquire('../../../api', {
+  './lib/logger': {
+    child: sinon.stub().callsFake(() => loggerMock)
+  }
+})
+const { createError, Exception } = require('../../../lib/errors')
+const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
+
+tap.test('Agent API = set user id', (t) => {
+  t.autoend()
+  let agent = null
+  let api
+
+  t.beforeEach(() => {
+    loggerMock.warn.reset()
+    agent = helper.loadMockedAgent({
+      attributes: {
+        enabled: true
+      }
+    })
+    api = new API(agent)
+  })
+
+  t.afterEach(() => {
+    helper.unloadAgent(agent)
+  })
+
+  t.test('should have a setUserID method', (t) => {
+    t.ok(api.setUserID)
+    t.equal(typeof api.setUserID, 'function', 'api.setUserID should be a function')
+    t.end()
+  })
+
+  t.test('should set the enduser.id on transaction attributes', (t) => {
+    const id = 'anonymizedUser123456'
+    helper.runInTransaction(agent, (tx) => {
+      api.setUserID(id)
+      t.equal(loggerMock.warn.callCount, 0, 'should not log warnings when setUserID succeeds')
+      const attrs = tx.trace.attributes.get(DESTINATIONS.TRANS_EVENT)
+      t.equal(attrs['enduser.id'], id, 'should set enduser.id attribute on transaction')
+      t.end()
+    })
+  })
+
+  t.test('should set enduser.id attribute on error event when in a transaction', (t) => {
+    const id = 'anonymizedUser567890'
+    helper.runInTransaction(agent, (tx) => {
+      api.setUserID(id)
+      const exception = new Exception(new Error('Test error.'))
+      const [...data] = createError(tx, exception, agent.config)
+      const params = data.pop()
+      t.equal(params.agentAttributes['enduser.id'], id, 'should set enduser.id attribute on error')
+      t.end()
+    })
+  })
+
+  const emptyOptions = [null, undefined, '']
+  emptyOptions.forEach((value) => {
+    t.test(`should not assign enduser.id if id is '${value}'`, (t) => {
+      api.setUserID(value)
+      t.equal(loggerMock.warn.callCount, 1, 'should warn not id is present')
+      t.equal(
+        loggerMock.warn.args[0][0],
+        'User Id is empty, not assign to transaction and/or errors'
+      )
+      t.end()
+    })
+  })
+
+  t.test('should not assign enduser.id if no transaction is present', (t) => {
+    api.setUserID('my-unit-test-id')
+    t.equal(loggerMock.warn.callCount, 1, 'should warn not id is present')
+    t.equal(
+      loggerMock.warn.args[0][0],
+      'No transaction found when trying to assign User Id to transaction'
+    )
+    t.end()
+  })
+})

--- a/test/unit/api/api-set-user-id.test.js
+++ b/test/unit/api/api-set-user-id.test.js
@@ -69,15 +69,15 @@ tap.test('Agent API = set user id', (t) => {
     })
   })
 
+  const WARN_MSG =
+    'User id is empty or not in a transaction, not assigning `enduser.id` attribute to transaction events, trace events, and/or errors.'
+
   const emptyOptions = [null, undefined, '']
   emptyOptions.forEach((value) => {
     t.test(`should not assign enduser.id if id is '${value}'`, (t) => {
       api.setUserID(value)
       t.equal(loggerMock.warn.callCount, 1, 'should warn not id is present')
-      t.equal(
-        loggerMock.warn.args[0][0],
-        'User Id is empty, not assign to transaction and/or errors'
-      )
+      t.equal(loggerMock.warn.args[0][0], WARN_MSG)
       t.end()
     })
   })
@@ -85,10 +85,7 @@ tap.test('Agent API = set user id', (t) => {
   t.test('should not assign enduser.id if no transaction is present', (t) => {
     api.setUserID('my-unit-test-id')
     t.equal(loggerMock.warn.callCount, 1, 'should warn not id is present')
-    t.equal(
-      loggerMock.warn.args[0][0],
-      'No transaction found when trying to assign User Id to transaction'
-    )
+    t.equal(loggerMock.warn.args[0][0], WARN_MSG)
     t.end()
   })
 })

--- a/test/unit/api/stub.test.js
+++ b/test/unit/api/stub.test.js
@@ -8,7 +8,7 @@
 const tap = require('tap')
 const API = require('../../../stub_api')
 
-const EXPECTED_API_COUNT = 31
+const EXPECTED_API_COUNT = 32
 
 tap.test('Agent API - Stubbed Agent API', (t) => {
   t.autoend()
@@ -19,7 +19,7 @@ tap.test('Agent API - Stubbed Agent API', (t) => {
     api = new API()
   })
 
-  t.test('should export 30 API calls', (t) => {
+  t.test(`should export ${EXPECTED_API_COUNT - 1} API calls`, (t) => {
     const apiKeys = Object.keys(api.constructor.prototype)
     t.equal(apiKeys.length, EXPECTED_API_COUNT)
     t.end()


### PR DESCRIPTION
## Proposed Release Notes
 * Added an API method `setUserID` to provide an ability to associate a unique identifier with a transaction event, transaction trace and errors within transaction.  The attribute will be `enduser.id`.  

## Links
Closes NEWRELIC-7538

## Details
