### PR TITLE
DO NOT MERGE - Route/URL parameters are now stored on request.parameters.route.* attributes

### DIFF
--- a/lib/serverless/aws-lambda.js
+++ b/lib/serverless/aws-lambda.js
@@ -328,6 +328,7 @@ function setWebRequest(shim, transaction, request) {
 
   transaction.port = request.url.port
 
+  // These are only query parameters, from lib/serverless/api-gateway.js
   transaction.addRequestParameters(request.url.requestParameters)
 
   // URL is sent as an agent attribute with transaction events

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -2121,7 +2121,7 @@ function _es5WrapClass(shim, Base, fnName, spec, args) {
  * @returns {object} the updated object, `key` will now be `request.parameters.route.key`, value remains untouched
  */
 function prefixRouteParameters(params) {
-  if (params) {
+  if (params && isObject(params)) {
     return Object.fromEntries(
       Object.entries(params).map(([key, value]) => [`request.parameters.route.${key}`, value])
     )

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -139,6 +139,7 @@ Shim.prototype.setDefaults = setDefaults
 Shim.prototype.proxy = proxy
 Shim.prototype.require = shimRequire
 Shim.prototype.copySegmentParameters = copySegmentParameters
+Shim.prototype.prefixRouteParameters = prefixRouteParameters
 Shim.prototype.interceptPromise = interceptPromise
 Shim.prototype.fixArity = arity.fixArity
 
@@ -2099,4 +2100,30 @@ function _es5WrapClass(shim, Base, fnName, spec, args) {
   WrappedClass.prototype = Base.prototype
 
   return WrappedClass
+}
+
+/**
+ * Method for prefixing Route (aka URL) parameters with `request.parameters.route`
+ *
+ * Many web frameworks support adding parameters to routes when defining your API structure, and this function
+ * updates those parameters names to be prefixed by `request.parameters.route`. This is to avoid collision with reserved
+ * attribute names, as parameters used to be blindly stored on router span attributes (see https://github.com/newrelic/node-newrelic/issues/1574)
+ * in addition to being prefixed by `request.parameters`.
+ *
+ * Route parameters used to be stored under `request.parameters.*` just like query parameters pre v10, but we
+ * now prefix with `request.parameter.route` to avoid collision in the event an application uses the same name for a query and route
+ * parameter. Additionally, we now store the same key on the attributes of the base segment, trace, and router span.
+ *
+ * Exported on shim to be used in our Next.js instrumentation, as that instrumentation does not follow the same pattern as all the other
+ * web frameworks we support.
+ *
+ * @param {object} params - Object containing route/url parameter key/value pairs
+ * @returns {object} the updated object, `key` will now be `request.parameters.route.key`, value remains untouched
+ */
+function prefixRouteParameters(params) {
+  if (params) {
+    return Object.fromEntries(
+      Object.entries(params).map(([key, value]) => [`request.parameters.route.${key}`, value])
+    )
+  }
 }

--- a/lib/shim/webframework-shim.js
+++ b/lib/shim/webframework-shim.js
@@ -13,7 +13,6 @@ const metrics = require('../metrics/names')
 const TransactionShim = require('./transaction-shim')
 const Shim = require('./shim')
 const specs = require('./specs')
-const urltils = require('../util/urltils')
 const util = require('util')
 const symbols = require('../symbols')
 const { assignCLMSymbol } = require('../util/code-level-metrics')
@@ -117,7 +116,6 @@ WebFrameworkShim.prototype.errorHandled = errorHandled
 WebFrameworkShim.prototype.setErrorPredicate = setErrorPredicate
 WebFrameworkShim.prototype.setResponsePredicate = setResponsePredicate
 WebFrameworkShim.prototype.savePossibleTransactionName = savePossibleTransactionName
-WebFrameworkShim.prototype.captureUrlParams = captureUrlParams
 
 // -------------------------------------------------------------------------- //
 
@@ -618,20 +616,6 @@ function setResponsePredicate(pred) {
   this._responsePredicate = pred
 }
 
-/**
- * Capture URL parameters from a request object as attributes of the current segment.
- *
- * @memberof WebFrameworkShim.prototype
- * @param {object} params
- *  An object with key-value pairs.
- */
-function captureUrlParams(params) {
-  const segment = this.getSegment()
-  if (segment && !this.agent.config.high_security) {
-    urltils.copyParameters(params, segment.parameters)
-  }
-}
-
 // -------------------------------------------------------------------------- //
 
 /**
@@ -771,9 +755,12 @@ function _recordMiddleware(shim, middleware, spec) {
     txInfo.errorHandled |= isErrorWare
 
     // Copy over route parameters onto the transaction root.
-    const params = shim.agent.config.high_security
+    let params = shim.agent.config.high_security
       ? null
       : spec.params.call(this, shim, fn, fnName, args, req)
+
+    // Route parameters are handled here, query parameters are handled in lib/transaction/index.js#_markAsWeb as part of finalization
+    params = shim.prefixRouteParameters(params)
 
     // Wrap up `next` and push on our name state if we find it. We only want to
     // push the name state if there is a next so that we can safely remove it
@@ -869,9 +856,12 @@ function _recordMiddleware(shim, middleware, spec) {
     txInfo.errorHandled |= isErrorWare
 
     // Copy over route parameters onto the transaction root.
-    const params = shim.agent.config.high_security
+    let params = shim.agent.config.high_security
       ? null
       : spec.params.call(this, shim, fn, fnName, args, req)
+
+    // Route parameters are handled here, query parameters are handled in lib/transaction/index.js#_markAsWeb as part of finalization
+    params = shim.prefixRouteParameters(params)
 
     // Append this middleware's mount point and possibly construct a recorder.
     if (spec.appendPath) {

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -457,17 +457,17 @@ function finalizeNameFromUri(requestURL, statusCode) {
 function forEachRouteParams(params) {
   for (const key in params) {
     if (props.hasOwn(params, key)) {
-      this.trace.attributes.addAttribute(DESTS.NONE, REQUEST_PARAMS_PATH + key, params[key])
+      this.trace.attributes.addAttribute(DESTS.NONE, key, params[key])
 
       const segment = this.agent.tracer.getSegment()
 
       if (!segment) {
         logger.trace(
-          'Active segment not available, not adding request.parameters attribute for %s',
+          'Active segment not available, not adding request.parameters.route attribute for %s',
           key
         )
       } else {
-        segment.attributes.addAttribute(DESTS.NONE, REQUEST_PARAMS_PATH + key, params[key])
+        segment.attributes.addAttribute(DESTS.NONE, key, params[key])
       }
     }
   }
@@ -486,6 +486,8 @@ Transaction.prototype._copyNameToActiveSpan = function _copyNameToActiveSpan(nam
 /**
  * Copies final base segment parameters to trace attributes before reapplying
  * them to the segment.
+ *
+ * Handles adding query parameters to `request.parameter.*` attributes
  *
  * @param {string} rawURL The URL, as it came in, for parameter extraction.
  */
@@ -1376,9 +1378,11 @@ function _makeValueSet(obj) {
 Transaction.prototype.addRequestParameters = addRequestParameters
 
 /**
- * Adds request/query parameters to create attributes in the form
+ * Adds query parameters to create attributes in the form
  * 'request.parameters.{key}'. These attributes will only be created
  * when 'request.parameters.*' is included in the attribute config.
+ *
+ * Used by the "serverless mode" lambda logic
  *
  * @param {Object<string, string>} requestParameters of the request object
  */

--- a/test/unit/shim/shim.test.js
+++ b/test/unit/shim/shim.test.js
@@ -2729,4 +2729,25 @@ tap.test('Shim', function (t) {
       t.end()
     })
   })
+
+  t.test('prefixRouteParameters', (t) => {
+    t.autoend()
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    t.test('should return undefined if input is falsey', (t) => {
+      const result = shim.prefixRouteParameters(null)
+      t.equal(result, undefined)
+      t.end()
+    })
+
+    t.test('should return the object with route param prefix applied to keys', (t) => {
+      const result = shim.prefixRouteParameters({ id: '123abc', foo: 'bar' })
+      t.same(result, {
+        'request.parameters.route.id': '123abc',
+        'request.parameters.route.foo': 'bar'
+      })
+      t.end()
+    })
+  })
 })

--- a/test/unit/shim/shim.test.js
+++ b/test/unit/shim/shim.test.js
@@ -2735,9 +2735,12 @@ tap.test('Shim', function (t) {
     t.beforeEach(beforeEach)
     t.afterEach(afterEach)
 
-    t.test('should return undefined if input is falsey', (t) => {
-      const result = shim.prefixRouteParameters(null)
-      t.equal(result, undefined)
+    t.test('should not prefix parameters when given invalid input', (t) => {
+      const resultNull = shim.prefixRouteParameters(null)
+      t.equal(resultNull, undefined)
+
+      const resultString = shim.prefixRouteParameters('parameters')
+      t.equal(resultString, undefined)
       t.end()
     })
 

--- a/test/unit/shim/webframework-shim.test.js
+++ b/test/unit/shim/webframework-shim.test.js
@@ -599,8 +599,8 @@ test('WebFrameworkShim', function (t) {
 
         t.ok(segment.attributes)
         t.same(segment.getAttributes(), {
-          foo: 'bar',
-          biz: 'bang'
+          'request.parameters.route.foo': 'bar',
+          'request.parameters.route.biz': 'bang'
         })
         t.end()
       })
@@ -1436,61 +1436,6 @@ test('WebFrameworkShim', function (t) {
       t.notOk(called)
       shim.noticeError(req, new Error('test error'))
       t.ok(called)
-      t.end()
-    })
-  })
-
-  t.test('#captureUrlParams', function (t) {
-    t.autoend()
-    t.beforeEach(function () {
-      beforeEach()
-      agent.config.attributes.enabled = true
-    })
-    t.afterEach(afterEach)
-
-    t.test('should copy the provided params onto the segment parameters', function (t) {
-      const segment = { parameters: { foo: 'other', bang: 'bam' } }
-      shim.getSegment = function () {
-        return segment
-      }
-      shim.captureUrlParams({ foo: 'bar', biz: 'baz' })
-      t.same(segment.parameters, {
-        foo: 'other',
-        biz: 'baz',
-        bang: 'bam'
-      })
-      t.end()
-    })
-
-    t.test('should not obey the attributes.enabled configuration', function (t) {
-      agent.config.attributes.enabled = false
-      const segment = { parameters: { foo: 'other', bang: 'bam' } }
-      shim.getSegment = function () {
-        return segment
-      }
-      shim.captureUrlParams({ foo: 'bar', biz: 'baz' })
-      t.same(segment.parameters, { foo: 'other', biz: 'baz', bang: 'bam' })
-      t.end()
-    })
-
-    t.test('should obey high_security mode', function (t) {
-      agent.config.high_security = true
-      const segment = { parameters: { foo: 'other' } }
-      shim.getSegment = function () {
-        return segment
-      }
-      shim.captureUrlParams({ foo: 'bar', biz: 'baz' })
-      t.same(segment.parameters, { foo: 'other' })
-      t.end()
-    })
-
-    t.test('should not throw when out of a transaction', function (t) {
-      shim.getSegment = function () {
-        return null
-      }
-      t.doesNotThrow(function () {
-        shim.captureUrlParams({ foo: 'bar' })
-      })
       t.end()
     })
   })

--- a/test/unit/transaction.test.js
+++ b/test/unit/transaction.test.js
@@ -1925,8 +1925,8 @@ function setupNameState(transaction) {
   transaction.nameState.setPrefix('Restify')
   transaction.nameState.setVerb('COOL')
   transaction.nameState.setDelimiter('/')
-  transaction.nameState.appendPath('/foo/:foo', { foo: 'biz' })
-  transaction.nameState.appendPath('/bar/:bar', { bar: 'bang' })
+  transaction.nameState.appendPath('/foo/:foo', { 'request.parameters.foo': 'biz' })
+  transaction.nameState.appendPath('/bar/:bar', { 'request.parameters.bar': 'bang' })
 }
 
 function setupHighSecurity(agent) {

--- a/test/versioned-external/external-repos.js
+++ b/test/versioned-external/external-repos.js
@@ -25,7 +25,7 @@ const repos = [
   {
     name: 'next',
     repository: 'https://github.com/newrelic/newrelic-node-nextjs.git',
-    branch: 'main'
+    branch: 'prefix-route-params'
   },
   {
     name: 'superagent',

--- a/test/versioned/express/captures-params.tap.js
+++ b/test/versioned/express/captures-params.tap.js
@@ -103,7 +103,11 @@ tap.test('test attributes.enabled for express', function (t) {
     agent.on('transactionFinished', function (transaction) {
       t.ok(transaction.trace, 'transaction has a trace.')
       const attributes = transaction.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
-      t.equal(attributes['request.parameters.id'], '5', 'Trace attributes include `id` route param')
+      t.equal(
+        attributes['request.parameters.route.id'],
+        '5',
+        'Trace attributes include `id` route param'
+      )
     })
 
     helper.randomPort(function (_port) {
@@ -193,7 +197,11 @@ tap.test('test attributes.enabled for express', function (t) {
     agent.on('transactionFinished', function (transaction) {
       t.ok(transaction.trace, 'transaction has a trace.')
       const attributes = transaction.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
-      t.equal(attributes['request.parameters.id'], '5', 'Trace attributes include `id` route param')
+      t.equal(
+        attributes['request.parameters.route.id'],
+        '5',
+        'Trace attributes include `id` route param'
+      )
       t.equal(
         attributes['request.parameters.name'],
         'bob',
@@ -218,33 +226,6 @@ tap.test('test attributes.enabled for express', function (t) {
           t.deepEqual(JSON.parse(body), { yep: true }, 'Express correctly serves.')
           t.end()
         })
-      })
-    })
-  })
-
-  t.test('query params mask route attributes', function (t) {
-    const app = require('express')()
-    const server = require('http').createServer(app)
-    let port = null
-
-    t.teardown(function () {
-      server.close()
-    })
-
-    app.get('/user/:id', function (req, res) {
-      res.end()
-    })
-
-    agent.on('transactionFinished', function (transaction) {
-      const attributes = transaction.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
-      t.equal(attributes['request.parameters.id'], '6', 'attributes should include query params')
-      t.end()
-    })
-
-    helper.randomPort(function (_port) {
-      port = _port
-      server.listen(port, TEST_HOST, function () {
-        helper.makeGetRequest(TEST_URL + port + '/user/5?id=6')
       })
     })
   })

--- a/test/versioned/express/captures-params.tap.js
+++ b/test/versioned/express/captures-params.tap.js
@@ -229,4 +229,36 @@ tap.test('test attributes.enabled for express', function (t) {
       })
     })
   })
+
+  t.test('query params should not mask route attributes', function (t) {
+    const app = require('express')()
+    const server = require('http').createServer(app)
+    let port = null
+
+    t.teardown(function () {
+      server.close()
+    })
+
+    app.get('/user/:id', function (req, res) {
+      res.end()
+    })
+
+    agent.on('transactionFinished', function (transaction) {
+      const attributes = transaction.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
+      t.equal(
+        attributes['request.parameters.route.id'],
+        '5',
+        'attributes should include route params'
+      )
+      t.equal(attributes['request.parameters.id'], '6', 'attributes should include query params')
+      t.end()
+    })
+
+    helper.randomPort(function (_port) {
+      port = _port
+      server.listen(port, TEST_HOST, function () {
+        helper.makeGetRequest(TEST_URL + port + '/user/5?id=6')
+      })
+    })
+  })
 })

--- a/test/versioned/express/router-params.tap.js
+++ b/test/versioned/express/router-params.tap.js
@@ -59,8 +59,8 @@ test('Express router introspection', function (t) {
       'should have partial name for apdex'
     )
     const attributes = web.getAttributes()
-    t.equal(attributes['request.parameters.param1'], 'foo', 'should have param1')
-    t.equal(attributes['request.parameters.param2'], 'bar', 'should have param2')
+    t.equal(attributes['request.parameters.route.param1'], 'foo', 'should have param1')
+    t.equal(attributes['request.parameters.route.param2'], 'bar', 'should have param2')
   })
 
   server.listen(0, function () {

--- a/test/versioned/hapi/capture-params.tap.js
+++ b/test/versioned/hapi/capture-params.tap.js
@@ -66,7 +66,7 @@ tap.test('Hapi capture params support', function (t) {
       t.ok(tx.trace, 'transaction has a trace.')
       const attributes = tx.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
       t.equal(
-        attributes['request.parameters.id'],
+        attributes['request.parameters.route.id'],
         '1337',
         'Trace attributes include `id` route param'
       )
@@ -118,7 +118,7 @@ tap.test('Hapi capture params support', function (t) {
       t.ok(tx.trace, 'transaction has a trace.')
       const attributes = tx.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
       t.equal(
-        attributes['request.parameters.id'],
+        attributes['request.parameters.route.id'],
         '1337',
         'Trace attributes include `id` route param'
       )

--- a/test/versioned/hapi/router.tap.js
+++ b/test/versioned/hapi/router.tap.js
@@ -390,7 +390,7 @@ function verifier(t, verb) {
     t.equal(web.partialName, 'Hapi/' + verb + '//test/{id}', 'should have partial name for apdex')
 
     t.equal(
-      web.getAttributes()['request.parameters.id'],
+      web.getAttributes()['request.parameters.route.id'],
       '31337',
       'namer gets attributes out of route'
     )

--- a/test/versioned/hapi/vhost.tap.js
+++ b/test/versioned/hapi/vhost.tap.js
@@ -37,7 +37,7 @@ tap.test('Hapi vhost support', function (t) {
         t.ok(attributes[key], 'Trace contains expected HTTP attribute: ' + key)
       })
       t.equal(
-        attributes['request.parameters.id'],
+        attributes['request.parameters.route.id'],
         '1337',
         'Trace attributes include `id` route param'
       )

--- a/test/versioned/restify/restify-post-7/capture-params.tap.js
+++ b/test/versioned/restify/restify-post-7/capture-params.tap.js
@@ -80,7 +80,7 @@ test('Restify capture params introspection', function (t) {
       // on older versions of node response messages aren't included
       const attributes = transaction.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
       t.equal(
-        attributes['request.parameters.id'],
+        attributes['request.parameters.route.id'],
         '1337',
         'Trace attributes include `id` route param'
       )
@@ -153,7 +153,7 @@ test('Restify capture params introspection', function (t) {
       // on older versions of node response messages aren't included
       const attributes = transaction.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
       t.equal(
-        attributes['request.parameters.id'],
+        attributes['request.parameters.route.id'],
         '1337',
         'Trace attributes include `id` route param'
       )

--- a/test/versioned/restify/restify-post-7/router.tap.js
+++ b/test/versioned/restify/restify-post-7/router.tap.js
@@ -59,7 +59,7 @@ tap.test('Restify router', function (t) {
       t.equal(web.name, transaction.name, 'segment name and transaction name match')
       t.equal(web.partialName, 'Restify/GET//test/:id', 'should have partial name for apdex')
       t.equal(
-        web.getAttributes()['request.parameters.id'],
+        web.getAttributes()['request.parameters.route.id'],
         '31337',
         'namer gets parameters out of route'
       )

--- a/test/versioned/restify/restify-pre-7/capture-params.tap.js
+++ b/test/versioned/restify/restify-pre-7/capture-params.tap.js
@@ -80,7 +80,7 @@ test('Restify capture params introspection', function (t) {
       // on older versions of node response messages aren't included
       const attributes = transaction.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
       t.equal(
-        attributes['request.parameters.id'],
+        attributes['request.parameters.route.id'],
         '1337',
         'Trace attributes include `id` route param'
       )
@@ -153,7 +153,7 @@ test('Restify capture params introspection', function (t) {
       // on older versions of node response messages aren't included
       const attributes = transaction.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
       t.equal(
-        attributes['request.parameters.id'],
+        attributes['request.parameters.route.id'],
         '1337',
         'Trace attributes include `id` route param'
       )

--- a/test/versioned/restify/restify-pre-7/router.tap.js
+++ b/test/versioned/restify/restify-pre-7/router.tap.js
@@ -57,7 +57,7 @@ tap.test('Restify router', function (t) {
       t.equal(web.name, transaction.name, 'segment name and transaction name match')
       t.equal(web.partialName, 'Restify/GET//test/:id', 'should have partial name for apdex')
       t.equal(
-        web.getAttributes()['request.parameters.id'],
+        web.getAttributes()['request.parameters.route.id'],
         '31337',
         'namer gets parameters out of route'
       )


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
* **BREAKING** - Route (URL) parameters are now stored as `request.parameters.route.*` attributes on Transactions and Spans
* **BREAKING** - Removed `captureUrlParams` from `WebFrameworkShim` class

## Links
* Closes #1574 
* [PR](https://github.com/newrelic/newrelic-node-nextjs/pull/117) to update Next.js instrumentation and tests

## Details
This breaking change fixes two issues with storing request parameter related attributes:
1. Reserved attribute name collisions on spans - Reported issue, `id` is a reserved attribute name for Distributed Tracing, and spans were getting the bare route parameters added as attributes which, in conjunction with the flattening of data that occurs when we send over the wire, caused the DT parent/child span association to break.

2. Collisions between query parameters and route parameters on transactions - Discovered while investigating reported issue, having a query parameter and a route parameter named the same is a maybe strange, but valid use case. Before this change, in the event that there was a query parameter and route parameter with the same name (key), the query parameter would overwrite the route parameter. With this change, both will be respected and added as attributes.

After this change, the following becomes true:
1. Query parameters will be available as attributes prefixed with `request.parameters.*` on Transactions and Spans
2. Route parameters will be available as attributes prefixed with `request.parameters.route.*` on Transactions and Spans

Route parameters (aka url parameters) are a common feature of various web frameworks, where you can create a placeholder as part of an API route definition.

For example, given the following Express route definition and request url:
```
app.get('/api/users/:id', myMiddleware, myController)
```

```
curl http://localhost:3000/api/users/abc123?full=true
```

the route parameter is `id`, and has a value of `abc123`. This would become `request.parameters.route.id: abc123` on the Transaction and Span attributes. This example also has a query parameter of `full`, which has a value of `true`. This would become `request.parameters.full: true` on the Transaction and Span attributes.