### PR TITLE
feat: add ability to customize Error Groups

### DIFF
--- a/api.js
+++ b/api.js
@@ -1739,4 +1739,49 @@ function _filterAttributes(attributes, name) {
   return filteredAttributes
 }
 
+/**
+ * Function for adding a custom callback to generate Error Group names, which
+ * will be used by the Errors Inbox to group similar errors together via the `error.group.name`
+ * agent attribute.
+ *
+ * Provided functions must return a string, and receive an object as an argument,
+ * which contains information related to the Error that occurred, and has the
+ * following format:
+ *
+ * ```
+ * {
+ *   customAttributes: object,
+ *   'request.uri': string,
+ *   'http.statusCode': string,
+ *   'http.method': string,
+ *   error: Error,
+ *   'error.expected': boolean
+ * }
+ * ```
+ *
+ * Calling this function multiple times will replace previously defined functions
+ *
+ * @param {Function} callback - callback function to generate `error.group.name` attribute
+ * @example
+ * function myCallback(metadata) {
+ *   if (metadata['http.statusCode'] === '400') {
+ *     return 'Bad User Input'
+ *   }
+ * }
+ * newrelic.setErrorGroupCallback(myCallback)
+ */
+API.prototype.setErrorGroupCallback = function setErrorGroupCallback(callback) {
+  const metric = this.agent.metrics.getOrCreateMetric(
+    NAMES.SUPPORTABILITY.API + '/setErrorGroupCallback'
+  )
+  metric.incrementCallCount()
+
+  if (!this.shim.isFunction(callback)) {
+    logger.warn('Error Group callback must be a function, Error Group attribute will not be added')
+    return
+  }
+
+  this.agent.errors.errorGroupCallback = callback
+}
+
 module.exports = API

--- a/api.js
+++ b/api.js
@@ -1776,8 +1776,10 @@ API.prototype.setErrorGroupCallback = function setErrorGroupCallback(callback) {
   )
   metric.incrementCallCount()
 
