### PR TITLE
Restore dunder prop for agent on require.cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ require('./lib/util/unwrapped-core')
 
 const featureFlags = require('./lib/feature_flags').prerelease
 const psemver = require('./lib/util/process-version')
-const symbols = require('./lib/symbols')
 let logger = require('./lib/logger') // Gets re-loaded after initialization.
 
 const pkgJSON = require('./package.json')
@@ -24,15 +23,15 @@ logger.info(
   process.version
 )
 
-if (require.cache[symbols.cache]) {
+if (require.cache.__NR_cache) {
   logger.warn(
     'Attempting to load a second copy of newrelic from %s, using cache instead',
     __dirname
   )
-  if (require.cache[symbols.cache].agent) {
-    require.cache[symbols.cache].agent.recordSupportability('Agent/DoubleLoad')
+  if (require.cache.__NR_cache.agent) {
+    require.cache.__NR_cache.agent.recordSupportability('Agent/DoubleLoad')
   }
-  module.exports = require.cache[symbols.cache]
+  module.exports = require.cache.__NR_cache
 } else {
   initialize()
 }
@@ -99,7 +98,7 @@ function initialize() {
     API = require('./stub_api')
   }
 
-  require.cache[symbols.cache] = module.exports = new API(agent)
+  require.cache.__NR_cache = module.exports = new API(agent)
 
   // If we loaded an agent, record a startup time for the agent.
   // NOTE: Metrics are recorded in seconds, so divide the value by 1000.

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -6,7 +6,6 @@
 'use strict'
 
 module.exports = {
-  cache: Symbol('cache'),
   clm: Symbol('codeLevelMetrics'),
   context: Symbol('context'),
   databaseName: Symbol('databaseName'),


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Restored assigning loaded version of agent to require.cache as `__NR_cache` instead of a symbol to properly detect attempts at loading agent twice.

## Links
Closes #1565

## Details
