### PR TITLE
ci: bump the test utils version to get new makeFullyInstrumented function

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1800,7 +1800,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ### @newrelic/test-utilities
 
-This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v7.2.0](https://github.com/newrelic/node-test-utilities/tree/v7.2.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v7.2.0/LICENSE):
+This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v7.3.0](https://github.com/newrelic/node-test-utilities/tree/v7.3.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v7.3.0/LICENSE):
 
 ```
                                  Apache License
@@ -2177,7 +2177,7 @@ SOFTWARE.
 
 ### clean-jsdoc-theme
 
-This product includes source derived from [clean-jsdoc-theme](https://github.com/ankitskvmdam/clean-jsdoc-theme) ([v4.2.4](https://github.com/ankitskvmdam/clean-jsdoc-theme/tree/v4.2.4)), distributed under the [MIT License](https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/v4.2.4/LICENSE):
+This product includes source derived from [clean-jsdoc-theme](https://github.com/ankitskvmdam/clean-jsdoc-theme) ([v4.2.7](https://github.com/ankitskvmdam/clean-jsdoc-theme/tree/v4.2.7)), distributed under the [MIT License](https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/v4.2.7/LICENSE):
 
 ```
 MIT License
@@ -2709,7 +2709,7 @@ SOFTWARE.
 
 ### jsdoc
 
-This product includes source derived from [jsdoc](https://github.com/jsdoc/jsdoc) ([v4.0.0](https://github.com/jsdoc/jsdoc/tree/v4.0.0)), distributed under the [Apache-2.0 License](https://github.com/jsdoc/jsdoc/blob/v4.0.0/LICENSE.md):
+This product includes source derived from [jsdoc](https://github.com/jsdoc/jsdoc) ([v4.0.2](https://github.com/jsdoc/jsdoc/tree/v4.0.2)), distributed under the [Apache-2.0 License](https://github.com/jsdoc/jsdoc/blob/v4.0.2/LICENSE.md):
 
 ```
 # License

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@newrelic/eslint-config": "^0.3.0",
         "@newrelic/newrelic-oss-cli": "^0.1.2",
         "@newrelic/proxy": "^2.0.0",
-        "@newrelic/test-utilities": "^7.2.0",
+        "@newrelic/test-utilities": "^7.3.0",
         "@octokit/rest": "^18.0.15",
         "@slack/bolt": "^3.7.0",
         "ajv": "^6.12.6",
@@ -926,9 +926,9 @@
       }
     },
     "node_modules/@newrelic/test-utilities": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-7.2.0.tgz",
-      "integrity": "sha512-tSHXPqS996JIHcJlJl2z6HAZegIgDE+VX/mNeQm7fS1gcXZ3kGDUFCbVsJLsku2wkqNueYX+lqhpmtOwMsJbNQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-7.3.0.tgz",
+      "integrity": "sha512-hIP2/iJgv1EZrNNB3AQQxRAIsRYu4Gq6oAumdodhynk4FRYLcGRuMkCJqFNHcqAJSKeK8I3h/lxj+1BObQwxhQ==",
       "dev": true,
       "dependencies": {
         "async": "^3.2.3",
@@ -14906,9 +14906,9 @@
       "requires": {}
     },
     "@newrelic/test-utilities": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-7.2.0.tgz",
-      "integrity": "sha512-tSHXPqS996JIHcJlJl2z6HAZegIgDE+VX/mNeQm7fS1gcXZ3kGDUFCbVsJLsku2wkqNueYX+lqhpmtOwMsJbNQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-7.3.0.tgz",
+      "integrity": "sha512-hIP2/iJgv1EZrNNB3AQQxRAIsRYu4Gq6oAumdodhynk4FRYLcGRuMkCJqFNHcqAJSKeK8I3h/lxj+1BObQwxhQ==",
       "dev": true,
       "requires": {
         "async": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "@newrelic/eslint-config": "^0.3.0",
     "@newrelic/newrelic-oss-cli": "^0.1.2",
     "@newrelic/proxy": "^2.0.0",
-    "@newrelic/test-utilities": "^7.2.0",
+    "@newrelic/test-utilities": "^7.3.0",
     "@octokit/rest": "^18.0.15",
     "@slack/bolt": "^3.7.0",
     "ajv": "^6.12.6",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Mon Mar 27 2023 14:12:05 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Fri Apr 14 2023 10:40:55 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -238,15 +238,15 @@
       "email": "nathan@tootallnate.net",
       "url": "http://n8.io/"
     },
-    "@newrelic/test-utilities@7.2.0": {
+    "@newrelic/test-utilities@7.3.0": {
       "name": "@newrelic/test-utilities",
-      "version": "7.2.0",
-      "range": "^7.2.0",
+      "version": "7.3.0",
+      "range": "^7.3.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-test-utilities",
-      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v7.2.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v7.3.0",
       "licenseFile": "node_modules/@newrelic/test-utilities/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v7.2.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v7.3.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"
@@ -324,15 +324,15 @@
       "publisher": "Jake Luer",
       "email": "jake@alogicalparadox.com"
     },
-    "clean-jsdoc-theme@4.2.4": {
+    "clean-jsdoc-theme@4.2.7": {
       "name": "clean-jsdoc-theme",
-      "version": "4.2.4",
+      "version": "4.2.7",
       "range": "^4.2.4",
       "licenses": "MIT",
       "repoUrl": "https://github.com/ankitskvmdam/clean-jsdoc-theme",
-      "versionedRepoUrl": "https://github.com/ankitskvmdam/clean-jsdoc-theme/tree/v4.2.4",
+      "versionedRepoUrl": "https://github.com/ankitskvmdam/clean-jsdoc-theme/tree/v4.2.7",
       "licenseFile": "node_modules/clean-jsdoc-theme/LICENSE",
-      "licenseUrl": "https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/v4.2.4/LICENSE",
+      "licenseUrl": "https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/v4.2.7/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Ank"
     },
@@ -499,15 +499,15 @@
       "publisher": "Typicode",
       "email": "typicode@gmail.com"
     },
-    "jsdoc@4.0.0": {
+    "jsdoc@4.0.2": {
       "name": "jsdoc",
-      "version": "4.0.0",
+      "version": "4.0.2",
       "range": "^4.0.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/jsdoc/jsdoc",
-      "versionedRepoUrl": "https://github.com/jsdoc/jsdoc/tree/v4.0.0",
+      "versionedRepoUrl": "https://github.com/jsdoc/jsdoc/tree/v4.0.2",
       "licenseFile": "node_modules/jsdoc/LICENSE.md",
-      "licenseUrl": "https://github.com/jsdoc/jsdoc/blob/v4.0.0/LICENSE.md",
+      "licenseUrl": "https://github.com/jsdoc/jsdoc/blob/v4.0.2/LICENSE.md",
       "licenseTextSource": "file",
       "publisher": "Michael Mathews",
       "email": "micmath@gmail.com"


### PR DESCRIPTION

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
Our Apollo/graphql versioned tests started failing last night, because a recently merged PR https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/243 relies on a new function from our test utilities that wasn't currently available with the version we install in the agent. This PR bumps the version of test utilities to have the newer functionality.