-  if (!this.shim.isFunction(callback)) {
-    logger.warn('Error Group callback must be a function, Error Group attribute will not be added')
+  if (!this.shim.isFunction(callback) || this.shim.isPromise(callback)) {
+    logger.warn(
+      'Error Group callback must be a synchronous function, Error Group attribute will not be added'
+    )
     return
   }
 

--- a/lib/errors/error-collector.js
+++ b/lib/errors/error-collector.js
@@ -36,6 +36,8 @@ class ErrorCollector {
     this.seenStringsByTransaction = Object.create(null)
 
     this.traceAggregator.on('starting error_data data send.', this._onSendErrorTrace.bind(this))
+
+    this.errorGroupCallback = null
   }
 
   _onSendErrorTrace() {
@@ -328,6 +330,10 @@ class ErrorCollector {
   collect(transaction, exception = new Exception({})) {
     if (!this._isValidException(exception, transaction)) {
       return false
+    }
+
+    if (this.errorGroupCallback) {
+      exception.errorGroupCallback = this.errorGroupCallback
     }
 
     const errorTrace = createError(transaction, exception, this.config)

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -5,6 +5,7 @@
 
 'use strict'
 
+const logger = require('../logger').child({ component: 'errors_lib' })
 const DESTINATIONS = require('../config/attribute-filter').DESTINATIONS
 const props = require('../util/properties')
 const urltils = require('../util/urltils')
@@ -25,6 +26,7 @@ class Exception {
     this.customAttributes = customAttributes || {}
     this.agentAttributes = agentAttributes || {}
     this._expected = expected
+    this.errorGroupCallback = null
   }
 
   getErrorDetails(config) {
@@ -107,7 +109,42 @@ function createError(transaction, exception, config) {
   params.intrinsics[ERROR_EXPECTED_PATH] =
     exception._expected || errorHelper.isExpected(type, message, transaction, config, urltils)
 
+  maybeAddAgentAttributes(params, exception)
+
   return [0, name, message, type, params]
+}
+
+function isValidErrorGroupOutput(output) {
+  return (typeof output === 'string' || output instanceof String) && output !== ''
+}
+
+function maybeAddAgentAttributes(attributes, exception) {
+  if (exception.errorGroupCallback) {
+    const callbackInput = {
+      'error': exception.error,
+      'customAttributes': Object.assign({}, attributes.userAttributes),
+      'request.uri': attributes.agentAttributes['request.uri'],
+      'http.statusCode': attributes.agentAttributes['http.statusCode'],
+      'http.method': attributes.agentAttributes['request.method'],
+      'error.expected': attributes.intrinsics[ERROR_EXPECTED_PATH]
+    }
+
+    try {
+      const callbackOutput = exception.errorGroupCallback(callbackInput)
+
+      if (!isValidErrorGroupOutput(callbackOutput)) {
+        logger.warn('Function provided via setErrorGroupCallback return value malformed')
+        return
+      }
+
+      attributes.agentAttributes['error.group.name'] = callbackOutput
+    } catch (err) {
+      logger.warn(
+        err,
+        'Function provided via setErrorGroupCallback failed, not generating `error.group.name`'
+      )
+    }
+  }
 }
 
 function maybeAddUserAttributes(userAttributes, exception, config) {

--- a/test/integration/api/set-error-group-callback.tap.js
+++ b/test/integration/api/set-error-group-callback.tap.js
@@ -1,0 +1,327 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const helper = require('../../lib/agent_helper')
+const API = require('../../../api')
+
+tap.test('api.setErrorGroupCallback()', (t) => {
+  t.autoend()
+
+  let agent
+  let api
+  let http
+  let express
+  let app
+  let server
+
+  t.beforeEach(() => {
+    agent = helper.loadTestAgent(t)
+    api = new API(agent)
+    http = require('http')
+    express = require('express')
+    app = express()
+  })
+
+  t.afterEach(() => {
+    server.close()
+    helper.unloadAgent(agent)
+  })
+
+  t.test('should not add the Error Group when callback is not a function', (t) => {
+    api.setErrorGroupCallback('this-is-a-string')
+
+    app.get('/test', (req, res) => {
+      return res.status(500).json({ message: 'Boom' })
+    })
+
+    server = app.listen(0)
+    const url = `http://localhost:${server.address().port}/test`
+
+    http.get(url, function (res) {
+      t.equal(res.statusCode, 500, 'request should return a 500')
+      t.end()
+    })
+
+    agent.on('transactionFinished', function () {
+      t.notOk(
+        agent.errors.traceAggregator.errors[0][4].agentAttributes['error.group.name'],
+        'should not add `error.group.name` attribute to trace'
+      )
+      t.notOk(
+        agent.errors.eventAggregator.getEvents()[0][2]['error.group.name'],
+        'should not add `error.group.name` attribute to event'
+      )
+    })
+  })
+
+  t.test('should not add the Error Group when callback throws', (t) => {
+    api.setErrorGroupCallback(function callback() {
+      throw new Error('whoops')
+    })
+
+    app.get('/test', (req, res) => {
+      return res.status(500).json({ message: 'Boom' })
+    })
+
+    server = app.listen(0)
+    const url = `http://localhost:${server.address().port}/test`
+
+    http.get(url, function (res) {
+      t.equal(res.statusCode, 500, 'request should return a 500')
+      t.end()
+    })
+
+    agent.on('transactionFinished', function () {
+      t.notOk(
+        agent.errors.traceAggregator.errors[0][4].agentAttributes['error.group.name'],
+        'should not add `error.group.name` attribute to trace'
+      )
+      t.notOk(
+        agent.errors.eventAggregator.getEvents()[0][2]['error.group.name'],
+        'should not add `error.group.name` attribute to event'
+      )
+    })
+  })
+
+  t.test('should not add the Error Group when callback returns empty string', (t) => {
+    api.setErrorGroupCallback(function callback() {
+      return ''
+    })
+
+    app.get('/test', (req, res) => {
+      return res.status(500).json({ message: 'Boom' })
+    })
+
+    server = app.listen(0)
+    const url = `http://localhost:${server.address().port}/test`
+
+    http.get(url, function (res) {
+      t.equal(res.statusCode, 500, 'request should return a 500')
+      t.end()
+    })
+
+    agent.on('transactionFinished', function () {
+      t.notOk(
+        agent.errors.traceAggregator.errors[0][4].agentAttributes['error.group.name'],
+        'should not add `error.group.name` attribute to trace'
+      )
+      t.notOk(
+        agent.errors.eventAggregator.getEvents()[0][2]['error.group.name'],
+        'should not add `error.group.name` attribute to event'
+      )
+    })
+  })
+
+  t.test('should not add the Error Group when callback returns not string', (t) => {
+    api.setErrorGroupCallback(function callback() {
+      return { 'error.group.name': 'test-group' }
+    })
+
+    app.get('/test', (req, res) => {
+      return res.status(500).json({ message: 'Boom' })
+    })
+
+    server = app.listen(0)
+    const url = `http://localhost:${server.address().port}/test`
+
+    http.get(url, function (res) {
+      t.equal(res.statusCode, 500, 'request should return a 500')
+      t.end()
+    })
+
+    agent.on('transactionFinished', function () {
+      t.notOk(
+        agent.errors.traceAggregator.errors[0][4].agentAttributes['error.group.name'],
+        'should not add `error.group.name` attribute to trace'
+      )
+      t.notOk(
+        agent.errors.eventAggregator.getEvents()[0][2]['error.group.name'],
+        'should not add `error.group.name` attribute to event'
+      )
+    })
+  })
+
+  t.test('should pass the correct arguments to the callback (transaction)', (t) => {
+    api.setErrorGroupCallback(function callback(metadata) {
+      t.equal(metadata['request.uri'], '/test', 'should give the request.uri attribute')
+      t.equal(metadata['http.statusCode'], '500', 'should give the http.statusCode attribute')
+      t.equal(metadata['http.method'], 'GET', 'should give the http.method attribute')
+
+      return 'test-group'
+    })
+
+    app.get('/test', (req, res) => {
+      return res.status(500).json({ message: 'Boom' })
+    })
+
+    server = app.listen(0)
+    const url = `http://localhost:${server.address().port}/test`
+
+    http.get(url, function (res) {
+      t.equal(res.statusCode, 500, 'request should return a 500')
+      t.end()
+    })
+
+    agent.on('transactionFinished', function () {
+      t.equal(
+        agent.errors.traceAggregator.errors[0][4].agentAttributes['error.group.name'],
+        'test-group',
+        'should add `error.group.name` attribute to trace'
+      )
+      t.equal(
+        agent.errors.eventAggregator.getEvents()[0][2]['error.group.name'],
+        'test-group',
+        'should add `error.group.name` attribute to event'
+      )
+    })
+  })
+
+  t.test('should pass the correct arguments to the callback (error)', (t) => {
+    const expectedError = new Error('boom')
+    api.setErrorGroupCallback(function callback(metadata) {
+      t.equal(metadata.error, expectedError, 'should give the error attribute')
+
+      return 'test-group'
+    })
+
+    app.get('/test', () => {
+      throw expectedError
+    })
+
+    server = app.listen(0)
+    const url = `http://localhost:${server.address().port}/test`
+
+    http.get(url, function (res) {
+      t.equal(res.statusCode, 500, 'request should return a 500')
+      t.end()
+    })
+
+    agent.on('transactionFinished', function () {
+      t.equal(
+        agent.errors.traceAggregator.errors[0][4].agentAttributes['error.group.name'],
+        'test-group',
+        'should add `error.group.name` attribute to trace'
+      )
+      t.equal(
+        agent.errors.eventAggregator.getEvents()[0][2]['error.group.name'],
+        'test-group',
+        'should add `error.group.name` attribute to event'
+      )
+    })
+  })
+
+  t.test('should pass the correct arguments to the callback (custom attributes)', (t) => {
+    api.setErrorGroupCallback(function callback(metadata) {
+      t.same(metadata.customAttributes, { foo: 'bar' })
+
+      return 'test-group'
+    })
+
+    app.get('/test', (req, res) => {
+      api.addCustomAttribute('foo', 'bar')
+      api.noticeError(new Error('boom'))
+      return res.status(200).json({ message: 'OK' })
+    })
+
+    server = app.listen(0)
+    const url = `http://localhost:${server.address().port}/test`
+
+    http.get(url, function (res) {
+      t.equal(res.statusCode, 200, 'request should return a 500')
+      t.end()
+    })
+
+    agent.on('transactionFinished', function () {
+      t.equal(
+        agent.errors.traceAggregator.errors[0][4].agentAttributes['error.group.name'],
+        'test-group',
+        'should add `error.group.name` attribute to trace'
+      )
+      t.equal(
+        agent.errors.eventAggregator.getEvents()[0][2]['error.group.name'],
+        'test-group',
+        'should add `error.group.name` attribute to event'
+      )
+    })
+  })
+
+  t.test('should pass the correct arguments to the callback (noticeError + is expected)', (t) => {
+    const expectedError = new Error('boom')
+    api.setErrorGroupCallback(function callback(metadata) {
+      t.equal(metadata.error, expectedError, 'should give the error')
+      t.equal(metadata['error.expected'], true, 'should give the error.expected')
+      t.equal(metadata['request.uri'], '/test', 'should give the request.uri')
+      t.equal(metadata['http.statusCode'], '200', 'should give the http.statusCode')
+      t.equal(metadata['http.method'], 'GET', 'should give the http.method')
+
+      return 'test-group'
+    })
+
+    app.get('/test', (req, res) => {
+      api.noticeError(expectedError, true)
+      return res.status(200).json({ message: 'OK' })
+    })
+
+    server = app.listen(0)
+    const url = `http://localhost:${server.address().port}/test`
+
+    http.get(url, function (res) {
+      t.equal(res.statusCode, 200, 'request should return a 200')
+      t.end()
+    })
+
+    agent.on('transactionFinished', function () {
+      t.equal(
+        agent.errors.traceAggregator.errors[0][4].agentAttributes['error.group.name'],
+        'test-group',
+        'should add `error.group.name` attribute to trace'
+      )
+      t.equal(
+        agent.errors.eventAggregator.getEvents()[0][2]['error.group.name'],
+        'test-group',
+        'should add `error.group.name` attribute to event'
+      )
+    })
+  })
+
+  t.test('should overwrite previous callbacks if called more than once', (t) => {
+    const expectedError = new Error('boom')
+    api.setErrorGroupCallback(function callback() {
+      return 'group #1'
+    })
+
+    app.get('/test', (req, res) => {
+      api.setErrorGroupCallback(function secondCallback() {
+        return 'group #2'
+      })
+      api.noticeError(expectedError, true)
+      return res.status(200).json({ message: 'OK' })
+    })
+
+    server = app.listen(0)
+    const url = `http://localhost:${server.address().port}/test`
+
+    http.get(url, function (res) {
+      t.equal(res.statusCode, 200, 'request should return a 200')
+      t.end()
+    })
+
+    agent.on('transactionFinished', function () {
+      t.equal(
+        agent.errors.traceAggregator.errors[0][4].agentAttributes['error.group.name'],
+        'group #2',
+        'should add `error.group.name` attribute to trace'
+      )
+      t.equal(
+        agent.errors.eventAggregator.getEvents()[0][2]['error.group.name'],
+        'group #2',
+        'should add `error.group.name` attribute to event'
+      )
+    })
+  })
+})

--- a/test/unit/api/api-set-error-group-callback.test.js
+++ b/test/unit/api/api-set-error-group-callback.test.js
@@ -82,4 +82,28 @@ tap.test('Agent API = set Error Group callback', (t) => {
     )
     t.end()
   })
+
+  t.test('should not attach the callback when async function', (t) => {
+    function callback() {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve()
+        }, 200)
+      }).then(() => 'error-group')
+    }
+    api.setErrorGroupCallback(callback())
+
+    t.equal(loggerMock.warn.callCount, 1, 'should log warning when failed')
+    t.notOk(
+      api.agent.errors.errorGroupCallback,
+      'should not attach the callback on the error collector'
+    )
+    t.equal(
+      api.agent.metrics.getOrCreateMetric(NAMES.SUPPORTABILITY.API + '/setErrorGroupCallback')
+        .callCount,
+      1,
+      'should increment the API tracking metric'
+    )
+    t.end()
+  })
 })

