### PR TITLE
NEWRELIC-7414 separated out the ability to register core and 3rd party instrumentation

### DIFF
--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -352,33 +352,15 @@ const shimmer = (module.exports = {
     shimmer.unwrapMethod(Module, 'Module', '_load')
   },
 
-  bootstrapInstrumentation: function bootstrapInstrumentation(agent) {
-    // Instrument global.
-    const globalShim = new shims.Shim(agent, 'globals', 'globals')
-    applyDebugState(globalShim, global)
-    const globalsFilepath = path.join(__dirname, 'instrumentation', 'core', 'globals.js')
-    _firstPartyInstrumentation(agent, globalsFilepath, globalShim, global, 'globals')
-
-    // Instrument each of the core modules.
-    Object.keys(CORE_INSTRUMENTATION).forEach(function forEachCore(mojule) {
-      const core = CORE_INSTRUMENTATION[mojule]
-      const filePath = path.join(__dirname, 'instrumentation', 'core', core.file)
-      let uninstrumented = null
-
-      try {
-        uninstrumented = require(mojule)
-      } catch (err) {
-        logger.trace('Could not load core module %s got error %s', mojule, err)
-      }
-
-      const shim = shims.createShimFromType(core.type, agent, mojule, mojule)
-      applyDebugState(shim, core)
-      _firstPartyInstrumentation(agent, filePath, shim, uninstrumented, mojule)
-    })
-
-    // Register all the first-party instrumentations.
-    Object.keys(INSTRUMENTATIONS).forEach(function forEachInstrumentation(moduleName) {
-      const instrInfo = INSTRUMENTATIONS[moduleName]
+  /**
+   * Registers all instrumentation for "first-party" libraries.
+   *
+   * This is all 3rd party libs with the exception of the domain library in Node.js core
+   *
+   * @param {object} agent NR agent
+   */
+  registerFirstPartyInstrumentation(agent) {
+    for (const [moduleName, instrInfo] of Object.entries(INSTRUMENTATIONS)) {
       if (instrInfo.module) {
         // Because external instrumentations can change independent of
         // the agent core, we don't want breakages in them to entirely
@@ -401,7 +383,7 @@ const shimmer = (module.exports = {
           onRequire: _firstPartyInstrumentation.bind(null, agent, fileName)
         })
       }
-    })
+    }
 
     // Even though domain is a core module we add it as a registered
     // instrumentation to be lazy-loaded because we do not want to cause domain
@@ -412,6 +394,40 @@ const shimmer = (module.exports = {
       type: null,
       onRequire: _firstPartyInstrumentation.bind(null, agent, domainPath)
     })
+  },
+
+  /**
+   * Registers all instrumentation for Node.js core libraries.
+   *
+   * @param {object} agent NR agent
+   */
+  registerCoreInstrumentation(agent) {
+    // Instrument global.
+    const globalShim = new shims.Shim(agent, 'globals', 'globals')
+    applyDebugState(globalShim, global)
+    const globalsFilepath = path.join(__dirname, 'instrumentation', 'core', 'globals.js')
+    _firstPartyInstrumentation(agent, globalsFilepath, globalShim, global, 'globals')
+
+    // Instrument each of the core modules.
+    for (const [mojule, core] of Object.entries(CORE_INSTRUMENTATION)) {
+      const filePath = path.join(__dirname, 'instrumentation', 'core', core.file)
+      let uninstrumented = null
+
+      try {
+        uninstrumented = require(mojule)
+      } catch (err) {
+        logger.trace('Could not load core module %s got error %s', mojule, err)
+      }
+
+      const shim = shims.createShimFromType(core.type, agent, mojule, mojule)
+      applyDebugState(shim, core)
+      _firstPartyInstrumentation(agent, filePath, shim, uninstrumented, mojule)
+    }
+  },
+
+  bootstrapInstrumentation: function bootstrapInstrumentation(agent) {
+    shimmer.registerCoreInstrumentation(agent)
+    shimmer.registerFirstPartyInstrumentation(agent)
   },
 
   registerInstrumentation: function registerInstrumentation(opts) {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links
 * https://issues.newrelic.com/browse/NEWRELIC-7414
 * https://github.com/newrelic/node-test-utilities/pull/162

## Details
This is an enhancment to support the [Test utils PR](https://github.com/newrelic/node-test-utilities/pull/162).  We need to provide an ability to register core and 3rd party instrumentation separately now that we will work towards supporting the ability to register multiple instrumentation hooks for a given module.
