### PR TITLE
test: added unit tests for MySQL instrumentation

### DIFF
--- a/lib/instrumentation/mysql/mysql.js
+++ b/lib/instrumentation/mysql/mysql.js
@@ -19,7 +19,7 @@ exports.callbackInitialize = function callbackInitialize(shim, mysql) {
       return
     }
     shim.logger.debug('Wrapping Connection#query')
-    if (wrapQueryable(shim, connection, false)) {
+    if (exports.wrapQueryable(shim, connection, false)) {
       const connProto = Object.getPrototypeOf(connection)
       connProto[symbols.storeDatabase] = true
       shim[symbols.unwrapConnection] = true
@@ -32,7 +32,7 @@ exports.callbackInitialize = function callbackInitialize(shim, mysql) {
       return
     }
     shim.logger.debug('Wrapping Pool#query and Pool#getConnection')
-    if (wrapQueryable(shim, pool, true) && wrapGetConnection(shim, pool)) {
+    if (exports.wrapQueryable(shim, pool, true) && exports.wrapGetConnection(shim, pool)) {
       shim[symbols.unwrapPool] = true
     }
   }
@@ -50,13 +50,16 @@ exports.callbackInitialize = function callbackInitialize(shim, mysql) {
         return
       }
 
-      if (wrapGetConnection(shim, poolNamespace) && wrapQueryable(shim, poolNamespace, false)) {
+      if (
+        exports.wrapGetConnection(shim, poolNamespace) &&
+        exports.wrapQueryable(shim, poolNamespace, false)
+      ) {
         poolNamespace[symbols.clusterOf] = true
       }
     }
 
     shim.logger.debug('Wrapping PoolCluster#getConnection')
-    if (wrapGetConnection(shim, poolCluster)) {
+    if (exports.wrapGetConnection(shim, poolCluster)) {
       shim[symbols.createPoolCluster] = true
     }
   }
@@ -69,7 +72,7 @@ exports.promiseInitialize = function promiseInitialize(shim) {
   }
 }
 
-function wrapGetConnection(shim, connectable) {
+exports.wrapGetConnection = function wrapGetConnection(shim, connectable) {
   if (!connectable || !connectable.getConnection || shim.isWrapped(connectable.getConnection)) {
     shim.logger.trace(
       {
@@ -97,7 +100,7 @@ function wrapGetConnection(shim, connectable) {
         )
         let cb = args[cbIdx]
         if (!shim[symbols.wrappedPoolConnection]) {
-          cb = shim.wrap(cb, wrapGetConnectionCallback)
+          cb = shim.wrap(cb, exports.wrapGetConnectionCallback)
         }
         args[cbIdx] = shim.bindSegment(cb)
       }
@@ -108,11 +111,11 @@ function wrapGetConnection(shim, connectable) {
   return true
 }
 
-function wrapGetConnectionCallback(shim, cb) {
+exports.wrapGetConnectionCallback = function wrapGetConnectionCallback(shim, cb) {
   return function wrappedGetConnectionCallback(err, conn) {
     try {
       shim.logger.debug('Wrapping PoolConnection#query')
-      if (!err && wrapQueryable(shim, conn, false)) {
+      if (!err && exports.wrapQueryable(shim, conn, false)) {
         // Leave getConnection wrapped in order to maintain TX state, but we can
         // simplify the wrapping of its callback in future calls.
         shim[symbols.wrappedPoolConnection] = true
@@ -127,7 +130,7 @@ function wrapGetConnectionCallback(shim, cb) {
   }
 }
 
-function wrapQueryable(shim, queryable, isPoolQuery) {
+exports.wrapQueryable = function wrapQueryable(shim, queryable, isPoolQuery) {
   if (!queryable || !queryable.query || shim.isWrapped(queryable.query)) {
     shim.logger.debug(
       {
@@ -144,9 +147,9 @@ function wrapQueryable(shim, queryable, isPoolQuery) {
 
   let describe
   if (isPoolQuery) {
-    describe = describePoolQuery
+    describe = exports.describePoolQuery
   } else {
-    describe = describeQuery
+    describe = exports.describeQuery
     proto[symbols.databaseName] = null
   }
 
@@ -159,7 +162,7 @@ function wrapQueryable(shim, queryable, isPoolQuery) {
   return true
 }
 
-function extractQueryArgs(shim, args) {
+exports.extractQueryArgs = function extractQueryArgs(shim, args) {
   let query = ''
   let callback = null
 
@@ -187,12 +190,12 @@ function extractQueryArgs(shim, args) {
   }
 }
 
-function describeQuery(shim, queryFn, fnName, args) {
+exports.describeQuery = function describeQuery(shim, queryFn, fnName, args) {
   shim.logger.trace('Recording query')
-  const extractedArgs = extractQueryArgs(shim, args)
+  const extractedArgs = exports.extractQueryArgs(shim, args)
 
   // Pull out instance attributes.
-  const parameters = getInstanceParameters(shim, this, extractedArgs.query)
+  const parameters = exports.getInstanceParameters(shim, this, extractedArgs.query)
 
   shim.logger.trace(
     {
@@ -212,9 +215,9 @@ function describeQuery(shim, queryFn, fnName, args) {
   }
 }
 
-function describePoolQuery(shim, queryFn, fnName, args) {
+exports.describePoolQuery = function describePoolQuery(shim, queryFn, fnName, args) {
   shim.logger.trace('Recording pool query')
-  const extractedArgs = extractQueryArgs(shim, args)
+  const extractedArgs = exports.extractQueryArgs(shim, args)
   return {
     stream: true,
     query: null,
@@ -224,7 +227,7 @@ function describePoolQuery(shim, queryFn, fnName, args) {
   }
 }
 
-function getInstanceParameters(shim, queryable, query) {
+exports.getInstanceParameters = function getInstanceParameters(shim, queryable, query) {
   const parameters = { host: null, port_path_or_id: null, database_name: null }
   let conf = queryable.config
   conf = (conf && conf.connectionConfig) || conf
@@ -244,11 +247,11 @@ function getInstanceParameters(shim, queryable, query) {
     shim.logger.trace('No query config detected, not collecting db instance data')
   }
 
-  storeDatabaseName(shim, queryable, query)
+  exports.storeDatabaseName(queryable, query)
   return parameters
 }
 
-function storeDatabaseName(shim, queryable, query) {
+exports.storeDatabaseName = function storeDatabaseName(queryable, query) {
   if (queryable[symbols.storeDatabase]) {
     const databaseName = dbutils.extractDatabaseChangeFromUse(query)
     if (databaseName) {

--- a/lib/instrumentation/mysql/mysql.js
+++ b/lib/instrumentation/mysql/mysql.js
@@ -9,7 +9,7 @@ const dbutils = require('../../db/utils')
 const properties = require('../../util/properties')
 const symbols = require('../../symbols')
 
-exports.callbackInitialize = function callbackInitialize(shim, mysql) {
+function callbackInitialize(shim, mysql) {
   shim.setDatastore(shim.MYSQL)
   shim[symbols.wrappedPoolConnection] = false
 
@@ -19,7 +19,7 @@ exports.callbackInitialize = function callbackInitialize(shim, mysql) {
       return
     }
     shim.logger.debug('Wrapping Connection#query')
-    if (exports.wrapQueryable(shim, connection, false)) {
+    if (wrapQueryable(shim, connection, false)) {
       const connProto = Object.getPrototypeOf(connection)
       connProto[symbols.storeDatabase] = true
       shim[symbols.unwrapConnection] = true
@@ -32,7 +32,7 @@ exports.callbackInitialize = function callbackInitialize(shim, mysql) {
       return
     }
     shim.logger.debug('Wrapping Pool#query and Pool#getConnection')
-    if (exports.wrapQueryable(shim, pool, true) && exports.wrapGetConnection(shim, pool)) {
+    if (wrapQueryable(shim, pool, true) && wrapGetConnection(shim, pool)) {
       shim[symbols.unwrapPool] = true
     }
   }
@@ -50,29 +50,26 @@ exports.callbackInitialize = function callbackInitialize(shim, mysql) {
         return
       }
 
-      if (
-        exports.wrapGetConnection(shim, poolNamespace) &&
-        exports.wrapQueryable(shim, poolNamespace, false)
-      ) {
+      if (wrapGetConnection(shim, poolNamespace) && wrapQueryable(shim, poolNamespace, false)) {
         poolNamespace[symbols.clusterOf] = true
       }
     }
 
     shim.logger.debug('Wrapping PoolCluster#getConnection')
-    if (exports.wrapGetConnection(shim, poolCluster)) {
+    if (wrapGetConnection(shim, poolCluster)) {
       shim[symbols.createPoolCluster] = true
     }
   }
 }
 
-exports.promiseInitialize = function promiseInitialize(shim) {
+function promiseInitialize(shim) {
   const callbackAPI = shim.require('./index')
   if (callbackAPI && !shim.isWrapped(callbackAPI.createConnection)) {
-    exports.callbackInitialize(shim, callbackAPI)
+    callbackInitialize(shim, callbackAPI)
   }
 }
 
-exports.wrapGetConnection = function wrapGetConnection(shim, connectable) {
+function wrapGetConnection(shim, connectable) {
   if (!connectable || !connectable.getConnection || shim.isWrapped(connectable.getConnection)) {
     shim.logger.trace(
       {
@@ -100,7 +97,7 @@ exports.wrapGetConnection = function wrapGetConnection(shim, connectable) {
         )
         let cb = args[cbIdx]
         if (!shim[symbols.wrappedPoolConnection]) {
-          cb = shim.wrap(cb, exports.wrapGetConnectionCallback)
+          cb = shim.wrap(cb, wrapGetConnectionCallback)
         }
         args[cbIdx] = shim.bindSegment(cb)
       }
@@ -111,11 +108,11 @@ exports.wrapGetConnection = function wrapGetConnection(shim, connectable) {
   return true
 }
 
-exports.wrapGetConnectionCallback = function wrapGetConnectionCallback(shim, cb) {
+function wrapGetConnectionCallback(shim, cb) {
   return function wrappedGetConnectionCallback(err, conn) {
     try {
       shim.logger.debug('Wrapping PoolConnection#query')
-      if (!err && exports.wrapQueryable(shim, conn, false)) {
+      if (!err && wrapQueryable(shim, conn, false)) {
         // Leave getConnection wrapped in order to maintain TX state, but we can
         // simplify the wrapping of its callback in future calls.
         shim[symbols.wrappedPoolConnection] = true
@@ -130,7 +127,7 @@ exports.wrapGetConnectionCallback = function wrapGetConnectionCallback(shim, cb)
   }
 }
 
-exports.wrapQueryable = function wrapQueryable(shim, queryable, isPoolQuery) {
+function wrapQueryable(shim, queryable, isPoolQuery) {
   if (!queryable || !queryable.query || shim.isWrapped(queryable.query)) {
     shim.logger.debug(
       {
@@ -147,9 +144,9 @@ exports.wrapQueryable = function wrapQueryable(shim, queryable, isPoolQuery) {
 
   let describe
   if (isPoolQuery) {
-    describe = exports.describePoolQuery
+    describe = describePoolQuery
   } else {
-    describe = exports.describeQuery
+    describe = describeQuery
     proto[symbols.databaseName] = null
   }
 
@@ -162,7 +159,7 @@ exports.wrapQueryable = function wrapQueryable(shim, queryable, isPoolQuery) {
   return true
 }
 
-exports.extractQueryArgs = function extractQueryArgs(shim, args) {
+function extractQueryArgs(shim, args) {
   let query = ''
   let callback = null
 
@@ -190,12 +187,12 @@ exports.extractQueryArgs = function extractQueryArgs(shim, args) {
   }
 }
 
-exports.describeQuery = function describeQuery(shim, queryFn, fnName, args) {
+function describeQuery(shim, queryFn, fnName, args) {
   shim.logger.trace('Recording query')
-  const extractedArgs = exports.extractQueryArgs(shim, args)
+  const extractedArgs = extractQueryArgs(shim, args)
 
   // Pull out instance attributes.
-  const parameters = exports.getInstanceParameters(shim, this, extractedArgs.query)
+  const parameters = getInstanceParameters(shim, this, extractedArgs.query)
 
   shim.logger.trace(
     {
@@ -215,9 +212,9 @@ exports.describeQuery = function describeQuery(shim, queryFn, fnName, args) {
   }
 }
 
-exports.describePoolQuery = function describePoolQuery(shim, queryFn, fnName, args) {
+function describePoolQuery(shim, queryFn, fnName, args) {
   shim.logger.trace('Recording pool query')
-  const extractedArgs = exports.extractQueryArgs(shim, args)
+  const extractedArgs = extractQueryArgs(shim, args)
   return {
     stream: true,
     query: null,
@@ -227,7 +224,7 @@ exports.describePoolQuery = function describePoolQuery(shim, queryFn, fnName, ar
   }
 }
 
-exports.getInstanceParameters = function getInstanceParameters(shim, queryable, query) {
+function getInstanceParameters(shim, queryable, query) {
   const parameters = { host: null, port_path_or_id: null, database_name: null }
   let conf = queryable.config
   conf = (conf && conf.connectionConfig) || conf
@@ -247,15 +244,28 @@ exports.getInstanceParameters = function getInstanceParameters(shim, queryable, 
     shim.logger.trace('No query config detected, not collecting db instance data')
   }
 
-  exports.storeDatabaseName(queryable, query)
+  storeDatabaseName(queryable, query)
   return parameters
 }
 
-exports.storeDatabaseName = function storeDatabaseName(queryable, query) {
+function storeDatabaseName(queryable, query) {
   if (queryable[symbols.storeDatabase]) {
     const databaseName = dbutils.extractDatabaseChangeFromUse(query)
     if (databaseName) {
       queryable[symbols.databaseName] = databaseName
     }
   }
+}
+
+module.exports = {
+  callbackInitialize,
+  promiseInitialize,
+  wrapGetConnection,
+  wrapGetConnectionCallback,
+  wrapQueryable,
+  extractQueryArgs,
+  describeQuery,
+  describePoolQuery,
+  getInstanceParameters,
+  storeDatabaseName
 }

--- a/test/unit/instrumentation/mysql/describePoolQuery.test.js
+++ b/test/unit/instrumentation/mysql/describePoolQuery.test.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const sinon = require('sinon')
+const instrumentation = require('../../../../lib/instrumentation/mysql/mysql')
+
+tap.test('describeQuery', (t) => {
+  t.autoend()
+
+  t.test('should pull the configuration for the query segment', (t) => {
+    const mockShim = {
+      logger: {
+        trace: sinon.stub().returns()
+      },
+      isString: sinon.stub().returns(true),
+      isArray: sinon.stub().returns(false)
+    }
+
+    const mockArgs = ['SELECT * FROM foo', sinon.stub()]
+
+    const result = instrumentation.describePoolQuery(mockShim, null, null, mockArgs)
+    t.same(result, {
+      stream: true,
+      query: null,
+      callback: 1,
+      name: 'MySQL Pool#query',
+      record: false
+    })
+
+    t.ok(mockShim.logger.trace.calledWith('Recording pool query'))
+
+    t.end()
+  })
+})

--- a/test/unit/instrumentation/mysql/describeQuery.test.js
+++ b/test/unit/instrumentation/mysql/describeQuery.test.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const sinon = require('sinon')
+const instrumentation = require('../../../../lib/instrumentation/mysql/mysql')
+const symbols = require('../../../../lib/symbols')
+
+tap.test('describeQuery', (t) => {
+  t.autoend()
+
+  t.test('should pull the configuration for the query segment', (t) => {
+    const mockShim = {
+      logger: {
+        trace: sinon.stub().returns()
+      },
+      isString: sinon.stub().returns(true),
+      isArray: sinon.stub().returns(false)
+    }
+
+    const mockArgs = ['SELECT * FROM foo', sinon.stub()]
+
+    instrumentation[symbols.databaseName] = 'my-db-name'
+    instrumentation.config = {
+      host: 'example.com',
+      port: '1234'
+    }
+    const result = instrumentation.describeQuery(mockShim, null, null, mockArgs)
+    t.same(result, {
+      stream: true,
+      query: 'SELECT * FROM foo',
+      callback: 1,
+      parameters: { host: 'example.com', port_path_or_id: '1234', database_name: 'my-db-name' },
+      record: true
+    })
+
+    t.ok(mockShim.logger.trace.calledWith('Recording query'))
+    t.ok(
+      mockShim.logger.trace.calledWith(
+        { query: true, callback: true, parameters: true },
+        'Query segment descriptor'
+      )
+    )
+
+    t.end()
+  })
+})

--- a/test/unit/instrumentation/mysql/extractQueryArgs.test.js
+++ b/test/unit/instrumentation/mysql/extractQueryArgs.test.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const sinon = require('sinon')
+const instrumentation = require('../../../../lib/instrumentation/mysql/mysql')
+
+tap.test('extractQueryArgs', (t) => {
+  t.autoend()
+
+  let mockShim
+  let mockArgs
+  let mockCallback
+
+  t.beforeEach(() => {
+    mockShim = {
+      isString: sinon.stub().returns(),
+      isArray: sinon.stub().returns()
+    }
+
+    mockArgs = []
+
+    mockCallback = sinon.stub()
+  })
+
+  t.test('should extract the query and callback when the first arg is a string', (t) => {
+    mockShim.isString.returns(true)
+    mockArgs.push('SELECT * FROM foo', mockCallback)
+
+    const results = instrumentation.extractQueryArgs(mockShim, mockArgs)
+    t.same(results, { query: 'SELECT * FROM foo', callback: 1 })
+
+    t.end()
+  })
+
+  t.test('should extract the query and callback when the first arg is an object property', (t) => {
+    mockShim.isString.returns(false)
+    mockShim.isArray.returns(true)
+
+    mockArgs.push({ sql: 'SELECT * FROM foo' }, [], mockCallback)
+
+    const results = instrumentation.extractQueryArgs(mockShim, mockArgs)
+    t.same(results, { query: 'SELECT * FROM foo', callback: 2 })
+
+    t.end()
+  })
+})

--- a/test/unit/instrumentation/mysql/getInstanceParameters.test.js
+++ b/test/unit/instrumentation/mysql/getInstanceParameters.test.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const sinon = require('sinon')
+const instrumentation = require('../../../../lib/instrumentation/mysql/mysql')
+const symbols = require('../../../../lib/symbols')
+
+tap.test('getInstanceParameters', (t) => {
+  t.autoend()
+
+  let mockShim
+  let mockQueryable
+  let mockQuery
+
+  t.beforeEach(() => {
+    mockShim = {
+      logger: {
+        trace: sinon.stub().returns()
+      }
+    }
+
+    mockQueryable = {}
+
+    mockQuery = 'SELECT * FROM foo'
+  })
+
+  t.test('should log if unable to find configuration to pull info', (t) => {
+    const result = instrumentation.getInstanceParameters(mockShim, mockQueryable, mockQuery)
+
+    t.same(
+      result,
+      { host: null, port_path_or_id: null, database_name: null },
+      'should return the default parameters'
+    )
+    t.ok(
+      mockShim.logger.trace.calledWith('No query config detected, not collecting db instance data'),
+      'should log'
+    )
+
+    t.end()
+  })
+
+  t.test('should favor connectionConfig over config', (t) => {
+    mockQueryable = {
+      config: {
+        port: '1234',
+        connectionConfig: {
+          port: '5678'
+        }
+      }
+    }
+
+    const result = instrumentation.getInstanceParameters(mockShim, mockQueryable, mockQuery)
+    t.equal(result.port_path_or_id, '5678')
+    t.end()
+  })
+
+  t.test('should favor the symbol DB name over config', (t) => {
+    mockQueryable = {
+      config: {
+        database: 'database-a'
+      }
+    }
+
+    mockQueryable[symbols.databaseName] = 'database-b'
+
+    const result = instrumentation.getInstanceParameters(mockShim, mockQueryable, mockQuery)
+    t.equal(result.database_name, 'database-b')
+    t.end()
+  })
+
+  t.test('should set the appropriate parameters for "normal" connections', (t) => {
+    mockQueryable = {
+      config: {
+        database: 'test-database',
+        host: 'example.com',
+        port: '1234'
+      }
+    }
+
+    const result = instrumentation.getInstanceParameters(mockShim, mockQueryable, mockQuery)
+    t.same(result, { host: 'example.com', port_path_or_id: '1234', database_name: 'test-database' })
+    t.end()
+  })
+
+  t.test('should set the appropriate parameters for unix socket connections', (t) => {
+    mockQueryable = {
+      config: {
+        database: 'test-database',
+        socketPath: '/var/run/mysqld/mysqld.sock'
+      }
+    }
+
+    const result = instrumentation.getInstanceParameters(mockShim, mockQueryable, mockQuery)
+    t.same(result, {
+      host: 'localhost',
+      port_path_or_id: '/var/run/mysqld/mysqld.sock',
+      database_name: 'test-database'
+    })
+    t.end()
+  })
+})

--- a/test/unit/instrumentation/mysql/index.test.js
+++ b/test/unit/instrumentation/mysql/index.test.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+
+const symbols = require('../../../../lib/symbols')
+
+tap.test('mysql instrumentation', (t) => {
+  t.autoend()
+
+  let mockShim
+  let mockMysql
+  let instrumentation
+
+  t.beforeEach(() => {
+    mockShim = {
+      MYSQL: 'test-mysql',
+      setDatastore: sinon.stub().returns(),
+      wrapReturn: sinon.stub().returns(),
+      isWrapped: sinon.stub().returns(),
+      require: sinon.stub().returns(mockMysql)
+    }
+
+    mockMysql = {
+      createConnection: sinon.stub().returns(),
+      createPool: sinon.stub().returns(),
+      createPoolCluster: sinon.stub().returns()
+    }
+
+    instrumentation = proxyquire('../../../../lib/instrumentation/mysql/mysql', {})
+  })
+
+  t.test('callbackInitialize should set the datastore and symbols', (t) => {
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+
+    t.ok(mockShim.setDatastore.calledWith('test-mysql'), 'should set the datastore to mysql')
+    t.equal(
+      mockShim[symbols.wrappedPoolConnection],
+      false,
+      'should default the wrappedPoolConnection symbol to false'
+    )
+    t.end()
+  })
+
+  t.test(
+    'promiseInitialize not should call callbackInitialized if createConnection is already wrapped',
+    (t) => {
+      instrumentation.callbackInitialize = sinon.stub().returns()
+      mockShim.isWrapped.returns(true)
+      instrumentation.promiseInitialize(mockShim, mockMysql)
+
+      t.equal(
+        instrumentation.callbackInitialize.callCount,
+        0,
+        'should not have called callbackInitialize'
+      )
+      t.end()
+    }
+  )
+
+  t.test('promiseInitialize should call callbackInitialized', (t) => {
+    instrumentation.callbackInitialize = sinon.stub().returns()
+    mockShim.isWrapped.returns(false)
+    instrumentation.promiseInitialize(mockShim, mockMysql)
+
+    t.equal(
+      instrumentation.callbackInitialize.callCount,
+      1,
+      'should have called callbackInitialize'
+    )
+    t.end()
+  })
+})

--- a/test/unit/instrumentation/mysql/index.test.js
+++ b/test/unit/instrumentation/mysql/index.test.js
@@ -55,10 +55,10 @@ tap.test('mysql instrumentation', (t) => {
       mockShim.isWrapped.returns(true)
       instrumentation.promiseInitialize(mockShim, mockMysql)
 
-      t.equal(
-        instrumentation.callbackInitialize.callCount,
-        0,
-        'should not have called callbackInitialize'
+      t.notOk(
+        mockShim[symbols.wrappedPoolConnection],
+
+        'should not have applied the symbol'
       )
       t.end()
     }
@@ -69,10 +69,11 @@ tap.test('mysql instrumentation', (t) => {
     mockShim.isWrapped.returns(false)
     instrumentation.promiseInitialize(mockShim, mockMysql)
 
+    t.ok(mockShim.setDatastore.calledWith('test-mysql'), 'should set the datastore to mysql')
     t.equal(
-      instrumentation.callbackInitialize.callCount,
-      1,
-      'should have called callbackInitialize'
+      mockShim[symbols.wrappedPoolConnection],
+      false,
+      'should default the wrappedPoolConnection symbol to false'
     )
     t.end()
   })

--- a/test/unit/instrumentation/mysql/storeDatabaseName.test.js
+++ b/test/unit/instrumentation/mysql/storeDatabaseName.test.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+const symbols = require('../../../../lib/symbols')
+
+tap.test('storeDatabaseName', (t) => {
+  t.autoend()
+
+  let mockDbUtils
+  let instrumentation
+
+  t.beforeEach(() => {
+    mockDbUtils = {
+      extractDatabaseChangeFromUse: sinon.stub()
+    }
+    instrumentation = proxyquire('../../../../lib/instrumentation/mysql/mysql', {
+      '../../db/utils': mockDbUtils
+    })
+  })
+
+  t.test('should do nothing if the storeDatabase symbol is missing', (t) => {
+    const mockQueryable = {}
+    const mockQuery = 'SELECT * FROM foo'
+
+    instrumentation.storeDatabaseName(mockQueryable, mockQuery)
+
+    t.equal(
+      mockDbUtils.extractDatabaseChangeFromUse.callCount,
+      0,
+      'should not have tried to extract the name'
+    )
+    t.notOk(mockQueryable[symbols.databaseName])
+
+    t.end()
+  })
+
+  t.test('should do nothing if unable to determine the name from the use statement', (t) => {
+    const mockQueryable = {}
+    mockQueryable[symbols.storeDatabase] = true
+    const mockQuery = 'SELECT * FROM foo'
+
+    instrumentation.storeDatabaseName(mockQueryable, mockQuery)
+
+    t.ok(
+      mockDbUtils.extractDatabaseChangeFromUse.calledWith(mockQuery),
+      'should try to extract the name'
+    )
+    t.notOk(mockQueryable[symbols.databaseName])
+
+    t.end()
+  })
+
+  t.test('should store the database name on a symbol', (t) => {
+    const mockQueryable = {}
+    mockQueryable[symbols.storeDatabase] = true
+    const mockQuery = 'SELECT * FROM foo'
+
+    mockDbUtils.extractDatabaseChangeFromUse.returns('mockDb')
+
+    instrumentation.storeDatabaseName(mockQueryable, mockQuery)
+
+    t.ok(
+      mockDbUtils.extractDatabaseChangeFromUse.calledWith(mockQuery),
+      'should try to extract the name'
+    )
+    t.equal(
+      mockQueryable[symbols.databaseName],
+      'mockDb',
+      'should set the database name on the appropriate symbol'
+    )
+
+    t.end()
+  })
+})

--- a/test/unit/instrumentation/mysql/wrapCreateConnection.test.js
+++ b/test/unit/instrumentation/mysql/wrapCreateConnection.test.js
@@ -25,7 +25,9 @@ tap.test('wrapCreateConnection', (t) => {
       wrapReturn: sinon.stub().returns(),
       logger: {
         debug: sinon.stub().returns()
-      }
+      },
+      isWrapped: sinon.stub().returns(),
+      recordQuery: sinon.stub().returns()
     }
 
     mockMysql = {
@@ -50,7 +52,6 @@ tap.test('wrapCreateConnection', (t) => {
   })
 
   t.test('should return early if wrapping symbol exists', (t) => {
-    instrumentation.wrapQueryable = sinon.stub().returns(false)
     mockShim[symbols.unwrapConnection] = true
 
     instrumentation.callbackInitialize(mockShim, mockMysql)
@@ -63,16 +64,12 @@ tap.test('wrapCreateConnection', (t) => {
   })
 
   t.test('should not set the symbols if wrapQueryable returns false', (t) => {
-    instrumentation.wrapQueryable = sinon.stub().returns(false)
+    mockShim.isWrapped.returns(true)
 
     instrumentation.callbackInitialize(mockShim, mockMysql)
     const wrapCreateConnection = mockShim.wrapReturn.args[0][2]
     wrapCreateConnection(mockShim, null, null, mockConnection)
 
-    t.ok(
-      instrumentation.wrapQueryable.calledWith(mockShim, mockConnection, false),
-      'should have called wrapQueryable'
-    )
     t.notOk(mockConnection[symbols.storeDatabase], 'should not have set the storeDatabase symbol')
     t.notOk(mockShim[symbols.unwrapConnection], 'should not have set the unwrapConnection symbol')
 
@@ -86,10 +83,6 @@ tap.test('wrapCreateConnection', (t) => {
     const wrapCreateConnection = mockShim.wrapReturn.args[0][2]
     wrapCreateConnection(mockShim, null, null, mockConnection)
 
-    t.ok(
-      instrumentation.wrapQueryable.calledWith(mockShim, mockConnection, false),
-      'wrapQueryable should have been called'
-    )
     t.equal(mockConnection[symbols.storeDatabase], true, 'should have set the storeDatabase symbol')
     t.equal(mockShim[symbols.unwrapConnection], true, 'should have set the unwrapConnection symbol')
 

--- a/test/unit/instrumentation/mysql/wrapCreateConnection.test.js
+++ b/test/unit/instrumentation/mysql/wrapCreateConnection.test.js
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire').noPreserveCache()
+const symbols = require('../../../../lib/symbols')
+
+tap.test('wrapCreateConnection', (t) => {
+  t.autoend()
+
+  let mockShim
+  let mockMysql
+  let mockConnection
+  let instrumentation
+
+  t.beforeEach(() => {
+    mockShim = {
+      MYSQL: 'test-mysql',
+      setDatastore: sinon.stub().returns(),
+      wrapReturn: sinon.stub().returns(),
+      logger: {
+        debug: sinon.stub().returns()
+      }
+    }
+
+    mockMysql = {
+      createConnection: sinon.stub().returns()
+    }
+
+    mockConnection = {
+      query: sinon.stub().returns()
+    }
+
+    instrumentation = proxyquire('../../../../lib/instrumentation/mysql/mysql', {})
+  })
+
+  t.test('should wrap mysql.getConnection', (t) => {
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+    t.ok(
+      mockShim.wrapReturn.calledWith(mockMysql, 'createConnection'),
+      'should have called wrapReturn for createConnection'
+    )
+
+    t.end()
+  })
+
+  t.test('should return early if wrapping symbol exists', (t) => {
+    instrumentation.wrapQueryable = sinon.stub().returns(false)
+    mockShim[symbols.unwrapConnection] = true
+
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+    const wrapCreateConnection = mockShim.wrapReturn.args[0][2]
+    wrapCreateConnection(mockShim, null, null, mockConnection)
+
+    t.notOk(instrumentation.wrapQueryable.called, 'wrapQueryable should not have been called')
+
+    t.end()
+  })
+
+  t.test('should not set the symbols if wrapQueryable returns false', (t) => {
+    instrumentation.wrapQueryable = sinon.stub().returns(false)
+
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+    const wrapCreateConnection = mockShim.wrapReturn.args[0][2]
+    wrapCreateConnection(mockShim, null, null, mockConnection)
+
+    t.ok(
+      instrumentation.wrapQueryable.calledWith(mockShim, mockConnection, false),
+      'should have called wrapQueryable'
+    )
+    t.notOk(mockConnection[symbols.storeDatabase], 'should not have set the storeDatabase symbol')
+    t.notOk(mockShim[symbols.unwrapConnection], 'should not have set the unwrapConnection symbol')
+
+    t.end()
+  })
+
+  t.test('should set the symbols if wrapQueryable is successful', (t) => {
+    instrumentation.wrapQueryable = sinon.stub().returns(true)
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+
+    const wrapCreateConnection = mockShim.wrapReturn.args[0][2]
+    wrapCreateConnection(mockShim, null, null, mockConnection)
+
+    t.ok(
+      instrumentation.wrapQueryable.calledWith(mockShim, mockConnection, false),
+      'wrapQueryable should have been called'
+    )
+    t.equal(mockConnection[symbols.storeDatabase], true, 'should have set the storeDatabase symbol')
+    t.equal(mockShim[symbols.unwrapConnection], true, 'should have set the unwrapConnection symbol')
+
+    t.end()
+  })
+})

--- a/test/unit/instrumentation/mysql/wrapCreatePool.test.js
+++ b/test/unit/instrumentation/mysql/wrapCreatePool.test.js
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire').noPreserveCache()
+const symbols = require('../../../../lib/symbols')
+
+tap.test('wrapCreatePool', (t) => {
+  t.autoend()
+
+  let mockShim
+  let mockMysql
+  let mockPool
+  let instrumentation
+
+  t.beforeEach(() => {
+    mockShim = {
+      MYSQL: 'test-mysql',
+      setDatastore: sinon.stub().returns(),
+      wrapReturn: sinon.stub().returns(),
+      logger: {
+        debug: sinon.stub().returns()
+      }
+    }
+
+    mockMysql = {
+      createPool: sinon.stub().returns()
+    }
+
+    mockPool = {
+      query: sinon.stub().returns()
+    }
+
+    instrumentation = proxyquire('../../../../lib/instrumentation/mysql/mysql', {})
+  })
+
+  t.test('should wrap mysql.createPool', (t) => {
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+    t.ok(
+      mockShim.wrapReturn.calledWith(mockMysql, 'createPool'),
+      'should have called wrapReturn for createPool'
+    )
+
+    t.end()
+  })
+
+  t.test('should return early if wrapping symbol exists', (t) => {
+    instrumentation.wrapQueryable = sinon.stub().returns(false)
+    instrumentation.wrapGetConnection = sinon.stub().returns(false)
+    mockShim[symbols.unwrapPool] = true
+
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+    const wrapCreatePool = mockShim.wrapReturn.args[1][2]
+    wrapCreatePool(mockShim, null, null, mockPool)
+
+    t.notOk(instrumentation.wrapQueryable.called, 'wrapQueryable should not have been called')
+    t.notOk(
+      instrumentation.wrapGetConnection.called,
+      'wrapGetConnection should not have been called'
+    )
+
+    t.end()
+  })
+
+  t.test('should not set the symbol if wrapQueryable returns false', (t) => {
+    instrumentation.wrapQueryable = sinon.stub().returns(false)
+    instrumentation.wrapGetConnection = sinon.stub().returns(false)
+
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+    const wrapCreatePool = mockShim.wrapReturn.args[1][2]
+    wrapCreatePool(mockShim, null, null, mockPool)
+
+    t.ok(
+      instrumentation.wrapQueryable.calledWith(mockShim, mockPool, true),
+      'should have called wrapQueryable'
+    )
+
+    t.notOk(mockShim[symbols.unwrapPool], 'should not have set the unwrapPool symbol')
+
+    t.end()
+  })
+
+  t.test('should not set the symbol if wrapGetConnection returns false', (t) => {
+    instrumentation.wrapQueryable = sinon.stub().returns(true)
+    instrumentation.wrapGetConnection = sinon.stub().returns(false)
+
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+    const wrapCreatePool = mockShim.wrapReturn.args[1][2]
+    wrapCreatePool(mockShim, null, null, mockPool)
+
+    t.ok(
+      instrumentation.wrapQueryable.calledWith(mockShim, mockPool, true),
+      'should have called wrapQueryable'
+    )
+    t.ok(
+      instrumentation.wrapGetConnection.calledWith(mockShim, mockPool),
+      'should have called wrapGetConnection'
+    )
+
+    t.notOk(mockShim[symbols.unwrapPool], 'should not have set the unwrapPool symbol')
+
+    t.end()
+  })
+
+  t.test('should set the symbols if wrapQueryable and wrapGetConnection is successful', (t) => {
+    instrumentation.wrapQueryable = sinon.stub().returns(true)
+    instrumentation.wrapGetConnection = sinon.stub().returns(true)
+
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+    const wrapCreatePool = mockShim.wrapReturn.args[1][2]
+    wrapCreatePool(mockShim, null, null, mockPool)
+
+    t.ok(
+      instrumentation.wrapQueryable.calledWith(mockShim, mockPool, true),
+      'should have called wrapQueryable'
+    )
+    t.ok(
+      instrumentation.wrapGetConnection.calledWith(mockShim, mockPool),
+      'should have called wrapGetConnection'
+    )
+
+    t.equal(mockShim[symbols.unwrapPool], true, 'should have set the unwrapPool symbol')
+
+    t.end()
+  })
+})

--- a/test/unit/instrumentation/mysql/wrapCreatePoolCluster.test.js
+++ b/test/unit/instrumentation/mysql/wrapCreatePoolCluster.test.js
@@ -134,14 +134,6 @@ tap.test('wrapCreatePoolCluster', (t) => {
     const wrapPoolClusterOf = mockShim.wrapReturn.args[3][2]
     wrapPoolClusterOf(mockShim, null, null, mockNamespace)
 
-    t.ok(
-      instrumentation.wrapGetConnection.calledWith(mockShim, mockNamespace),
-      'should have called wrapGetConnection on the namespace'
-    )
-    t.ok(
-      instrumentation.wrapQueryable.calledWith(mockShim, mockNamespace),
-      'should have called wrapQueryable on the namespace'
-    )
     t.notOk(mockNamespace[symbols.clusterOf], 'should not have set the clusterOf symbol')
 
     t.end()
@@ -158,14 +150,6 @@ tap.test('wrapCreatePoolCluster', (t) => {
     const wrapPoolClusterOf = mockShim.wrapReturn.args[3][2]
     wrapPoolClusterOf(mockShim, null, null, mockNamespace)
 
-    t.notOk(
-      instrumentation.wrapGetConnection.calledWith(mockShim, mockNamespace),
-      'should not have called wrapGetConnection on the namespace'
-    )
-    t.ok(
-      instrumentation.wrapQueryable.calledWith(mockShim, mockNamespace),
-      'should have called wrapQueryable on the namespace'
-    )
     t.notOk(mockNamespace[symbols.clusterOf], 'should not have set the clusterOf symbol')
 
     t.end()

--- a/test/unit/instrumentation/mysql/wrapCreatePoolCluster.test.js
+++ b/test/unit/instrumentation/mysql/wrapCreatePoolCluster.test.js
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire').noPreserveCache()
+const symbols = require('../../../../lib/symbols')
+
+tap.test('wrapCreatePoolCluster', (t) => {
+  t.autoend()
+
+  let mockShim
+  let mockMysql
+  let mockPoolCluster
+  let mockNamespace
+  let instrumentation
+
+  t.beforeEach(() => {
+    mockShim = {
+      MYSQL: 'test-mysql',
+      setDatastore: sinon.stub().returns(),
+      wrapReturn: sinon.stub().returns(),
+      logger: {
+        debug: sinon.stub().returns()
+      }
+    }
+
+    mockMysql = {
+      createPoolCluster: sinon.stub().returns()
+    }
+
+    mockPoolCluster = {
+      of: sinon.stub.returns()
+    }
+
+    mockNamespace = {
+      query: sinon.stub().returns()
+    }
+
+    instrumentation = proxyquire('../../../../lib/instrumentation/mysql/mysql', {})
+  })
+
+  t.test('should wrap mysql.createPoolCluster', (t) => {
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+    t.ok(
+      mockShim.wrapReturn.calledWith(mockMysql, 'createPoolCluster'),
+      'should have called wrapReturn for createPoolCluster'
+    )
+
+    t.end()
+  })
+
+  t.test('should return early if createPoolCluster symbol exists', (t) => {
+    mockShim[symbols.createPoolCluster] = true
+    instrumentation.wrapGetConnection = sinon.stub().returns(false)
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+
+    const wrapCreatePool = mockShim.wrapReturn.args[2][2]
+    wrapCreatePool(mockShim, null, null, mockPoolCluster)
+    t.notOk(
+      instrumentation.wrapGetConnection.called,
+      'wrapGetConnection should not have been called'
+    )
+
+    t.end()
+  })
+
+  t.test('should not set createPoolCluster symbol if wrapGetConnection returns false', (t) => {
+    instrumentation.wrapGetConnection = sinon.stub().returns(false)
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+
+    const wrapCreatePool = mockShim.wrapReturn.args[2][2]
+    wrapCreatePool(mockShim, null, null, mockPoolCluster)
+    t.notOk(
+      mockShim[symbols.createPoolCluster],
+      'should not have assigned the createPoolCluster symbol'
+    )
+
+    t.end()
+  })
+
+  t.test('should set createPoolCluster symbol if wrapGetConnection returns true', (t) => {
+    instrumentation.wrapGetConnection = sinon.stub().returns(true)
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+
+    const wrapCreatePool = mockShim.wrapReturn.args[2][2]
+    wrapCreatePool(mockShim, null, null, mockPoolCluster)
+    t.equal(
+      mockShim[symbols.createPoolCluster],
+      true,
+      'should have assigned the createPoolCluster symbol'
+    )
+
+    t.end()
+  })
+
+  t.test('should return early if PoolCluster.of is already wrapped', (t) => {
+    mockNamespace[symbols.clusterOf] = true
+    instrumentation.wrapGetConnection = sinon.stub().returns(false)
+    instrumentation.wrapQueryable = sinon.stub().returns(false)
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+
+    const wrapCreatePool = mockShim.wrapReturn.args[2][2]
+    wrapCreatePool(mockShim, null, null, mockPoolCluster)
+
+    const wrapPoolClusterOf = mockShim.wrapReturn.args[3][2]
+    wrapPoolClusterOf(mockShim, null, null, mockNamespace)
+
+    t.notOk(
+      instrumentation.wrapGetConnection.calledWith(mockShim, mockNamespace),
+      'should not have called wrapGetConnection on the namespace'
+    )
+
+    t.notOk(
+      instrumentation.wrapQueryable.calledWith(mockShim, mockNamespace),
+      'should not have called wrapQueryable on the namespace'
+    )
+
+    t.end()
+  })
+
+  t.test('should not set the symbol if wrapGetConnection returns false', (t) => {
+    instrumentation.wrapGetConnection = sinon.stub().returns(false)
+    instrumentation.wrapQueryable = sinon.stub().returns(true)
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+
+    const wrapCreatePool = mockShim.wrapReturn.args[2][2]
+    wrapCreatePool(mockShim, null, null, mockPoolCluster)
+
+    const wrapPoolClusterOf = mockShim.wrapReturn.args[3][2]
+    wrapPoolClusterOf(mockShim, null, null, mockNamespace)
+
+    t.ok(
+      instrumentation.wrapGetConnection.calledWith(mockShim, mockNamespace),
+      'should have called wrapGetConnection on the namespace'
+    )
+    t.ok(
+      instrumentation.wrapQueryable.calledWith(mockShim, mockNamespace),
+      'should have called wrapQueryable on the namespace'
+    )
+    t.notOk(mockNamespace[symbols.clusterOf], 'should not have set the clusterOf symbol')
+
+    t.end()
+  })
+
+  t.test('should not set the symbol if wrapQueryable returns false', (t) => {
+    instrumentation.wrapGetConnection = sinon.stub().returns(true)
+    instrumentation.wrapQueryable = sinon.stub().returns(false)
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+
+    const wrapCreatePool = mockShim.wrapReturn.args[2][2]
+    wrapCreatePool(mockShim, null, null, mockPoolCluster)
+
+    const wrapPoolClusterOf = mockShim.wrapReturn.args[3][2]
+    wrapPoolClusterOf(mockShim, null, null, mockNamespace)
+
+    t.notOk(
+      instrumentation.wrapGetConnection.calledWith(mockShim, mockNamespace),
+      'should not have called wrapGetConnection on the namespace'
+    )
+    t.ok(
+      instrumentation.wrapQueryable.calledWith(mockShim, mockNamespace),
+      'should have called wrapQueryable on the namespace'
+    )
+    t.notOk(mockNamespace[symbols.clusterOf], 'should not have set the clusterOf symbol')
+
+    t.end()
+  })
+
+  t.test('should wrap PoolCluster.of', (t) => {
+    instrumentation.wrapGetConnection = sinon.stub().returns(true)
+    instrumentation.wrapQueryable = sinon.stub().returns(true)
+    instrumentation.callbackInitialize(mockShim, mockMysql)
+
+    const wrapCreatePool = mockShim.wrapReturn.args[2][2]
+    wrapCreatePool(mockShim, null, null, mockPoolCluster)
+
+    const wrapPoolClusterOf = mockShim.wrapReturn.args[3][2]
+    wrapPoolClusterOf(mockShim, null, null, mockNamespace)
+
+    t.ok(
+      instrumentation.wrapGetConnection.calledWith(mockShim, mockNamespace),
+      'should have called wrapGetConnection on the namespace'
+    )
+    t.equal(mockNamespace[symbols.clusterOf], true, 'should have set the clusterOf symbol')
+
+    t.end()
+  })
+})

--- a/test/unit/instrumentation/mysql/wrapGetConnection.test.js
+++ b/test/unit/instrumentation/mysql/wrapGetConnection.test.js
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const sinon = require('sinon')
+const instrumentation = require('../../../../lib/instrumentation/mysql/mysql')
+const symbols = require('../../../../lib/symbols')
+
+tap.test('wrapGetConnection', (t) => {
+  t.autoend()
+
+  let mockShim
+  let mockConnection
+
+  t.beforeEach(() => {
+    mockShim = {
+      toArray: sinon.stub().returns(),
+      isFunction: sinon.stub().returns(),
+      isWrapped: sinon.stub().returns(),
+      logger: {
+        trace: sinon.stub().returns()
+      },
+      getSegment: sinon.stub().returns(),
+      wrap: sinon.stub().returns(),
+      bindSegment: sinon.stub().returns()
+    }
+
+    mockConnection = {}
+  })
+
+  t.test('should return false if Connection is undefined', (t) => {
+    const result = instrumentation.wrapGetConnection(mockShim, undefined)
+
+    t.equal(result, false)
+    t.ok(
+      mockShim.logger.trace.calledWith(
+        { connectable: false, getConnection: false, isWrapped: false },
+        'Not wrapping getConnection'
+      )
+    )
+
+    t.end()
+  })
+
+  t.test('should return false if getConnection is undefined', (t) => {
+    const result = instrumentation.wrapGetConnection(mockShim, mockConnection)
+
+    t.equal(result, false)
+    t.ok(
+      mockShim.logger.trace.calledWith(
+        { connectable: true, getConnection: false, isWrapped: false },
+        'Not wrapping getConnection'
+      )
+    )
+
+    t.end()
+  })
+
+  t.test('should return false if getConnection is already wrapped', (t) => {
+    mockShim.isWrapped.returns(true)
+    mockConnection.getConnection = sinon.stub().returns()
+    const result = instrumentation.wrapGetConnection(mockShim, mockConnection)
+
+    t.equal(result, false)
+    t.ok(
+      mockShim.logger.trace.calledWith(
+        { connectable: true, getConnection: true, isWrapped: true },
+        'Not wrapping getConnection'
+      )
+    )
+
+    t.end()
+  })
+
+  t.test('should attempt to wrap the getConnection callback if it is not wrapped', (t) => {
+    const mockCallback = sinon.stub().returns('lol')
+    mockConnection.getConnection = sinon.stub().returns()
+    mockShim.isWrapped.returns(false)
+    mockShim.toArray.returns([null, mockCallback])
+    mockShim.isFunction.returns(true)
+    mockShim.wrap.returnsArg(1)
+
+    const result = instrumentation.wrapGetConnection(mockShim, mockConnection)
+
+    t.equal(result, true)
+    t.ok(mockShim.wrap.calledWithMatch(Object.getPrototypeOf(mockConnection), 'getConnection'))
+
+    const wrapper = mockShim.wrap.args[0][2]
+    const callbackWrapper = wrapper(mockShim, mockCallback)
+    callbackWrapper()
+
+    t.equal(mockShim.wrap.callCount, 2)
+    t.ok(
+      mockShim.logger.trace.calledOnceWith({ hasSegment: false }, 'Wrapping callback with segment')
+    )
+    t.ok(mockShim.wrap.calledWith(mockCallback, instrumentation.wrapGetConnectionCallback))
+    t.ok(mockShim.bindSegment.calledOnceWith(instrumentation.wrapGetConnectionCallback))
+
+    t.end()
+  })
+
+  t.test('should not double wrap getConnection callback', (t) => {
+    const mockCallback = sinon.stub().returns('lol')
+    mockConnection.getConnection = sinon.stub().returns()
+    mockShim[symbols.wrappedPoolConnection] = true
+    mockShim.isWrapped.returns(false)
+    mockShim.toArray.returns([null, mockCallback])
+    mockShim.isFunction.returns(true)
+    mockShim.wrap.returnsArg(1)
+
+    const result = instrumentation.wrapGetConnection(mockShim, mockConnection)
+
+    t.equal(result, true)
+    t.ok(mockShim.wrap.calledWithMatch(Object.getPrototypeOf(mockConnection), 'getConnection'))
+
+    const wrapper = mockShim.wrap.args[0][2]
+    const callbackWrapper = wrapper(mockShim, mockCallback)
+    callbackWrapper()
+
+    t.equal(mockShim.wrap.callCount, 1)
+    t.ok(mockShim.bindSegment.calledOnceWith(mockCallback))
+
+    t.end()
+  })
+})

--- a/test/unit/instrumentation/mysql/wrapGetConnectionCallback.test.js
+++ b/test/unit/instrumentation/mysql/wrapGetConnectionCallback.test.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const sinon = require('sinon')
+const instrumentation = require('../../../../lib/instrumentation/mysql/mysql')
+const symbols = require('../../../../lib/symbols')
+
+tap.test('wrapGetConnectionCallback', (t) => {
+  t.autoend()
+
+  let mockCallback
+  let mockConnection
+  let mockShim
+
+  t.beforeEach(() => {
+    mockCallback = sinon.stub().returns('foo')
+
+    mockShim = {
+      logger: {
+        debug: sinon.stub().returns()
+      }
+    }
+
+    mockConnection = {}
+  })
+
+  t.test('should not wrap if the callback received an error', (t) => {
+    instrumentation.wrapQueryable = sinon.stub().returns(false)
+    const wrappedGetConnectionCallback = instrumentation.wrapGetConnectionCallback(
+      mockShim,
+      mockCallback
+    )
+
+    const expectedError = new Error('whoops')
+    wrappedGetConnectionCallback(expectedError)
+
+    t.ok(mockCallback.calledOnceWith(expectedError), 'should still have called the callback')
+    t.notOk(mockShim[symbols.wrappedPoolConnection], 'should not have added the symbol')
+    t.end()
+  })
+
+  t.test('should catch the error if wrapping the callback throws', (t) => {
+    const expectedError = new Error('whoops')
+    instrumentation.wrapQueryable = sinon.stub().throws(expectedError)
+    const wrappedGetConnectionCallback = instrumentation.wrapGetConnectionCallback(
+      mockShim,
+      mockCallback
+    )
+
+    wrappedGetConnectionCallback(null, mockConnection)
+
+    t.ok(mockCallback.calledOnceWith(null, mockConnection), 'should still have called the callback')
+    t.notOk(mockShim[symbols.wrappedPoolConnection], 'should not have added the symbol')
+    t.end()
+  })
+
+  t.test('should assign a symbol if wrapping is successful', (t) => {
+    instrumentation.wrapQueryable = sinon.stub().returns(true)
+    const wrappedGetConnectionCallback = instrumentation.wrapGetConnectionCallback(
+      mockShim,
+      mockCallback
+    )
+
+    wrappedGetConnectionCallback(null, mockConnection)
+
+    t.ok(mockCallback.calledOnceWith(null, mockConnection), 'should still have called the callback')
+    t.ok(mockShim[symbols.wrappedPoolConnection], 'should have added the symbol')
+    t.end()
+  })
+})

--- a/test/unit/instrumentation/mysql/wrapQueryable.test.js
+++ b/test/unit/instrumentation/mysql/wrapQueryable.test.js
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const sinon = require('sinon')
+const instrumentation = require('../../../../lib/instrumentation/mysql/mysql')
+const symbols = require('../../../../lib/symbols')
+
+tap.test('wrapQueryable', (t) => {
+  t.autoend()
+
+  let mockShim
+  let mockQueryable
+
+  t.beforeEach(() => {
+    mockShim = {
+      isWrapped: sinon.stub().returns(),
+      logger: {
+        debug: sinon.stub().returns()
+      },
+      recordQuery: sinon.stub().returns()
+    }
+  })
+
+  t.test('should return false if queryable definition is undefined', (t) => {
+    const result = instrumentation.wrapQueryable(mockShim, undefined)
+    t.equal(result, false)
+    t.ok(
+      mockShim.logger.debug.calledOnceWith(
+        {
+          queryable: false,
+          query: false,
+          isWrapped: false
+        },
+        'Not wrapping queryable'
+      )
+    )
+
+    t.end()
+  })
+
+  t.test('should return false if query function is missing', (t) => {
+    mockQueryable = {}
+    const result = instrumentation.wrapQueryable(mockShim, mockQueryable)
+    t.equal(result, false)
+    t.ok(
+      mockShim.logger.debug.calledOnceWith(
+        {
+          queryable: true,
+          query: false,
+          isWrapped: false
+        },
+        'Not wrapping queryable'
+      )
+    )
+
+    t.end()
+  })
+
+  t.test('should return false if query function is already wrapped', (t) => {
+    mockQueryable = {
+      query: sinon.stub().returns()
+    }
+    mockShim.isWrapped.returns(true)
+    const result = instrumentation.wrapQueryable(mockShim, mockQueryable)
+    t.equal(result, false)
+    t.ok(
+      mockShim.logger.debug.calledOnceWith(
+        {
+          queryable: true,
+          query: true,
+          isWrapped: true
+        },
+        'Not wrapping queryable'
+      )
+    )
+
+    t.end()
+  })
+
+  t.test('should wrap query when using pooling', (t) => {
+    mockQueryable = {
+      query: sinon.stub().returns()
+    }
+
+    const result = instrumentation.wrapQueryable(mockShim, mockQueryable, true)
+    t.equal(result, true)
+    t.equal(mockShim.logger.debug.callCount, 0)
+
+    t.ok(
+      mockShim.recordQuery.calledOnceWith(
+        Object.getPrototypeOf(mockQueryable),
+        'query',
+        instrumentation.describePoolQuery
+      )
+    )
+
+    t.end()
+  })
+
+  t.test('should wrap query', (t) => {
+    mockQueryable = {
+      query: sinon.stub().returns()
+    }
+
+    const result = instrumentation.wrapQueryable(mockShim, mockQueryable)
+    t.equal(result, true)
+    t.equal(mockShim.logger.debug.callCount, 0)
+
+    t.ok(
+      mockShim.recordQuery.calledOnceWith(
+        Object.getPrototypeOf(mockQueryable),
+        'query',
+        instrumentation.describeQuery
+      )
+    )
+    t.equal(Object.getPrototypeOf(mockQueryable)[symbols.databaseName], null)
+
+    t.end()
+  })
+  t.test('should wrap execute if it is defined', (t) => {
+    mockQueryable = {
+      query: sinon.stub().returns(),
+      execute: sinon.stub().returns()
+    }
+
+    const result = instrumentation.wrapQueryable(mockShim, mockQueryable)
+    t.equal(result, true)
+    t.equal(mockShim.logger.debug.callCount, 0)
+
+    t.ok(
+      mockShim.recordQuery.calledWith(
+        Object.getPrototypeOf(mockQueryable),
+        'execute',
+        instrumentation.describeQuery
+      )
+    )
+
+    t.end()
+  })
+})


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
In the aftermath of #1645, we though it prudent to add additional automated tests to ensure that our use of shim symbols is correct and consistent, as the symbols are heavily used in our logic to determine if something is already instrumented or needs to be instrumented. In order to minimize the amount of code shuffling and room for error, I took the route of updating functions to be part of the export.

## How to Test
Tested via `npm run unit` and also with `npm run versioned:major mysql`

## Related Issues
Closes https://issues.newrelic.com/browse/NEWRELIC-4868