### PR TITLE
chore: pin testdobule to 3.17.2 as 3.18.0 no longer works on node 14

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -9417,7 +9417,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ### testdouble
 
-This product includes source derived from [testdouble](https://github.com/testdouble/testdouble.js) ([v3.16.6](https://github.com/testdouble/testdouble.js/tree/v3.16.6)), distributed under the [MIT License](https://github.com/testdouble/testdouble.js/blob/v3.16.6/LICENSE.txt):
+This product includes source derived from [testdouble](https://github.com/testdouble/testdouble.js) ([v3.17.2](https://github.com/testdouble/testdouble.js/tree/v3.17.2)), distributed under the [MIT License](https://github.com/testdouble/testdouble.js/blob/v3.17.2/LICENSE.txt):
 
 ```
 The MIT License (MIT)

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "sinon": "^4.5.0",
         "tap": "^16.3.4",
         "temp": "^0.8.1",
-        "testdouble": "^3.16.6",
+        "testdouble": "3.17.2",
         "when": "*"
       },
       "engines": {
@@ -10701,17 +10701,16 @@
       ]
     },
     "node_modules/quibble": {
-      "version": "0.6.14",
-      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.14.tgz",
-      "integrity": "sha512-r5noQhWx61qMOjaMQ48ePOKc9MKXzXFKUNj4S7/wIB9rzht3yyyf/Ms3BhXEVEPJtUvTNNnQxnT/6sHzcbkRoA==",
+      "version": "0.6.17",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.17.tgz",
+      "integrity": "sha512-uybGnGrx1hAhBCmzmVny+ycKaS5F71+q+iWVzbf8x/HyeEMDGeiQFVjWl1zhi4rwfTHa05+/NIExC4L5YRNPjQ==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.21",
-        "resolve": "^1.20.0"
+        "resolve": "^1.22.1"
       },
       "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
+        "node": ">= 0.14.0"
       }
     },
     "node_modules/quick-lru": {
@@ -13919,18 +13918,18 @@
       }
     },
     "node_modules/testdouble": {
-      "version": "3.16.6",
-      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.16.6.tgz",
-      "integrity": "sha512-mijMgc9y7buK9IG9zSVhzlXsFMqWbLQHRei4SLX7F7K4Qtrcnglg6lIMTCmNs6RwDUyLGWtpIe+TzkugYHB+qA==",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.17.2.tgz",
+      "integrity": "sha512-oRrk1DJISNoFr3aaczIqrrhkOUQ26BsXN3SopYT/U0GTvk9hlKPCEbd9R2uxkcufKZgEfo9D1JAB4CJrjHE9cw==",
       "dev": true,
       "dependencies": {
-        "lodash": "^4.17.15",
-        "quibble": "^0.6.7",
+        "lodash": "^4.17.21",
+        "quibble": "^0.6.17",
         "stringify-object-es5": "^2.5.0",
         "theredoc": "^1.0.0"
       },
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/text-extensions": {
@@ -22663,13 +22662,13 @@
       "dev": true
     },
     "quibble": {
-      "version": "0.6.14",
-      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.14.tgz",
-      "integrity": "sha512-r5noQhWx61qMOjaMQ48ePOKc9MKXzXFKUNj4S7/wIB9rzht3yyyf/Ms3BhXEVEPJtUvTNNnQxnT/6sHzcbkRoA==",
+      "version": "0.6.17",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.17.tgz",
+      "integrity": "sha512-uybGnGrx1hAhBCmzmVny+ycKaS5F71+q+iWVzbf8x/HyeEMDGeiQFVjWl1zhi4rwfTHa05+/NIExC4L5YRNPjQ==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.21",
-        "resolve": "^1.20.0"
+        "resolve": "^1.22.1"
       }
     },
     "quick-lru": {
@@ -24927,13 +24926,13 @@
       }
     },
     "testdouble": {
-      "version": "3.16.6",
-      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.16.6.tgz",
-      "integrity": "sha512-mijMgc9y7buK9IG9zSVhzlXsFMqWbLQHRei4SLX7F7K4Qtrcnglg6lIMTCmNs6RwDUyLGWtpIe+TzkugYHB+qA==",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.17.2.tgz",
+      "integrity": "sha512-oRrk1DJISNoFr3aaczIqrrhkOUQ26BsXN3SopYT/U0GTvk9hlKPCEbd9R2uxkcufKZgEfo9D1JAB4CJrjHE9cw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15",
-        "quibble": "^0.6.7",
+        "lodash": "^4.17.21",
+        "quibble": "^0.6.17",
         "stringify-object-es5": "^2.5.0",
         "theredoc": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -240,7 +240,7 @@
     "sinon": "^4.5.0",
     "tap": "^16.3.4",
     "temp": "^0.8.1",
-    "testdouble": "^3.16.6",
+    "testdouble": "3.17.2",
     "when": "*"
   },
   "repository": {

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Thu May 04 2023 11:13:33 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Tue May 09 2023 11:02:46 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -722,15 +722,15 @@
       "publisher": "Bruce Williams",
       "email": "brwcodes@gmail.com"
     },
-    "testdouble@3.16.6": {
+    "testdouble@3.17.2": {
       "name": "testdouble",
-      "version": "3.16.6",
-      "range": "^3.16.6",
+      "version": "3.17.2",
+      "range": "3.17.2",
       "licenses": "MIT",
       "repoUrl": "https://github.com/testdouble/testdouble.js",
-      "versionedRepoUrl": "https://github.com/testdouble/testdouble.js/tree/v3.16.6",
+      "versionedRepoUrl": "https://github.com/testdouble/testdouble.js/tree/v3.17.2",
       "licenseFile": "node_modules/testdouble/LICENSE.txt",
-      "licenseUrl": "https://github.com/testdouble/testdouble.js/blob/v3.16.6/LICENSE.txt",
+      "licenseUrl": "https://github.com/testdouble/testdouble.js/blob/v3.17.2/LICENSE.txt",
       "licenseTextSource": "file",
       "publisher": "Justin Searls",
       "email": "justin@testdouble.com",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
We have to pin `testdouble` until we drop support for node 14. [3.18.0](https://github.com/testdouble/testdouble.js/blob/main/CHANGELOG.md#3180) release added support for Node 20 which even though it doesn't call it out dropped support for 14 and it's breaking our esm unit tests.  
