### PR TITLE
updated docs and smoke tests that were still referencing symbols.cache

### DIFF
--- a/documentation/function-wrapping.md
+++ b/documentation/function-wrapping.md
@@ -14,12 +14,11 @@ Normally, in order to use a shim helper you need to configure and setup an [inst
 //File: test.js
 
 const newrelic = require('newrelic');
-const symbols = require('newrelic/lib/symbols');
 
 // grab the agent instance from cache and manually
 // require the shim library -- normally the agent
 // will handle this for you
-const agent = require.cache[symbols.cache].agent;
+const agent = require.cache.__NR_cache.agent;
 const Shim = require('newrelic/lib/shim/shim');
 
 // do the same fnApply/apply shenangins as the shim library

--- a/test/smoke/index/index-bad-version.tap.js
+++ b/test/smoke/index/index-bad-version.tap.js
@@ -8,7 +8,6 @@
 const tap = require('tap')
 const { getTestSecret } = require('../../helpers/secrets')
 const StubApi = require('../../../stub_api')
-const symbols = require('../../../lib/symbols')
 
 const license = getTestSecret('TEST_LICENSE')
 const VERSIONS = ['garbage', '4.0.0']
@@ -20,7 +19,7 @@ tap.test('load agent with bad versions should load stub agent', (t) => {
   t.afterEach(() => {
     // must delete both of these to force a reload
     // of the index.js file
-    delete require.cache[symbols.cache]
+    delete require.cache.__NR_cache
     delete require.cache[require.resolve('../../../index.js')]
   })
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
In #1566 I restored the agent on require.cache as `__NR_cache` and removed the `symbols.cache`.  I forgot to update docs and a smoke test.
