### PR TITLE
test: pin prisma to < 4.14.0 until we fix instrumentation

### DIFF
--- a/test/versioned/prisma/package.json
+++ b/test/versioned/prisma/package.json
@@ -11,7 +11,7 @@
         "node": ">=14"
       },
       "dependencies": {
-        "@prisma/client": "^4.0.0",
+        "@prisma/client": ">=4.0.0 <4.14.0",
         "prisma": "latest"
       },
       "files": [


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
Prisma Client 4.14.0 changed how the library configuration functions and removed some functions we instrument. This pins prisma down to 4.13.0 until we can fix the instrumentation in https://github.com/newrelic/node-newrelic/issues/1632