### PR TITLE
DO NOT MERGE - NEWRELIC-5296: reduce cognitive complexity of lib/shim/message-shim.js

### DIFF
--- a/lib/shim/message-shim.js
+++ b/lib/shim/message-shim.js
@@ -5,8 +5,6 @@
 
 'use strict'
 
-/* eslint sonarjs/cognitive-complexity: ["error", 72] -- TODO: https://issues.newrelic.com/browse/NEWRELIC-5252*/
-
 const copy = require('../util/copy')
 const genericRecorder = require('../metrics/recorders/generic')
 const logger = require('../logger').child({ component: 'MessageShim' })

--- a/lib/shim/message-shim.js
+++ b/lib/shim/message-shim.js
@@ -356,108 +356,37 @@ function recordConsume(nodule, properties, spec) {
     destinationName: null,
     promise: false,
     callback: null,
-    messageHandler: null
-  }
-  if (!this.isFunction(spec)) {
-    spec = this.setDefaults(spec, DEFAULT_SPEC)
+    after: null
   }
 
-  // This is using wrap instead of record because the spec allows for a messageHandler
-  // which is being used to handle the result of the callback or promise of the
-  // original wrapped consume function.
-  // TODO: https://github.com/newrelic/node-newrelic/issues/981
-  return this.wrap(nodule, properties, function wrapConsume(shim, fn, fnName) {
-    if (!shim.isFunction(fn)) {
-      shim.logger.debug('Not wrapping %s (%s) as consume', fn, fnName)
-      return fn
+  return this.record(nodule, properties, function consumeRecorder(shim, fn, fnName, args) {
+    if (shim.isFunction(spec)) {
+      spec = spec.apply(this, arguments)
+    } else {
+      spec = { ...DEFAULT_SPEC, ...spec }
+      const destIdx = shim.normalizeIndex(args.length, spec.destinationName)
+      if (destIdx !== null) {
+        spec.destinationName = args[destIdx]
+      }
+    }
+    const messageHandler = spec.messageHandler
+    const getParams = shim.agent.config.message_tracer.segment_parameters.enabled
+
+    if (messageHandler) {
+      spec.after = function afterPromise({ shim, val, segment }) {
+        const msgProps = messageHandler.call(this, shim, fn, fnName, val)
+        if (getParams && msgProps?.parameters) {
+          shim.copySegmentParameters(segment, msgProps.parameters)
+        }
+        return val
+      }
     }
 
-    return function consumeRecorder() {
-      const parent = shim.getSegment()
-      if (!parent || !parent.transaction.isActive()) {
-        shim.logger.trace('Not recording consume, no active transaction.')
-        return fn.apply(this, arguments)
-      }
-
-      // Process the message args.
-      const args = shim.argsToArray.apply(shim, arguments)
-      let msgDesc = null
-      if (shim.isFunction(spec)) {
-        msgDesc = spec.call(this, shim, fn, fnName, args)
-        shim.setDefaults(msgDesc, DEFAULT_SPEC)
-      } else {
-        msgDesc = {
-          destinationName: null,
-          callback: spec.callback,
-          promise: spec.promise,
-          messageHandler: spec.messageHandler
-        }
-
-        const destIdx = shim.normalizeIndex(args.length, spec.destinationName)
-        if (destIdx !== null) {
-          msgDesc.destinationName = args[destIdx]
-        }
-      }
-
-      // Make the segment if we can.
-      if (!msgDesc) {
-        shim.logger.trace('Not recording consume, no message descriptor.')
-        return fn.apply(this, args)
-      }
-
-      const name = _nameMessageSegment(shim, msgDesc, shim._metrics.CONSUME)
-
-      // Adds details needed by createSegment when used with a spec
-      msgDesc.name = name
-      msgDesc.recorder = genericRecorder
-      msgDesc.parent = parent
-
-      const segment = shim.createSegment(msgDesc)
-      const getParams = shim.agent.config.message_tracer.segment_parameters.enabled
-      const resHandler = shim.isFunction(msgDesc.messageHandler) ? msgDesc.messageHandler : null
-
-      const cbIdx = shim.normalizeIndex(args.length, msgDesc.callback)
-      if (cbIdx !== null) {
-        shim.bindCallbackSegment(args, cbIdx, segment)
-
-        // If we have a callback and a results handler, then wrap the callback so
-        // we can call the results handler and get the message properties.
-        if (resHandler) {
-          shim.wrap(args, cbIdx, function wrapCb(shim, cb, cbName) {
-            if (shim.isFunction(cb)) {
-              return function cbWrapper() {
-                const cbArgs = shim.argsToArray.apply(shim, arguments)
-                const msgProps = resHandler.call(this, shim, cb, cbName, cbArgs)
-                if (getParams && msgProps && msgProps.parameters) {
-                  shim.copySegmentParameters(segment, msgProps.parameters)
-                }
-
-                return cb.apply(this, arguments)
-              }
-            }
-          })
-        }
-      }
-
-      // Call the method in the context of our segment.
-      let ret = shim.applySegment(fn, segment, true, this, args)
-
-      if (ret && msgDesc.promise && shim.isPromise(ret)) {
-        ret = shim.bindPromise(ret, segment)
-
-        // Intercept the promise to handle the result.
-        if (resHandler) {
-          ret = ret.then(function interceptValue(res) {
-            const msgProps = resHandler.call(this, shim, fn, fnName, res)
-            if (getParams && msgProps && msgProps.parameters) {
-              shim.copySegmentParameters(segment, msgProps.parameters)
-            }
-            return res
-          })
-        }
-      }
-
-      return ret
+    const name = _nameMessageSegment(shim, spec, shim._metrics.CONSUME)
+    return {
+      name: name,
+      recorder: genericRecorder,
+      ...spec
     }
   })
 }

--- a/lib/shim/message-shim.js
+++ b/lib/shim/message-shim.js
@@ -518,43 +518,13 @@ function recordSubscribedConsume(nodule, properties, spec) {
     promise: false
   })
 
-  // Make sure our spec has what we need.
-  if (!this.isFunction(spec.messageHandler)) {
-    this.logger.debug('spec.messageHandler should be a function')
-    return nodule
-  } else if (!this.isNumber(spec.consumer)) {
-    this.logger.debug('spec.consumer is required for recordSubscribedConsume')
-    return nodule
-  }
-
-  const destNameIsArg = this.isNumber(spec.destinationName)
-
   // Must wrap the subscribe method independently to ensure that we can wrap
   // the consumer regardless of transaction state.
   const wrapped = this.wrap(nodule, properties, function wrapSubscribe(shim, fn) {
     if (!shim.isFunction(fn)) {
       return fn
     }
-    return function wrappedSubscribe() {
-      const args = shim.argsToArray.apply(shim, arguments)
-      const queueIdx = shim.normalizeIndex(args.length, spec.queue)
-      const consumerIdx = shim.normalizeIndex(args.length, spec.consumer)
-      const queue = queueIdx === null ? null : args[queueIdx]
-      let destName = null
-
-      if (destNameIsArg) {
-        const destNameIdx = shim.normalizeIndex(args.length, spec.destinationName)
-        if (destNameIdx !== null) {
-          destName = args[destNameIdx]
-        }
-      }
-
-      if (consumerIdx !== null) {
-        args[consumerIdx] = shim.wrap(args[consumerIdx], makeWrapConsumer(queue, destName))
-      }
-
-      return fn.apply(this, args)
-    }
+    return _makeWrappedSubscribe(shim, spec, fn)
   })
 
   // Wrap the subscriber with segment creation.
@@ -578,132 +548,176 @@ function recordSubscribedConsume(nodule, properties, spec) {
       internal: false
     }
   })
