### PR TITLE
chore(test): Fixed tap end/autoend use in trace unit test

### DIFF
--- a/test/unit/trace.test.js
+++ b/test/unit/trace.test.js
@@ -429,7 +429,6 @@ tap.test('when serializing asynchronously', (t) => {
 
         t.equal(json[1], 1234)
         t.equal(trace, details.trace)
-        t.end()
         resolve()
       })
     })

--- a/test/unit/trace.test.js
+++ b/test/unit/trace.test.js
@@ -429,10 +429,10 @@ tap.test('when serializing asynchronously', (t) => {
 
         t.equal(json[1], 1234)
         t.equal(trace, details.trace)
+        t.end()
         resolve()
       })
     })
-    t.end()
   })
 
   t.test('when `simple_compression` is `false`, should compress the segment arrays', async (t) => {

--- a/test/unit/trace.test.js
+++ b/test/unit/trace.test.js
@@ -779,7 +779,6 @@ tap.test('should set URI to null when request.uri attribute is excluded globally
 })
 
 tap.test('should set URI to null when request.uri attribute is exluded from traces', async (t) => {
-  t.autoend()
   const URL = '/test'
 
   const agent = helper.loadMockedAgent({
@@ -806,6 +805,7 @@ tap.test('should set URI to null when request.uri attribute is exluded from trac
   const traceJSON = await trace.generateJSON()
   const { 3: requestUri } = traceJSON
   t.notOk(requestUri)
+  t.end()
 })
 
 tap.test('should set URI to /Unknown when URL is not known/set on transaction', async (t) => {

--- a/test/unit/trace.test.js
+++ b/test/unit/trace.test.js
@@ -806,7 +806,6 @@ tap.test('should set URI to null when request.uri attribute is exluded from trac
   const traceJSON = await trace.generateJSON()
   const { 3: requestUri } = traceJSON
   t.notOk(requestUri)
-  t.end()
 })
 
 tap.test('should set URI to /Unknown when URL is not known/set on transaction', async (t) => {


### PR DESCRIPTION
## Description

Removed unneeded t.end() calls in trace unit test.