### PR TITLE
ci: update Snyk generated PR titles to have a Conventional Commit prefix

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -22,8 +22,6 @@ jobs:
       run: npm run lint
     - name: Inspect Lockfile
       run: npm run lint:lockfile
-    - name: Run CI Script Unit Tests
-      run: npm run unit:scripts
 
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,8 +36,11 @@ jobs:
         run: echo "RELEASE_TAG=${{ steps.release.outputs.tag_name }}" >> $GITHUB_ENV
         if: ${{ steps.release.outputs.release_created }}
       - name: Update GH Release with Support Statement
-        run: RELEASE_REPO=node-newrelic RELEASE_ORG=newrelic node -e 'require("./bin/add-support-statement")()'
+        run: node ./bin/add-support-statement.js'
         if: ${{ steps.release.outputs.release_created }}
+        env:
+          RELEASE_REPO: node-newrelic
+          RELEASE_ORG: newrelic
       - name: Publish to Npm
         run: npm publish
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/update-snyk-prs.yml
+++ b/.github/workflows/update-snyk-prs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Dependencies
         run: npm ci
       - name: Update Snyk PR Title
-        run: node -e 'require("./bin/update-snyk-pr")()'
+        run: node ./bin/update-snyk-pr.js'
         env:
           RELEASE_REPO: node-newrelic
           RELEASE_ORG: newrelic