+}
 
-  /**
-   * @param queue
-   * @param destinationName
-   */
-  function makeWrapConsumer(queue, destinationName) {
-    const msgDescDefaults = copy.shallow(spec)
-    if (destNameIsArg && destinationName != null) {
-      msgDescDefaults.destinationName = destinationName
-    }
-    if (queue != null) {
-      msgDescDefaults.queue = queue
-    }
+/**
+ * Helper function for recordSubscribedConsume
+ *
+ * @private
+ * @param {MessageShim} shim
+ *  The shim used to wrap the subscribe function
+ * @param {MessageSubscribeSpec} spec
+ *  The specification for this subscription method's interface.
+ * @param {Function} subscribe
+ *  The original subscribe function to wrap.
+ * @returns {Function} the wrapped subsribe function
+ */
+function _makeWrappedSubscribe(shim, spec, subscribe) {
+  return function wrappedSubscribe() {
+    const args = shim.argsToArray.apply(shim, arguments)
+    const queueIdx = shim.normalizeIndex(args.length, spec.queue)
+    const consumerIdx = shim.normalizeIndex(args.length, spec.consumer)
+    const queue = queueIdx === null ? null : args[queueIdx]
+    let destName = null
 
-    return function wrapConsumer(shim, consumer, cName) {
-      if (!shim.isFunction(consumer)) {
-        return consumer
+    // create a copy so we don't modify the original passed in by the
+    // user
+    spec = copy.shallow(spec)
+    if (shim.isNumber(spec.destinationName)) {
+      const destNameIdx = shim.normalizeIndex(args.length, spec.destinationName)
+      if (destNameIdx !== null) {
+        destName = args[destNameIdx]
       }
+      if (destName != null) {
+        spec.destinationName = destName
+      }
+    }
 
-      return shim.bindCreateTransaction(
-        function createConsumeTrans() {
-          // If there is no transaction or we're in a pre-existing transaction,
-          // then don't do anything. Note that the latter should never happen.
-          const args = shim.argsToArray.apply(shim, arguments)
-          const tx = shim.tracer.getTransaction()
+    if (queue != null) {
+      spec.queue = queue
+    }
 
-          if (!tx || tx.baseSegment) {
-            shim.logger.debug({ transaction: !!tx }, 'Failed to start message transaction.')
-            return consumer.apply(this, args)
-          }
+    if (consumerIdx !== null) {
+      args[consumerIdx] = shim.wrap(args[consumerIdx], function wrapConsumer(shim, consumer, name) {
+        if (!shim.isFunction(consumer)) {
+          return consumer
+        }
 
-          const msgDesc = spec.messageHandler.call(this, shim, consumer, cName, args)
-
-          // If message could not be handled, immediately kill this transaction.
-          if (!msgDesc) {
-            shim.logger.debug('No description for message, cancelling transaction.')
-            tx.setForceIgnore(true)
-            tx.end()
-            return consumer.apply(this, args)
-          }
-
-          // Derive the transaction name.
-          shim.setDefaults(msgDesc, msgDescDefaults)
-          const txName = _nameMessageTransaction(shim, msgDesc)
-          tx.setPartialName(txName)
-          tx.baseSegment = shim.createSegment({
-            name: tx.getFullName(),
-            recorder: messageTransactionRecorder
-          })
-
-          // Add would-be baseSegment attributes to transaction trace
-          for (const key in msgDesc.parameters) {
-            if (props.hasOwn(msgDesc.parameters, key)) {
-              tx.trace.attributes.addAttribute(
-                ATTR_DESTS.NONE,
-                'message.parameters.' + key,
-                msgDesc.parameters[key]
-              )
-
-              tx.baseSegment.attributes.addAttribute(
-                ATTR_DESTS.NONE,
-                'message.parameters.' + key,
-                msgDesc.parameters[key]
-              )
-            }
-          }
-
-          // If we have a routing key, add it to the transaction. Note that it is
-          // camel cased here, but snake cased in the segment parameters.
-          if (!shim.agent.config.high_security) {
-            if (msgDesc.routingKey) {
-              tx.trace.attributes.addAttribute(
-                ATTR_DESTS.TRANS_COMMON,
-                'message.routingKey',
-                msgDesc.routingKey
-              )
-
-              tx.baseSegment.addSpanAttribute('message.routingKey', msgDesc.routingKey)
-            }
-            if (shim.isString(msgDesc.queue)) {
-              tx.trace.attributes.addAttribute(
-                ATTR_DESTS.TRANS_COMMON,
-                'message.queueName',
-                msgDesc.queue
-              )
-
-              tx.baseSegment.addSpanAttribute('message.queueName', msgDesc.queue)
-            }
-          }
-          if (msgDesc.headers) {
-            shim.handleCATHeaders(msgDesc.headers, tx.baseSegment, shim._transportType)
-          }
-
-          shim.logger.trace('Started message transaction %s named %s', tx.id, txName)
-
-          // Execute the original function and attempt to hook in the transaction
-          // finish.
-          let ret = null
-          try {
-            ret = shim.applySegment(consumer, tx.baseSegment, true, this, args)
-          } finally {
-            if (shim.isPromise(ret)) {
-              shim.logger.trace('Got a promise, attaching tx %s ending to promise', tx.id)
-              ret = shim.interceptPromise(ret, endTransaction)
-            } else if (!tx.handledExternally) {
-              // We have no way of knowing when this transaction ended! ABORT!
-              shim.logger.trace('Immediately ending message tx %s', tx.id)
-              setImmediate(endTransaction)
-            }
-          }
-
-          return ret
-
-          /**
-           *
-           */
-          function endTransaction() {
-            tx.finalizeName(null) // Use existing partial name.
-            tx.end()
-          }
-        },
-        {
+        return shim.bindCreateTransaction(_createConsumeTrans(shim, spec, consumer, name), {
           type: shim.MESSAGE,
           nest: true
-        }
-      )
+        })
+      })
+    }
+
+    return subscribe.apply(this, args)
+  }
+}
+
+/**
+ * Helper function for recordSubscribedConsume, via _makeWrappedSubscribe
+ *
+ * @private
+ * @param {MessageShim} shim
+ *  The shim used to wrap the subscribe function
+ * @param {MessageSubscribeSpec} spec
+ *  The specification for this subscription method's interface.
+ * @param {Function} consumer
+ *  The original consumer function to wrap.
+ * @param {string} name
+ *  The name of the consumer function.
+ * @returns {Function} function that will consume the transaction
+ */
+function _createConsumeTrans(shim, spec, consumer, name) {
+  return function consumeTrans() {
+    // If there is no transaction or we're in a pre-existing transaction,
+    // then don't do anything. Note that the latter should never happen.
+    const args = shim.argsToArray.apply(shim, arguments)
+    const tx = shim.tracer.getTransaction()
+
+    if (!tx || tx.baseSegment) {
+      shim.logger.debug({ transaction: !!tx }, 'Failed to start message transaction.')
+      return consumer.apply(this, args)
+    }
+
+    const msgDesc = spec.messageHandler.call(this, shim, consumer, name, args)
+
+    // If message could not be handled, immediately kill this transaction.
+    if (!msgDesc) {
+      shim.logger.debug('No description for message, cancelling transaction.')
+      tx.setForceIgnore(true)
+      tx.end()
+      return consumer.apply(this, args)
+    }
+
+    // Derive the transaction name.
+    shim.setDefaults(msgDesc, spec)
+    const txName = _nameMessageTransaction(shim, msgDesc)
+    tx.setPartialName(txName)
+    tx.baseSegment = shim.createSegment({
+      name: tx.getFullName(),
+      recorder: messageTransactionRecorder
+    })
+
+    // Add would-be baseSegment attributes to transaction trace
+    for (const key in msgDesc.parameters) {
+      if (props.hasOwn(msgDesc.parameters, key)) {
+        tx.trace.attributes.addAttribute(
+          ATTR_DESTS.NONE,
+          'message.parameters.' + key,
+          msgDesc.parameters[key]
+        )
+
+        tx.baseSegment.attributes.addAttribute(
+          ATTR_DESTS.NONE,
+          'message.parameters.' + key,
+          msgDesc.parameters[key]
+        )
+      }
+    }
+
+    // If we have a routing key, add it to the transaction. Note that it is
+    // camel cased here, but snake cased in the segment parameters.
+    if (!shim.agent.config.high_security) {
+      if (msgDesc.routingKey) {
+        tx.trace.attributes.addAttribute(
+          ATTR_DESTS.TRANS_COMMON,
+          'message.routingKey',
+          msgDesc.routingKey
+        )
+
+        tx.baseSegment.addSpanAttribute('message.routingKey', msgDesc.routingKey)
+      }
+      if (shim.isString(msgDesc.queue)) {
+        tx.trace.attributes.addAttribute(
+          ATTR_DESTS.TRANS_COMMON,
+          'message.queueName',
+          msgDesc.queue
+        )
+
+        tx.baseSegment.addSpanAttribute('message.queueName', msgDesc.queue)
+      }
+    }
+    if (msgDesc.headers) {
+      shim.handleCATHeaders(msgDesc.headers, tx.baseSegment, shim._transportType)
+    }
+
+    shim.logger.trace('Started message transaction %s named %s', tx.id, txName)
+
+    // Execute the original function and attempt to hook in the transaction
+    // finish.
+    let ret = null
+    try {
+      ret = shim.applySegment(consumer, tx.baseSegment, true, this, args)
+    } finally {
+      if (shim.isPromise(ret)) {
+        shim.logger.trace('Got a promise, attaching tx %s ending to promise', tx.id)
+        ret = shim.interceptPromise(ret, endTransaction)
+      } else if (!tx.handledExternally) {
+        // We have no way of knowing when this transaction ended! ABORT!
+        shim.logger.trace('Immediately ending message tx %s', tx.id)
+        setImmediate(endTransaction)
+      }
+    }
+
+    return ret
+
+    /**
+     *
+     */
+    function endTransaction() {
+      tx.finalizeName(null) // Use existing partial name.
+      tx.end()
     }
   }
 }

--- a/lib/shim/message-shim.js
+++ b/lib/shim/message-shim.js
@@ -368,16 +368,9 @@ function recordConsume(nodule, properties, spec) {
       }
     }
     const messageHandler = spec.messageHandler
-    const getParams = shim.agent.config.message_tracer.segment_parameters.enabled
 
     if (messageHandler) {
-      spec.after = function afterPromise({ shim, val, segment }) {
-        const msgProps = messageHandler.call(this, shim, fn, fnName, val)
-        if (getParams && msgProps?.parameters) {
-          shim.copySegmentParameters(segment, msgProps.parameters)
-        }
-        return val
-      }
+      _wrapCallBackWithMessageHandler(shim, messageHandler, args, spec)
     }
 
     const name = _nameMessageSegment(shim, spec, shim._metrics.CONSUME)
@@ -389,6 +382,46 @@ function recordConsume(nodule, properties, spec) {
   })
 }
 
