### PR TITLE
fix: remove Exception import to resolve Node warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
     'jsdoc/require-jsdoc': 'off',
     'jsdoc/no-undefined-types': [
       'warn',
-      { definedTypes: ['Logger', 'Agent', 'Shim', 'TraceSegment', 'Transaction'] }
+      { definedTypes: ['Logger', 'Agent', 'Shim', 'TraceSegment', 'Transaction', 'Exception'] }
     ]
   },
   parserOptions: {

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -54,7 +54,6 @@ const TRANSPORT_TYPES = {
 const TRANSPORT_TYPES_SET = _makeValueSet(TRANSPORT_TYPES)
 const REQUIRED_DT_KEYS = ['ty', 'ac', 'ap', 'tr', 'ti']
 const DTPayload = require('./dt-payload')
-const { Exception } = require('../errors')
 const DTPayloadStub = DTPayload.Stub
 
 const TRACE_CONTEXT_PARENT_HEADER = 'traceparent'


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
* Fixed issue causing `Accessing non-existent property 'Exception' of module exports inside circular dependency` Node.js warning

## Links

## Details
The `Exception` import introduced in #1569 was causing the following error on `main`, removed it since it was only used for jsdoc typings and updated our ESLint config to allow Exception in jsdocs without the import. Additionally, this issue only affects `main`, we never published a package with the offending code.

```(node:98030) Warning: Accessing non-existent property 'Exception' of module exports inside circular dependency```