### PR TITLE
ci: update to conditionally add CLI flag to prep-release

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -15,9 +15,8 @@ on:
         default: NEWS.md
       use_new_release:
         description: Whether or not to use the new conventional commit release note workflow
-        type: boolean
+        type: string
         required: false
-        default: false
 
 jobs:
   generate-release-notes:
@@ -46,6 +45,6 @@ jobs:
         git config user.name $GITHUB_ACTOR
         git config user.email gh-actions-${GITHUB_ACTOR}@github.com
     - name: Create Release Notes
-      run: node ./agent-repo/bin/prepare-release.js --release-type ${{ inputs.release_type }} --branch ${{ github.ref }} --repo ${{ github.repository }} --changelog ${{ inputs.changelog_file }} --use-new-release ${{ inputs.use_new_release }}
+      run: node ./agent-repo/bin/prepare-release.js --release-type ${{ inputs.release_type }} --branch ${{ github.ref }} --repo ${{ github.repository }} --changelog ${{ inputs.changelog_file }} ${{ inputs.use_new_release == 'true' && '--use-new-release' || '' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
Updated prep-release to use a string instead of a boolean. The variables come in from Github as strings, so a boolean check is incorrect. Instead, we now do a check to see if it's defined, and if so, set `--use-new-release` on the CLI