### PR TITLE
chore: temporarily limit prisma tests to non-breaking version

### DIFF
--- a/test/versioned/prisma/package.json
+++ b/test/versioned/prisma/package.json
@@ -11,7 +11,7 @@
         "node": ">=14"
       },
       "dependencies": {
-        "@prisma/client": ">=4.0.0",
+        "@prisma/client": ">=4.0.0 <4.16.0",
         "prisma": "latest"
       },
       "files": [


### PR DESCRIPTION
## Description

Until we fix #1679, we need to limit our tests to get the build passing.