### PR TITLE
DO NOT MERGE - Allow registering multiple instrumentation hooks for the same resolved module

### DIFF
--- a/esm-loader.mjs
+++ b/esm-loader.mjs
@@ -68,19 +68,18 @@ export async function resolve(specifier, context, nextResolve) {
 
     if (format === 'commonjs') {
       // ES Modules translate import statements into fully qualified filepaths, so we create a copy of our instrumentation under this filepath
-      const instrumentationDefinitionCopy = Object.assign({}, instrumentationDefinition)
+      const instrumentationDefinitionCopy = [...instrumentationDefinition]
+      instrumentationDefinitionCopy.forEach((copy) => {
+        // Stripping the prefix is necessary because the code downstream gets this url without it
+        copy.moduleName = fileURLToPath(url)
 
-      // Stripping the prefix is necessary because the code downstream gets this url without it
-      instrumentationDefinitionCopy.moduleName = fileURLToPath(url)
-
-      // Added to keep our Supportability metrics from exploding/including customer info via full filepath
-      instrumentationDefinitionCopy.specifier = specifier
-
-      shimmer.registerInstrumentation(instrumentationDefinitionCopy)
-
-      logger.debug(
-        `Registered CommonJS instrumentation for ${specifier} under ${instrumentationDefinitionCopy.moduleName}`
-      )
+        // Added to keep our Supportability metrics from exploding/including customer info via full filepath
+        copy.specifier = specifier
+        shimmer.registerInstrumentation(copy)
+        logger.debug(
+          `Registered CommonJS instrumentation for ${specifier} under ${copy.moduleName}`
+        )
+      })
     } else if (format === 'module') {
       registeredSpecifiers.set(url, specifier)
       const modifiedUrl = new URL(url)

--- a/lib/instrumentation/@hapi/vision.js
+++ b/lib/instrumentation/@hapi/vision.js
@@ -20,13 +20,11 @@ module.exports = function initialize(agent, vision, moduleName, shim) {
 
   shim.wrap(plugin, 'register', function wrapRegister(shim, register) {
     return function wrappedRegister(server) {
-      shim.wrap(server, 'decorate', wrapDecorate)
+      if (!shim.isWrapped(server, 'decorate')) {
+        shim.wrap(server, 'decorate', wrapDecorate)
+      }
 
-      const ret = register.apply(this, arguments)
-
-      shim.unwrapOnce(server, 'decorate')
-
-      return ret
+      return register.apply(this, arguments)
     }
   })
 }

--- a/lib/instrumentation/mysql/mysql.js
+++ b/lib/instrumentation/mysql/mysql.js
@@ -11,41 +11,52 @@ const symbols = require('../../symbols')
 
 exports.callbackInitialize = function callbackInitialize(shim, mysql) {
   shim.setDatastore(shim.MYSQL)
-  shim.__wrappedPoolConnection = false
+  shim[symbols.wrappedPoolConnection] = true
 
   shim.wrapReturn(mysql, 'createConnection', wrapCreateConnection)
-  // TODO: update this code to short circuit based on something within it being wrapped already
   function wrapCreateConnection(shim, fn, fnName, connection) {
+    if (shim[symbols.unwrapConnection]) {
+      return
+    }
     shim.logger.debug('Wrapping Connection#query')
     if (wrapQueryable(shim, connection, false)) {
       const connProto = Object.getPrototypeOf(connection)
       connProto[symbols.storeDatabase] = true
-      shim.unwrap(mysql, 'createConnection')
+      shim[symbols.unwrapConnection] = true
     }
   }
 
   shim.wrapReturn(mysql, 'createPool', wrapCreatePool)
   function wrapCreatePool(shim, fn, fnName, pool) {
+    if (shim[symbols.unwrapPool]) {
+      return
+    }
     shim.logger.debug('Wrapping Pool#query and Pool#getConnection')
     if (wrapQueryable(shim, pool, true) && wrapGetConnection(shim, pool)) {
-      shim.unwrap(mysql, 'createPool')
+      shim[symbols.unwrapPool] = true
     }
   }
 
   shim.wrapReturn(mysql, 'createPoolCluster', wrapCreatePoolCluster)
   function wrapCreatePoolCluster(shim, fn, fnName, poolCluster) {
+    if (shim[symbols.createPoolCluster]) {
+      return
+    }
     shim.logger.debug('Wrapping PoolCluster#of')
     const proto = Object.getPrototypeOf(poolCluster)
     shim.wrapReturn(proto, 'of', wrapPoolClusterOf)
     function wrapPoolClusterOf(shim, of, _n, poolNamespace) {
+      if (shim[symbols.clusterOf]) {
+        return
+      }
       if (wrapGetConnection(shim, poolNamespace)) {
-        shim.unwrap(proto, 'of')
+        shim[symbols.clusterOf] = true
       }
     }
 
     shim.logger.debug('Wrapping PoolCluster#getConnection')
     if (wrapGetConnection(shim, poolCluster)) {
-      shim.unwrap(mysql, 'createPoolCluster')
+      shim[symbols.createPoolCluster] = true
     }
   }
 }
@@ -84,7 +95,7 @@ function wrapGetConnection(shim, connectable) {
           'Wrapping callback with segment'
         )
         let cb = args[cbIdx]
-        if (!shim.__wrappedPoolConnection) {
+        if (!shim[symbols.wrappedPoolConnection]) {
           cb = shim.wrap(cb, wrapGetConnectionCallback)
         }
         args[cbIdx] = shim.bindSegment(cb)
@@ -103,7 +114,7 @@ function wrapGetConnectionCallback(shim, cb) {
       if (!err && wrapQueryable(shim, conn, false)) {
         // Leave getConnection wrapped in order to maintain TX state, but we can
         // simplify the wrapping of its callback in future calls.
-        shim.__wrappedPoolConnection = true
+        shim[symbols.wrappedPoolConnection] = true
       }
     } catch (_err) {
       shim.logger.debug(

--- a/lib/instrumentation/mysql/mysql.js
+++ b/lib/instrumentation/mysql/mysql.js
@@ -14,6 +14,7 @@ exports.callbackInitialize = function callbackInitialize(shim, mysql) {
   shim.__wrappedPoolConnection = false
 
   shim.wrapReturn(mysql, 'createConnection', wrapCreateConnection)
+  // TODO: update this code to short circuit based on something within it being wrapped already
   function wrapCreateConnection(shim, fn, fnName, connection) {
     shim.logger.debug('Wrapping Connection#query')
     if (wrapQueryable(shim, connection, false)) {

--- a/lib/instrumentation/mysql/nr-hooks.js
+++ b/lib/instrumentation/mysql/nr-hooks.js
@@ -6,11 +6,6 @@
 'use strict'
 const instrumentation = require('./mysql')
 
-/**
- * We only need to register the instrumentation once for both mysql and mysql2
- *  because there is some 🪄 in shimmer
- * See: https://github.com/newrelic/node-newrelic/blob/main/lib/shimmer.js#L459
- */
 module.exports = [
   {
     type: 'datastore',

--- a/lib/instrumentation/mysql/nr-hooks.js
+++ b/lib/instrumentation/mysql/nr-hooks.js
@@ -19,6 +19,11 @@ module.exports = [
   },
   {
     type: 'datastore',
+    moduleName: 'mysql2',
+    onRequire: instrumentation.callbackInitialize
+  },
+  {
+    type: 'datastore',
     moduleName: 'mysql2/promise',
     onRequire: instrumentation.promiseInitialize
   }

--- a/lib/shim/conglomerate-shim.js
+++ b/lib/shim/conglomerate-shim.js
@@ -25,8 +25,8 @@ const SHIM_CLASSES = {
  * @augments Shim
  */
 class ConglomerateShim extends Shim {
-  constructor(agent, moduleName, resolvedName) {
-    super(agent, moduleName, resolvedName)
+  constructor(agent, moduleName, resolvedName, shimName) {
+    super(agent, moduleName, resolvedName, shimName)
     this._logger = logger.child({ module: moduleName })
     this._resolvedName = resolvedName
   }

--- a/lib/shim/conglomerate-shim.js
+++ b/lib/shim/conglomerate-shim.js
@@ -23,6 +23,10 @@ const SHIM_CLASSES = {
  *
  * @private
  * @augments Shim
+ * @param {Agent} agent The agent this shim will use.
+ * @param {string} moduleName The name of the module being instrumented.
+ * @param {string} resolvedName The full path to the loaded module.
+ * @param {string} shimName Used to persist shim ids across different shim instances.
  */
 class ConglomerateShim extends Shim {
   constructor(agent, moduleName, resolvedName, shimName) {

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -75,24 +75,17 @@ const QUERY_PARSERS = {
  *  A helper class for wrapping datastore modules.
  * @param {Agent} agent
  *  The agent this shim will use.
+ * @param shimName
  * @param {string} moduleName
  *  The name of the module being instrumented.
  * @param {string} resolvedName
  *  The full path to the loaded module.
- * @param {string} [datastoreId]
- *  The name of the datastore being instrumented. If available, use one of the
- *  values from {@link DatastoreShim.DATASTORE_NAMES}.
- *  Calls {@link DatastoreShim#setDatastore} if datastoreId is
- *  specified.
  * @see Shim
  * @see DatastoreShim.DATASTORE_NAMES
  */
-function DatastoreShim(agent, moduleName, resolvedName, datastoreId) {
-  Shim.call(this, agent, moduleName, resolvedName)
+function DatastoreShim(agent, moduleName, resolvedName, shimName) {
+  Shim.call(this, agent, moduleName, resolvedName, shimName)
   this._logger = logger.child({ module: moduleName })
-  if (datastoreId) {
-    this.setDatastore(datastoreId)
-  }
   this.queryParser = defaultParsers[this.SQL_PARSER]
 }
 module.exports = DatastoreShim

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -538,8 +538,11 @@ function bindRowCallbackSegment(args, cbIdx, parentSegment) {
     return shim.applySegment(cb, segment, true, this, arguments)
   }, parentSegment)
 
+  // TODO: enscapsulate assigning original and marking wrapped
+  // into a function within shim to avoid this bs
   // Mark this as wrapped and put it in the args array.
   wrapper[symbols.original] = cb
+  wrapper[symbols.wrapped] = shim.id
   args[idx] = wrapper
 }
 

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -14,7 +14,6 @@ const ParsedStatement = require('../db/parsed-statement')
 const Shim = require('./shim')
 const urltils = require('../util/urltils')
 const util = require('util')
-const symbols = require('../symbols')
 
 /**
  * An enumeration of well-known datastores so that new instrumentations can use
@@ -71,15 +70,11 @@ const QUERY_PARSERS = {
  *
  * @class
  * @augments Shim
- * @classdesc
- *  A helper class for wrapping datastore modules.
- * @param {Agent} agent
- *  The agent this shim will use.
- * @param shimName
- * @param {string} moduleName
- *  The name of the module being instrumented.
- * @param {string} resolvedName
- *  The full path to the loaded module.
+ * @classdesc A helper class for wrapping datastore modules.
+ * @param {Agent} agent The agent this shim will use.
+ * @param {string} moduleName The name of the module being instrumented.
+ * @param {string} resolvedName The full path to the loaded module.
+ * @param {string} shimName Used to persist shim ids across different shim instances.
  * @see Shim
  * @see DatastoreShim.DATASTORE_NAMES
  */
@@ -538,11 +533,7 @@ function bindRowCallbackSegment(args, cbIdx, parentSegment) {
     return shim.applySegment(cb, segment, true, this, arguments)
   }, parentSegment)
 
-  // TODO: enscapsulate assigning original and marking wrapped
-  // into a function within shim to avoid this bs
-  // Mark this as wrapped and put it in the args array.
-  wrapper[symbols.original] = cb
-  wrapper[symbols.wrapped] = shim.id
+  shim.assignOriginal(wrapper, cb, true)
   args[idx] = wrapper
 }
 

--- a/lib/shim/index.js
+++ b/lib/shim/index.js
@@ -30,14 +30,15 @@ SHIM_TYPE_MAP[constants.MODULE_TYPE.WEB_FRAMEWORK] = WebFrameworkShim
  * @param agent
  * @param moduleName
  * @param resolvedName
+ * @param shimName
  */
-function createShimFromType(type, agent, moduleName, resolvedName) {
+function createShimFromType(type, agent, moduleName, resolvedName, shimName) {
   let shim = null
   if (properties.hasOwn(SHIM_TYPE_MAP, type)) {
     const ShimClass = SHIM_TYPE_MAP[type]
-    shim = new ShimClass(agent, moduleName, resolvedName)
+    shim = new ShimClass(agent, moduleName, resolvedName, shimName)
   } else {
-    shim = new Shim(agent, moduleName, resolvedName)
+    shim = new Shim(agent, moduleName, resolvedName, shimName)
   }
   return shim
 }

--- a/lib/shim/message-shim.js
+++ b/lib/shim/message-shim.js
@@ -70,6 +70,7 @@ const DESTINATION_TYPES = {
  *  Used for instrumenting message broker client libraries.
  * @param {Agent} agent
  *  The agent this shim will use.
+ * @param shimName
  * @param {string} moduleName
  *  The name of the module being instrumented.
  * @param {string} resolvedName
@@ -77,8 +78,8 @@ const DESTINATION_TYPES = {
  * @see Shim
  * @see TransactionShim
  */
-function MessageShim(agent, moduleName, resolvedName) {
-  TransactionShim.call(this, agent, moduleName, resolvedName)
+function MessageShim(agent, moduleName, resolvedName, shimName) {
+  TransactionShim.call(this, agent, moduleName, resolvedName, shimName)
   this._logger = logger.child({ module: moduleName })
   this._metrics = null
   this._transportType = TransactionShim.TRANSPORT_TYPES.UNKNOWN

--- a/lib/shim/message-shim.js
+++ b/lib/shim/message-shim.js
@@ -66,15 +66,11 @@ const DESTINATION_TYPES = {
  *
  * @class
  * @augments TransactionShim
- * @classdesc
- *  Used for instrumenting message broker client libraries.
- * @param {Agent} agent
- *  The agent this shim will use.
- * @param shimName
- * @param {string} moduleName
- *  The name of the module being instrumented.
- * @param {string} resolvedName
- *  The full path to the loaded module.
+ * @classdesc Used for instrumenting message broker client libraries.
+ * @param {Agent} agent The agent this shim will use.
+ * @param {string} moduleName The name of the module being instrumented.
+ * @param {string} resolvedName The full path to the loaded module.
+ * @param {string} shimName Used to persist shim ids across different shim instances.
  * @see Shim
  * @see TransactionShim
  */

--- a/lib/shim/promise-shim.js
+++ b/lib/shim/promise-shim.js
@@ -22,12 +22,10 @@ class PromiseShim extends Shim {
    * Constructs a shim associated with the given agent instance, specialized for
    * instrumenting promise libraries.
    *
-   * @param {Agent} agent
-   *  The agent this shim will use.
-   * @param {string} moduleName
-   *  The name of the module being instrumented.
-   * @param {string} resolvedName
-   *  The full path to the loaded module.
+   * @param {Agent} agent The agent this shim will use.
+   * @param {string} moduleName The name of the module being instrumented.
+   * @param {string} resolvedName The full path to the loaded module.
+   * @param {string} shimName Used to persist shim ids across different shim instances.
    * @param shimName
    * @see Shim
    */

--- a/lib/shim/promise-shim.js
+++ b/lib/shim/promise-shim.js
@@ -28,10 +28,11 @@ class PromiseShim extends Shim {
    *  The name of the module being instrumented.
    * @param {string} resolvedName
    *  The full path to the loaded module.
+   * @param shimName
    * @see Shim
    */
-  constructor(agent, moduleName, resolvedName) {
-    super(agent, moduleName, resolvedName)
+  constructor(agent, moduleName, resolvedName, shimName) {
+    super(agent, moduleName, resolvedName, shimName)
     this._logger = logger.child({ module: moduleName })
     this._class = null
   }

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -624,6 +624,9 @@ function wrapReturn(nodule, properties, spec, args) {
     let unwrapReference = null
     const handler = {
       get: function getTrap(target, prop) {
+        if (prop === symbols.wrapped) {
+          return this[prop]
+        }
         // Allow for look up of the target
         if (prop === symbols.original) {
           return target
@@ -643,7 +646,9 @@ function wrapReturn(nodule, properties, spec, args) {
         return true
       },
       set: function setTrap(target, key, val) {
-        if (key === symbols.unwrap) {
+        if (key === symbols.wrapped) {
+          this[key] = val
+        } else if (key === symbols.unwrap) {
           unwrapReference = val
         } else {
           target[key] = val

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -20,7 +20,6 @@ const { makeId } = require('../util/hashes')
 // Some modules do terrible things, like change the prototype of functions. To
 // avoid crashing things we'll use a cached copy of apply everywhere.
 const fnApply = Function.prototype.apply
-const shimIds = new Map()
 
 /**
  * Constructs a shim associated with the given agent instance.
@@ -44,11 +43,7 @@ function Shim(agent, moduleName, resolvedName, shimName) {
   this._toExport = null
   this._debug = false
   this.defineProperty(this, 'moduleName', moduleName)
-  const id = shimIds.get(shimName)
-  this.id = id || makeId()
-  if (shimName && !id) {
-    shimIds.set(shimName, this.id)
-  }
+  this.assignId(shimName)
 
   // Determine the root directory of the module.
   let moduleRoot = null
@@ -121,6 +116,7 @@ Shim.prototype.isWrapped = isWrapped
 Shim.prototype.unwrap = unwrap
 Shim.prototype.unwrapOnce = unwrap
 Shim.prototype.getOriginal = getOriginal
+Shim.prototype.assignOriginal = assignOriginal
 Shim.prototype.getSegment = getSegment
 Shim.prototype.getActiveSegment = getActiveSegment
 Shim.prototype.setActiveSegment = setActiveSegment
@@ -151,6 +147,7 @@ Shim.prototype.copySegmentParameters = copySegmentParameters
 Shim.prototype.prefixRouteParameters = prefixRouteParameters
 Shim.prototype.interceptPromise = interceptPromise
 Shim.prototype.fixArity = arity.fixArity
+Shim.prototype.assignId = assignId
 
 // Internal methods.
 Shim.prototype.getExport = getExport
@@ -624,6 +621,8 @@ function wrapReturn(nodule, properties, spec, args) {
     let unwrapReference = null
     const handler = {
       get: function getTrap(target, prop) {
+        // The wrapped symbol only lives on proxy
+        // not the proxied item.
         if (prop === symbols.wrapped) {
           return this[prop]
         }
@@ -646,6 +645,9 @@ function wrapReturn(nodule, properties, spec, args) {
         return true
       },
       set: function setTrap(target, key, val) {
+        // If we are setting the wrapped symbol on proxy
+        // we do not actually want to assign to proxied
+        // item but the proxy itself.
         if (key === symbols.wrapped) {
           this[key] = val
         } else if (key === symbols.unwrap) {
@@ -800,14 +802,9 @@ function getExport(defaultExport) {
  */
 function isWrapped(nodule, property) {
   if (property) {
-    return !!(
-      nodule &&
-      nodule[property] &&
-      nodule[property][symbols.wrapped] &&
-      nodule[property][symbols.wrapped] === this.id
-    )
+    return !!(nodule?.[property]?.[symbols.wrapped] === this.id)
   }
-  return !!(nodule && nodule[symbols.wrapped] && nodule[symbols.wrapped] === this.id)
+  return !!(nodule?.[symbols.wrapped] === this.id)
 }
 
 /**
@@ -1017,11 +1014,7 @@ function unwrap(nodule, properties) {
   const original = properties ? nodule[properties] : nodule
   if (!original || (original && !original[symbols.original])) {
     return original
-  } else if (
-    original &&
-    original[symbols.original] &&
-    original[symbols.original][symbols.original]
-  ) {
+  } else if (original?.[symbols.original]?.[symbols.original]) {
     this.logger.warn(
       'Attempting to unwrap %s, which its unwrapped version is also wrapped. This is unsupported, unwrap will not occur.',
       unwrapObj
@@ -1786,6 +1779,41 @@ function _specToFunction(spec) {
 /* eslint-enable no-unused-vars */
 
 /**
+ * Assigns the shim id and original on the wrapped item.
+ * TODO: Once all wrapping is converted to proxies, we won't need to
+ * set this property as the trap on 'get' will return the original for
+ * symbols.original. For now, we have to prevent setting this on original.
+ *
+ * @param {*} wrapped wrapped item
+ * @param {*} original * The item being wrapped.
+ * @param {boolean} forceOrig flag to indicate to overwrite original function
+ */
+function assignOriginal(wrapped, original, forceOrig) {
+  wrapped[symbols.wrapped] = this.id
+  if (!wrapped[symbols.original] || forceOrig) {
+    wrapped[symbols.original] = original
+  }
+}
+
+const shimIds = new Map()
+
+/**
+ * Assigns id to shim instance.
+ * If shimName is present it will reuse an id
+ * otherwise it'll create a unique id.
+ *
+ * @param {string} shimName Used to persist shim ids across different instances.
+ */
+function assignId(shimName) {
+  const id = shimIds.get(shimName)
+  this.id = id || makeId()
+
+  if (shimName && !id) {
+    shimIds.set(shimName, this.id)
+  }
+}
+
+/**
  * Executes the provided spec on the given object.
  *
  * - `_wrap(shim, original, name, spec [, args])`
@@ -1818,13 +1846,7 @@ function _wrap(shim, original, name, spec, args) {
       wrapped = arity.fixArity(original, wrapped)
     }
 
-    // TODO: Once all wrapping is converted to proxies, we won't need to
-    // set this property as the trap on 'get' will return the original for
-    // symbols.original. For now, we have to prevent setting this on original.
-    wrapped[symbols.wrapped] = shim.id
-    if (!wrapped[symbols.original]) {
-      wrapped[symbols.original] = original
-    }
+    shim.assignOriginal(wrapped, original)
 
     if (shim._debug) {
       shim._wrapped.push(wrapped)

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -15,10 +15,12 @@ const specs = require('./specs')
 const util = require('util')
 const symbols = require('../symbols')
 const { addCLMAttributes: maybeAddCLMAttributes } = require('../util/code-level-metrics')
+const { makeId } = require('../util/hashes')
 
 // Some modules do terrible things, like change the prototype of functions. To
 // avoid crashing things we'll use a cached copy of apply everywhere.
 const fnApply = Function.prototype.apply
+const shimIds = new Map()
 
 /**
  * Constructs a shim associated with the given agent instance.
@@ -28,8 +30,10 @@ const fnApply = Function.prototype.apply
  * @param {Agent}   agent         - The agent this shim will use.
  * @param {string}  moduleName    - The name of the module being instrumented.
  * @param {string}  resolvedName  - The full path to the loaded module.
+ * @param {string}  shimName      - Used to persist shim ids across different instances. This is
+ * applicable to instrument that compliments each other across libraries(i.e - koa + koa-route/koa-router)
  */
-function Shim(agent, moduleName, resolvedName) {
+function Shim(agent, moduleName, resolvedName, shimName) {
   if (!agent || !moduleName) {
     throw new Error('Shim must be initialized with an agent and module name.')
   }
@@ -40,6 +44,11 @@ function Shim(agent, moduleName, resolvedName) {
   this._toExport = null
   this._debug = false
   this.defineProperty(this, 'moduleName', moduleName)
+  const id = shimIds.get(shimName)
+  this.id = id || makeId()
+  if (shimName && !id) {
+    shimIds.set(shimName, this.id)
+  }
 
   // Determine the root directory of the module.
   let moduleRoot = null
@@ -786,9 +795,14 @@ function getExport(defaultExport) {
  */
 function isWrapped(nodule, property) {
   if (property) {
-    return !!(nodule && nodule[property] && nodule[property][symbols.original])
+    return !!(
+      nodule &&
+      nodule[property] &&
+      nodule[property][symbols.wrapped] &&
+      nodule[property][symbols.wrapped] === this.id
+    )
   }
-  return !!(nodule && nodule[symbols.original])
+  return !!(nodule && nodule[symbols.wrapped] && nodule[symbols.wrapped] === this.id)
 }
 
 /**
@@ -1829,6 +1843,7 @@ function _wrap(shim, original, name, spec, args) {
     // TODO: Once all wrapping is converted to proxies, we won't need to
     // set this property as the trap on 'get' will return the original for
     // symbols.original. For now, we have to prevent setting this on original.
+    wrapped[symbols.wrapped] = shim.id
     if (!wrapped[symbols.original]) {
       wrapped[symbols.original] = original
     }

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -119,7 +119,7 @@ Shim.prototype.wrapExport = wrapExport
 Shim.prototype.record = record
 Shim.prototype.isWrapped = isWrapped
 Shim.prototype.unwrap = unwrap
-Shim.prototype.unwrapOnce = unwrapOnce
+Shim.prototype.unwrapOnce = unwrap
 Shim.prototype.getOriginal = getOriginal
 Shim.prototype.getSegment = getSegment
 Shim.prototype.getActiveSegment = getActiveSegment
@@ -983,12 +983,13 @@ function record(nodule, properties, recordNamer) {
 }
 
 /**
- * Unwraps one or more items, revealing the original value.
+ * Unwraps one item, revealing the underlying value. If item is wrapped multiple times,
+ * the unwrap will not occur as we cannot safely unwrap.
  *
  * - `unwrap(nodule, property)`
  * - `unwrap(func)`
  *
- * If called with a `nodule` and properties, the unwrapped values will be put
+ * If called with a `nodule` and properties, the unwrapped value will be put
  * back on the nodule. Otherwise, the unwrapped function is just returned.
  *
  * @memberof Shim.prototype
@@ -1011,53 +1012,25 @@ function unwrap(nodule, properties) {
     return nodule
   }
 
-  this.logger.trace('Unwrapping %s', properties || '<nodule>')
-  let original = properties ? nodule[properties] : nodule
-  while (original && original[symbols.original]) {
-    original = this.isFunction(original[symbols.unwrap])
-      ? original[symbols.unwrap]()
-      : original[symbols.original]
+  const unwrapObj = properties || '<nodule>'
+  this.logger.trace('Unwrapping %s', unwrapObj)
+  const original = properties ? nodule[properties] : nodule
+  if (!original || (original && !original[symbols.original])) {
+    return original
+  } else if (
+    original &&
+    original[symbols.original] &&
+    original[symbols.original][symbols.original]
+  ) {
+    this.logger.warn(
+      'Attempting to unwrap %s, which its unwrapped version is also wrapped. This is unsupported, unwrap will not occur.',
+      unwrapObj
+    )
+    return original
   }
-  return original
-}
-
-/**
- * Unwraps one item, revealing the underlying value.
- *
- * - `unwrapOnce(nodule, property)`
- * - `unwrapOnce(func)`
- *
- * If called with a `nodule` and properties, the unwrapped value will be put
- * back on the nodule. Otherwise, the unwrapped function is just returned.
- *
- * @memberof Shim.prototype
- * @param {object | Function} nodule
- *  The source for the properties to unwrap, or a single function to unwrap.
- * @param {string|Array.<string>} [properties]
- *  One or more properties to unwrap. If omitted, the `nodule` parameter is
- *  assumed to be the function to unwrap.
- * @returns {object | Function} The first parameter after unwrapping.
- */
-function unwrapOnce(nodule, properties) {
-  // Don't try to unwrap potentially `null` or `undefined` things.
-  if (!nodule) {
-    return nodule
-  }
-
-  // If we're unwrapping multiple things
-  if (this.isArray(properties)) {
-    properties.forEach(unwrapOnce.bind(this, nodule))
-    return nodule
-  }
-
-  this.logger.trace('Unwrapping %s', properties || '<nodule>')
-  let original = properties ? nodule[properties] : nodule
-  if (original && original[symbols.original]) {
-    original = this.isFunction(original[symbols.unwrap])
-      ? original[symbols.unwrap]()
-      : original[symbols.original]
-  }
-  return original
+  return this.isFunction(original[symbols.unwrap])
+    ? original[symbols.unwrap]()
+    : original[symbols.original]
 }
 
 /**

--- a/lib/shim/transaction-shim.js
+++ b/lib/shim/transaction-shim.js
@@ -19,6 +19,7 @@ const TRANSACTION_TYPES_SET = Transaction.TYPES_SET
  * @class
  * @augments Shim
  * @classdesc
+ * @param shimName
  *  A helper class for working with transactions.
  * @param {Agent}   agent         - The agent the shim will use.
  * @param {string}  moduleName    - The name of the module being instrumented.
@@ -26,8 +27,8 @@ const TRANSACTION_TYPES_SET = Transaction.TYPES_SET
  * @see Shim
  * @see WebFrameworkShim
  */
-function TransactionShim(agent, moduleName, resolvedName) {
-  Shim.call(this, agent, moduleName, resolvedName)
+function TransactionShim(agent, moduleName, resolvedName, shimName) {
+  Shim.call(this, agent, moduleName, resolvedName, shimName)
   this._logger = logger.child({ module: moduleName })
 }
 module.exports = TransactionShim

--- a/lib/shim/webframework-shim.js
+++ b/lib/shim/webframework-shim.js
@@ -67,23 +67,17 @@ const MIDDLEWARE_TYPE_NAMES = {
  *  A helper class for wrapping web framework modules.
  * @param {Agent} agent
  *  The agent this shim will use.
+ * @param shimName
  * @param {string} moduleName
  *  The name of the module being instrumented.
  * @param {string} resolvedName
  *  The full path to the loaded module.
- * @param {string} [frameworkId]
- *  The name of the web framework being instrumented. If available, use one of
- *  the values from {@link WebFrameworkShim.FRAMEWORK_NAMES}.
  * @see TransactionShim
  * @see WebFrameworkShim.FRAMEWORK_NAMES
  */
-function WebFrameworkShim(agent, moduleName, resolvedName, frameworkId) {
-  TransactionShim.call(this, agent, moduleName, resolvedName)
+function WebFrameworkShim(agent, moduleName, resolvedName, shimName) {
+  TransactionShim.call(this, agent, moduleName, resolvedName, shimName)
   this._logger = logger.child({ module: moduleName })
-  if (frameworkId) {
-    this.setFramework(frameworkId)
-  }
-
   this._routeParser = _defaultRouteParser
   this._errorPredicate = _defaultErrorPredicate
   this._responsePredicate = _defaultResponsePredicate

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -353,13 +353,13 @@ const shimmer = (module.exports = {
   },
 
   /**
-   * Registers all instrumentation for "first-party" libraries.
+   * Registers all instrumentation for 3rd party libraries.
    *
    * This is all 3rd party libs with the exception of the domain library in Node.js core
    *
    * @param {object} agent NR agent
    */
-  registerFirstPartyInstrumentation(agent) {
+  registerThirdPartyInstrumentation(agent) {
     for (const [moduleName, instrInfo] of Object.entries(INSTRUMENTATIONS)) {
       if (instrInfo.module) {
         // Because external instrumentations can change independent of
@@ -427,7 +427,7 @@ const shimmer = (module.exports = {
 
   bootstrapInstrumentation: function bootstrapInstrumentation(agent) {
     shimmer.registerCoreInstrumentation(agent)
-    shimmer.registerFirstPartyInstrumentation(agent)
+    shimmer.registerThirdPartyInstrumentation(agent)
   },
 
   registerInstrumentation: function registerInstrumentation(opts) {
@@ -568,6 +568,7 @@ function instrumentPostLoad(agent, nodule, moduleName, resolvedName) {
     // that occur directly above this.  No reason to attempt to load instrumentation
     // as it does not exist.
     if (instrumentation.type === MODULE_TYPE.TRACKING) {
+      instrumentation[symbols.instrumented] = true
       return
     }
 

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -487,14 +487,27 @@ const shimmer = (module.exports = {
     return moduleName
   },
 
+  /**
+   * Checks all registered instrumentation for a module and returns true
+   * only if every hook succeeded.
+   *
+   * @param {string} moduleName name of registered instrumentation
+   * @returns {boolean}
+   */
+  isInstrumented(moduleName) {
+    const instrumentations = shimmer.registeredInstrumentations[moduleName]
+    const didInstrument = instrumentations.filter(
+      (instrumentation) => instrumentation[symbols.instrumented]
+    )
+    return didInstrument.length === instrumentations.length
+  },
+
   instrumentPostLoad(agent, module, moduleName, resolvedName, returnModule = false) {
     const result = _postLoad(agent, module, moduleName, resolvedName)
     // This is to not break the public API
     // previously it would just call instrumentation
     // and not check the result
-    // TODO: moved instrumented to the given hook onRequire, onResolved etc
-    // return returnModule ? result : !!result[symbols.instrumented]
-    return returnModule ? result : true
+    return returnModule ? result : shimmer.isInstrumented(moduleName)
   }
 })
 
@@ -504,8 +517,6 @@ function applyDebugState(shim, nodule) {
     instrumented.push(shim)
     instrumented.push({
       [symbols.unwrap]: function unwrapNodule() {
-        delete nodule[symbols.instrumentedErrored]
-        delete nodule[symbols.instrumented]
         delete nodule[symbols.shim]
       }
     })
@@ -526,8 +537,6 @@ function applyDebugState(shim, nodule) {
 function instrumentPostLoad(agent, nodule, moduleName, resolvedName) {
   const instrumentations = shimmer.registeredInstrumentations[moduleName]
   instrumentations.forEach((instrumentation) => {
-    // TODO: this is not working and making many versioned tests fail
-    // without this redis,pg versioned tests fail
     if (
       properties.hasOwn(instrumentation, symbols.instrumented) ||
       properties.hasOwn(instrumentation, symbols.instrumentedErrored)
@@ -669,9 +678,9 @@ function _instrumentOnResolved(agent, moduleName, resolvedFilepath) {
     try {
       instrumentation.onResolved(shim, moduleName, resolvedFilepath)
     } catch (instrumentationError) {
-      if (instrumentation.onError.length) {
+      if (instrumentation.onError) {
         try {
-          instrumentation.onError.forEach(instrumentationError)
+          instrumentation.onError(instrumentationError)
         } catch (error) {
           logger.warn(
             error,

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -397,7 +397,7 @@ const shimmer = (module.exports = {
   },
 
   /**
-   * Registers all instrumentation for Node.js core libraries.
+   * Registers all instrumentation for Node.js core libraries.  
    *
    * @param {object} agent NR agent
    */
@@ -435,7 +435,35 @@ const shimmer = (module.exports = {
       return
     }
 
-    shimmer.registeredInstrumentations[opts.moduleName] = opts
+    const registeredInstrumentation = shimmer.registeredInstrumentations[opts.moduleName]
+
+    if (!registeredInstrumentation) {
+      const options = { type: opts.type }
+      if (opts.onRequire) {
+        options.onRequire = Array.isArray(opts.onRequire) ? opts.onRequire : [ opts.onRequire ]
+      } else {
+        options.onRequire = []
+      }
+
+      if (opts.onResolved) {
+        options.onResolved = Array.isArray(opts.onResolved) ? opts.onResolved : [ opts.onResolved ]
+      } else {
+        options.onResolved = []
+      }
+
+      if (opts.onError) {
+        options.onError = Array.isArray(opts.onError) ? opts.onError : [ opts.onError ]
+      } else {
+        options.onError = []
+      }
+
+      shimmer.registeredInstrumentations[opts.moduleName] = options 
+    } else {
+      opts.onRequire && registeredInstrumentation.onRequire.push(opts.onRequire)
+      opts.onResolved && registeredInstrumentation.onResolved.push(opts.onResolved)
+      opts.onError && registeredInstrumentation.onError.push(opts.onError)
+    }
+
   },
 
   registeredInstrumentations: Object.create(null),
@@ -554,7 +582,11 @@ function instrumentPostLoad(agent, nodule, moduleName, resolvedName) {
   }
 
   try {
-    if (instrumentation.onRequire(shim, nodule, moduleName) !== false) {
+    const didInstrument = instrumentation.onRequire.filter((hook) => {
+      return hook(shim, nodule, moduleName) !== false
+    })
+
+    if (didInstrument.length > 0) {
       nodule = shim.getExport(nodule)
       nodule[symbols.instrumented] = true
     }
@@ -605,7 +637,7 @@ function _postLoad(agent, nodule, name, resolvedName) {
   const instrumentation = shimmer.getInstrumentationNameFromModuleName(name)
   const registeredInstrumentation = shimmer.registeredInstrumentations[instrumentation]
   const hasPostLoadInstrumentation =
-    registeredInstrumentation && registeredInstrumentation.onRequire
+    registeredInstrumentation && registeredInstrumentation.onRequire.length
 
   // Check if this is a known instrumentation and then run it.
   if (hasPostLoadInstrumentation) {
@@ -620,7 +652,7 @@ function _onResolveFileName(agent, requiredNameOrPath, resolvedFilepath) {
   const instrumentation = shimmer.getInstrumentationNameFromModuleName(requiredNameOrPath)
   const registeredInstrumentation = shimmer.registeredInstrumentations[instrumentation]
   const hasResolvedFileInstrumentation =
-    registeredInstrumentation && registeredInstrumentation.onResolved
+    registeredInstrumentation && registeredInstrumentation.onResolved.length
 
   // Check if this is a known instrumentation and then run it.
   if (hasResolvedFileInstrumentation) {
@@ -653,11 +685,13 @@ function _instrumentOnResolved(agent, moduleName, resolvedFilepath) {
   )
 
   try {
-    instrumentation.onResolved(shim, moduleName, resolvedFilepath)
+    instrumentation.onResolved.forEach((hook) => {
+      hook(shim, moduleName, resolvedFilepath)
+    })
   } catch (instrumentationError) {
-    if (instrumentation.onError) {
+    if (instrumentation.onError.length) {
       try {
-        instrumentation.onError(instrumentationError)
+        instrumentation.onError.forEach(instrumentationError)
       } catch (error) {
         logger.warn(
           error,

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -397,7 +397,7 @@ const shimmer = (module.exports = {
   },
 
   /**
-   * Registers all instrumentation for Node.js core libraries.  
+   * Registers all instrumentation for Node.js core libraries.
    *
    * @param {object} agent NR agent
    */
@@ -438,32 +438,10 @@ const shimmer = (module.exports = {
     const registeredInstrumentation = shimmer.registeredInstrumentations[opts.moduleName]
 
     if (!registeredInstrumentation) {
-      const options = { type: opts.type }
-      if (opts.onRequire) {
-        options.onRequire = Array.isArray(opts.onRequire) ? opts.onRequire : [ opts.onRequire ]
-      } else {
-        options.onRequire = []
-      }
-
-      if (opts.onResolved) {
-        options.onResolved = Array.isArray(opts.onResolved) ? opts.onResolved : [ opts.onResolved ]
-      } else {
-        options.onResolved = []
-      }
-
-      if (opts.onError) {
-        options.onError = Array.isArray(opts.onError) ? opts.onError : [ opts.onError ]
-      } else {
-        options.onError = []
-      }
-
-      shimmer.registeredInstrumentations[opts.moduleName] = options 
-    } else {
-      opts.onRequire && registeredInstrumentation.onRequire.push(opts.onRequire)
-      opts.onResolved && registeredInstrumentation.onResolved.push(opts.onResolved)
-      opts.onError && registeredInstrumentation.onError.push(opts.onError)
+      shimmer.registeredInstrumentations[opts.moduleName] = []
     }
 
+    shimmer.registeredInstrumentations[opts.moduleName].push({ ...opts })
   },
 
   registeredInstrumentations: Object.create(null),
@@ -500,21 +478,13 @@ const shimmer = (module.exports = {
    * @param moduleName
    */
   getInstrumentationNameFromModuleName(moduleName) {
-    let instrumentation
     // XXX When updating these special cases, also update `uninstrumented`.
     // To allow for instrumenting both 'pg' and 'pg.js'.
     if (moduleName === 'pg.js') {
-      instrumentation = 'pg'
+      moduleName = 'pg'
     }
-    if (moduleName === 'mysql2') {
-      // mysql2 (https://github.com/sidorares/node-mysql2) is a drop in replacement for
-      // mysql which conforms to the existing mysql API. If we see mysql2, treat it as
-      // mysql
-      instrumentation = 'mysql'
-    } else {
-      instrumentation = moduleName
-    }
-    return instrumentation
+
+    return moduleName
   },
 
   instrumentPostLoad(agent, module, moduleName, resolvedName, returnModule = false) {
@@ -522,7 +492,9 @@ const shimmer = (module.exports = {
     // This is to not break the public API
     // previously it would just call instrumentation
     // and not check the result
-    return returnModule ? result : !!result[symbols.instrumented]
+    // TODO: moved instrumented to the given hook onRequire, onResolved etc
+    // return returnModule ? result : !!result[symbols.instrumented]
+    return returnModule ? result : true
   }
 })
 
@@ -552,66 +524,72 @@ function applyDebugState(shim, nodule) {
  * @param resolvedName
  */
 function instrumentPostLoad(agent, nodule, moduleName, resolvedName) {
-  const instrumentation = shimmer.registeredInstrumentations[moduleName]
-  if (
-    properties.hasOwn(nodule, symbols.instrumented) ||
-    properties.hasOwn(nodule, symbols.instrumentedErrored)
-  ) {
-    logger.trace(
-      'Already instrumented or failed to instrument %s, skipping redundant instrumentation',
-      moduleName
-    )
-    return nodule
-  }
-
-  const shim = shims.createShimFromType(instrumentation.type, agent, moduleName, resolvedName)
-
-  applyDebugState(shim, nodule)
-  trackInstrumentationUsage(
-    agent,
-    shim,
-    instrumentation.specifier || moduleName,
-    NAMES.FEATURES.INSTRUMENTATION.ON_REQUIRE
-  )
-
-  // Tracking instrumentation is only used to add the supportability metrics
-  // that occur directly above this.  No reason to attempt to load instrumentation
-  // as it does not exist.
-  if (instrumentation.type === MODULE_TYPE.TRACKING) {
-    return nodule
-  }
-
-  try {
-    const didInstrument = instrumentation.onRequire.filter((hook) => {
-      return hook(shim, nodule, moduleName) !== false
-    })
-
-    if (didInstrument.length > 0) {
-      nodule = shim.getExport(nodule)
-      nodule[symbols.instrumented] = true
+  const instrumentations = shimmer.registeredInstrumentations[moduleName]
+  instrumentations.forEach((instrumentation) => {
+    // TODO: this is not working and making many versioned tests fail
+    // without this redis,pg versioned tests fail
+    if (
+      properties.hasOwn(instrumentation, symbols.instrumented) ||
+      properties.hasOwn(instrumentation, symbols.instrumentedErrored)
+    ) {
+      logger.trace(
+        'Already instrumented or failed to instrument %s, skipping redundant instrumentation',
+        moduleName
+      )
+      return
     }
-  } catch (instrumentationError) {
-    nodule[symbols.instrumentedErrored] = true
-    if (instrumentation.onError) {
-      try {
-        instrumentation.onError(instrumentationError)
-      } catch (e) {
+
+    const shim = shims.createShimFromType(
+      instrumentation.type,
+      agent,
+      moduleName,
+      resolvedName,
+      instrumentation.shimName
+    )
+
+    applyDebugState(shim, nodule)
+    trackInstrumentationUsage(
+      agent,
+      shim,
+      instrumentation.specifier || moduleName,
+      NAMES.FEATURES.INSTRUMENTATION.ON_REQUIRE
+    )
+
+    // Tracking instrumentation is only used to add the supportability metrics
+    // that occur directly above this.  No reason to attempt to load instrumentation
+    // as it does not exist.
+    if (instrumentation.type === MODULE_TYPE.TRACKING) {
+      return
+    }
+
+    try {
+      if (instrumentation.onRequire(shim, nodule, moduleName) !== false) {
+        nodule = shim.getExport(nodule)
+        instrumentation[symbols.instrumented] = true
+      }
+    } catch (instrumentationError) {
+      instrumentation[symbols.instrumentedErrored] = true
+      if (instrumentation.onError) {
+        try {
+          instrumentation.onError(instrumentationError)
+        } catch (e) {
+          logger.warn(
+            e,
+            instrumentationError,
+            'Custom instrumentation for %s failed, then the onError handler threw an error',
+            moduleName
+          )
+        }
+      } else {
         logger.warn(
-          e,
           instrumentationError,
-          'Custom instrumentation for %s failed, then the onError handler threw an error',
+          'Custom instrumentation for %s failed. Please report this to the ' +
+            'maintainers of the custom instrumentation.',
           moduleName
         )
       }
-    } else {
-      logger.warn(
-        instrumentationError,
-        'Custom instrumentation for %s failed. Please report this to the ' +
-          'maintainers of the custom instrumentation.',
-        moduleName
-      )
     }
-  }
+  })
 
   return nodule
 }
@@ -637,7 +615,9 @@ function _postLoad(agent, nodule, name, resolvedName) {
   const instrumentation = shimmer.getInstrumentationNameFromModuleName(name)
   const registeredInstrumentation = shimmer.registeredInstrumentations[instrumentation]
   const hasPostLoadInstrumentation =
-    registeredInstrumentation && registeredInstrumentation.onRequire.length
+    registeredInstrumentation &&
+    registeredInstrumentation.length &&
+    registeredInstrumentation.filter((instrumentation) => instrumentation.onRequire).length
 
   // Check if this is a known instrumentation and then run it.
   if (hasPostLoadInstrumentation) {
@@ -652,7 +632,9 @@ function _onResolveFileName(agent, requiredNameOrPath, resolvedFilepath) {
   const instrumentation = shimmer.getInstrumentationNameFromModuleName(requiredNameOrPath)
   const registeredInstrumentation = shimmer.registeredInstrumentations[instrumentation]
   const hasResolvedFileInstrumentation =
-    registeredInstrumentation && registeredInstrumentation.onResolved.length
+    registeredInstrumentation &&
+    registeredInstrumentation.length &&
+    registeredInstrumentation.filter((instrumentation) => instrumentation.onResolved).length
 
   // Check if this is a known instrumentation and then run it.
   if (hasResolvedFileInstrumentation) {
@@ -673,42 +655,41 @@ function _onResolveFileName(agent, requiredNameOrPath, resolvedFilepath) {
  * @param resolvedFilepath
  */
 function _instrumentOnResolved(agent, moduleName, resolvedFilepath) {
-  const instrumentation = shimmer.registeredInstrumentations[moduleName]
+  const instrumentations = shimmer.registeredInstrumentations[moduleName]
+  instrumentations.forEach((instrumentation) => {
+    const shim = shims.createShimFromType(instrumentation.type, agent, moduleName, resolvedFilepath)
 
-  const shim = shims.createShimFromType(instrumentation.type, agent, moduleName, resolvedFilepath)
+    trackInstrumentationUsage(
+      agent,
+      shim,
+      instrumentation.specifier || moduleName,
+      NAMES.FEATURES.INSTRUMENTATION.ON_RESOLVED
+    )
 
-  trackInstrumentationUsage(
-    agent,
-    shim,
-    instrumentation.specifier || moduleName,
-    NAMES.FEATURES.INSTRUMENTATION.ON_RESOLVED
-  )
-
-  try {
-    instrumentation.onResolved.forEach((hook) => {
-      hook(shim, moduleName, resolvedFilepath)
-    })
-  } catch (instrumentationError) {
-    if (instrumentation.onError.length) {
-      try {
-        instrumentation.onError.forEach(instrumentationError)
-      } catch (error) {
+    try {
+      instrumentation.onResolved(shim, moduleName, resolvedFilepath)
+    } catch (instrumentationError) {
+      if (instrumentation.onError.length) {
+        try {
+          instrumentation.onError.forEach(instrumentationError)
+        } catch (error) {
+          logger.warn(
+            error,
+            instrumentationError,
+            'OnResolved instrumentation for %s failed, then the onError handler threw an error',
+            moduleName
+          )
+        }
+      } else {
         logger.warn(
-          error,
           instrumentationError,
-          'OnResolved instrumentation for %s failed, then the onError handler threw an error',
+          'OnResolved instrumentation for %s failed. Please report this to the ' +
+            'maintainers of the custom instrumentation.',
           moduleName
         )
       }
-    } else {
-      logger.warn(
-        instrumentationError,
-        'OnResolved instrumentation for %s failed. Please report this to the ' +
-          'maintainers of the custom instrumentation.',
-        moduleName
-      )
     }
-  }
+  })
 }
 
 function hasValidRegisterOptions(opts) {

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -25,5 +25,11 @@ module.exports = {
   storeDatabase: Symbol('storeDatabase'),
   transaction: Symbol('transaction'),
   transactionInfo: Symbol('transactionInfo'),
-  unwrap: Symbol('unwrap')
+  unwrap: Symbol('unwrap'),
+  // mysql instrumentation symbols
+  unwrapConnection: Symbol('unwrapConnection'),
+  unwrapPool: Symbol('unwrapPool'),
+  clusterOf: Symbol('clusterOf'),
+  createPoolCluster: Symbol('createPoolCluster'),
+  wrappedPoolConnection: Symbol('wrappedPoolConnection')
 }

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -17,6 +17,7 @@ module.exports = {
   onceExecuted: Symbol('onceExecuted'),
   offTheRecord: Symbol('offTheRecord'),
   original: Symbol('original'),
+  wrapped: Symbol('shimWrapped'),
   prismaConnection: Symbol('prismaConnection'),
   prismaModelCall: Symbol('modelCall'),
   segment: Symbol('segment'),

--- a/test/integration/api/TestMod.js
+++ b/test/integration/api/TestMod.js
@@ -1,0 +1,7 @@
+'use strict'
+function TestMod() {}
+TestMod.prototype.foo = function foo(bar) {
+  return `value of ${bar}`
+}
+module.exports = TestMod
+

--- a/test/integration/api/TestMod.js
+++ b/test/integration/api/TestMod.js
@@ -1,7 +1,11 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 'use strict'
 function TestMod() {}
 TestMod.prototype.foo = function foo(bar) {
   return `value of ${bar}`
 }
 module.exports = TestMod
-

--- a/test/integration/api/instrument.tap.js
+++ b/test/integration/api/instrument.tap.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 New Relic Corporation. All rights reserved.
+ * Copyright 2023 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,11 +7,13 @@
 const { test } = require('tap')
 const API = require('../../../api')
 const agentHelper = require('../../lib/agent_helper')
+const symbols = require('../../../lib/symbols')
+const sinon = require('sinon')
 
 test('should allow registering of multiple onRequire hooks', (t) => {
-
   const agent = agentHelper.instrumentMockedAgent()
   t.teardown(() => {
+    delete require.cache[require.resolve('./TestMod')]
     agentHelper.unloadAgent(agent)
   })
 
@@ -20,24 +22,35 @@ test('should allow registering of multiple onRequire hooks', (t) => {
   const moduleName = './TestMod'
   api.instrument(moduleName, onRequire)
   api.instrument(moduleName, onRequire2)
+  let firstShim
+  let secondShim
 
   function onRequire(shim, TestMod) {
+    firstShim = shim
     shim.wrap(TestMod.prototype, 'foo', function wrapFoo(shim, orig) {
+      t.notOk(shim.isWrapped(orig))
       return function wrappedFoo(...args) {
-        args[0] = `${args[0]} in onRequire` 
+        t.ok(secondShim.isWrapped(TestMod.prototype.foo))
+        args[0] = `${args[0]} in onRequire`
         return orig.apply(this, args)
       }
     })
+    t.ok(shim.isWrapped(TestMod.prototype.foo))
   }
 
   function onRequire2(shim, TestMod) {
+    secondShim = shim
     shim.wrap(TestMod.prototype, 'foo', function wrapFoo(shim, orig) {
-      return function wrappedFoo(...args) {
-        args[0] = `${args[0]} in onRequire2` 
+      t.ok(firstShim.isWrapped(orig))
+      t.notOk(shim.isWrapped(TestMod.prototype.foo))
+      return function wrappedFoo2(...args) {
+        t.ok(shim.isWrapped(TestMod.prototype.foo))
+        args[0] = `${args[0]} in onRequire2`
         return orig.apply(this, args)
       }
     })
-  } 
+    t.ok(shim.isWrapped(TestMod.prototype.foo))
+  }
 
   const TestMod = require('./TestMod')
 
@@ -50,6 +63,7 @@ test('should allow registering of multiple onRequire hooks', (t) => {
 test('should allow checking for isWrapped relevant to the wrapping you are about to do', (t) => {
   const agent = agentHelper.instrumentMockedAgent()
   t.teardown(() => {
+    delete require.cache[require.resolve('./TestMod')]
     agentHelper.unloadAgent(agent)
   })
 
@@ -64,7 +78,7 @@ test('should allow checking for isWrapped relevant to the wrapping you are about
     if (!isWrapped) {
       shim.wrap(TestMod.prototype, 'foo', function wrapFoo(shim, orig) {
         return function wrappedFoo(...args) {
-          args[0] = `${args[0]} in onRequire` 
+          args[0] = `${args[0]} in onRequire`
           return orig.apply(this, args)
         }
       })
@@ -75,18 +89,19 @@ test('should allow checking for isWrapped relevant to the wrapping you are about
     const isWrapped = shim.isWrapped(TestMod.prototype.foo)
     if (!isWrapped) {
       shim.wrap(TestMod.prototype, 'foo', function wrapFoo(shim, orig) {
-        return function wrappedFoo(...args) {
-          args[0] = `${args[0]} in onRequire2` 
+        return function wrappedFoo2(...args) {
+          args[0] = `${args[0]} in onRequire2`
           return orig.apply(this, args)
         }
       })
     }
-  } 
+  }
 
   const TestMod = require('./TestMod')
 
   const testMod = new TestMod()
   const ret = testMod.foo('this is orig arg')
+  require('./TestMod')
   t.equal(ret, 'value of this is orig arg in onRequire2 in onRequire')
   t.end()
 })
@@ -94,6 +109,7 @@ test('should allow checking for isWrapped relevant to the wrapping you are about
 test('shim.unwrap should not break instrumentation registered after it', (t) => {
   const agent = agentHelper.instrumentMockedAgent()
   t.teardown(() => {
+    delete require.cache[require.resolve('./TestMod')]
     agentHelper.unloadAgent(agent)
   })
 
@@ -101,32 +117,30 @@ test('shim.unwrap should not break instrumentation registered after it', (t) => 
 
   const moduleName = './TestMod'
   api.instrument(moduleName, onRequire)
-  api.instrument(moduleName, onRequire2)
 
   function onRequire(shim, TestMod) {
-    shim.unwrap(TestMod.prototype.foo)
-  }
-
-  function onRequire2(shim, TestMod) {
-    shim.wrap(TestMod.prototype, 'foo', function wrapFoo(shim, orig) {
-      return function wrappedFoo(...args) {
-        args[0] = `${args[0]} in onRequire2` 
+    shim.wrap(TestMod.prototype, 'foo', function wrapStuff(shim, orig) {
+      return function wrapped1(...args) {
+        shim.unwrap(TestMod.prototype, 'foo')
         return orig.apply(this, args)
       }
     })
-  } 
+  }
 
   const TestMod = require('./TestMod')
 
   const testMod = new TestMod()
-  const ret = testMod.foo('this is orig arg')
-  t.equal(ret, 'value of this is orig arg in onRequire2')
+  const ret = testMod.foo('Hello world')
+  t.equal(ret, 'value of Hello world')
+  const shim = TestMod[symbols.shim]
+  t.notOk(shim.isWrapped(TestMod.prototype.foo), 'should unwrap as expected')
   t.end()
 })
 
-test('shim.unwrap should not break instrumentation registered before it', (t) => {
+test('shim.unwrap should not log warning if you try to unwrap and it has been wrapped more than once', (t) => {
   const agent = agentHelper.instrumentMockedAgent()
   t.teardown(() => {
+    delete require.cache[require.resolve('./TestMod')]
     agentHelper.unloadAgent(agent)
   })
 
@@ -135,25 +149,43 @@ test('shim.unwrap should not break instrumentation registered before it', (t) =>
   const moduleName = './TestMod'
   api.instrument(moduleName, onRequire)
   api.instrument(moduleName, onRequire2)
-
+  let shim1
+  let shim2
 
   function onRequire(shim, TestMod) {
+    shim1 = shim
     shim.wrap(TestMod.prototype, 'foo', function wrapFoo(shim, orig) {
-      return function wrappedFoo(...args) {
-        args[0] = `${args[0]} in onRequire` 
+      return function wrapped1(...args) {
+        shim.unwrap(TestMod.prototype, 'foo')
         return orig.apply(this, args)
       }
     })
-  } 
-  
+  }
+
   function onRequire2(shim, TestMod) {
-    shim.unwrap(TestMod.prototype.foo)
+    shim2 = shim
+    shim.wrap(TestMod.prototype, 'foo', function wrapStuff(shim, orig) {
+      return function wrapped2(...args) {
+        shim.unwrap(TestMod.prototype, 'foo')
+        return orig.apply(this, args)
+      }
+    })
   }
 
   const TestMod = require('./TestMod')
+  const loggerSpy1 = sinon.spy(shim1.logger, 'warn')
+  const loggerSpy2 = sinon.spy(shim2.logger, 'warn')
 
   const testMod = new TestMod()
-  const ret = testMod.foo('this is orig arg')
-  t.equal(ret, 'value of this is orig arg in onRequire')
+  testMod.foo('this is orig arg')
+  testMod.foo('this is call 2')
+  t.ok(shim2.isWrapped(TestMod.prototype.foo), 'should unwrap as expected')
+  ;[loggerSpy1, loggerSpy2].forEach((spy) => {
+    t.equal(
+      spy.args[0][0],
+      'Attempting to unwrap %s, which its unwrapped version is also wrapped. This is unsupported, unwrap will not occur.'
+    )
+    t.equal(spy.args[0][1], 'foo')
+  })
   t.end()
 })

--- a/test/integration/api/instrument.tap.js
+++ b/test/integration/api/instrument.tap.js
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const { test } = require('tap')
+const API = require('../../../api')
+const agentHelper = require('../../lib/agent_helper')
+
+test('should allow registering of multiple onRequire hooks', (t) => {
+
+  const agent = agentHelper.instrumentMockedAgent()
+  t.teardown(() => {
+    agentHelper.unloadAgent(agent)
+  })
+
+  const api = new API(agent)
+
+  const moduleName = './TestMod'
+  api.instrument(moduleName, onRequire)
+  api.instrument(moduleName, onRequire2)
+
+  function onRequire(shim, TestMod) {
+    shim.wrap(TestMod.prototype, 'foo', function wrapFoo(shim, orig) {
+      return function wrappedFoo(...args) {
+        args[0] = `${args[0]} in onRequire` 
+        return orig.apply(this, args)
+      }
+    })
+  }
+
+  function onRequire2(shim, TestMod) {
+    shim.wrap(TestMod.prototype, 'foo', function wrapFoo(shim, orig) {
+      return function wrappedFoo(...args) {
+        args[0] = `${args[0]} in onRequire2` 
+        return orig.apply(this, args)
+      }
+    })
+  } 
+
+  const TestMod = require('./TestMod')
+
+  const testMod = new TestMod()
+  const ret = testMod.foo('this is orig arg')
+  t.equal(ret, 'value of this is orig arg in onRequire2 in onRequire')
+  t.end()
+})
+
+test('should allow checking for isWrapped relevant to the wrapping you are about to do', (t) => {
+  const agent = agentHelper.instrumentMockedAgent()
+  t.teardown(() => {
+    agentHelper.unloadAgent(agent)
+  })
+
+  const api = new API(agent)
+
+  const moduleName = './TestMod'
+  api.instrument(moduleName, onRequire)
+  api.instrument(moduleName, onRequire2)
+
+  function onRequire(shim, TestMod) {
+    const isWrapped = shim.isWrapped(TestMod.prototype.foo)
+    if (!isWrapped) {
+      shim.wrap(TestMod.prototype, 'foo', function wrapFoo(shim, orig) {
+        return function wrappedFoo(...args) {
+          args[0] = `${args[0]} in onRequire` 
+          return orig.apply(this, args)
+        }
+      })
+    }
+  }
+
+  function onRequire2(shim, TestMod) {
+    const isWrapped = shim.isWrapped(TestMod.prototype.foo)
+    if (!isWrapped) {
+      shim.wrap(TestMod.prototype, 'foo', function wrapFoo(shim, orig) {
+        return function wrappedFoo(...args) {
+          args[0] = `${args[0]} in onRequire2` 
+          return orig.apply(this, args)
+        }
+      })
+    }
+  } 
+
+  const TestMod = require('./TestMod')
+
+  const testMod = new TestMod()
+  const ret = testMod.foo('this is orig arg')
+  t.equal(ret, 'value of this is orig arg in onRequire2 in onRequire')
+  t.end()
+})
+
+test('shim.unwrap should not break instrumentation registered after it', (t) => {
+  const agent = agentHelper.instrumentMockedAgent()
+  t.teardown(() => {
+    agentHelper.unloadAgent(agent)
+  })
+
+  const api = new API(agent)
+
+  const moduleName = './TestMod'
+  api.instrument(moduleName, onRequire)
+  api.instrument(moduleName, onRequire2)
+
+  function onRequire(shim, TestMod) {
+    shim.unwrap(TestMod.prototype.foo)
+  }
+
+  function onRequire2(shim, TestMod) {
+    shim.wrap(TestMod.prototype, 'foo', function wrapFoo(shim, orig) {
+      return function wrappedFoo(...args) {
+        args[0] = `${args[0]} in onRequire2` 
+        return orig.apply(this, args)
+      }
+    })
+  } 
+
+  const TestMod = require('./TestMod')
+
+  const testMod = new TestMod()
+  const ret = testMod.foo('this is orig arg')
+  t.equal(ret, 'value of this is orig arg in onRequire2')
+  t.end()
+})
+
+test('shim.unwrap should not break instrumentation registered before it', (t) => {
+  const agent = agentHelper.instrumentMockedAgent()
+  t.teardown(() => {
+    agentHelper.unloadAgent(agent)
+  })
+
+  const api = new API(agent)
+
+  const moduleName = './TestMod'
+  api.instrument(moduleName, onRequire)
+  api.instrument(moduleName, onRequire2)
+
+
+  function onRequire(shim, TestMod) {
+    shim.wrap(TestMod.prototype, 'foo', function wrapFoo(shim, orig) {
+      return function wrappedFoo(...args) {
+        args[0] = `${args[0]} in onRequire` 
+        return orig.apply(this, args)
+      }
+    })
+  } 
+  
+  function onRequire2(shim, TestMod) {
+    shim.unwrap(TestMod.prototype.foo)
+  }
+
+  const TestMod = require('./TestMod')
+
+  const testMod = new TestMod()
+  const ret = testMod.foo('this is orig arg')
+  t.equal(ret, 'value of this is orig arg in onRequire')
+  t.end()
+})

--- a/test/integration/module-loading/module-loading.tap.js
+++ b/test/integration/module-loading/module-loading.tap.js
@@ -62,15 +62,12 @@ tap.test('should only log supportability metric for tracking type instrumentatio
   const PKG_VERSION = `${FEATURES.INSTRUMENTATION.ON_REQUIRE}/knex/Version/1`
 
   // eslint-disable-next-line node/no-extraneous-require
-  const prisma = require('knex')
-  const prismaOnRequiredMetric = agent.metrics._metrics.unscoped[PKG]
-  t.equal(prismaOnRequiredMetric.callCount, 1, `should record ${PKG}`)
-  const prismaVersionMetric = agent.metrics._metrics.unscoped[PKG_VERSION]
-  t.equal(prismaVersionMetric.callCount, 1, `should record ${PKG_VERSION}`)
-  t.notOk(
-    prisma[symbols.instrumented],
-    'should not try to instrument a package that is of type tracking'
-  )
+  require('knex')
+  const knexOnRequiredMetric = agent.metrics._metrics.unscoped[PKG]
+  t.equal(knexOnRequiredMetric.callCount, 1, `should record ${PKG}`)
+  const knexVersionMetric = agent.metrics._metrics.unscoped[PKG_VERSION]
+  t.equal(knexVersionMetric.callCount, 1, `should record ${PKG_VERSION}`)
+  t.ok(shimmer.isInstrumented('knex'), 'should mark tracking modules as instrumented')
   t.end()
 })
 

--- a/test/unit/api/api-instrument-loaded-module.test.js
+++ b/test/unit/api/api-instrument-loaded-module.test.js
@@ -8,7 +8,6 @@
 const tap = require('tap')
 const API = require('../../../api')
 const agentHelper = require('../../lib/agent_helper')
-const Shim = require('../../../lib/shim/shim')
 const symbols = require('../../../lib/symbols')
 
 tap.test('Agent API - instrumentLoadedModule', (t) => {
@@ -17,7 +16,6 @@ tap.test('Agent API - instrumentLoadedModule', (t) => {
   let agent
   let api
   let expressMock
-  let shimHelper
 
   t.beforeEach(() => {
     agent = agentHelper.instrumentMockedAgent()
@@ -28,8 +26,6 @@ tap.test('Agent API - instrumentLoadedModule', (t) => {
     expressMock.application = {}
     expressMock.application.use = function use() {}
     expressMock.Router = {}
-
-    shimHelper = new Shim(agent, 'fake')
   })
 
   t.afterEach(() => {
@@ -57,7 +53,8 @@ tap.test('Agent API - instrumentLoadedModule', (t) => {
 
     t.type(expressMock, 'object')
 
-    const isWrapped = shimHelper.isWrapped(expressMock.application.use)
+    const shim = expressMock[symbols.shim]
+    const isWrapped = shim.isWrapped(expressMock.application.use)
     t.ok(isWrapped)
 
     t.end()

--- a/test/unit/esm-loader.test.mjs
+++ b/test/unit/esm-loader.test.mjs
@@ -63,11 +63,13 @@ tap.test('ES Module Loader', { skip: !esmHelpers.supportedLoaderVersion() }, (t)
       registerInstrumentation: sinon.stub(),
       getInstrumentationNameFromModuleName: sinon.stub(),
       registeredInstrumentations: {
-        express: {
-          moduleName: 'express',
-          type: 'web-framework',
-          onRequire: sinon.stub()
-        }
+        express: [
+          {
+            moduleName: 'express',
+            type: 'web-framework',
+            onRequire: sinon.stub()
+          }
+        ]
       }
     }
 
@@ -157,11 +159,13 @@ tap.test('ES Module Loader', { skip: !esmHelpers.supportedLoaderVersion() }, (t)
     'should add specifier to map and append hasNrInstrumentation to url if module we are resolving has instrumentation',
     async (t) => {
       fakeShimmer.getInstrumentationNameFromModuleName.returnsArg(0)
-      fakeShimmer.registeredInstrumentations['my-test-dep'] = {
-        moduleName: 'my-test-dep',
-        type: 'generic',
-        onRequire: sinon.stub()
-      }
+      fakeShimmer.registeredInstrumentations['my-test-dep'] = [
+        {
+          moduleName: 'my-test-dep',
+          type: 'generic',
+          onRequire: sinon.stub()
+        }
+      ]
       fakeNextResolve.returns({ url: 'file:///path/to/my-test-dep/index.js', format: 'module' })
 
       const expected = await loader.resolve(fakeSpecifier, fakeContext, fakeNextResolve)
@@ -187,11 +191,13 @@ tap.test('ES Module Loader', { skip: !esmHelpers.supportedLoaderVersion() }, (t)
     'should register a copy of CommonJS instrumentation under the full filepath',
     async (t) => {
       fakeShimmer.getInstrumentationNameFromModuleName.returnsArg(0)
-      fakeShimmer.registeredInstrumentations['my-test-dep'] = {
-        moduleName: 'my-test-dep',
-        type: 'generic',
-        onRequire: sinon.stub()
-      }
+      fakeShimmer.registeredInstrumentations['my-test-dep'] = [
+        {
+          moduleName: 'my-test-dep',
+          type: 'generic',
+          onRequire: sinon.stub()
+        }
+      ]
       fakeNextResolve.returns({ url: 'file:///path/to/my-test-dep/index.js', format: 'commonjs' })
 
       const expected = await loader.resolve(fakeSpecifier, fakeContext, fakeNextResolve)
@@ -215,15 +221,11 @@ tap.test('ES Module Loader', { skip: !esmHelpers.supportedLoaderVersion() }, (t)
         'should log debug about instrumentation registration'
       )
 
-      const expectedInstrumentation = Object.assign(
-        {},
-        fakeShimmer.registeredInstrumentations['my-test-dep']
-      )
-      expectedInstrumentation.moduleName = '/path/to/my-test-dep/index.js'
-      expectedInstrumentation.specifier = 'my-test-dep'
-
+      const expectedInstrumentation = [...fakeShimmer.registeredInstrumentations['my-test-dep']]
+      expectedInstrumentation[0].moduleName = '/path/to/my-test-dep/index.js'
+      expectedInstrumentation[0].specifier = 'my-test-dep'
       t.ok(
-        fakeShimmer.registerInstrumentation.calledOnceWithExactly(expectedInstrumentation),
+        fakeShimmer.registerInstrumentation.calledOnceWithExactly(expectedInstrumentation[0]),
         'should have registered an instrumentation copy'
       )
     }
@@ -231,11 +233,13 @@ tap.test('ES Module Loader', { skip: !esmHelpers.supportedLoaderVersion() }, (t)
 
   t.test('should register CJS instrumentation if url has urlencoded characters', async (t) => {
     fakeShimmer.getInstrumentationNameFromModuleName.returnsArg(0)
-    fakeShimmer.registeredInstrumentations['my-test-dep'] = {
-      moduleName: 'my-test-dep',
-      type: 'generic',
-      onRequire: sinon.stub()
-    }
+    fakeShimmer.registeredInstrumentations['my-test-dep'] = [
+      {
+        moduleName: 'my-test-dep',
+        type: 'generic',
+        onRequire: sinon.stub()
+      }
+    ]
     fakeNextResolve.returns({
       url: 'file:///path/that%20leads%20to/my-test-dep/index.js',
       format: 'commonjs'
@@ -260,15 +264,12 @@ tap.test('ES Module Loader', { skip: !esmHelpers.supportedLoaderVersion() }, (t)
       'should log debug about instrumentation registration'
     )
 
-    const expectedInstrumentation = Object.assign(
-      {},
-      fakeShimmer.registeredInstrumentations['my-test-dep']
-    )
-    expectedInstrumentation.moduleName = '/path/that leads to/my-test-dep/index.js'
-    expectedInstrumentation.specifier = 'my-test-dep'
+    const expectedInstrumentation = [...fakeShimmer.registeredInstrumentations['my-test-dep']]
+    expectedInstrumentation[0].moduleName = '/path/that leads to/my-test-dep/index.js'
+    expectedInstrumentation[0].specifier = 'my-test-dep'
 
     t.ok(
-      fakeShimmer.registerInstrumentation.calledOnceWithExactly(expectedInstrumentation),
+      fakeShimmer.registerInstrumentation.calledOnceWithExactly(expectedInstrumentation[0]),
       'should have registered an instrumentation copy'
     )
   })

--- a/test/unit/metric/datastore-instance.test.js
+++ b/test/unit/metric/datastore-instance.test.js
@@ -35,7 +35,8 @@ describe('Datastore instance metrics collected via the datastore shim', function
         return test.system_hostname
       }
 
-      const shim = new DatastoreShim(agent, 'testModule', null, test.product)
+      const shim = new DatastoreShim(agent, 'testModule', null)
+      shim.setDatastore(test.product)
 
       const testInstrumented = {
         query: function () {}

--- a/test/unit/shim/datastore-shim.test.js
+++ b/test/unit/shim/datastore-shim.test.js
@@ -21,7 +21,8 @@ test('DatastoreShim', function (t) {
 
   function beforeEach() {
     agent = helper.loadMockedAgent()
-    shim = new DatastoreShim(agent, 'test-cassandra', null, DatastoreShim.CASSANDRA)
+    shim = new DatastoreShim(agent, 'test-cassandra')
+    shim.setDatastore(DatastoreShim.CASSANDRA)
     wrappable = {
       name: 'this is a name',
       bar: function barsName() {

--- a/test/unit/shim/message-shim.test.js
+++ b/test/unit/shim/message-shim.test.js
@@ -164,7 +164,7 @@ tap.test('MessageShim', function (t) {
       const wrapped = shim.recordProduce(wrappable.bar, function () {})
       t.not(wrapped, wrappable.bar)
       t.ok(shim.isWrapped(wrapped))
-      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.equal(helper.unwrap(wrapped), wrappable.bar)
       t.end()
     })
 
@@ -172,7 +172,7 @@ tap.test('MessageShim', function (t) {
       const wrapped = shim.recordProduce(wrappable.bar, null, function () {})
       t.not(wrapped, wrappable.bar)
       t.ok(shim.isWrapped(wrapped))
-      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.equal(helper.unwrap(wrapped), wrappable.bar)
       t.end()
     })
 
@@ -181,7 +181,7 @@ tap.test('MessageShim', function (t) {
       shim.recordProduce(wrappable, 'bar', function () {})
       t.not(wrappable.bar, original)
       t.ok(shim.isWrapped(wrappable.bar))
-      t.equal(shim.unwrap(wrappable.bar), original)
+      t.equal(helper.unwrap(wrappable.bar), original)
       t.end()
     })
 
@@ -855,7 +855,7 @@ tap.test('MessageShim', function (t) {
       })
       t.not(wrapped, wrappable.bar)
       t.ok(shim.isWrapped(wrapped))
-      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.equal(helper.unwrap(wrapped), wrappable.bar)
       t.end()
     })
 
@@ -867,7 +867,7 @@ tap.test('MessageShim', function (t) {
       })
       t.not(wrapped, wrappable.bar)
       t.ok(shim.isWrapped(wrapped))
-      t.equal(shim.unwrap(wrapped), wrappable.bar)
+      t.equal(helper.unwrap(wrapped), wrappable.bar)
       t.end()
     })
 
@@ -880,7 +880,7 @@ tap.test('MessageShim', function (t) {
       })
       t.not(wrappable.bar, original)
       t.ok(shim.isWrapped(wrappable.bar))
-      t.equal(shim.unwrap(wrappable.bar), original)
+      t.equal(helper.unwrap(wrappable.bar), original)
       t.end()
     })
 

--- a/test/unit/shim/shim.test.js
+++ b/test/unit/shim/shim.test.js
@@ -1648,19 +1648,6 @@ tap.test('Shim', function (t) {
       t.end()
     })
 
-    t.test('should fully unwrap nested wrappers', function (t) {
-      for (let i = 0; i < 10; ++i) {
-        wrapped = shim.wrap(wrapped, function () {
-          return function () {}
-        })
-      }
-
-      t.not(wrapped, original)
-      t.not(wrapped[symbols.original], original)
-      t.equal(shim.unwrap(wrapped), original)
-      t.end()
-    })
-
     t.test('should unwrap the first parameter', function (t) {
       t.equal(shim.unwrap(wrapped), original)
       t.end()

--- a/test/unit/shim/shim.test.js
+++ b/test/unit/shim/shim.test.js
@@ -2717,6 +2717,82 @@ tap.test('Shim', function (t) {
     })
   })
 
+  t.test('assignOriginal', (t) => {
+    const mod = 'originalShimTests'
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    t.test('should assign shim id to wrapped item as symbol', (t) => {
+      const shim = new Shim(agent, mod, mod)
+      const wrapped = function wrapped() {}
+      const original = function original() {}
+      shim.assignOriginal(wrapped, original)
+      t.equal(wrapped[symbols.wrapped], shim.id)
+      t.end()
+    })
+
+    t.test('should assign original on wrapped item as symbol', (t) => {
+      const shim = new Shim(agent, mod, mod)
+      const wrapped = function wrapped() {}
+      const original = function original() {}
+      shim.assignOriginal(wrapped, original)
+      t.equal(wrapped[symbols.original], original)
+      t.end()
+    })
+
+    t.test('should should overwrite original when forceOrig is true', (t) => {
+      const shim = new Shim(agent, mod, mod)
+      const wrapped = function wrapped() {}
+      const original = function original() {}
+      const firstOriginal = function firstOriginal() {}
+      wrapped[symbols.original] = firstOriginal
+      shim.assignOriginal(wrapped, original, true)
+      t.equal(wrapped[symbols.original], original)
+      t.end()
+    })
+
+    t.test('should not assign original if symbol already exists on wrapped item', (t) => {
+      const shim = new Shim(agent, mod, mod)
+      const wrapped = function wrapped() {}
+      const original = function original() {}
+      const firstOriginal = function firstOriginal() {}
+      wrapped[symbols.original] = firstOriginal
+      shim.assignOriginal(wrapped, original)
+      t.not(wrapped[symbols.original], original)
+      t.equal(wrapped[symbols.original], firstOriginal)
+      t.end()
+    })
+  })
+
+  t.test('assignId', (t) => {
+    const mod1 = 'mod1'
+    const mod2 = 'mod2'
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    t.test('should assign an id to a shim instance', (t) => {
+      const shim = new Shim(agent, mod1, mod1)
+      t.ok(shim.id)
+      t.end()
+    })
+
+    t.test('should associate same id to a different shim instance when shimName matches', (t) => {
+      const shim = new Shim(agent, mod1, mod1, mod1)
+      const shim2 = new Shim(agent, mod2, mod2, mod1)
+      t.equal(shim.id, shim2.id, 'ids should be the same')
+      t.end()
+    })
+
+    t.test('should not associate id when shimName does not match', (t) => {
+      const shim = new Shim(agent, mod1, mod1, mod1)
+      const shim2 = new Shim(agent, mod2, mod2, mod2)
+      t.not(shim.id, shim2.id, 'ids should not be the same')
+      t.end()
+    })
+  })
+
   t.test('prefixRouteParameters', (t) => {
     t.autoend()
     t.beforeEach(beforeEach)

--- a/test/unit/shim/webframework-shim.test.js
+++ b/test/unit/shim/webframework-shim.test.js
@@ -22,7 +22,8 @@ test('WebFrameworkShim', function (t) {
 
   function beforeEach() {
     agent = helper.loadMockedAgent()
-    shim = new WebFrameworkShim(agent, 'test-restify', null, WebFrameworkShim.RESTIFY)
+    shim = new WebFrameworkShim(agent, 'test-restify')
+    shim.setFramework(WebFrameworkShim.RESTIFY)
     wrappable = {
       name: 'this is a name',
       bar: function barsName(unused, params) { return 'bar' }, // eslint-disable-line

--- a/test/unit/shimmer.test.js
+++ b/test/unit/shimmer.test.js
@@ -48,12 +48,11 @@ describe('shimmer', function () {
       let agent = null
       let onRequireArgs = null
       let counter = 0
-      let instrumentationOpts = null
       let instrumentedModule = null
 
       beforeEach(function () {
         agent = helper.instrumentMockedAgent()
-        instrumentationOpts = {
+        const instrumentationOpts = {
           moduleName: moduleName,
           onRequire: function (shim, module) {
             instrumentedModule = module
@@ -86,7 +85,7 @@ describe('shimmer', function () {
       })
 
       it('should construct a DatastoreShim if the type is "datastore"', function () {
-        instrumentationOpts.type = 'datastore'
+        shimmer.registeredInstrumentations[moduleName][0].type = 'datastore'
         require(moduleName)
         expect(onRequireArgs[0]).to.be.an.instanceof(shims.DatastoreShim)
       })

--- a/test/unit/spans/span-event.test.js
+++ b/test/unit/spans/span-event.test.js
@@ -185,7 +185,8 @@ tap.test('fromSegment()', (t) => {
   t.test('should create an datastore span with an datastore segment', (t) => {
     agent.config.transaction_tracer.record_sql = 'raw'
 
-    const shim = new DatastoreShim(agent, 'test-data-store', '', 'TestStore')
+    const shim = new DatastoreShim(agent, 'test-data-store')
+    shim.setDatastore('TestStore')
 
     const dsConn = { myDbOp: (query, cb) => setTimeout(cb, 50) }
     let longQuery = ''

--- a/test/unit/spans/streaming-span-event.test.js
+++ b/test/unit/spans/streaming-span-event.test.js
@@ -176,7 +176,8 @@ tap.test('fromSegment()', (t) => {
   t.test('should create an datastore span with an datastore segment', (t) => {
     agent.config.transaction_tracer.record_sql = 'raw'
 
-    const shim = new DatastoreShim(agent, 'test-data-store', '', 'TestStore')
+    const shim = new DatastoreShim(agent, 'test-data-store')
+    shim.setDatastore('TestStore')
 
     const dsConn = { myDbOp: (query, cb) => setTimeout(cb, 50) }
     let longQuery = ''

--- a/test/versioned-external/external-repos.js
+++ b/test/versioned-external/external-repos.js
@@ -20,7 +20,7 @@ const repos = [
   {
     name: 'koa',
     repository: 'https://github.com/newrelic/node-newrelic-koa.git',
-    branch: 'main'
+    branch: 'shim-fixes'
   },
   {
     name: 'next',
@@ -35,7 +35,7 @@ const repos = [
   {
     name: 'apollo-server',
     repository: 'https://github.com/newrelic/newrelic-node-apollo-server-plugin.git',
-    branch: 'main',
+    branch: 'shim-fixes',
     additionalFiles: [
       'tests/agent-testing.js',
       'tests/create-apollo-server-setup.js',


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added the ability to register instrumentation multiple hooks (onRequire, onResolved) for the same resolved moduleName.
    * This has been a limitation of the agent from the beginning.  If a customer used the api to instrument `api.instrument`, `api.instrumentDatastore`, `api.instrumentWebframework`, `api.instrumentMessages`, or `api.instrumentConglomerate`, it would override existing instrumentation hooks.  The effect was that the Node.js agent would not function as designed.  
  * **DEPRECATION NOTICE**: `shim.unwrap` and `shim.unwrapOnce` will no longer function if you attempt to unwrap an item that has been wrapped multiple times.
    * This is because since we now allow instrumenting the same module more than once, you cannot safely unwrap without breaking all registered instrumentation.  We plan to remove `shim.unwrap` and `shim.unwrapOnce` in the next major release.  

## Links
Closes NEWRELIC-7414

## Details
CI is broken because it requires that we release a new version of the agent so that https://github.com/newrelic/node-test-utilities/pull/162 can be merged and released.  Then these PRs(https://github.com/newrelic/node-newrelic-koa/pull/141, and https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/243) can be merged and then update the `test/versioned-external/external-repos.js` to point koa and apollo server to main.

Even with all those caveats this has a `DO NOT MERGE` flag because this change is high risk and we need to do more manual testing against applications that are registering multiple instrumentation hooks for a given module.  The plan is to get the k2 agent running with our versioned tests against this branch and see how well it does