### PR TITLE
NEWRELIC-7612 removed deleting x-new-relic-disable-dt header to appease the AWS gods

### DIFF
--- a/lib/instrumentation/core/http-outbound.js
+++ b/lib/instrumentation/core/http-outbound.js
@@ -167,11 +167,8 @@ function maybeAddDtCatHeaders(agent, transaction, outboundHeaders, headers = {})
   if (agent.config.distributed_tracing.enabled) {
     if (!!(headers[symbols.disableDT] || headers['x-new-relic-disable-dt'])) {
       logger.trace('Distributed tracing disabled by instrumentation.')
-      // we do not need to remove symbol as it will get implicitly removed
-      // when the request is serialized. in fact removing the symbol will cause
-      // the same issue that we had to change this to a string header
-      // see: https://github.com/newrelic/node-newrelic-aws-sdk/issues/168
-      delete headers['x-new-relic-disable-dt']
+      // do not try to delete this header because AWS will fail with signature fail
+      // See: https://github.com/newrelic/node-newrelic/issues/1549
     } else {
       transaction.insertDistributedTraceHeaders(outboundHeaders)
     }

--- a/test/integration/distributed-tracing/dt.tap.js
+++ b/test/integration/distributed-tracing/dt.tap.js
@@ -301,16 +301,14 @@ tap.test('distributed tracing', (t) => {
     })
   })
 
-  const headers = [symbols.disableDT, 'x-new-relic-disable-dt']
-  headers.forEach((header) => {
+  const headerValues = [symbols.disableDT, 'x-new-relic-disable-dt']
+  headerValues.forEach((header) => {
     t.test(`should be disabled by ${header.toString()}`, (t) => {
       helper.runInTransaction(agent, (tx) => {
         const OLD_HEADER = 'x-newrelic-transaction'
         const headers = { [header]: 'true' }
-        get(generateUrl(START_PORT, 'start'), { headers }, (err, { body, reqHeaders }) => {
+        get(generateUrl(START_PORT, 'start'), { headers }, (err, { body }) => {
           t.error(err)
-          t.notOk(reqHeaders['x-new-relic-disable-dt'], 'should remove x-new-relic-disable-dt')
-
           t.notOk(body.start.newrelic, 'should not add DT header when disabled')
           t.notOk(body.start[OLD_HEADER], 'should not add old CAT header either')
           t.ok(body.middle.newrelic, 'should not stop down-stream DT from working')


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated http instrumentation to no longer remove the `x-new-relic-disable-dt` header when using AWS SDK v3.  This was done to prevent the "The request signature we calculated does not match the signature you provided. Check your key and signing method." error from AWS SDK.

## Links
Closes #1549
Closes NEWRELIC-7612

## Details
We didn't catch this in aws sdk versioned tests because we mock out AWS services.  This basically pares down the fix in #1541.  We wanted to clean up in flight headers because we can no longer use symbols to store context on an AWS request.  There will be a PR in AWS SDK as well.
