### PR TITLE
feat: Updated @newrelic/security agent to 0.1.1 

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -953,7 +953,7 @@ Apache License
 
 ### @newrelic/security-agent
 
-This product includes source derived from [@newrelic/security-agent](https://github.com/newrelic/csec-node-agent) ([v0.1.0](https://github.com/newrelic/csec-node-agent/tree/v0.1.0)), distributed under the [New Relic Pre-Release License](https://github.com/newrelic/csec-node-agent/blob/v0.1.0/LICENSE):
+This product includes source derived from [@newrelic/security-agent](https://github.com/newrelic/csec-node-agent) ([v0.1.1](https://github.com/newrelic/csec-node-agent/tree/v0.1.1)), distributed under the [New Relic Pre-Release License](https://github.com/newrelic/csec-node-agent/blob/v0.1.1/LICENSE):
 
 ```
 ## New Relic Pre-Release Software Notice

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@mrleebo/prisma-ast": "^0.5.2",
         "@newrelic/aws-sdk": "^5.0.2",
         "@newrelic/koa": "^7.1.1",
-        "@newrelic/security-agent": "0.1.0",
+        "@newrelic/security-agent": "0.1.1",
         "@newrelic/superagent": "^6.0.0",
         "@tyriar/fibonacci-heap": "^2.0.7",
         "concat-stream": "^2.0.0",
@@ -1993,9 +1993,9 @@
       }
     },
     "node_modules/@newrelic/security-agent": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/security-agent/-/security-agent-0.1.0.tgz",
-      "integrity": "sha512-itKfqhm2gZDGALlI3xPPUccua9SqFCGT9oAPGFCPpycAtgH511QDIBZSUXwqfN94YejN6ClIpXxhL/WrPyd8jw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/security-agent/-/security-agent-0.1.1.tgz",
+      "integrity": "sha512-YVKMXzZDZ4LZ3H8dBe9R2dBJnelMPyWQ1F+fd65TwRETF90g3bGp9ITlJ2DEr8eckUJSxnBMJ1bFvu9Qym/P1A==",
       "dependencies": {
         "@aws-sdk/client-lambda": "3.276.0",
         "axios": "0.21.4",
@@ -18075,9 +18075,9 @@
       }
     },
     "@newrelic/security-agent": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/security-agent/-/security-agent-0.1.0.tgz",
-      "integrity": "sha512-itKfqhm2gZDGALlI3xPPUccua9SqFCGT9oAPGFCPpycAtgH511QDIBZSUXwqfN94YejN6ClIpXxhL/WrPyd8jw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/security-agent/-/security-agent-0.1.1.tgz",
+      "integrity": "sha512-YVKMXzZDZ4LZ3H8dBe9R2dBJnelMPyWQ1F+fd65TwRETF90g3bGp9ITlJ2DEr8eckUJSxnBMJ1bFvu9Qym/P1A==",
       "requires": {
         "@aws-sdk/client-lambda": "3.276.0",
         "axios": "0.21.4",

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "@mrleebo/prisma-ast": "^0.5.2",
     "@newrelic/aws-sdk": "^5.0.2",
     "@newrelic/koa": "^7.1.1",
-    "@newrelic/security-agent": "0.1.0",
+    "@newrelic/security-agent": "0.1.1",
     "@newrelic/superagent": "^6.0.0",
     "@tyriar/fibonacci-heap": "^2.0.7",
     "concat-stream": "^2.0.0",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Tue May 30 2023 14:26:27 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Wed Jun 07 2023 17:59:28 GMT+0530 (India Standard Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -94,15 +94,15 @@
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"
     },
-    "@newrelic/security-agent@0.1.0": {
+    "@newrelic/security-agent@0.1.1": {
       "name": "@newrelic/security-agent",
-      "version": "0.1.0",
-      "range": "0.1.0",
+      "version": "0.1.1",
+      "range": "0.1.1",
       "licenses": "New Relic Pre-Release",
       "repoUrl": "https://github.com/newrelic/csec-node-agent",
-      "versionedRepoUrl": "https://github.com/newrelic/csec-node-agent/tree/v0.1.0",
+      "versionedRepoUrl": "https://github.com/newrelic/csec-node-agent/tree/v0.1.1",
       "licenseFile": "node_modules/@newrelic/security-agent/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/csec-node-agent/blob/v0.1.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/csec-node-agent/blob/v0.1.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "newrelic"
     },


### PR DESCRIPTION

## Description
* @newrelic/security-agent dependency is updated to its latest version.
* Fix in mysql instrumentation on getConnection to check if callback is wrapped
* Support for fire and forget vulnerability detection
* Snapshot file fixes.
* Handling for high_security config.

## How to Test
Run following command to test.
`npm run versioned:security`

