### PR TITLE
fix: Set username/email to machine user by default

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -44,3 +44,5 @@ jobs:
       run: node ./bin/create-docs-pr.js --tag v${{ steps.get_tag.outputs.latest_tag }}
       env:
         GITHUB_TOKEN: ${{ secrets.NODE_AGENT_GH_TOKEN }}
+        GITHUB_USER: ${{ secrets.NODE_AGENT_CI_USER_NAME }}
+        GITHUB_EMAIL: ${{ secrets.NODE_AGENT_CI_USER_EMAIL }}

--- a/bin/create-docs-pr.js
+++ b/bin/create-docs-pr.js
@@ -283,8 +283,9 @@ async function createPR(version, branch, dryRun, repoOwner) {
 
   const github = new Github(repoOwner, 'docs-website')
   const title = `Node.js Agent ${version} Release Notes`
+  const head = repoOwner === `newrelic` ? branch : `${repoOwner}:${branch}`
   const prOptions = {
-    head: `${branch}`,
+    head,
     base: BASE_BRANCH,
     title,
     body: title

--- a/bin/create-docs-pr.js
+++ b/bin/create-docs-pr.js
@@ -17,9 +17,13 @@ const DEFAULT_FILE_NAME = 'NEWS.md'
 const TAG_VALID_REGEX = /v\d+\.\d+\.\d+/
 const BASE_BRANCH = 'develop'
 
+let GITHUB_USER
+let GITHUB_EMAIL
+
 program.requiredOption('--tag <tag>', 'tag name to get version of released agent')
 program.option('--remote <remote>', 'remote to push branch to', 'origin')
 program.option('--username <github username>', 'Owner of the fork of docs-website')
+program.option('--email <github email>', 'Email of the fork owner')
 program.option(
   '--changelog <changelog>',
   'Name of changelog(defaults to NEWS.md)',
@@ -50,7 +54,8 @@ async function createReleaseNotesPr() {
 
   console.log(`Script running with following options: ${JSON.stringify(options)}`)
 
-  const username = options.username || process.env.GITHUB_ACTOR
+  GITHUB_USER = options.username || process.env.GITHUB_USER || process.env.GITHUB_ACTOR
+  GITHUB_EMAIL = options.email || process.env.GITHUB_EMAIL || `gh-actions-${GITHUB_USER}@github.com`
   const repoOwner = options.repoOwner
 
   try {
@@ -74,7 +79,7 @@ async function createReleaseNotesPr() {
     logStep('Commit Release Notes')
     await commitReleaseNotes(version, options.remote, branchName, options.dryRun)
     logStep('Create Pull Request')
-    await createPR(username, version, branchName, options.dryRun, repoOwner)
+    await createPR(version, branchName, options.dryRun, repoOwner)
     console.log('*** Full Run Successful ***')
   } catch (err) {
     if (err.status && err.status === 404) {
@@ -251,9 +256,8 @@ async function commitReleaseNotes(version, remote, branch, dryRun) {
     console.log('Dry run indicated (--dry-run), skipping committing release notes.')
     return
   }
-  const GITHUB_ACTOR = process.env.GITHUB_ACTOR
-  const GITHUB_EMAIL = `gh-actions-${GITHUB_ACTOR}@github.com`
-  await git.setUser(GITHUB_ACTOR, GITHUB_EMAIL)
+
+  await git.setUser(GITHUB_USER, GITHUB_EMAIL)
 
   console.log(`Adding release notes for ${version}`)
   const files = [getFileName(version)]
@@ -266,13 +270,12 @@ async function commitReleaseNotes(version, remote, branch, dryRun) {
 /**
  * Creates a PR to the newrelic/docs-website with new release notes
  *
- * @param {string} username fork owner's github username
  * @param {string} version version number
  * @param {string} branch github branch
  * @param {boolean} dryRun whether or not we should actually create the PR
  * @param {string} repoOwner Owner of the docs-website repo, if targeting a fork instead of newrelic
  */
-async function createPR(username, version, branch, dryRun, repoOwner) {
+async function createPR(version, branch, dryRun, repoOwner) {
   if (!process.env.GITHUB_TOKEN) {
     console.log('GITHUB_TOKEN required to create a pull request')
     stopOnError()
@@ -281,7 +284,7 @@ async function createPR(username, version, branch, dryRun, repoOwner) {
   const github = new Github(repoOwner, 'docs-website')
   const title = `Node.js Agent ${version} Release Notes`
   const prOptions = {
-    head: `${username}:${branch}`,
+    head: `${branch}`,
     base: BASE_BRANCH,
     title,
     body: title

--- a/bin/create-docs-pr.js
+++ b/bin/create-docs-pr.js
@@ -67,8 +67,10 @@ async function createReleaseNotesPr() {
     logStep('Get Release Notes from File')
     const { body, releaseDate } = await getReleaseNotes(version, options.changelog)
 
-    logStep('Set up docs repo')
-    await cloneDocsRepo(options.repoPath, repoOwner)
+    if (!fs.existsSync(options.repoPath)) {
+      logStep('Clone docs repo')
+      await cloneDocsRepo(options.repoPath, repoOwner)
+    }
 
     logStep('Branch Creation')
     const branchName = await createBranch(options.repoPath, version, options.dryRun)


### PR DESCRIPTION
## Proposed Release Notes
Changed post-release create-docs-pr job to use the machine user username/email, and removed the fork syntax from the docs PR.

## Links
[NR-96240](https://issues.newrelic.com/browse/NR-96240)

## Details
