### PR TITLE
NEWRELIC-5252: simplify datastore-shim.js

### DIFF
--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -357,19 +357,17 @@ function recordOperation(nodule, properties, opSpec) {
   return this.record(nodule, properties, function opRecorder(shim, fn, fnName, args) {
     shim.logger.trace('Recording datastore operation "%s"', fnName)
 
-    // Derive the segment information.
+    // Derive the segment information, starting from some defaults
     let segDesc = null
     if (shim.isFunction(opSpec)) {
       segDesc = opSpec.call(this, shim, fn, fnName, args)
     } else {
       segDesc = {
-        name: opSpec.name || fnName || 'other',
-        parameters: opSpec.parameters,
-        callback: opSpec.callback,
-        after: 'after' in opSpec ? opSpec.after : null,
-        promise: 'promise' in opSpec ? opSpec.promise : null,
-        record: opSpec.record,
-        opaque: opSpec.opaque || false
+        name: fnName || 'other',
+        opaque: false,
+        after: null,
+        promise: null,
+        ...opSpec
       }
     }
     if (hasOwnProperty(segDesc, 'parameters')) {

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -5,8 +5,6 @@
 
 'use strict'
 
-/* eslint sonarjs/cognitive-complexity: ["error", 57] -- TODO: https://issues.newrelic.com/browse/NEWRELIC-5252 */
-
 const dbutil = require('../db/utils')
 const hasOwnProperty = require('../util/properties').hasOwn
 const logger = require('../logger').child({ component: 'DatastoreShim' })

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -804,6 +804,20 @@ function _normalizeParameters(parameters) {
 
   parameters.product = parameters.product || this._datastore
 
+  _normalizeDatabaseName(parameters, dsTracerConf)
+  _normalizeInstanceInformation(parameters, dsTracerConf, config)
+
+  return parameters
+}
+
+/**
+ * Normalizes the database name from segment parameter values.
+ *
+ * @private
+ * @param {object} parameters   - The segment parameters to clean up.
+ * @param {object} dsTracerConf - The datastore tracer configuration
+ */
+function _normalizeDatabaseName(parameters, dsTracerConf) {
   // Add database name if provided and enabled.
   if (!dsTracerConf.database_name_reporting.enabled) {
     delete parameters.database_name
@@ -813,7 +827,18 @@ function _normalizeParameters(parameters) {
         ? String(parameters.database_name)
         : parameters.database_name || INSTANCE_UNKNOWN
   }
+}
 
+/**
+ * Normalizes the database instance information from segment parameter
+ * values: host and the port/path/id.
+ *
+ * @private
+ * @param {object} parameters   - The segment parameters to clean up.
+ * @param {object} dsTracerConf - The datastore tracer configuration
+ * @param {object} config       - The agent configuration
+ */
+function _normalizeInstanceInformation(parameters, dsTracerConf, config) {
   // Add instance information if enabled.
   if (!dsTracerConf.instance_reporting.enabled) {
     delete parameters.host
@@ -834,6 +859,4 @@ function _normalizeParameters(parameters) {
       }
     }
   }
-
-  return parameters
 }

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -646,26 +646,31 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
 
     let queryDesc = querySpec
     if (shim.isFunction(querySpec)) {
-      queryDesc = querySpec.call(this, shim, fn, fnName, args)
+      queryDesc = querySpec.call(this, shim, fn, fnName, args) || Object.create(null)
     }
+
+    // Set some default values, in case they're missing.
+    queryDesc = {
+      name: fnName,
+      callback: null,
+      rowCallback: null,
+      stream: null,
+      after: null,
+      promise: null,
+      opaque: false,
+      inContext: null,
+      ...queryDesc
+    }
+
+    const parameters = _normalizeParameters.call(shim, queryDesc.parameters || Object.create(null))
 
     // If we're not actually recording this, then just return the segment
     // descriptor now.
-    if (hasOwnProperty(queryDesc, 'record') && queryDesc.record === false) {
-      const parameters = _normalizeParameters.call(
-        shim,
-        queryDesc.parameters || Object.create(null)
-      )
+    if (queryDesc?.record === false) {
       return {
-        name: queryDesc.name || fnName,
-        parameters,
-        callback: 'callback' in queryDesc ? queryDesc.callback : null,
-        rowCallback: 'rowCallback' in queryDesc ? queryDesc.rowCallback : null,
-        stream: 'stream' in queryDesc ? queryDesc.stream : null,
-        after: 'after' in queryDesc ? queryDesc.after : null,
-        promise: 'promise' in queryDesc ? queryDesc.promise : null,
-        internal: 'internal' in queryDesc ? queryDesc.internal : false,
-        opaque: 'opaque' in queryDesc ? queryDesc.opaque : false
+        internal: false,
+        ...queryDesc,
+        parameters
       }
     }
 
@@ -681,18 +686,13 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
     shim.logger.trace('Found and parsed query %s -> %s', parsed.type, name)
 
     // Return the segment descriptor.
-    const parameters = _normalizeParameters.call(shim, queryDesc.parameters || Object.create(null))
     return {
+      internal: true,
+      ...queryDesc,
+      // This name and parameters might override those in the original
+      // queryDesc.
       name: shim._metrics.STATEMENT + name,
       parameters,
-      callback: 'callback' in queryDesc ? queryDesc.callback : null,
-      rowCallback: 'rowCallback' in queryDesc ? queryDesc.rowCallback : null,
-      stream: 'stream' in queryDesc ? queryDesc.stream : null,
-      after: 'after' in queryDesc ? queryDesc.after : null,
-      promise: 'promise' in queryDesc ? queryDesc.promise : null,
-      internal: 'internal' in queryDesc ? queryDesc.internal : true,
-      opaque: 'opaque' in queryDesc ? queryDesc.opaque : false,
-      inContext: 'inContext' in queryDesc ? queryDesc.inContext : null,
       recorder: function queryRecorder(segment, scope) {
         if (segment) {
           parsed.recordMetrics(segment, scope)


### PR DESCRIPTION
## Links

* NEWRELIC-5252

## Details

Commit messages:

*NEWRELIC-5252: (datastore-shim) remove eslint rule for cognitive complexity

File now passes without this rule.

*NEWRELIC-5252: (datastore-shim) simplify _recordQuery

It's easier to use the spread operator and some default arguments than
to do all of those ternaries or logical operators to decide if
defaults should be used or not.

Another simplicity win is to move the remove the duplicate call to
`_normalizeParameters`.

*NEWRELIC-5252: (datastore-shim) simplify _normalizeParameters

Split up the function into two extra functions, because each side has
a bunch of bits irreducible fiddly logic.

*NEWRELIC-5295: (datastore-shim) simplify recordOperation

It's easier to use the spread operator and some default arguments than
to do all of those ternaries or logical operators to decide if
defaults should be used or not.