### PR TITLE
ci: disable dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
+    # Disable version updates for npm dependencies, security updates don't use this configuration
+    # See: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates
+    open-pull-requests-limit: 0
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
We've turned off this functionality in Snyk, and I accidentally enabled this functionality in Dependabot as part of #1580, so updating the Dependabot configuration to only do security updates a la https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates
