### PR TITLE
ci: skip running test suite when merging releases

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -3,7 +3,23 @@ name: Node Agent CI
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
+  skip_if_release:
+    runs-on: ubuntu-latest
+
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          paths_ignore: '["NEWS.md", "changelog.json", "package.json", "package-lock.json"]'
+          skip_after_successful_duplicate: false
+          do_not_skip: '["workflow_dispatch", "pull_request"]'
+
   lint:
+    needs: skip_if_release
+    if: needs.skip_if_release.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -24,6 +40,8 @@ jobs:
       run: npm run lint:lockfile
 
   ci:
+    needs: skip_if_release
+    if: needs.skip_if_release.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -42,6 +60,8 @@ jobs:
       run: npm run unit:scripts
 
   unit:
+    needs: skip_if_release
+    if: needs.skip_if_release.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -72,6 +92,8 @@ jobs:
         path: ./coverage/esm-unit/lcov.info
 
   integration:
+    needs: skip_if_release
+    if: needs.skip_if_release.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -90,13 +112,15 @@ jobs:
       run: npm run services
     - name: Run Integration Tests
       run: npm run integration
-    - name: Archive Integration Test Coverage 
+    - name: Archive Integration Test Coverage
       uses: actions/upload-artifact@v3
       with:
         name: integration-tests-${{ matrix.node-version }}
         path: ./coverage/integration/lcov.info
 
   versioned:
+    needs: skip_if_release
+    if: needs.skip_if_release.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -2,6 +2,8 @@ name: Node Agent CI
 
 on: [push, pull_request, workflow_dispatch]
 
+
+
 jobs:
   skip_if_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Updates our `ci-workflow.yml` to use [fkirc/skip-duplicate-actions](https://github.com/fkirc/skip-duplicate-actions) to skip running our test suite when we merge a release PR. This will reduce the amount of human interaction (babysitting) it takes to perform our releases.

We will still run CI for all pull requests to fulfill our required status check requirement, and will not skip any manual invocations of the workflow.

We use `fkirc/skip-duplicate-actions`'s `ignore_path` to detect a release PR, as these PRs only update a specific subset of files, specifically `package.json`, `package-lock.json`, `changelog.json` and `NEWS.md`.

This PR has it disabled to minimize risk/impact, but in the future, this action has a robust duplicate run detection algorithm, which we could leverage in the future to further cut down on time spent in CI. This would be even more important if we ever switch to larger GHA runners.

## How to Test
Tested using my fork (which is why I'm submitting this via a branch)

* Run where we bump a dep, which should not be skipped (like a dependabot/snyk PR): https://github.com/jmartin4563/node-newrelic/actions/runs/5405475382
* Run where we merge a release, which should be skipped: https://github.com/jmartin4563/node-newrelic/actions/runs/5405441888
* Run where we do a PR that isn't a release, which should not be skipped: https://github.com/jmartin4563/node-newrelic/actions/runs/5405055821

## Related Issues
Closes NR-138283