### PR TITLE
ci: added PR title check automation

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,53 @@
+name: Validate Pull Request
+
+permissions:
+  pull-requests: write
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  validate-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull Request Title is Conventional
+        id: lint_pr_title
+        uses: amannn/action-semantic-pull-request@v5
+        with:
+          # Recommended Prefixes from https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/config-conventional/README.md#type-enum
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            security
+            style
+            test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: failure()
+        name: Add PR comment if failed
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          message: |
+            Thank you for your contribution! We require all PR titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
+            Please update your PR title with the appropriate type and we'll try again!
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message}}
+            ```
+      - if: success()
+        name: Remove PR comment if valid
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:   
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links
Closes NR-96233

## Details
Added a check to ensure that a PR title matches our Conventional Commit requirements, and if not, adds a comment to the PR listing our allowed prefixes. Note that we'll have to disable this workflow until we're ready to migrate to the new release flow.

**Comment Example**
<img width="1721" alt="Screenshot 2023-04-20 at 3 20 13 PM" src="https://user-images.githubusercontent.com/3333180/233468645-3916425f-b210-4acf-8903-870def76306b.png">

