### PR TITLE
revert: reverts #1671 changes to CI workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,21 +1,9 @@
 name: Node Agent CI
 
-on:
-  workflow_dispatch: {}
-  pull_request:
-    types:
-      # Created PR
-      - opened
-      # Added commits to the PR
-      - synchronize
-      # Sometimes we need to do this to trigger a run
-      - reopened
-      # Merged the PR (check below ensures non-merge closing events don't trigger)
-      - closed
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   lint:
-    if: ${{ !startsWith(github.head_ref, 'release/v') && (github.event.pull_request.merged == true || github.event.action != 'closed') }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -36,7 +24,6 @@ jobs:
       run: npm run lint:lockfile
 
   ci:
-    if: ${{ !startsWith(github.head_ref, 'release/v') && (github.event.pull_request.merged == true || github.event.action != 'closed') }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -55,7 +42,6 @@ jobs:
       run: npm run unit:scripts
 
   unit:
-    if: ${{ !startsWith(github.head_ref, 'release/v') && (github.event.pull_request.merged == true || github.event.action != 'closed') }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -86,7 +72,6 @@ jobs:
         path: ./coverage/esm-unit/lcov.info
 
   integration:
-    if: ${{ !startsWith(github.head_ref, 'release/v') && (github.event.pull_request.merged == true || github.event.action != 'closed') }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -112,7 +97,6 @@ jobs:
         path: ./coverage/integration/lcov.info
 
   versioned:
-    if: ${{ !startsWith(github.head_ref, 'release/v') && (github.event.pull_request.merged == true || github.event.action != 'closed') }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -133,14 +117,14 @@ jobs:
       if: ${{ matrix.node-version == '14.x' }}
       run: TEST_CHILD_TIMEOUT=600000 npm run versioned:npm6
       env:
-        VERSIONED_MODE: ${{ github.event.pull_request.merged == true && '--minor' || '--major' }}
+        VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}
         JOBS: 4 # 2 per CPU seems to be the sweet spot in GHA (July 2022)
         C8_REPORTER: lcovonly
     - name: Run Versioned Tests (npm v7 / Node 16+)
       if: ${{ matrix.node-version != '14.x' }}
       run: TEST_CHILD_TIMEOUT=600000 npm run versioned:npm7
       env:
-        VERSIONED_MODE: ${{ github.event.pull_request.merged == true && '--minor' || '--major' }}
+        VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}
         JOBS: 4 # 2 per CPU seems to be the sweet spot in GHA (July 2022)
         C8_REPORTER: lcovonly
     - name: Archive Versioned Test Coverage


### PR DESCRIPTION
## Description
Reverts changes from #1671, after discovering that changes are not compatible with our branch protections and that closing a PR causes the CI workflow to run scoped to the branch, not to `main`

## How to Test
N/A

## Related Issues
Reverts #1671 