### PR TITLE
ci: add --use-new-release functionality

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -13,6 +13,10 @@ on:
         type: string
         required: false
         default: NEWS.md
+      use_new_release:
+        description: Whether or not to use the new conventional commit release note workflow
+        required: false
+        default: false
 
 jobs:
   generate-release-notes:
@@ -41,6 +45,6 @@ jobs:
         git config user.name $GITHUB_ACTOR
         git config user.email gh-actions-${GITHUB_ACTOR}@github.com
     - name: Create Release Notes
-      run: node ./agent-repo/bin/prepare-release.js --release-type ${{ inputs.release_type }} --branch ${{ github.ref }} --repo ${{ github.repository }} --changelog ${{ inputs.changelog_file }}
+      run: node ./agent-repo/bin/prepare-release.js --release-type ${{ inputs.release_type }} --branch ${{ github.ref }} --repo ${{ github.repository }} --changelog ${{ inputs.changelog_file }} --use-new-release ${{ inputs.use_new_release }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -14,3 +14,4 @@ jobs:
     uses: newrelic/node-newrelic/.github/workflows/prep-release.yml@main
     with:
       release_type: ${{ github.event.inputs.release_type }}
+      use_new_release: ${{ vars.USE_NEW_RELEASE }}

--- a/bin/.eslintrc.js
+++ b/bin/.eslintrc.js
@@ -7,6 +7,7 @@
 module.exports = {
   rules: {
     'no-process-exit': 'off',
-    'no-console': 'off'
+    'no-console': 'off',
+    'no-shadow': 'off'
   }
 }

--- a/bin/conventional-changelog.js
+++ b/bin/conventional-changelog.js
@@ -214,9 +214,8 @@ class ConventionalChangelog {
    * @param {string} markdownFile path to the markdown file to update, defaults to NEWS.md
    * @returns {void}
    */
-  async writeMarkdownChangelog(newEntry, markdownFile = '../NEWS.md') {
-    const filename = path.resolve(__dirname, markdownFile)
-    const changelog = await readFile(filename, 'utf-8')
+  async writeMarkdownChangelog(newEntry, markdownFile = 'NEWS.md') {
+    const changelog = await readFile(markdownFile, 'utf-8')
 
     const heading = `### v${this.newVersion}`
 
@@ -225,7 +224,7 @@ class ConventionalChangelog {
       return
     }
 
-    await writeFile(filename, `${newEntry}\n${changelog}`, 'utf-8')
+    await writeFile(markdownFile, `${newEntry}\n${changelog}`, 'utf-8')
   }
 
   /**
@@ -237,9 +236,8 @@ class ConventionalChangelog {
    * @param {string} jsonFile path to the markdown file to update, defaults to changelog.json
    * @returns {void}
    */
-  async writeJsonChangelog(newEntry, jsonFile = '../changelog.json') {
-    const filename = path.resolve(__dirname, jsonFile)
-    const rawChangelog = await readFile(filename, 'utf-8')
+  async writeJsonChangelog(newEntry, jsonFile = 'changelog.json') {
+    const rawChangelog = await readFile(jsonFile, 'utf-8')
     const changelog = JSON.parse(rawChangelog)
 
     if (changelog.entries.find((entry) => entry.version === this.newVersion)) {
@@ -248,7 +246,7 @@ class ConventionalChangelog {
     }
 
     changelog.entries.unshift(newEntry)
-    await writeFile(filename, JSON.stringify(changelog, null, 2), 'utf-8')
+    await writeFile(jsonFile, JSON.stringify(changelog, null, 2), 'utf-8')
   }
 }
 

--- a/bin/conventional-changelog.js
+++ b/bin/conventional-changelog.js
@@ -114,27 +114,43 @@ class ConventionalChangelog {
   }
 
   /**
+   * Helper method to strip out the PR links that Github
+   * likes to add to the end of commit messages when
+   * using squash and merge
+   *
+   * Also since we're already manipulating the string,
+   * use .trim() to strip any trailing or leading whitespace
+   *
+   * @param {string} subject commit message header
+   * @returns {string} the commit message header with any PR links removed and whitespace trimmed
+   */
+  removePrLinks(subject) {
+    return subject.replace(/\(\#\d+\)$/, '').trim()
+  }
+
+  /**
    * Function for generating our front-matter content in a machine readable format
    *
    * @param {object[]} commits list of conventional commits
    * @returns {object} the entry to add to the JSON changelog
    */
   generateJsonChangelog(commits) {
+    const self = this
     const securityChanges = []
     const bugfixChanges = []
     const featureChanges = []
 
     commits.forEach((commit) => {
       if (commit.type === 'security') {
-        securityChanges.push(commit.subject)
+        securityChanges.push(self.removePrLinks(commit.subject))
       }
 
       if (commit.type === 'fix') {
-        bugfixChanges.push(commit.subject)
+        bugfixChanges.push(self.removePrLinks(commit.subject))
       }
 
       if (commit.type === 'feat') {
-        featureChanges.push(commit.subject)
+        featureChanges.push(self.removePrLinks(commit.subject))
       }
     })
 

--- a/bin/create-docs-pr.js
+++ b/bin/create-docs-pr.js
@@ -31,6 +31,11 @@ program.option(
   'Path to the docs-website fork on local machine',
   '/tmp/docs-website'
 )
+program.option(
+  '--front-matter-file <json file>',
+  'Name of changelog(defaults to changelog.json)',
+  'changelog.json'
+)
 
 program.option('--repo-owner <owner>', 'Owner of the target repo', 'newrelic')
 
@@ -61,6 +66,7 @@ async function createReleaseNotesPr() {
     validateTag(version, options.force)
     logStep('Get Release Notes from File')
     const { body, releaseDate } = await getReleaseNotes(version, options.changelog)
+    const frontmatter = await getFrontMatter(version, options.frontMatterFile)
 
     logStep('Set up docs repo')
     await cloneDocsRepo(options.repoPath, repoOwner)
@@ -68,7 +74,7 @@ async function createReleaseNotesPr() {
     logStep('Branch Creation')
     const branchName = await createBranch(options.repoPath, version, options.dryRun)
     logStep('Format release notes file')
-    const releaseNotesBody = formatReleaseNotes(releaseDate, version, body)
+    const releaseNotesBody = formatReleaseNotes(releaseDate, version, body, frontmatter)
     logStep('Create Release Notes')
     await addReleaseNotesFile(releaseNotesBody, version)
     logStep('Commit Release Notes')
@@ -117,7 +123,7 @@ async function getReleaseNotes(version, releaseNotesFile) {
 
   const data = await readReleaseNoteFile(releaseNotesFile)
 
-  const sections = data.split('### ')
+  const sections = data.split(/^### /m)
   // Iterate over all past releases to find the version we want
   const versionChangeLog = sections.find((section) => section.startsWith(version))
   // e.g. v7.1.2 (2021-02-24)\n\n
@@ -126,6 +132,33 @@ async function getReleaseNotes(version, releaseNotesFile) {
   const [, releaseDate] = headingRegex.exec(versionChangeLog)
 
   return { body, releaseDate }
+}
+
+/**
+ * Pulls the necessary frontmatter content for the given version
+ * from our JSON based changelog
+ *
+ * @param {string} tagName version tag name
+ * @param {string} frontMatterFile JSON changelog file
+ * @returns {object} frontmatter hash containing security, bugfix and feature lists
+ */
+async function getFrontMatter(tagName, frontMatterFile) {
+  console.log(`Retrieving release notes from file: ${frontMatterFile}`)
+
+  const version = tagName.replace('v', '')
+  const data = await readReleaseNoteFile(frontMatterFile)
+  const changelog = JSON.parse(data)
+  const frontmatter = changelog.entries.find((entry) => entry.version === version)
+
+  if (!frontmatter) {
+    throw new Error(`Unable to find ${version} entry in ${frontMatterFile}`)
+  }
+
+  return {
+    security: JSON.stringify(frontmatter.changes.security),
+    bugfixes: JSON.stringify(frontmatter.changes.bugfixes),
+    features: JSON.stringify(frontmatter.changes.features)
+  }
 }
 
 /**
@@ -148,8 +181,8 @@ async function readReleaseNoteFile(file) {
 /**
  * Clones docs repo
  *
- * @param repoPath
- * @param repoOwner
+ * @param {string} repoPath where to checkout the repo
+ * @param {string} repoOwner Github organization/owner name
  * @returns {boolean} success or failure
  */
 async function cloneDocsRepo(repoPath, repoOwner) {
@@ -191,15 +224,19 @@ async function createBranch(filePath, version, dryRun) {
  * @param {string} releaseDate date the release was created
  * @param {string} version version number
  * @param {string} body list of changes
+ * @param {object} frontmatter agent version metadata information about the release
  * @returns {string} appropriately formatted release notes
  */
-function formatReleaseNotes(releaseDate, version, body) {
+function formatReleaseNotes(releaseDate, version, body, frontmatter) {
   const releaseNotesBody = [
     '---',
     'subject: Node.js agent',
     `releaseDate: '${releaseDate}'`,
     `version: ${version.substr(1)}`, // remove the `v` from start of version
     `downloadLink: 'https://www.npmjs.com/package/newrelic'`,
+    `security: ${frontmatter.security}`,
+    `bugs: ${frontmatter.bugfixes}`,
+    `features: ${frontmatter.features}`,
     '---',
     '',
     '## Notes',
@@ -279,12 +316,15 @@ async function createPR(username, version, branch, dryRun, repoOwner) {
   }
 
   const github = new Github(repoOwner, 'docs-website')
-  const title = `Node.js Agent ${version} Release Notes`
+  const title = `chore: add Node.js Agent ${version} Release Notes`
+  const body =
+    'This is an automated PR generated when the Node.js agent is released. Please merge as soon as possible.'
+
   const prOptions = {
     head: `${username}:${branch}`,
     base: BASE_BRANCH,
     title,
-    body: title
+    body
   }
 
   console.log(`Creating PR with following options: ${JSON.stringify(prOptions)}\n\n`)
@@ -320,4 +360,17 @@ function logStep(step) {
   console.log(`\n ----- [Step]: ${step} -----\n`)
 }
 
-createReleaseNotesPr()
+/*
+ * Exports slightly differ for tests vs. Github Actions
+ * this allows us to require the function without it executing for tests,
+ * and executing via `node` cli in GHA
+ */
+if (require.main === module) {
+  createReleaseNotesPr()
+} else {
+  module.exports = {
+    getReleaseNotes,
+    getFrontMatter,
+    formatReleaseNotes
+  }
+}

--- a/bin/templates/header.hbs
+++ b/bin/templates/header.hbs
@@ -2,4 +2,4 @@
 {{~#if title}} "{{title}}"
 {{~/if}}
 {{~#if date}} ({{date}})
-{{/if}}
+{{~/if}}

--- a/bin/test/conventional-changelog.test.js
+++ b/bin/test/conventional-changelog.test.js
@@ -186,10 +186,10 @@ tap.test('Conventional Changelog Class', (testHarness) => {
 
   testHarness.test('generateJsonChangelog - should create the new JSON changelog entry', (t) => {
     const commits = [
-      { type: 'fix', subject: 'Fixed issue one' },
-      { type: 'fix', subject: 'Fixed issue two' },
-      { type: 'feat', subject: 'Added something new' },
-      { type: 'security', subject: 'Bumped some dep' }
+      { type: 'fix', subject: 'Fixed issue one (#1234)' },
+      { type: 'fix', subject: ' Fixed issue two' },
+      { type: 'feat', subject: 'Added something new ' },
+      { type: 'security', subject: ' Bumped some dep (#4567)' }
     ]
     const changelog = new ConventionalChangelog({ newVersion: '1.0.0', previousVersion: '0.9.0' })
 

--- a/bin/test/conventional-changelog.test.js
+++ b/bin/test/conventional-changelog.test.js
@@ -53,7 +53,6 @@ const exampleCommit = {
 }
 
 const exampleMarkdown = `### v1.0.0 (2020-04-03)
-
 #### ⚠ BREAKING CHANGES
 
 * **thing:** updated Thing to prevent accidental modifications to inputs

--- a/bin/test/create-docs-pr.test.js
+++ b/bin/test/create-docs-pr.test.js
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+const SCRIPT_PATH = '../create-docs-pr'
+
+tap.test('Create Docs PR script', (testHarness) => {
+  testHarness.autoend()
+
+  testHarness.test('getReleaseNotes', (t) => {
+    t.autoend()
+
+    let mockFs
+    let script
+
+    t.beforeEach(() => {
+      mockFs = {
+        readFile: sinon.stub()
+      }
+      script = proxyquire(SCRIPT_PATH, {
+        fs: mockFs
+      })
+    })
+
+    t.test('should return our release notes', async (t) => {
+      const expectedMarkdown = [
+        '### v1.2.3 (2020-04-03)',
+        '',
+        '#### Stuff heading',
+        '* first commit',
+        '',
+        '### v1.2.2 (2020-01-01)',
+        '',
+        '#### Things heading',
+        '* second commit'
+      ].join('\n')
+
+      mockFs.readFile.yields(null, expectedMarkdown)
+
+      const result = await script.getReleaseNotes('v1.2.3', 'NEWS.md')
+
+      t.equal(result.releaseDate, '2020-04-03')
+
+      const body = result.body.split('\n')
+      t.equal(body[0], '#### Stuff heading')
+      t.equal(body[1], '* first commit')
+      t.equal(body[4], '### Support statement:')
+
+      t.end()
+    })
+  })
+
+  testHarness.test('getFrontMatter', (t) => {
+    t.autoend()
+
+    let mockFs
+    let script
+
+    t.beforeEach(() => {
+      mockFs = {
+        readFile: sinon.stub()
+      }
+      script = proxyquire(SCRIPT_PATH, {
+        fs: mockFs
+      })
+    })
+
+    t.test('should throw an error if there is no frontmatter', async (t) => {
+      mockFs.readFile.yields(null, JSON.stringify({ entries: [{ version: '1.2.3', changes: [] }] }))
+
+      const func = () => script.getFrontMatter('v2.0.0', 'changelog.json')
+      t.rejects(func, 'Unable to find 2.0.0 entry in changelog.json')
+
+      t.end()
+    })
+
+    t.test('should return our formatted frontmatter', async (t) => {
+      mockFs.readFile.yields(
+        null,
+        JSON.stringify({
+          entries: [
+            {
+              version: '2.0.0',
+              changes: {
+                security: ['one', 'two'],
+                features: ['three', 'four'],
+                bugfixes: ['five', 'six']
+              }
+            }
+          ]
+        })
+      )
+
+      const result = await script.getFrontMatter('v2.0.0', 'changelog.json')
+
+      t.same(result, {
+        security: '["one","two"]',
+        bugfixes: '["five","six"]',
+        features: '["three","four"]'
+      })
+      t.end()
+    })
+  })
+
+  testHarness.test('formatReleaseNotes', (t) => {
+    t.autoend()
+
+    let script
+
+    t.beforeEach(() => {
+      script = proxyquire(SCRIPT_PATH, {})
+    })
+
+    t.test('should generate the release note markdown', (t) => {
+      const markdown = [
+        '#### Stuff',
+        '* commit number one',
+        '#### Things',
+        '* commit number two'
+      ].join('\n')
+
+      const frontmatter = {
+        security: '["upgraded a dep"]',
+        bugfixes: '["fixed a bug"]',
+        features: '["added new api method"]'
+      }
+      const result = script.formatReleaseNotes('2020-04-03', 'v2.0.0', markdown, frontmatter)
+
+      const expected = [
+        '---',
+        'subject: Node.js agent',
+        `releaseDate: '2020-04-03'`,
+        'version: 2.0.0',
+        `downloadLink: 'https://www.npmjs.com/package/newrelic'`,
+        `security: ["upgraded a dep"]`,
+        `bugs: ["fixed a bug"]`,
+        `features: ["added new api method"]`,
+        `---`,
+        '',
+        '## Notes',
+        '',
+        '#### Stuff',
+        '* commit number one',
+        '#### Things',
+        '* commit number two'
+      ].join('\n')
+
+      t.equal(result, expected)
+
+      t.end()
+    })
+  })
+})

--- a/bin/test/prepare-release.test.js
+++ b/bin/test/prepare-release.test.js
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+tap.test('Prepare Release script', (testHarness) => {
+  testHarness.autoend()
+
+  testHarness.test('generateConventionalReleaseNotes', (t) => {
+    t.autoend()
+
+    let mockConventionalCommands
+    let MockConventionalChangelog
+    let mockGithubCommands
+    let MockGithubSdk
+    let script
+
+    t.beforeEach(() => {
+      mockConventionalCommands = {
+        getFormattedCommits: sinon.stub(),
+        generateMarkdownChangelog: sinon.stub(),
+        generateJsonChangelog: sinon.stub(),
+        writeMarkdownChangelog: sinon.stub(),
+        writeJsonChangelog: sinon.stub()
+      }
+      MockConventionalChangelog = sinon.stub().returns(mockConventionalCommands)
+
+      mockGithubCommands = {
+        getLatestRelease: sinon.stub()
+      }
+      MockGithubSdk = sinon.stub().returns(mockGithubCommands)
+
+      script = proxyquire('../prepare-release', {
+        './github': MockGithubSdk,
+        './conventional-changelog': MockConventionalChangelog
+      })
+    })
+
+    t.test('should return the markdown and json generated notes', async (t) => {
+      mockGithubCommands.getLatestRelease.resolves({ tag_name: 'v1.2.3' })
+      const expectedCommits = [{ title: 'stuff: commit number one' }]
+      mockConventionalCommands.getFormattedCommits.resolves(expectedCommits)
+      const expectedMarkdown = `
+      ### v2.0.0
+
+      #### Stuff
+        * commit number 1
+
+      ### v1.2.3
+      `
+      mockConventionalCommands.generateMarkdownChangelog.resolves(expectedMarkdown)
+      const expectedJson = {
+        entries: [
+          { version: '2.0.0', changes: [{ type: 'stuff', subject: 'commit number one' }] },
+          { version: '1.2.3', changes: [] }
+        ]
+      }
+      mockConventionalCommands.generateJsonChangelog.resolves(expectedJson)
+
+      const [markdown, json] = await script.generateConventionalReleaseNotes(
+        'org',
+        'repo',
+        '2.0.0',
+        'changelog.json'
+      )
+
+      t.same(json, expectedJson)
+      t.equal(markdown, expectedMarkdown)
+
+      t.ok(MockGithubSdk.calledWith('org', 'repo'))
+      t.ok(
+        MockConventionalChangelog.calledWith({
+          org: 'org',
+          repo: 'repo',
+          newVersion: '2.0.0',
+          previousVersion: '1.2.3'
+        })
+      )
+
+      t.equal(mockConventionalCommands.getFormattedCommits.callCount, 1)
+
+      t.ok(mockConventionalCommands.generateMarkdownChangelog.calledWith(expectedCommits))
+      t.ok(mockConventionalCommands.generateJsonChangelog.calledWith(expectedCommits))
+
+      t.ok(
+        mockConventionalCommands.writeMarkdownChangelog.calledWith(
+          expectedMarkdown,
+          'changelog.json'
+        )
+      )
+      t.ok(mockConventionalCommands.writeJsonChangelog.calledWith(expectedJson))
+
+      t.end()
+    })
+  })
+
+  testHarness.test('isValid', (t) => {
+    t.autoend()
+
+    let mockGitCommands
+    let script
+
+    t.beforeEach(() => {
+      mockGitCommands = {
+        getPushRemotes: sinon.stub(),
+        getLocalChanges: sinon.stub(),
+        getCurrentBranch: sinon.stub()
+      }
+
+      script = proxyquire('../prepare-release', {
+        './git-commands': mockGitCommands
+      })
+    })
+
+    t.test('should return true if force mode enabled', async (t) => {
+      const result = await script.isValid({ force: true })
+
+      t.equal(result, true)
+      t.end()
+    })
+
+    t.test('should return true when all checks pass', async (t) => {
+      mockGitCommands.getPushRemotes.resolves({ origin: 'stuff' })
+      mockGitCommands.getLocalChanges.resolves([])
+      mockGitCommands.getCurrentBranch.resolves('test-branch')
+
+      const result = await script.isValid({ force: false, branch: 'test-branch', remote: 'origin' })
+
+      t.equal(result, true)
+      t.end()
+    })
+
+    t.test('should return false if one check fails', async (t) => {
+      mockGitCommands.getPushRemotes.resolves({ origin: 'stuff' })
+      mockGitCommands.getLocalChanges.resolves(['stuff'])
+      mockGitCommands.getCurrentBranch.resolves('another-branch')
+
+      const result = await script.isValid({
+        force: false,
+        branch: 'another-branch',
+        remote: 'origin'
+      })
+
+      t.equal(result, false)
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
## Proposed Release Notes
Updated the prepare release workflow to accept a new, optional input from workflows. Setting USE_NEW_RELEASE to true in a given repo's actions variables configuration will cause the workflow to use the new Conventional Commit based release notes. This flag is set to false by default, which will allow our external repos to slowly be migrated over without interruption.

## Links
Closes NR-96236

## Details
When `USE_NEW_RELEASE` is set, prepare-release has been enhanced to use previous work around conventional commit parsing / changelog generation. Additionally, the docs-website script has also been enhanced to use conventional commits all the time now. I believe this is a safe enough change because create-docs-pr is only used in this repo, whereas prepare-release is used in all repos.

To test this, do the following while on this branch
1. Use `prepare-release.js` to update `NEWS.md` and `changelog.json`
```
node bin/prepare-release.js --release-type minor --branch refs/heads/update-prep-and-docs-scripts --repo newrelic/node-newrelic --changelog NEWS.md --dry-run --use-new-release
```
2. Use `create-docs-pr.js` to simulate a run
```
GITHUB_TOKEN=token node ./bin/create-docs-pr.js --tag v10.2.0 --repo-path ~/projects/docs-website --username gh-handle --dry-run
```

If you want to see more commit types, you can manually update https://github.com/jmartin4563/node-newrelic/blob/update-prep-and-docs-scripts/bin/prepare-release.js#L324-L325 to an older tag
```
const latestRelease = { tag_name: 'v9.8.0' }
```