### PR TITLE
 Report hostname on heroku as dyno name

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1318,6 +1318,13 @@ defaultConfig.definition = () => ({
         }
       }
     }
+  },
+
+  heroku: {
+    use_dyno_names: {
+      default: true,
+      formatter: boolean
+    }
   }
 })
 

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -918,7 +918,8 @@ function getHostnameSafe() {
     return _hostname
   }
   try {
-    _hostname = os.hostname()
+    const dynoName = process.env.DYNO
+    _hostname = dynoName || os.hostname()
     return _hostname
   } catch (e) {
     const addresses = this.getIPAddresses()

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -914,12 +914,17 @@ Config.prototype.getIPAddresses = function getIPAddresses() {
 
 function getHostnameSafe() {
   let _hostname
+  const config = this
   this.getHostnameSafe = function getCachedHostname() {
     return _hostname
   }
   try {
-    const dynoName = process.env.DYNO
-    _hostname = dynoName || os.hostname()
+    if (config.heroku.use_dyno_names) {
+      const dynoName = process.env.DYNO
+      _hostname = dynoName || os.hostname()
+    } else {
+      _hostname = os.hostname()
+    }
     return _hostname
   } catch (e) {
     const addresses = this.getIPAddresses()

--- a/test/unit/facts.test.js
+++ b/test/unit/facts.test.js
@@ -638,6 +638,7 @@ tap.test('display_host', { timeout: 20000 }, (t) => {
   t.afterEach(() => {
     os.hostname = originalHostname
     helper.unloadAgent(agent)
+    delete process.env.DYNO
 
     agent = null
   })
@@ -646,6 +647,25 @@ tap.test('display_host', { timeout: 20000 }, (t) => {
     agent.config.process_host.display_name = 'test-value'
     facts(agent, function getFacts(factsed) {
       t.equal(factsed.display_host, 'test-value')
+      t.end()
+    })
+  })
+
+  t.test('should be process.env.DYNO when use_heroku_dyno_names is true', (t) => {
+    process.env.DYNO = 'web.1'
+    agent.config.heroku.use_dyno_names = true
+    facts(agent, function getFacts(factsed) {
+      t.equal(factsed.display_host, 'web.1')
+      t.end()
+    })
+  })
+
+  t.test('should ignore process.env.DYNO when use_heroku_dyno_names is false', (t) => {
+    process.env.DYNO = 'web.1'
+    os.hostname = originalHostname
+    agent.config.heroku.use_dyno_names = false
+    facts(agent, function getFacts(factsed) {
+      t.equal(factsed.display_host, os.hostname())
       t.end()
     })
   })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added a new configuration option `heroku.use_dyno_names` to specify whether or not to use `process.env.DYNO` for naming the host name and display host.  This option defaults to true.  If you are on heroku and do not want this functionality set `heroku.use_dyno_names` to `false`.  You can also control this configuration options with the environment variable of `NEW_RELIC_HEROKU_USE_DYNO_NAMES`.

Thanks @benney-au-le  for your contribution 🚀 

## Links
Closes #1536 

## Details
The Ruby agent reports the Heroku dyno name as the hostname (for example, web.1). This allows you to view your data scoped to a particular dyno name. You can disable this behavior by setting the heroku.use_dyno_names setting to false. The agent will then use a single aggregated placeholder name called Dynamic Hostname.

Add the same behaviour to the nodejs agent.
