### PR TITLE
fix: Restored v prefix to version in docs PR job

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -41,6 +41,6 @@ jobs:
     - name: Publish API Docs
       run: npm run publish-docs
     - name: Create Docs Website PR
-      run: node ./bin/create-docs-pr.js --tag ${{ steps.get_tag.outputs.latest_tag }}
+      run: node ./bin/create-docs-pr.js --tag v${{ steps.get_tag.outputs.latest_tag }}
       env:
         GITHUB_TOKEN: ${{ secrets.NODE_AGENT_GH_TOKEN }}


### PR DESCRIPTION
## Proposed Release Notes
Restored v prefix for getting version tag in post-release job to create docs PR

## Links
https://issues.newrelic.com/browse/NR-96240

## Details
