### PR TITLE
feat(nestjs): capture stack traces NEWRELIC-8072

### DIFF
--- a/bin/run-versioned-tests.sh
+++ b/bin/run-versioned-tests.sh
@@ -7,6 +7,7 @@ set -x
 
 VERSIONED_MODE="${VERSIONED_MODE:---minor}"
 SAMPLES="${SAMPLES:-10}"
+export NODE_OPTIONS="--max-old-space-size=4096"
 
 # Determine context manager for sanity sake
 if [[ $NEW_RELIC_FEATURE_FLAG_ASYNC_LOCAL_CONTEXT == 1 ]];

--- a/lib/instrumentation/@nestjs/core.js
+++ b/lib/instrumentation/@nestjs/core.js
@@ -12,6 +12,9 @@ module.exports = function initialize(agent, core, moduleName, shim) {
   shim.setFramework(shim.NEST)
   // Earliest version that runs in the tests
   if (semver.lt(nestJsVersion, '8.0.0')) {
+    logger.debug(
+      `Not instrumenting Nest.js version ${nestJsVersion}; minimum instrumentable version is 8.0.0`
+    )
     return
   }
 

--- a/lib/instrumentation/@nestjs/core.js
+++ b/lib/instrumentation/@nestjs/core.js
@@ -10,7 +10,8 @@ module.exports = function initialize(agent, core, moduleName, shim) {
   shim.setFramework(shim.NEST)
   shim.wrap(core.BaseExceptionFilter.prototype, 'handleUnknownError', (shim, original) => {
     return function wrappedHandleUnknownError(exception) {
-      const { transaction } = shim.getActiveSegment()
+      const segment = shim.getActiveSegment()
+      const transaction = segment?.transaction
       if (transaction) {
         shim.agent.errors.add(transaction, exception)
         logger.trace(exception, 'Captured error handled by Nest.js exception filter.')

--- a/lib/instrumentation/@nestjs/core.js
+++ b/lib/instrumentation/@nestjs/core.js
@@ -5,9 +5,16 @@
 
 'use strict'
 const logger = require('../../logger').child({ component: 'nestjs' })
+const semver = require('semver')
 
 module.exports = function initialize(agent, core, moduleName, shim) {
+  const nestJsVersion = shim.require('./package.json').version
   shim.setFramework(shim.NEST)
+  // Earliest version that runs in the tests
+  if (semver.lt(nestJsVersion, '8.0.0')) {
+    return
+  }
+
   shim.wrap(core.BaseExceptionFilter.prototype, 'handleUnknownError', (shim, original) => {
     return function wrappedHandleUnknownError(exception) {
       const segment = shim.getActiveSegment()

--- a/lib/instrumentation/@nestjs/core.js
+++ b/lib/instrumentation/@nestjs/core.js
@@ -7,6 +7,7 @@
 const logger = require('../../logger').child({ component: 'nestjs' })
 
 module.exports = function initialize(agent, core, moduleName, shim) {
+  shim.setFramework(shim.NEST)
   shim.wrap(core.BaseExceptionFilter.prototype, 'handleUnknownError', (shim, original) => {
     return function wrappedHandleUnknownError(exception) {
       const { transaction } = shim.getActiveSegment()

--- a/lib/instrumentation/@nestjs/core.js
+++ b/lib/instrumentation/@nestjs/core.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const logger = require('../../logger').child({ component: 'nestjs' })
+
+module.exports = function initialize(agent, core, moduleName, shim) {
+  shim.wrap(core.BaseExceptionFilter.prototype, 'handleUnknownError', (shim, original) => {
+    return function wrappedHandleUnknownError(exception) {
+      const { transaction } = shim.getActiveSegment()
+      if (transaction) {
+        shim.agent.errors.add(transaction, exception)
+        logger.trace(exception, 'Captured error handled by Nest.js exception filter.')
+      } else {
+        logger.trace(
+          exception,
+          'Ignoring error handled by Nest.js exception filter: not in a transaction'
+        )
+      }
+
+      return original.apply(this, arguments)
+    }
+  })
+}

--- a/lib/instrumentations.js
+++ b/lib/instrumentations.js
@@ -27,6 +27,7 @@ module.exports = function instrumentations() {
     'memcached': { type: MODULE_TYPE.DATASTORE },
     'mongodb': { type: MODULE_TYPE.DATASTORE },
     'mysql': { module: './instrumentation/mysql' },
+    '@nestjs/core': { type: MODULE_TYPE.WEB_FRAMEWORK },
     'pino': { module: './instrumentation/pino' },
     'pg': { type: MODULE_TYPE.DATASTORE },
     'q': { type: null },
@@ -52,7 +53,6 @@ module.exports = function instrumentations() {
     'npmlog': { type: MODULE_TYPE.TRACKING },
     'fancy-log': { type: MODULE_TYPE.TRACKING },
     '@prisma/client': { type: MODULE_TYPE.DATASTORE },
-    '@nestjs/core': { type: MODULE_TYPE.TRACKING },
     'knex': { type: MODULE_TYPE.TRACKING }
   }
 }

--- a/lib/shim/webframework-shim.js
+++ b/lib/shim/webframework-shim.js
@@ -36,6 +36,7 @@ const FRAMEWORK_NAMES = {
   HAPI: 'Hapi',
   KOA: 'Koa',
   NEXT: 'Nextjs',
+  NEST: 'Nestjs',
   RESTIFY: 'Restify'
 }
 

--- a/test/unit/instrumentation/nest.test.js
+++ b/test/unit/instrumentation/nest.test.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { test } = require('tap')
+const helper = require('../../lib/agent_helper')
+const WebFrameworkShim = require('../../../lib/shim/webframework-shim')
+const sinon = require('sinon')
+
+test('Nest unit tests', (t) => {
+  t.autoend()
+
+  let agent = null
+  let initialize = null
+  let shim = null
+  let mockCore = null
+
+  function getMockModule() {
+    class BaseExceptionFilter {}
+    BaseExceptionFilter.prototype.handleUnknownError = sinon.stub()
+    return { BaseExceptionFilter }
+  }
+
+  t.beforeEach(() => {
+    agent = helper.loadMockedAgent()
+    initialize = require('../../../lib/instrumentation/@nestjs/core.js')
+    shim = new WebFrameworkShim(agent, 'nest')
+    mockCore = getMockModule()
+    initialize(agent, mockCore, '@nestjs/core', shim)
+  })
+
+  t.afterEach(() => {
+    helper.unloadAgent(agent)
+  })
+
+  t.test('Should record the error when in a transaction', (t) => {
+    helper.runInTransaction(agent, (tx) => {
+      const err = new Error('something went wrong')
+      const exceptionFilter = new mockCore.BaseExceptionFilter()
+      exceptionFilter.handleUnknownError(err)
+      tx.end()
+
+      t.equal(
+        shim.unwrap(exceptionFilter.handleUnknownError).callCount,
+        1,
+        'should have called the original error handler once'
+      )
+
+      const errors = agent.errors.traceAggregator.errors
+      t.equal(errors.length, 1, 'there should be one error')
+      t.equal(errors[0][2], 'something went wrong', 'should get the expected error')
+      t.ok(errors[0][4].stack_trace, 'should have the stack trace')
+
+      t.end()
+    })
+  })
+
+  t.test('Should ignore the error when not in a transaction', (t) => {
+    const err = new Error('something went wrong')
+    const exceptionFilter = new mockCore.BaseExceptionFilter()
+    exceptionFilter.handleUnknownError(err)
+
+    t.equal(
+      shim.unwrap(exceptionFilter.handleUnknownError).callCount,
+      1,
+      'should have called the original error handler once'
+    )
+    const errors = agent.errors.traceAggregator.errors
+    t.equal(errors.length, 0, 'there should be no errors')
+
+    t.end()
+  })
+})

--- a/test/versioned/nestjs/nest.tap.js
+++ b/test/versioned/nestjs/nest.tap.js
@@ -61,7 +61,6 @@ tap.test('Verify the Nest.js instrumentation', (t) => {
   t.test('should catch stack traces in errors', async (t) => {
     const res = await makeRequest(`${baseUrl}?please_error=yes`)
     t.equal(res.statusCode, 500, 'should return 500 status')
-    console.log(res.body)
     const errors = agent.errors.traceAggregator.errors
     t.equal(errors.length, 1, 'there should be one error')
     t.equal(errors[0][2], 'erroring out, as requested', 'should get the expected error')

--- a/test/versioned/nestjs/nest.tap.js
+++ b/test/versioned/nestjs/nest.tap.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const requestClient = require('request')
+const { promisify } = require('node:util')
+const makeRequest = promisify(requestClient.get)
+
+const helper = require('../../lib/agent_helper')
+const { initNestApp, deleteNestApp } = require('./setup')
+
+tap.test('Verify the Nest.js instrumentation', (t) => {
+  t.autoend()
+  let agent = null
+  let app = null
+  const port = 8972 // chosen by rand(), guaranteed to be random
+  const baseUrl = `http://localhost:${port}`
+
+  t.before(async () => {
+    await initNestApp()
+  })
+
+  t.teardown(async () => {
+    await deleteNestApp()
+  })
+
+  t.beforeEach(async () => {
+    agent = helper.instrumentMockedAgent()
+    const { bootstrap } = require('./test-app/dist/main.js')
+    app = await bootstrap(port)
+  })
+
+  t.afterEach(() => {
+    app.close()
+    helper.unloadAgent(agent)
+    Object.keys(require.cache).forEach((key) => {
+      if (/test-app/.test(key)) {
+        delete require.cache[key]
+      }
+    })
+    agent = null
+    app = null
+  })
+
+  t.test('should record a transaction in the base case', async (t) => {
+    const res = await makeRequest(baseUrl)
+    t.equal(res.body, 'Hello World!', 'should greet the world')
+    t.equal(res.statusCode, 200, 'should return 200 status')
+    t.equal(
+      agent.metrics.getMetric('WebTransaction').callCount,
+      1,
+      'should have recorded one web transaction'
+    )
+    t.end()
+  })
+
+  t.test('should catch stack traces in errors', async (t) => {
+    const res = await makeRequest(`${baseUrl}?please_error=yes`)
+    t.equal(res.statusCode, 500, 'should return 500 status')
+    console.log(res.body)
+    const errors = agent.errors.traceAggregator.errors
+    t.equal(errors.length, 1, 'there should be one error')
+    t.equal(errors[0][2], 'erroring out, as requested', 'should get the expected error')
+    t.ok(errors[0][4].stack_trace, 'should have the stack trace')
+    t.end()
+  })
+})

--- a/test/versioned/nestjs/package.json
+++ b/test/versioned/nestjs/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "nestjs-tests",
+  "version": "0.0.0",
+  "private": true,
+  "tests": [
+    {
+      "engines": {
+        "node": ">=14"
+      },
+      "dependencies": {
+        "@nestjs/cli": ">=8.0.0"
+      },
+      "files": [
+        "nest.tap.js"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/test/versioned/nestjs/setup.js
+++ b/test/versioned/nestjs/setup.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { promisify } = require('node:util')
+const exec = promisify(require('node:child_process').exec)
+const fsPromises = require('node:fs/promises')
+const fs = require('node:fs')
+
+const APP_DIR = `${__dirname}/test-app`
+const PATCH_DIR = `${__dirname}/test-app-replacements`
+
+async function initNestApp() {
+  if (fs.existsSync(APP_DIR)) {
+    // The `nest new` command will complain if the path already exists
+    // and is modified, so let's just throw it out. The tests are
+    // supposed to clean this up anyway, but sometimes the tests error
+    // out so badly that they can't clean up.
+    await deleteNestApp()
+  }
+  await exec('npx nest new --package-manager npm --skip-git test-app')
+  // We patch the default Nest app with some of our own functions.
+  for (const fname of ['main.ts', 'app.controller.ts']) {
+    await fsPromises.copyFile(`${PATCH_DIR}/${fname}`, `${APP_DIR}/src/${fname}`)
+  }
+  // Turn the typescript into commmonjs, so we can instrument it with
+  // the mocked agent.
+  await exec('npx nest build', { cwd: APP_DIR })
+}
+
+async function deleteNestApp() {
+  await fsPromises.rm(APP_DIR, { recursive: true })
+}
+
+module.exports = {
+  initNestApp,
+  deleteNestApp
+}

--- a/test/versioned/nestjs/test-app-replacements/app.controller.ts
+++ b/test/versioned/nestjs/test-app-replacements/app.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Req } from '@nestjs/common';
+import { AppService } from './app.service';
+import { Request } from 'express'
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getHello(@Req() request: Request): string {
+    if (request?.query?.please_error === 'yes') {
+      throw new Error('erroring out, as requested')
+    }
+    return this.appService.getHello();
+  }
+}

--- a/test/versioned/nestjs/test-app-replacements/main.ts
+++ b/test/versioned/nestjs/test-app-replacements/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+export async function bootstrap(port) {
+  const app = await NestFactory.create(AppModule, { logger: false });
+  await app.listen(port);
+  return app
+}


### PR DESCRIPTION
## Proposed Release Notes

* Added support to record Nest.js error stack traces.

## Links

* NEWRELIC-8072

## Details

We instrument `BaseExceptionFilter.handleUnknownError`, which gets called whenever Nest.js throws a 500. This is how Nest.js swallows exceptions, so it seems like a natural hook point.
