### PR TITLE
refactor(run-versioned-tests.sh): added ability to run versioned tests and skip collecting coverage by passing in `C8` env var to the job.

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,4 +1,5 @@
 {
-  "reporter": ["html", "lcov"],
-  "exclude": ["test/*", "*.mjs", "**/*.mjs"]
+  "reporter": ["lcov"],
+  "exclude": ["test/*", "*.mjs", "**/*.mjs"],
+  "clean": true
 }

--- a/.github/workflows/versioned-coverage.yml
+++ b/.github/workflows/versioned-coverage.yml
@@ -34,7 +34,7 @@ jobs:
       env:
         VERSIONED_MODE: --major 
         JOBS: 4 # 2 per CPU seems to be the sweet spot in GHA (July 2022)
-        C8: skip
+        SKIP_C8: true 
 
   versioned:
     runs-on: ubuntu-latest

--- a/.github/workflows/versioned-coverage.yml
+++ b/.github/workflows/versioned-coverage.yml
@@ -34,6 +34,7 @@ jobs:
       env:
         VERSIONED_MODE: --major 
         JOBS: 4 # 2 per CPU seems to be the sweet spot in GHA (July 2022)
+        C8: skip
 
   versioned:
     runs-on: ubuntu-latest

--- a/bin/run-versioned-tests.sh
+++ b/bin/run-versioned-tests.sh
@@ -33,14 +33,24 @@ else
   )
 fi
 
-# C8 runs out of heap when running against
-# patch/minor flag.  We will just skip it
-# and figure out another way to get coverage
-# when running on main branch. 
-if [[ $VERSIONED_MODE == '--major' ]];
+# When C8 is set as an env var the intention is to
+# run versioned tests without coverage.
+if [[ -z "$C8" ]];
 then
-  C8="c8 -o ./coverage/versioned"
+  # C8 runs out of heap when running against
+  # patch/minor flag.  We will just skip it
+  # and figure out another way to get coverage
+  # when running on main branch. 
+  if [[ $VERSIONED_MODE == '--major' ]];
+  then
+    # lcovonly only generates lcov report which will cut down on amount of time generating reports
+    C8="c8 -o ./coverage/versioned -r lcovonly"
+  else 
+    C8=""
+  fi
 else 
+  # C8 was pass in as an env var which is intended to skip 
+  # running versioned tests with c8
   C8=""
 fi
 
@@ -50,6 +60,7 @@ export AGENT_PATH=`pwd`
 echo "JOBS = ${JOBS}"
 echo "NPM7 = ${NPM7}"
 echo "CONTEXT MANAGER = ${CTX_MGR}"
+echo "C8 = ${C8}"
 
 # if $JOBS is not empy
 if [ ! -z "$JOBS" ];

--- a/bin/run-versioned-tests.sh
+++ b/bin/run-versioned-tests.sh
@@ -8,6 +8,7 @@ set -x
 VERSIONED_MODE="${VERSIONED_MODE:---minor}"
 SAMPLES="${SAMPLES:-10}"
 export NODE_OPTIONS="--max-old-space-size=4096"
+SKIP_C8="${SKIP_C8:-false}"
 
 # Determine context manager for sanity sake
 if [[ $NEW_RELIC_FEATURE_FLAG_ASYNC_LOCAL_CONTEXT == 1 ]];
@@ -33,10 +34,12 @@ else
   )
 fi
 
-# When C8 is set as an env var the intention is to
-# run versioned tests without coverage.
-if [[ -z "$C8" ]];
+# No coverage as env var is true
+# set C8 to ""
+if [[ "${SKIP_C8}" = "true" ]];
 then
+  C8=""
+else
   # C8 runs out of heap when running against
   # patch/minor flag.  We will just skip it
   # and figure out another way to get coverage
@@ -48,10 +51,6 @@ then
   else 
     C8=""
   fi
-else 
-  # C8 was pass in as an env var which is intended to skip 
-  # running versioned tests with c8
-  C8=""
 fi
 
 export AGENT_PATH=`pwd`


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * refactor (run-versioned-tests.sh): added ability to run versioned tests and skip collecting coverage by passing in `C8` env var to the job.
   * Updates `.c8rc.json` to remove redundant html reporter as lcov does both lcov and html.

## Links

## Details
I did this work in #1617 but that is not merging to main right away. I wanted to get these changes in.
