### PR TITLE
ci: added new file to apollo server tests to properly clone it when running versioned tests

### DIFF
--- a/test/versioned-external/external-repos.js
+++ b/test/versioned-external/external-repos.js
@@ -40,6 +40,7 @@ const repos = [
       'tests/agent-testing.js',
       'tests/create-apollo-server-setup.js',
       'tests/data-definitions.js',
+      'tests/metrics-tests.js',
       'tests/test-client.js',
       'tests/utils.js'
     ]


### PR DESCRIPTION
## Description

We added a new file to apollo server plugin in https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/252. Since the file is outside of the versioned folder it needs to be added to this file to properly clone it