### PR TITLE
fix(prisma): check for query args in string property

### DIFF
--- a/lib/instrumentation/@prisma/client.js
+++ b/lib/instrumentation/@prisma/client.js
@@ -87,7 +87,8 @@ function extractQueryArgs(args, pkgVersion) {
   let query = ''
   try {
     if (semver.gte(pkgVersion, '4.11.0')) {
-      query = args[0].args[0]
+      // Prisma 4.16.0 moved the query to a `strings` property
+      query = args[0].args[0] || args[0].args.strings[0]
       if (Array.isArray(query)) {
         // RawUnsafe pass in a string, but plain Raw methods pass in an
         // array containing a prepared SQL statement and the SQL parameters

--- a/test/versioned/prisma/package.json
+++ b/test/versioned/prisma/package.json
@@ -11,7 +11,7 @@
         "node": ">=14"
       },
       "dependencies": {
-        "@prisma/client": ">=4.0.0 <4.16.0",
+        "@prisma/client": ">=4.0.0",
         "prisma": "latest"
       },
       "files": [


### PR DESCRIPTION
Prisma 4.16.0 changed where the query comes from, so let's just make sure we get it from the right place.

Closes #1679