--- a/test/unit/api/api-set-error-group-callback.test.js
+++ b/test/unit/api/api-set-error-group-callback.test.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+const loggerMock = require('../mocks/logger')()
+
+const helper = require('../../lib/agent_helper')
+const API = proxyquire('../../../api', {
+  './lib/logger': {
+    child: sinon.stub().callsFake(() => loggerMock)
+  }
+})
+const NAMES = require('../../../lib/metrics/names')
+
+tap.test('Agent API = set Error Group callback', (t) => {
+  t.autoend()
+  let agent = null
+  let api
+
+  t.beforeEach(() => {
+    loggerMock.warn.reset()
+    agent = helper.loadMockedAgent({
+      attributes: {
+        enabled: true
+      }
+    })
+    api = new API(agent)
+  })
+
+  t.afterEach(() => {
+    helper.unloadAgent(agent)
+  })
+
+  t.test('should have a setErrorGroupCallback method', (t) => {
+    t.ok(api.setErrorGroupCallback)
+    t.equal(typeof api.setErrorGroupCallback, 'function')
+    t.end()
+  })
+
+  t.test('should attach callback function when a function', (t) => {
+    const callback = function myTestCallback() {
+      return 'test-error-group-1'
+    }
+    api.setErrorGroupCallback(callback)
+
+    t.equal(loggerMock.warn.callCount, 0, 'should not log warnings when successful')
+    t.equal(
+      api.agent.errors.errorGroupCallback,
+      callback,
+      'should attach the callback on the error collector'
+    )
+    t.equal(api.agent.errors.errorGroupCallback(), 'test-error-group-1')
+    t.equal(
+      api.agent.metrics.getOrCreateMetric(NAMES.SUPPORTABILITY.API + '/setErrorGroupCallback')
+        .callCount,
+      1,
+      'should increment the API tracking metric'
+    )
+    t.end()
+  })
+
+  t.test('should not attach the callback when not a function', (t) => {
+    const callback = 'test-error-group-2'
+    api.setErrorGroupCallback(callback)
+
+    t.equal(loggerMock.warn.callCount, 1, 'should log warning when failed')
+    t.notOk(
+      api.agent.errors.errorGroupCallback,
+      'should not attach the callback on the error collector'
+    )
+    t.equal(
+      api.agent.metrics.getOrCreateMetric(NAMES.SUPPORTABILITY.API + '/setErrorGroupCallback')
+        .callCount,
+      1,
+      'should increment the API tracking metric'
+    )
+    t.end()
+  })
+})

