### PR TITLE
chore: Add dependabot configuration file to configure conventional commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "security"
+      prefix-development: "chore"
+      include: "scope"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links
Closes NR-96231

## Details
Added `dependabot.yml` to configure the commit message prefixes for Dependabot updates. With this change, updates to production deps will be prefixed with `security`, and dev dependency updates will be prefixed with `chore`. Note that the dependabot code itself handles the adding of `:` (which can be seen [here](https://github.com/dependabot/dependabot-core/blob/main/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb#L248)). Additionally, `include_scope` ensures that the dep name and versions are included in the commit message.

Documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

There is currently no way to validate that the configuration is correct due to this [issue](https://github.com/dependabot/dependabot-core/issues/4605), so testing that this is correct before landing it on `main` is currently not possible