### PR TITLE
fix: Updated mysql instrumentation to properly wrap the connection pool.getConnection and poolCluster.of

### DIFF
--- a/lib/instrumentation/mysql/mysql.js
+++ b/lib/instrumentation/mysql/mysql.js
@@ -11,7 +11,7 @@ const symbols = require('../../symbols')
 
 exports.callbackInitialize = function callbackInitialize(shim, mysql) {
   shim.setDatastore(shim.MYSQL)
-  shim[symbols.wrappedPoolConnection] = true
+  shim[symbols.wrappedPoolConnection] = false
 
   shim.wrapReturn(mysql, 'createConnection', wrapCreateConnection)
   function wrapCreateConnection(shim, fn, fnName, connection) {

--- a/lib/instrumentation/mysql/mysql.js
+++ b/lib/instrumentation/mysql/mysql.js
@@ -49,7 +49,8 @@ exports.callbackInitialize = function callbackInitialize(shim, mysql) {
       if (poolNamespace[symbols.clusterOf]) {
         return
       }
-      if (wrapGetConnection(shim, poolNamespace)) {
+
+      if (wrapGetConnection(shim, poolNamespace) && wrapQueryable(shim, poolNamespace, false)) {
         poolNamespace[symbols.clusterOf] = true
       }
     }

--- a/lib/instrumentation/mysql/mysql.js
+++ b/lib/instrumentation/mysql/mysql.js
@@ -46,11 +46,11 @@ exports.callbackInitialize = function callbackInitialize(shim, mysql) {
     const proto = Object.getPrototypeOf(poolCluster)
     shim.wrapReturn(proto, 'of', wrapPoolClusterOf)
     function wrapPoolClusterOf(shim, of, _n, poolNamespace) {
-      if (shim[symbols.clusterOf]) {
+      if (poolNamespace[symbols.clusterOf]) {
         return
       }
       if (wrapGetConnection(shim, poolNamespace)) {
-        shim[symbols.clusterOf] = true
+        poolNamespace[symbols.clusterOf] = true
       }
     }
 

--- a/test/versioned/mysql/basic-pool.tap.js
+++ b/test/versioned/mysql/basic-pool.tap.js
@@ -251,11 +251,8 @@ tap.test('mysql built-in connection pools', function (t) {
   t.test('lack of callback does not explode', function (t) {
     helper.runInTransaction(agent, function transactionInScope(txn) {
       pool.query('SET SESSION auto_increment_increment=1')
-      setTimeout(function () {
-        // without the timeout, the pool is closed before the query is able to execute
-        txn.end()
-        t.end()
-      }, 500)
+      txn.end()
+      t.end()
     })
   })
 

--- a/test/versioned/mysql/basic-pool.tap.js
+++ b/test/versioned/mysql/basic-pool.tap.js
@@ -93,7 +93,6 @@ tap.test('mysql built-in connection pools', function (t) {
     agent = helper.instrumentMockedAgent()
     mysql = require('mysql')
     pool = mysql.createPool(config)
-    return setup(mysql)
   })
 
   t.afterEach(function () {
@@ -396,13 +395,11 @@ tap.test('poolCluster', function (t) {
   t.beforeEach(function () {
     agent = helper.instrumentMockedAgent()
     mysql = require('mysql')
-    return setup(mysql).then(() => {
-      poolCluster = mysql.createPoolCluster()
+    poolCluster = mysql.createPoolCluster()
 
-      poolCluster.add(config) // anonymous group
-      poolCluster.add('MASTER', config)
-      poolCluster.add('REPLICA', config)
-    })
+    poolCluster.add(config) // anonymous group
+    poolCluster.add('MASTER', config)
+    poolCluster.add('REPLICA', config)
   })
 
   t.afterEach(function () {

--- a/test/versioned/mysql/basic-pool.tap.js
+++ b/test/versioned/mysql/basic-pool.tap.js
@@ -631,9 +631,9 @@ tap.test('poolCluster', function (t) {
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
 
           t.error(err, 'no error occurred')
-          t.ok(transaction, 'transaction should exit')
+          t.ok(transaction, 'transaction should exist')
           t.equal(transaction, txn, 'transaction must be same')
-          t.ok(segment, 'segment should exit')
+          t.ok(segment, 'segment should exist')
           t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')

--- a/test/versioned/mysql/basic-pool.tap.js
+++ b/test/versioned/mysql/basic-pool.tap.js
@@ -63,10 +63,10 @@ tap.test('bad config', function (t) {
       const stack = new Error().stack
       const frames = stack.split('\n').slice(3, 8)
 
-      t.notEqual(frames[0], frames[1], 'do not multi-wrap')
-      t.notEqual(frames[0], frames[2], 'do not multi-wrap')
-      t.notEqual(frames[0], frames[3], 'do not multi-wrap')
-      t.notEqual(frames[0], frames[4], 'do not multi-wrap')
+      t.not(frames[0], frames[1], 'do not multi-wrap')
+      t.not(frames[0], frames[2], 'do not multi-wrap')
+      t.not(frames[0], frames[3], 'do not multi-wrap')
+      t.not(frames[0], frames[4], 'do not multi-wrap')
 
       t.ok(err, 'should be an error')
       poolCluster.end()

--- a/test/versioned/mysql/basic-pool.tap.js
+++ b/test/versioned/mysql/basic-pool.tap.js
@@ -89,7 +89,8 @@ tap.test('mysql built-in connection pools', function (t) {
   let mysql = null
   let pool = null
 
-  t.beforeEach(function () {
+  t.beforeEach(async function () {
+    await setup(require('mysql'))
     agent = helper.instrumentMockedAgent()
     mysql = require('mysql')
     pool = mysql.createPool(config)
@@ -395,7 +396,8 @@ tap.test('poolCluster', function (t) {
   let mysql = null
   let poolCluster = null
 
-  t.beforeEach(function () {
+  t.beforeEach(async function () {
+    await setup(require('mysql'))
     agent = helper.instrumentMockedAgent()
     mysql = require('mysql')
     poolCluster = mysql.createPoolCluster()
@@ -623,7 +625,7 @@ tap.test('poolCluster', function (t) {
           t.ok(transaction, 'transaction should exist')
           t.equal(transaction, txn, 'transaction must be same')
 
-          let segment = agent.tracer.getSegment().children[1]
+          let segment = agent.tracer.getSegment().parent
           t.ok(segment, 'segment should exist')
           t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
@@ -643,7 +645,7 @@ tap.test('poolCluster', function (t) {
             t.ok(transaction, 'transaction should exist')
             t.equal(transaction, txn, 'transaction must be same')
 
-            segment = agent.tracer.getSegment().children[1]
+            segment = agent.tracer.getSegment().parent
             t.ok(segment, 'segment should exist')
             t.ok(segment.timer.start > 0, 'starts at a positive time')
             t.ok(segment.timer.start <= Date.now(), 'starts in past')

--- a/test/versioned/mysql/basic-pool.tap.js
+++ b/test/versioned/mysql/basic-pool.tap.js
@@ -267,7 +267,7 @@ tap.test('mysql built-in connection pools', function (t) {
         t.error(err, 'no error occurred')
         t.ok(transaction, 'transaction should exist')
         t.ok(segment, 'segment should exist')
-        t.ok(segment.timer.start > 0, 'starts at a postitive time')
+        t.ok(segment.timer.start > 0, 'starts at a positive time')
         t.ok(segment.timer.start <= Date.now(), 'starts in past')
         t.equal(segment.name, 'MySQL Pool#query', 'is named')
         txn.end()
@@ -285,7 +285,7 @@ tap.test('mysql built-in connection pools', function (t) {
         if (transaction) {
           const segment = agent.tracer.getSegment().parent
           t.ok(segment, 'segment should exist')
-          t.ok(segment.timer.start > 0, 'starts at a postitive time')
+          t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'MySQL Pool#query', 'is named')
         }
@@ -312,7 +312,7 @@ tap.test('mysql built-in connection pools', function (t) {
           t.error(err, 'no error occurred')
           t.ok(transaction, 'transaction should exist')
           t.ok(segment, 'segment should exist')
-          t.ok(segment.timer.start > 0, 'starts at a postitive time')
+          t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
           txn.end()
@@ -338,7 +338,7 @@ tap.test('mysql built-in connection pools', function (t) {
           if (transaction) {
             const segment = agent.tracer.getSegment().parent
             t.ok(segment, 'segment should exist')
-            t.ok(segment.timer.start > 0, 'starts at a postitive time')
+            t.ok(segment.timer.start > 0, 'starts at a positive time')
             t.ok(segment.timer.start <= Date.now(), 'starts in past')
             t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
           }
@@ -455,9 +455,10 @@ tap.test('poolCluster', function (t) {
           t.equal(transaction.id, txn.id, 'transaction must be same')
           const segment = agent.tracer.getSegment().parent
           t.ok(segment, 'segment should exist')
-          t.ok(segment.timer.start > 0, 'starts at a postitive time')
+          t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
+
           txn.end()
           connection.release()
           t.end()
@@ -490,9 +491,10 @@ tap.test('poolCluster', function (t) {
           t.equal(transaction.id, txn.id, 'transaction must be same')
           const segment = agent.tracer.getSegment().parent
           t.ok(segment, 'segment should exist')
-          t.ok(segment.timer.start > 0, 'starts at a postitive time')
+          t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
+
           txn.end()
           connection.release()
           t.end()
@@ -525,9 +527,10 @@ tap.test('poolCluster', function (t) {
           t.equal(transaction.id, txn.id, 'transaction must be same')
           const segment = agent.tracer.getSegment().parent
           t.ok(segment, 'segment should exist')
-          t.ok(segment.timer.start > 0, 'starts at a postitive time')
+          t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
+
           txn.end()
           connection.release()
           t.end()
@@ -559,7 +562,7 @@ tap.test('poolCluster', function (t) {
           t.equal(transaction.id, txn.id, 'transaction must be same')
           const segment = agent.tracer.getSegment().parent
           t.ok(segment, 'segment should exist')
-          t.ok(segment.timer.start > 0, 'starts at a postitive time')
+          t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
 
@@ -596,9 +599,10 @@ tap.test('poolCluster', function (t) {
           t.equal(currentTransaction.id, txn.id, 'transaction must be same')
           const segment = agent.tracer.getSegment().parent
           t.ok(segment, 'segment should exist')
-          t.ok(segment.timer.start > 0, 'starts at a postitive time')
+          t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
+
           txn.end()
           connection.release()
           t.end()
@@ -621,7 +625,7 @@ tap.test('poolCluster', function (t) {
 
           let segment = agent.tracer.getSegment().children[1]
           t.ok(segment, 'segment should exist')
-          t.ok(segment.timer.start > 0, 'starts at a postitive time')
+          t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
 
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
@@ -630,7 +634,7 @@ tap.test('poolCluster', function (t) {
           t.ok(transaction, 'transaction should exit')
           t.equal(transaction, txn, 'transaction must be same')
           t.ok(segment, 'segment should exit')
-          t.ok(segment.timer.start > 0, 'starts at a postitive time')
+          t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
 
@@ -641,7 +645,7 @@ tap.test('poolCluster', function (t) {
 
             segment = agent.tracer.getSegment().children[1]
             t.ok(segment, 'segment should exist')
-            t.ok(segment.timer.start > 0, 'starts at a postitive time')
+            t.ok(segment.timer.start > 0, 'starts at a positive time')
             t.ok(segment.timer.start <= Date.now(), 'starts in past')
 
             t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
@@ -650,7 +654,7 @@ tap.test('poolCluster', function (t) {
             t.ok(transaction, 'transaction should exit')
             t.equal(transaction, txn, 'transaction must be same')
             t.ok(segment, 'segment should exit')
-            t.ok(segment.timer.start > 0, 'starts at a postitive time')
+            t.ok(segment.timer.start > 0, 'starts at a positive time')
             t.ok(segment.timer.start <= Date.now(), 'starts in past')
             t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
 

--- a/test/versioned/mysql/basic-pool.tap.js
+++ b/test/versioned/mysql/basic-pool.tap.js
@@ -148,10 +148,10 @@ tap.test('mysql built-in connection pools', function (t) {
       agent.config.datastore_tracer.instance_reporting.enabled = false
       pool.query('SELECT 1 + 1 AS solution', function (err) {
         const seg = getDatastoreSegment(agent.tracer.getSegment())
-        const attributes = seg.getAttributes()
         t.error(err, 'should not error making query')
         t.ok(seg, 'should have a segment')
 
+        const attributes = seg.getAttributes()
         t.notOk(attributes.host, 'should have no host parameter')
         t.notOk(attributes.port_path_or_id, 'should have no port parameter')
         t.equal(attributes.database_name, DATABASE, 'should set database name')

--- a/test/versioned/mysql/basic-pool.tap.js
+++ b/test/versioned/mysql/basic-pool.tap.js
@@ -651,9 +651,9 @@ tap.test('poolCluster', function (t) {
             t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
 
             t.error(err, 'no error occurred')
-            t.ok(transaction, 'transaction should exit')
+            t.ok(transaction, 'transaction should exist')
             t.equal(transaction, txn, 'transaction must be same')
-            t.ok(segment, 'segment should exit')
+            t.ok(segment, 'segment should exist')
             t.ok(segment.timer.start > 0, 'starts at a positive time')
             t.ok(segment.timer.start <= Date.now(), 'starts in past')
             t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')

--- a/test/versioned/mysql/helpers.js
+++ b/test/versioned/mysql/helpers.js
@@ -7,8 +7,14 @@
 const params = require('../../lib/params')
 
 module.exports = async function setupDb(user, db, table, mysql) {
+  const regex = new RegExp(/mysql/)
   await createDb(mysql, user, db)
   await createTable(mysql, user, db, table)
+  Object.keys(require.cache).forEach((key) => {
+    if (regex.test(key)) {
+      delete require.cache[key]
+    }
+  })
 }
 
 function runCommand(client, cmd) {

--- a/test/versioned/mysql2/basic-pool.tap.js
+++ b/test/versioned/mysql2/basic-pool.tap.js
@@ -93,7 +93,6 @@ tap.test('mysql2 built-in connection pools', function (t) {
     agent = helper.instrumentMockedAgent()
     mysql = require('mysql2')
     pool = mysql.createPool(config)
-    return setup(mysql)
   })
 
   t.afterEach(function () {
@@ -391,13 +390,11 @@ tap.test('poolCluster', function (t) {
   t.beforeEach(function () {
     agent = helper.instrumentMockedAgent()
     mysql = require('mysql2')
-    return setup(mysql).then(() => {
-      poolCluster = mysql.createPoolCluster()
+    poolCluster = mysql.createPoolCluster()
 
-      poolCluster.add(config) // anonymous group
-      poolCluster.add('MASTER', config)
-      poolCluster.add('REPLICA', config)
-    })
+    poolCluster.add(config) // anonymous group
+    poolCluster.add('MASTER', config)
+    poolCluster.add('REPLICA', config)
   })
 
   t.afterEach(function () {
@@ -406,6 +403,7 @@ tap.test('poolCluster', function (t) {
 
     agent = null
     mysql = null
+    poolCluster = null
   })
 
   t.test('primer', function (t) {

--- a/test/versioned/mysql2/basic-pool.tap.js
+++ b/test/versioned/mysql2/basic-pool.tap.js
@@ -89,7 +89,8 @@ tap.test('mysql2 built-in connection pools', function (t) {
   let mysql = null
   let pool = null
 
-  t.beforeEach(function () {
+  t.beforeEach(async function () {
+    await setup(require('mysql2'))
     agent = helper.instrumentMockedAgent()
     mysql = require('mysql2')
     pool = mysql.createPool(config)
@@ -387,7 +388,8 @@ tap.test('poolCluster', function (t) {
   let mysql = null
   let poolCluster = null
 
-  t.beforeEach(function () {
+  t.beforeEach(async function () {
+    await setup(require('mysql2'))
     agent = helper.instrumentMockedAgent()
     mysql = require('mysql2')
     poolCluster = mysql.createPoolCluster()

--- a/test/versioned/mysql2/basic-pool.tap.js
+++ b/test/versioned/mysql2/basic-pool.tap.js
@@ -294,7 +294,7 @@ tap.test('mysql2 built-in connection pools', function (t) {
         const transaction = agent.getTransaction()
         const segment = agent.tracer.getSegment().parent
 
-        t.error(err, 'no error ocurred')
+        t.error(err, 'no error occurred')
         t.ok(transaction, 'transaction should exist')
         t.ok(segment, 'segment should exist')
         t.ok(segment.timer.start > 0, 'starts at a positive time')
@@ -339,7 +339,7 @@ tap.test('mysql2 built-in connection pools', function (t) {
           const transaction = agent.getTransaction()
           const segment = agent.tracer.getSegment().parent
 
-          t.error(err, 'no error ocurred')
+          t.error(err, 'no error occurred')
           t.ok(transaction, 'transaction should exist')
           t.ok(segment, 'segment should exist')
           t.ok(segment.timer.start > 0, 'starts at a positive time')
@@ -443,12 +443,12 @@ tap.test('poolCluster', function (t) {
 
       helper.runInTransaction(agent, function (txn) {
         connection.query('SELECT ? + ? AS solution', [1, 1], function (err) {
-          t.error(err, 'no error ocurred')
+          t.error(err, 'no error occurred')
           const transaction = agent.getTransaction()
           t.ok(transaction, 'transaction should exist')
           t.equal(transaction.id, txn.id, 'transaction must be same')
           const segment = agent.tracer.getSegment().parent
-          t.ok(segment, 'segment should exit')
+          t.ok(segment, 'segment should exist')
           t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
@@ -479,12 +479,12 @@ tap.test('poolCluster', function (t) {
     poolCluster.getConnection('MASTER', function (err, connection) {
       helper.runInTransaction(agent, function (txn) {
         connection.query('SELECT ? + ? AS solution', [1, 1], function (err) {
-          t.error(err, 'no error ocurred')
+          t.error(err, 'no error occurred')
           const transaction = agent.getTransaction()
           t.ok(transaction, 'transaction should exist')
           t.equal(transaction.id, txn.id, 'transaction must be same')
           const segment = agent.tracer.getSegment().parent
-          t.ok(segment, 'segment should exit')
+          t.ok(segment, 'segment should exist')
           t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
@@ -515,12 +515,12 @@ tap.test('poolCluster', function (t) {
     poolCluster.getConnection('REPLICA*', 'ORDER', function (err, connection) {
       helper.runInTransaction(agent, function (txn) {
         connection.query('SELECT ? + ? AS solution', [1, 1], function (err) {
-          t.error(err, 'no error ocurred')
+          t.error(err, 'no error occurred')
           const transaction = agent.getTransaction()
           t.ok(transaction, 'transaction should exist')
           t.equal(transaction.id, txn.id, 'transaction must be same')
           const segment = agent.tracer.getSegment().parent
-          t.ok(segment, 'segment should exit')
+          t.ok(segment, 'segment should exist')
           t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
@@ -550,12 +550,12 @@ tap.test('poolCluster', function (t) {
     poolCluster.of('*').getConnection(function (err, connection) {
       helper.runInTransaction(agent, function (txn) {
         connection.query('SELECT ? + ? AS solution', [1, 1], function (err) {
-          t.error(err, 'no error ocurred')
+          t.error(err, 'no error occurred')
           const transaction = agent.getTransaction()
           t.ok(transaction, 'transaction should exist')
           t.equal(transaction.id, txn.id, 'transaction must be same')
           const segment = agent.tracer.getSegment().parent
-          t.ok(segment, 'segment should exit')
+          t.ok(segment, 'segment should exist')
           t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')
@@ -587,12 +587,12 @@ tap.test('poolCluster', function (t) {
     pool.getConnection(function (err, connection) {
       helper.runInTransaction(agent, function (txn) {
         connection.query('SELECT ? + ? AS solution', [1, 1], function (err) {
-          t.error(err, 'no error ocurred')
+          t.error(err, 'no error occurred')
           const currentTransaction = agent.getTransaction()
           t.ok(currentTransaction, 'transaction should exist')
           t.equal(currentTransaction.id, txn.id, 'transaction must be same')
           const segment = agent.tracer.getSegment().parent
-          t.ok(segment, 'segment should exit')
+          t.ok(segment, 'segment should exist')
           t.ok(segment.timer.start > 0, 'starts at a positive time')
           t.ok(segment.timer.start <= Date.now(), 'starts in past')
           t.equal(segment.name, 'Datastore/statement/MySQL/unknown/select', 'is named')

--- a/test/versioned/mysql2/basic-pool.tap.js
+++ b/test/versioned/mysql2/basic-pool.tap.js
@@ -147,10 +147,10 @@ tap.test('mysql2 built-in connection pools', function (t) {
       agent.config.datastore_tracer.instance_reporting.enabled = false
       pool.query('SELECT 1 + 1 AS solution', function (err) {
         const seg = getDatastoreSegment(agent.tracer.getSegment())
-        const attributes = seg.getAttributes()
         t.error(err, 'should not error making query')
         t.ok(seg, 'should have a segment')
 
+        const attributes = seg.getAttributes()
         t.notOk(attributes.host, 'should have no host parameter')
         t.notOk(attributes.port_path_or_id, 'should have no port parameter')
         t.equal(attributes.database_name, DATABASE, 'should set database name')

--- a/test/versioned/mysql2/basic-pool.tap.js
+++ b/test/versioned/mysql2/basic-pool.tap.js
@@ -61,10 +61,10 @@ tap.test('bad config', function (t) {
       const stack = new Error().stack
       const frames = stack.split('\n').slice(3, 8)
 
-      t.notEqual(frames[0], frames[1], 'do not multi-wrap')
-      t.notEqual(frames[0], frames[2], 'do not multi-wrap')
-      t.notEqual(frames[0], frames[3], 'do not multi-wrap')
-      t.notEqual(frames[0], frames[4], 'do not multi-wrap')
+      t.not(frames[0], frames[1], 'do not multi-wrap')
+      t.not(frames[0], frames[2], 'do not multi-wrap')
+      t.not(frames[0], frames[3], 'do not multi-wrap')
+      t.not(frames[0], frames[4], 'do not multi-wrap')
 
       t.ok(err, 'should be an error')
       poolCluster.end()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

**Note**: We need to add more information to the commit description on squash and merge to call out the fact we also instrument Poolnamespace.prototype.query now too.

This PR fixes the `setup` helper method in mysql by running before the agent instrumentation is loaded and busts the require cache.  This was found to hide the root cause of this PR which was a mistake on a symbol defaulting to true.  By fixing setup it also exposed an issue with PoolNamespace.prototype.query where it isn't getting instrumented thus some failing tests.  

## How to Test

Restore [this bit flip](https://github.com/newrelic/node-newrelic/pull/1647/files#diff-a19b1a5fade2ea9928d9a753cbf0fe66c12e4b9a912250f11b7c5cd7aa5e07d0L14), and the tests should fail

## Related Issues

Closes #1645 