--- a/test/unit/api/stub.test.js
+++ b/test/unit/api/stub.test.js
@@ -8,7 +8,7 @@
 const tap = require('tap')
 const API = require('../../../stub_api')
 
-const EXPECTED_API_COUNT = 32
+const EXPECTED_API_COUNT = 33
 
 tap.test('Agent API - Stubbed Agent API', (t) => {
   t.autoend()

--- a/test/unit/errors/error-group.test.js
+++ b/test/unit/errors/error-group.test.js
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const helper = require('../../lib/agent_helper')
+const Transaction = require('../../../lib/transaction')
+
+function getErrorTraces(errorCollector) {
+  return errorCollector.traceAggregator.errors
+}
+
+function getErrorEvents(errorCollector) {
+  return errorCollector.eventAggregator.getEvents()
+}
+
+tap.test('Error Group functionality', (t) => {
+  t.autoend()
+  let agent = null
+
+  t.beforeEach(() => {
+    if (agent) {
+      helper.unloadAgent(agent)
+    }
+    agent = helper.loadMockedAgent({
+      attributes: {
+        enabled: true
+      }
+    })
+  })
+
+  t.afterEach(() => {
+    helper.unloadAgent(agent)
+  })
+
+  t.test('should set error.group.name attribute when callback is set', (t) => {
+    const myCallback = function myCallback() {
+      return 'error-group-test-1'
+    }
+    agent.errors.errorGroupCallback = myCallback
+
+    const error = new Error('whoops')
+    const transaction = new Transaction(agent)
+    agent.errors.add(transaction, error)
+    agent.errors.onTransactionFinished(transaction)
+
+    const errorTraces = getErrorTraces(agent.errors)
+    const errorEvents = getErrorEvents(agent.errors)
+
+    t.same(errorTraces[0][4].agentAttributes, { 'error.group.name': 'error-group-test-1' })
+    t.same(errorEvents[0][2], { 'error.group.name': 'error-group-test-1' })
+
+    t.end()
+  })
+
+  t.test('should not set error.group.name attribute when callback throws', (t) => {
+    const myCallback = function myCallback() {
+      throw new Error('boom')
+    }
+    agent.errors.errorGroupCallback = myCallback
+
+    const error = new Error('whoops')
+    const transaction = new Transaction(agent)
+    agent.errors.add(transaction, error)
+    agent.errors.onTransactionFinished(transaction)
+
+    const errorTraces = getErrorTraces(agent.errors)
+    const errorEvents = getErrorEvents(agent.errors)
+
+    t.same(errorTraces[0][4].agentAttributes, {})
+    t.same(errorEvents[0][2], {})
+
+    t.end()
+  })
+
+  t.test('should not set error.group.name attribute when callback returns empty string', (t) => {
+    const myCallback = function myCallback() {
+      return ''
+    }
+    agent.errors.errorGroupCallback = myCallback
+
+    const error = new Error('whoops')
+    const transaction = new Transaction(agent)
+    agent.errors.add(transaction, error)
+    agent.errors.onTransactionFinished(transaction)
+
+    const errorTraces = getErrorTraces(agent.errors)
+    const errorEvents = getErrorEvents(agent.errors)
+
+    t.same(errorTraces[0][4].agentAttributes, {})
+    t.same(errorEvents[0][2], {})
+
+    t.end()
+  })
+
+  t.test('should not set error.group.name attribute when callback returns not a string', (t) => {
+    const myCallback = function myCallback() {
+      return { 'error.group.name': 'blah' }
+    }
+    agent.errors.errorGroupCallback = myCallback
+
+    const error = new Error('whoops')
+    const transaction = new Transaction(agent)
+    agent.errors.add(transaction, error)
+    agent.errors.onTransactionFinished(transaction)
+
+    const errorTraces = getErrorTraces(agent.errors)
+    const errorEvents = getErrorEvents(agent.errors)
+
+    t.same(errorTraces[0][4].agentAttributes, {})
+    t.same(errorEvents[0][2], {})
+
+    t.end()
+  })
+})


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
Added new API function called `setErrorGroupCallback`, which provides a way for you to customize the `error.group.name` attribute of errors that are captured by the agent. This attribute controls how the Errors Inbox functionality groups similar errors together.

To learn more about this function, please refer to our [example app](https://github.com/newrelic/newrelic-node-examples).

## Links
Closes NEWRELIC-7541
Example app PR: https://github.com/newrelic/newrelic-node-examples/pull/59

## Details