+/**
+ * Helper function for recordConsume
+ *
+ * @private
+ * @param {MessageShim} shim
+ *  The shim used to wrap the subscribe function
+ * @param {Function} messageHandler
+ *  The user-supplied message handler
+ * @param {Array} args
+ *  The arguments supplied to the message handler
+ * @param {MessageSubscribeSpec} spec
+ *  The user-supplied specification for this recording method's interface.
+ */
+function _wrapCallBackWithMessageHandler(shim, messageHandler, args, spec) {
+  const getParams = shim.agent.config.message_tracer.segment_parameters.enabled
+  let cbArgs
+  let origCb
+  let origCbName
+  const cbIdx = shim.normalizeIndex(args.length, spec.callback)
+  if (cbIdx !== null) {
+    // wrap the callback to save the args
+    origCb = args[cbIdx]
+    // eslint-disable-next-line func-names
+    const wrappedCallback = function () {
+      cbArgs = shim.argsToArray.apply(shim, arguments)
+      return origCb.apply(this, arguments)
+    }
+    // We want the callback to have the same name so that segments are properly named
+    Object.defineProperty(wrappedCallback, 'name', { value: origCb.name, writable: false })
+    args[cbIdx] = wrappedCallback
+  }
+  spec.after = function afterPromise({ shim, val, segment }) {
+    cbArgs = val === undefined ? cbArgs : val
+    const msgProps = messageHandler.call(this, shim, origCb, origCbName, cbArgs)
+    if (getParams && msgProps?.parameters) {
+      shim.copySegmentParameters(segment, msgProps.parameters)
+    }
+    return val
+  }
+}
 /**
  * Wraps the given properties as queue purging methods.
  *

--- a/lib/shim/message-shim.js
+++ b/lib/shim/message-shim.js
@@ -361,7 +361,7 @@ function recordConsume(nodule, properties, spec) {
     if (shim.isFunction(spec)) {
       spec = spec.apply(this, arguments)
     } else {
-      spec = { ...DEFAULT_SPEC, ...spec }
+      spec = shim.setDefaults(spec, DEFAULT_SPEC)
       const destIdx = shim.normalizeIndex(args.length, spec.destinationName)
       if (destIdx !== null) {
         spec.destinationName = args[destIdx]
@@ -382,7 +382,7 @@ function recordConsume(nodule, properties, spec) {
 
     const name = _nameMessageSegment(shim, spec, shim._metrics.CONSUME)
     return {
-      name: name,
+      name,
       recorder: genericRecorder,
       ...spec
     }

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -939,12 +939,12 @@ function record(nodule, properties, recordNamer) {
           return ret.then(
             function onThen(val) {
               segment.touch()
-              segDesc.after(shim, fn, name, null, val)
+              segDesc.after({ shim, fn, name, err: null, val, segment })
               return val
             },
             function onCatch(err) {
               segment.touch()
-              segDesc.after(shim, fn, name, err, null)
+              segDesc.after({ shim, fn, name, err, val: null, segment })
               throw err // NOTE: This is not an error from our instrumentation.
             }
           )
@@ -955,7 +955,7 @@ function record(nodule, properties, recordNamer) {
         throw err // Just rethrowing this error, not our error!
       } finally {
         if (segDesc.after && (error || !promised)) {
-          segDesc.after(shim, fn, name, error, ret)
+          segDesc.after({ shim, fn, name, err: error, val: ret, segment })
         }
       }
     }

--- a/lib/shim/webframework-shim.js
+++ b/lib/shim/webframework-shim.js
@@ -828,7 +828,7 @@ function _recordMiddleware(shim, middleware, spec) {
       parent: txInfo.segmentStack[txInfo.segmentStack.length - 1],
       recorder: recorder,
       parameters: params,
-      after: function afterExec(shim, _fn, _name, err) {
+      after: function afterExec({ shim, err }) {
         const errIsError = _isError(shim, err)
         if (errIsError) {
           _noticeError(shim, txInfo, err)
@@ -927,8 +927,8 @@ function _recordMiddleware(shim, middleware, spec) {
       callback: nextWrapper,
       recorder: recorder,
       parameters: params,
-      after: function afterExec(shim, _fn, _name, err, result) {
-        if (shim._responsePredicate(args, result)) {
+      after: function afterExec({ shim, err, val }) {
+        if (shim._responsePredicate(args, val)) {
           txInfo.transaction.nameState.freeze()
         }
         if (_isError(shim, err)) {


### PR DESCRIPTION
## Proposed Release Notes

## Links

* NEWRELIC-5296

## Details

Commit messages:

*NEWRELIC-5296: (recordConsume) reduce its cognitive complexity

Also closes #981, since it removes the biggest use of `shim.wrap` with
`this.record`. The resulting function is much simpler!

*NEWRELIC-5296: (message-shim) break up recordSubscribedConsume into functions

This one is kind of complicated and it's even more complicated to
simplify it. The only way I could see to make it better was to break
it up into smaller functions of acceptable complexity.

*NEWRELIC-5296: (message-shim) remove eslint cognitive complexity exception

File now lints properly without it.