### PR TITLE
fix: db connection status restored to unwrapped for initialization

### DIFF
--- a/lib/instrumentation/mysql/mysql.js
+++ b/lib/instrumentation/mysql/mysql.js
@@ -11,7 +11,7 @@ const symbols = require('../../symbols')
 
 exports.callbackInitialize = function callbackInitialize(shim, mysql) {
   shim.setDatastore(shim.MYSQL)
-  shim[symbols.wrappedPoolConnection] = true
+  shim[symbols.wrappedPoolConnection] = false
 
   shim.wrapReturn(mysql, 'createConnection', wrapCreateConnection)
   function wrapCreateConnection(shim, fn, fnName, connection) {


### PR DESCRIPTION
## Description

Version 10.x of the agent toggled the initial state that determines whether or not to wrap a connection callback on initialization. 

## How to Test

`npm run versioned mysql` and `npm run versioned mysql2` should test, though currently all pass whichever way this is toggled. 

## Related Issues

https://issues.newrelic.com/browse/NR-116646