### PR TITLE
ci: disable running CI for releases

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,9 +1,21 @@
 name: Node Agent CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  workflow_dispatch: {}
+  pull_request:
+    types:
+      # Created PR
+      - opened
+      # Added commits to the PR
+      - synchronize
+      # Sometimes we need to do this to trigger a run
+      - reopened
+      # Merged the PR (check below ensures non-merge closing events don't trigger)
+      - closed
 
 jobs:
   lint:
+    if: ${{ !startsWith(github.head_ref, 'release/v') && (github.event.pull_request.merged == true || github.event.action != 'closed') }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -24,6 +36,7 @@ jobs:
       run: npm run lint:lockfile
 
   ci:
+    if: ${{ !startsWith(github.head_ref, 'release/v') && (github.event.pull_request.merged == true || github.event.action != 'closed') }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -42,6 +55,7 @@ jobs:
       run: npm run unit:scripts
 
   unit:
+    if: ${{ !startsWith(github.head_ref, 'release/v') && (github.event.pull_request.merged == true || github.event.action != 'closed') }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -72,6 +86,7 @@ jobs:
         path: ./coverage/esm-unit/lcov.info
 
   integration:
+    if: ${{ !startsWith(github.head_ref, 'release/v') && (github.event.pull_request.merged == true || github.event.action != 'closed') }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -97,6 +112,7 @@ jobs:
         path: ./coverage/integration/lcov.info
 
   versioned:
+    if: ${{ !startsWith(github.head_ref, 'release/v') && (github.event.pull_request.merged == true || github.event.action != 'closed') }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -117,14 +133,14 @@ jobs:
       if: ${{ matrix.node-version == '14.x' }}
       run: TEST_CHILD_TIMEOUT=600000 npm run versioned:npm6
       env:
-        VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}
+        VERSIONED_MODE: ${{ github.event.pull_request.merged == true && '--minor' || '--major' }}
         JOBS: 4 # 2 per CPU seems to be the sweet spot in GHA (July 2022)
         C8_REPORTER: lcovonly
     - name: Run Versioned Tests (npm v7 / Node 16+)
       if: ${{ matrix.node-version != '14.x' }}
       run: TEST_CHILD_TIMEOUT=600000 npm run versioned:npm7
       env:
-        VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}
+        VERSIONED_MODE: ${{ github.event.pull_request.merged == true && '--minor' || '--major' }}
         JOBS: 4 # 2 per CPU seems to be the sweet spot in GHA (July 2022)
         C8_REPORTER: lcovonly
     - name: Archive Versioned Test Coverage


### PR DESCRIPTION
## Description

Please provide a brief description of the changes introduced in this pull request.
What problem does it solve? What is the context of this change?

There are a few parts to this:

1) First, disable running on pushes. This is because pushes don't have context when they come from a pull request. In particular, pushes don't have the branch name the pull request came from.

2) At the same time, enable running on `synchronize` and `close` actions on `pull_request` events. This will ensure that when a PR gets updated or merged, we'll see a CI run. This changes the default actions of only running on `opened`, `synchronize`, or `reopened`. 

3) Then, disable running if the branch name starts with release.

4) In the same condition check, enable runs only for branches that are closed via a merge. We don't want to trigger CI for a PR that is closed because we decided to abandon the idea.

## How to Test

Scenarios in my test repo, when running PRs from a fork:

* A normal PR, ran all of the CI, some tests failed due to missing secrets: https://github.com/jordigh/node-newrelic-testing-gha/actions/runs/5268762384
* The same normal PR, when getting new commits, triggered a `--major` versioned re-run: https://github.com/jordigh/node-newrelic-testing-gha/actions/runs/5269064911/jobs/9526651087#step:7:103
* The same normal PR, when getting merged, triggered a `--minor` versioned run on main: https://github.com/jordigh/node-newrelic-testing-gha/actions/runs/5269330927/jobs/9527313867#step:2:373 https://github.com/jordigh/node-newrelic-testing-gha/actions/runs/5269330927/jobs/9527313867#step:7:99 
* A release branch did not trigger CI: https://github.com/jordigh/node-newrelic-testing-gha/actions/runs/5268776550
* The same release branch, when getting new commits, did not trigger CI: https://github.com/jordigh/node-newrelic-testing-gha/actions/runs/5269303327
* The same release branch, when merged, did not trigger CI: https://github.com/jordigh/node-newrelic-testing-gha/actions/runs/5269373066

Note: this test repo has no secrets, which explains the CI failures.

## Related Issues

* NEWRELIC-8977