--- a/.github/workflows/update-snyk-prs.yml
+++ b/.github/workflows/update-snyk-prs.yml
@@ -1,0 +1,29 @@
+name: Update Snyk Vulnerability PRs
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+
+jobs:
+  update-snyk-pr:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    if:  ${{ github.event.sender.login == 'snyk-bot' }} 
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js LTS
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - name: Install Dependencies
+        run: npm ci
+      - name: Update Snyk PR Title
+        run: node -e 'require("./bin/update-snyk-pr")()'
+        env:
+          RELEASE_REPO: node-newrelic
+          RELEASE_ORG: newrelic
+          SNYK_PR_ID: ${{ github.event.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bin/add-support-statement.js
+++ b/bin/add-support-statement.js
@@ -10,7 +10,7 @@ const Github = require('./github')
 const SUPPORT_STATEMENT_HEADER = '### Support statement:'
 const SUPPORT_STATEMENT_BODY = `* New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach [end-of-life](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software).`
 
-module.exports = async function updateRelease() {
+async function updateRelease() {
   const org = process.env.RELEASE_ORG || 'newrelic'
   const repo = process.env.RELEASE_REPO || 'node-newrelic'
   const tag = process.env.RELEASE_TAG
@@ -32,4 +32,15 @@ module.exports = async function updateRelease() {
     release_id: id,
     body: [body, SUPPORT_STATEMENT_HEADER, SUPPORT_STATEMENT_BODY].join('\n')
   })
+}
+
+/*
+ * Exports slightly differ for tests vs. Github Actions
+ * this allows us to require the function without it executing for tests,
+ * and executing via `node` cli in GHA
+ */
+if (require.main === module) {
+  updateRelease()
+} else {
+  module.exports = updateRelease
 }

--- a/bin/test/update-snyk-pr.test.js
+++ b/bin/test/update-snyk-pr.test.js
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const proxyquire = require('proxyquire').noPreserveCache().noCallThru()
+const sinon = require('sinon')
+
+tap.test('Update Snyk PR Scripting', (testHarness) => {
+  testHarness.autoend()
+
+  let originalEnvVars
+  let originalConsoleLog
+  let MockGithubSdk
+  let getPullRequestMock
+  let updatePullRequestMock
+  let script
+
+  testHarness.beforeEach(() => {
+    originalEnvVars = process.env
+    originalConsoleLog = console.log
+
+    console.log = sinon.stub().returns()
+    getPullRequestMock = sinon.stub()
+    updatePullRequestMock = sinon.stub()
+
+    MockGithubSdk = sinon.stub().returns({
+      getPullRequest: getPullRequestMock,
+      updatePullRequest: updatePullRequestMock
+    })
+
+    script = proxyquire('../update-snyk-pr', {
+      './github': MockGithubSdk
+    })
+  })
+
+  testHarness.afterEach(() => {
+    process.env = originalEnvVars
+    console.log = originalConsoleLog
+  })
+
+  testHarness.test('should throw an error if SNYK_PR_ID is missing', async (t) => {
+    delete process.env.SNYK_PR_ID
+    t.rejects(() => script(), new Error('SNYK_PR_ID is a required environment variable'))
+  })
+
+  testHarness.test('should default the org/repo to agent', async (t) => {
+    getPullRequestMock.resolves({ id: '1234', title: 'oh hi, mark' })
+    updatePullRequestMock.resolves()
+    process.env.SNYK_PR_ID = '1234'
+
+    await script()
+
+    t.equal(MockGithubSdk.callCount, 1, 'should instantiate the Github SDK')
+    t.equal(MockGithubSdk.args[0][0], 'newrelic', 'should default to the newrelic org')
+    t.equal(MockGithubSdk.args[0][1], 'node-newrelic', 'should default to the agent repo')
+  })
+
+  testHarness.test('should set org/repo based on RELEASE_REPO and RELEASE_ORG', async () => {
+    getPullRequestMock.resolves({ id: '1234', title: 'hello from the other side' })
+    updatePullRequestMock.resolves()
+    process.env.SNYK_PR_ID = '1234'
+    process.env.RELEASE_ORG = 'foo'
+    process.env.RELEASE_REPO = 'bar'
+
+    await script()
+
+    testHarness.equal(MockGithubSdk.callCount, 1, 'should instantiate the Github SDK')
+    testHarness.equal(MockGithubSdk.args[0][0], 'foo', 'should respect RELEASE_ORG')
+    testHarness.equal(MockGithubSdk.args[0][1], 'bar', 'should respect RELEASE_REPO')
+  })
+
+  testHarness.test(
+    'should not update the PR if it already has the correct conventional commit prefix',
+    async (t) => {
+      getPullRequestMock.resolves({ id: '1234', title: 'security: oh hi, mark' })
+      updatePullRequestMock.resolves()
+      process.env.SNYK_PR_ID = '1234'
+
+      await script()
+
+      t.equal(updatePullRequestMock.callCount, 0, 'should not have updated the PR')
+      t.equal(console.log.args[0][0], 'PR #1234 already has correct prefix, skipping update')
+    }
+  )
+
+  testHarness.test(
+    'should update the PR with the security conventional commit prefix',
+    async (t) => {
+      getPullRequestMock.resolves({ id: '1234', title: 'hello from the other side' })
+      updatePullRequestMock.resolves()
+      process.env.SNYK_PR_ID = '1234'
+
+      await script()
+
+      t.equal(updatePullRequestMock.callCount, 1, 'should have called updatePullRequest')
+      t.same(
+        updatePullRequestMock.args[0][0],
+        {
+          id: '1234',
+          title: 'security: hello from the other side'
+        },
+        'should have prepended the security prefix'
+      )
+    }
+  )
+})

--- a/bin/update-snyk-pr.js
+++ b/bin/update-snyk-pr.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const Github = require('./github')
+const SECURITY_PREFIX = 'security:'
+
+module.exports = async function updateSnykPR() {
+  const org = process.env.RELEASE_ORG || 'newrelic'
+  const repo = process.env.RELEASE_REPO || 'node-newrelic'
+  const prId = process.env.SNYK_PR_ID
+
+  if (!prId) {
+    throw new Error('SNYK_PR_ID is a required environment variable')
+  }
+
+  const github = new Github(org, repo)
+
+  const { title: originalTitle } = await github.getPullRequest(prId)
+
+  if (originalTitle.startsWith(SECURITY_PREFIX)) {
+    console.log(`PR #${prId} already has correct prefix, skipping update`)
+    return
+  }
+  const newTitle = [SECURITY_PREFIX, originalTitle].join(' ')
+
+  await github.updatePullRequest({ id: prId, title: newTitle })
+}

--- a/bin/update-snyk-pr.js
+++ b/bin/update-snyk-pr.js
@@ -8,7 +8,7 @@
 const Github = require('./github')
 const SECURITY_PREFIX = 'security:'
 
-module.exports = async function updateSnykPR() {
+async function updateSnykPR() {
   const org = process.env.RELEASE_ORG || 'newrelic'
   const repo = process.env.RELEASE_REPO || 'node-newrelic'
   const prId = process.env.SNYK_PR_ID
@@ -28,4 +28,15 @@ module.exports = async function updateSnykPR() {
   const newTitle = [SECURITY_PREFIX, originalTitle].join(' ')
 
   await github.updatePullRequest({ id: prId, title: newTitle })
+}
+
+/*
+ * Exports slightly differ for tests vs. Github Actions
+ * this allows us to require the function without it executing for tests,
+ * and executing via `node` cli in GHA
+ */
+if (require.main === module) {
+  updateSnykPR()
+} else {
+  module.exports = updateSnykPR
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links
Closes NR-96232

## Details
Updates any PR that is generated by [Snyk Bot](https://github.com/snyk-bot) to add a `security:` prefix to the title. Snyk does not give us a way to configure the commit message or customize anything about the PR like Dependabot does, so since we're going to eventually update the PR process to use squash/merge with the PR title as the commit message, this (in a roundabout way) gets our Snyk PRs to be "conventional", and ensure that they end up in the appropriate release notes section.