### PR TITLE
ci: update prep-release to fetch entire history of caller repo

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     # Check out caller repo
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     # check out agent repo to agent-repo for the bin folders
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
This is necessary in order to get the tag history, which we require to determine commits that have occurred between this new version and the previous version

## How to Test
[Tested against my fork](https://github.com/jmartin4563/node-newrelic/actions/runs/4981959889/jobs/8916950685), confirmed that it got to the point where it was committing files (at which point it failed because secrets)