### PR TITLE
ci: fix issue with missing type in the prep-release

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -15,6 +15,7 @@ on:
         default: NEWS.md
       use_new_release:
         description: Whether or not to use the new conventional commit release note workflow
+        type: boolean
         required: false
         default: false
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
Discovered during first release attempt, I missed including a required `type` field
https://github.com/newrelic/node-newrelic/actions/runs/4962480712/workflow
