### PR TITLE
chore(test): Replaced t.equals with t.equal

### DIFF
--- a/test/unit/errors/error-event-aggregator.test.js
+++ b/test/unit/errors/error-event-aggregator.test.js
@@ -35,7 +35,7 @@ tap.test('Error Event Aggregator', (t) => {
   t.test('should set the correct default method', (t) => {
     const method = errorEventAggregator.method
 
-    t.equals(method, 'error_event_data', 'default method should be error_event_data')
+    t.equal(method, 'error_event_data', 'default method should be error_event_data')
     t.end()
   })
 

--- a/test/unit/errors/error-trace-aggregator.test.js
+++ b/test/unit/errors/error-trace-aggregator.test.js
@@ -30,7 +30,7 @@ tap.test('Error Trace Aggregator', (t) => {
   t.test('should set the correct default method', (t) => {
     const method = errorTraceAggregator.method
 
-    t.equals(method, 'error_data', 'default method should be error_data')
+    t.equal(method, 'error_data', 'default method should be error_data')
     t.end()
   })
 
@@ -39,7 +39,7 @@ tap.test('Error Trace Aggregator', (t) => {
     errorTraceAggregator.add(rawErrorTrace)
 
     const firstError = errorTraceAggregator.errors[0]
-    t.equals(rawErrorTrace, firstError)
+    t.equal(rawErrorTrace, firstError)
     t.end()
   })
 
@@ -48,10 +48,10 @@ tap.test('Error Trace Aggregator', (t) => {
     errorTraceAggregator.add(rawErrorTrace)
 
     const data = errorTraceAggregator._getMergeData()
-    t.equals(data.length, 1, 'there should be one error')
+    t.equal(data.length, 1, 'there should be one error')
 
     const firstError = data[0]
-    t.equals(rawErrorTrace, firstError, '_getMergeData should return the expected error trace')
+    t.equal(rawErrorTrace, firstError, '_getMergeData should return the expected error trace')
     t.end()
   })
 
@@ -60,10 +60,10 @@ tap.test('Error Trace Aggregator', (t) => {
     errorTraceAggregator.add(rawErrorTrace)
 
     const payload = errorTraceAggregator._toPayloadSync()
-    t.equals(payload.length, 2, 'sync payload should have runId and errorTraceData')
+    t.equal(payload.length, 2, 'sync payload should have runId and errorTraceData')
 
     const [runId, errorTraceData] = payload
-    t.equals(runId, RUN_ID, 'run ID should match')
+    t.equal(runId, RUN_ID, 'run ID should match')
 
     const expectedTraceData = [rawErrorTrace]
     t.same(errorTraceData, expectedTraceData, 'errorTraceData should match')
@@ -75,10 +75,10 @@ tap.test('Error Trace Aggregator', (t) => {
     errorTraceAggregator.add(rawErrorTrace)
 
     errorTraceAggregator._toPayload((err, payload) => {
-      t.equals(payload.length, 2, 'payload should have two elements')
+      t.equal(payload.length, 2, 'payload should have two elements')
 
       const [runId, errorTraceData] = payload
-      t.equals(runId, RUN_ID, 'run ID should match')
+      t.equal(runId, RUN_ID, 'run ID should match')
 
       const expectedTraceData = [rawErrorTrace]
       t.same(errorTraceData, expectedTraceData, 'errorTraceData should match')
@@ -97,12 +97,12 @@ tap.test('Error Trace Aggregator', (t) => {
 
     errorTraceAggregator._merge(mergeData)
 
-    t.equals(errorTraceAggregator.errors.length, 3, 'aggregator should have three errors')
+    t.equal(errorTraceAggregator.errors.length, 3, 'aggregator should have three errors')
 
     const [error1, error2, error3] = errorTraceAggregator.errors
-    t.equals(error1[1], 'name1', 'error1 should have expected name')
-    t.equals(error2[1], 'name2', 'error2 should have expected name')
-    t.equals(error3[1], 'name3', 'error3 should have expected name')
+    t.equal(error1[1], 'name1', 'error1 should have expected name')
+    t.equal(error2[1], 'name2', 'error2 should have expected name')
+    t.equal(error3[1], 'name3', 'error3 should have expected name')
     t.end()
   })
 
@@ -120,18 +120,18 @@ tap.test('Error Trace Aggregator', (t) => {
 
     errorTraceAggregator._merge(mergeData)
 
-    t.equals(
+    t.equal(
       errorTraceAggregator.errors.length,
       LIMIT,
       'aggregator should have received five errors'
     )
 
     const [error1, error2, error3, error4, error5] = errorTraceAggregator.errors
-    t.equals(error1[1], 'name1', 'error1 should have expected name')
-    t.equals(error2[1], 'name2', 'error2 should have expected name')
-    t.equals(error3[1], 'name3', 'error3 should have expected name')
-    t.equals(error4[1], 'name4', 'error4 should have expected name')
-    t.equals(error5[1], 'name5', 'error5 should have expected name')
+    t.equal(error1[1], 'name1', 'error1 should have expected name')
+    t.equal(error2[1], 'name2', 'error2 should have expected name')
+    t.equal(error3[1], 'name3', 'error3 should have expected name')
+    t.equal(error4[1], 'name4', 'error4 should have expected name')
+    t.equal(error5[1], 'name5', 'error5 should have expected name')
     t.end()
   })
 
@@ -139,7 +139,7 @@ tap.test('Error Trace Aggregator', (t) => {
     const rawErrorTrace = [0, 'name1', 'message', 'type', {}]
     errorTraceAggregator.add(rawErrorTrace)
 
-    t.equals(
+    t.equal(
       errorTraceAggregator.errors.length,
       1,
       'before clear(), there should be one error in the aggregator'
@@ -147,7 +147,7 @@ tap.test('Error Trace Aggregator', (t) => {
 
     errorTraceAggregator.clear()
 
-    t.equals(
+    t.equal(
       errorTraceAggregator.errors.length,
       0,
       'after clear(), there should be nothing in the aggregator'

--- a/test/unit/errors/expected.test.js
+++ b/test/unit/errors/expected.test.js
@@ -36,7 +36,7 @@ tap.test('Expected Errors, when expected configuration is present', (t) => {
       const json = apdexStats.toJSON()
       tx.end()
       // no errors in the frustrating column
-      t.equals(json[2], 0)
+      t.equal(json[2], 0)
       t.end()
     })
   })
@@ -57,24 +57,24 @@ tap.test('Expected Errors, when expected configuration is present', (t) => {
       tx.end()
 
       const errorUnexpected = agent.errors.eventAggregator.getEvents()[0]
-      t.equals(
+      t.equal(
         errorUnexpected[0]['error.message'],
         'NOT expected',
         'should be able to test unexpected errors'
       )
-      t.equals(
+      t.equal(
         errorUnexpected[0]['error.expected'],
         false,
         'unexpected errors should not have error.expected'
       )
 
       const errorExpected = agent.errors.eventAggregator.getEvents()[1]
-      t.equals(
+      t.equal(
         errorExpected[0]['error.message'],
         'expected',
         'should be able to test expected errors'
       )
-      t.equals(
+      t.equal(
         errorExpected[0]['error.expected'],
         true,
         'expected errors should have error.expected'
@@ -100,7 +100,7 @@ tap.test('Expected Errors, when expected configuration is present', (t) => {
       tx.end()
 
       const errorUnexpected = agent.errors.eventAggregator.getEvents()[0]
-      t.equals(
+      t.equal(
         errorUnexpected[0]['error.message'],
         'NOT expected',
         'should be able to test class-unexpected error'
@@ -111,12 +111,12 @@ tap.test('Expected Errors, when expected configuration is present', (t) => {
       )
 
       const errorExpected = agent.errors.eventAggregator.getEvents()[1]
-      t.equals(
+      t.equal(
         errorExpected[0]['error.message'],
         'expected',
         'should be able to test class-expected error'
       )
-      t.equals(
+      t.equal(
         errorExpected[0]['error.expected'],
         true,
         'class-expected error should have error.expected'
@@ -144,15 +144,15 @@ tap.test('Expected Errors, when expected configuration is present', (t) => {
       tx.end()
 
       const errorUnexpected = agent.errors.eventAggregator.getEvents()[0]
-      t.equals(errorUnexpected[0]['error.class'], 'Error')
+      t.equal(errorUnexpected[0]['error.class'], 'Error')
       t.notOk(
         errorUnexpected[2]['error.expected'],
         'type-unexpected errors should not have error.expected'
       )
 
       const errorExpected = agent.errors.eventAggregator.getEvents()[1]
-      t.equals(errorExpected[0]['error.class'], 'ReferenceError')
-      t.equals(
+      t.equal(errorExpected[0]['error.class'], 'ReferenceError')
+      t.equal(
         errorExpected[0]['error.expected'],
         true,
         'type-expected errors should have error.expected'
@@ -171,7 +171,7 @@ tap.test('Expected Errors, when expected configuration is present', (t) => {
       const json = apdexStats.toJSON()
       tx.end()
       // no errors in the frustrating column
-      t.equals(json[2], 0)
+      t.equal(json[2], 0)
       t.end()
     })
   })
@@ -194,12 +194,12 @@ tap.test('Expected Errors, when expected configuration is present', (t) => {
 
       const expectedErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.EXPECTED)
 
-      t.equals(
+      t.equal(
         transactionErrorMetric.callCount,
         1,
         'transactionErrorMetric.callCount should equal 1'
       )
-      t.equals(expectedErrorMetric.callCount, 1, 'expectedErrorMetric.callCount should equal 1')
+      t.equal(expectedErrorMetric.callCount, 1, 'expectedErrorMetric.callCount should equal 1')
       t.end()
     })
   })
@@ -224,10 +224,10 @@ tap.test('Expected Errors, when expected configuration is present', (t) => {
       const webErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.WEB)
       const otherErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.OTHER)
 
-      t.equals(transactionErrorMetric.callCount, 1, '')
+      t.equal(transactionErrorMetric.callCount, 1, '')
 
-      t.equals(allErrorMetric.callCount, 1, 'allErrorMetric.callCount should equal 1')
-      t.equals(webErrorMetric.callCount, 1, 'webErrorMetric.callCount should equal 1')
+      t.equal(allErrorMetric.callCount, 1, 'allErrorMetric.callCount should equal 1')
+      t.equal(webErrorMetric.callCount, 1, 'webErrorMetric.callCount should equal 1')
       t.notOk(otherErrorMetric, 'should not create other error metrics')
       t.end()
     })
@@ -283,15 +283,15 @@ tap.test('Expected Errors, when expected configuration is present', (t) => {
       const webErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.WEB)
       const otherErrorMetric = agent.metrics.getMetric(NAMES.ERRORS.OTHER)
 
-      t.equals(
+      t.equal(
         transactionErrorMetric.callCount,
         1,
         'should increment transactionErrorMetric.callCount'
       )
 
-      t.equals(allErrorMetric.callCount, 1, 'should increment allErrorMetric.callCount')
+      t.equal(allErrorMetric.callCount, 1, 'should increment allErrorMetric.callCount')
       t.notOk(webErrorMetric, 'should not increment webErrorMetric')
-      t.equals(otherErrorMetric.callCount, 1, 'should increment otherErrorMetric.callCount')
+      t.equal(otherErrorMetric.callCount, 1, 'should increment otherErrorMetric.callCount')
       t.end()
     })
   })
@@ -303,7 +303,7 @@ tap.test('Expected Errors, when expected configuration is present', (t) => {
       const exception = new Exception({ error })
       const result = errorHelper.isExpectedException(tx, exception, agent.config, urltils)
 
-      t.equals(result, true)
+      t.equal(result, true)
       t.end()
     })
   })
@@ -331,13 +331,13 @@ tap.test('Expected Errors, when expected configuration is present', (t) => {
       exception = new Exception({ error })
       tx.addException(exception)
 
-      t.equals(tx.hasOnlyExpectedErrors(), true)
+      t.equal(tx.hasOnlyExpectedErrors(), true)
 
       tx._setApdex(NAMES.APDEX, 1, 1)
       const json = apdexStats.toJSON()
       tx.end()
       // no errors in the frustrating column
-      t.equals(json[2], 0)
+      t.equal(json[2], 0)
       t.end()
     })
   })
@@ -346,13 +346,13 @@ tap.test('Expected Errors, when expected configuration is present', (t) => {
     helper.runInTransaction(agent, function (tx) {
       tx.statusCode = 500
       const apdexStats = tx.metrics.getOrCreateApdexMetric(NAMES.APDEX)
-      t.equals(tx.hasOnlyExpectedErrors(), false)
+      t.equal(tx.hasOnlyExpectedErrors(), false)
 
       tx._setApdex(NAMES.APDEX, 1, 1)
       const json = apdexStats.toJSON()
       tx.end()
       // should put an error in the frustrating column
-      t.equals(json[2], 1)
+      t.equal(json[2], 1)
       t.end()
     })
   })
@@ -382,7 +382,7 @@ tap.test('Expected Errors, when expected configuration is present', (t) => {
       const json = apdexStats.toJSON()
       tx.end()
       // should have an error in the frustrating column
-      t.equals(json[2], 1)
+      t.equal(json[2], 1)
       t.end()
     })
   })

--- a/test/versioned/hapi/errors.tap.js
+++ b/test/versioned/hapi/errors.tap.js
@@ -38,8 +38,8 @@ tap.test('Hapi error handling', function (t) {
     })
 
     runTest(t, function (errors, statusCode) {
-      t.equals(errors.length, 0, 'should have no errors')
-      t.equals(statusCode, 200, 'should have a 200 status code')
+      t.equal(errors.length, 0, 'should have no errors')
+      t.equal(statusCode, 200, 'should have a 200 status code')
       t.end()
     })
   })
@@ -54,11 +54,11 @@ tap.test('Hapi error handling', function (t) {
     })
 
     runTest(t, function (errors, statusCode) {
-      t.equals(errors.length, 1, 'should have one error')
+      t.equal(errors.length, 1, 'should have one error')
 
-      t.equals(errors[0][2], 'rejected promise error', 'should have expected error message')
+      t.equal(errors[0][2], 'rejected promise error', 'should have expected error message')
 
-      t.equals(statusCode, 500, 'should have expected error code')
+      t.equal(statusCode, 500, 'should have expected error code')
       t.end()
     })
   })
@@ -73,9 +73,9 @@ tap.test('Hapi error handling', function (t) {
     })
 
     runTest(t, function (errors, statusCode) {
-      t.equals(errors.length, 1, 'should have one error')
-      t.equals(errors[0][2], 'thrown error', 'should have expected error message')
-      t.equals(statusCode, 500, 'should have expected error code')
+      t.equal(errors.length, 1, 'should have one error')
+      t.equal(errors[0][2], 'thrown error', 'should have expected error message')
+      t.equal(statusCode, 500, 'should have expected error code')
       t.end()
     })
   })
@@ -94,9 +94,9 @@ tap.test('Hapi error handling', function (t) {
     })
 
     runTest(t, function (errors, statusCode) {
-      t.equals(errors.length, 1, 'should have one error')
-      t.equals(errors[0][2], 'middleware error', 'should have expected error message')
-      t.equals(statusCode, 500, 'should have expected error code')
+      t.equal(errors.length, 1, 'should have one error')
+      t.equal(errors[0][2], 'middleware error', 'should have expected error message')
+      t.equal(statusCode, 500, 'should have expected error code')
       t.end()
     })
   })
@@ -117,9 +117,9 @@ tap.test('Hapi error handling', function (t) {
     })
 
     runTest(t, (errors, statusCode) => {
-      t.equals(errors.length, 1, 'has 1 reported error')
-      t.equals(errors[0][2], 'route handler error', 'has correct error message')
-      t.equals(statusCode, 400, 'has expected 400 status code')
+      t.equal(errors.length, 1, 'has 1 reported error')
+      t.equal(errors[0][2], 'route handler error', 'has correct error message')
+      t.equal(statusCode, 400, 'has expected 400 status code')
       t.end()
     })
   })
@@ -140,9 +140,9 @@ tap.test('Hapi error handling', function (t) {
     })
 
     runTest(t, (errors, statusCode) => {
-      t.equals(errors.length, 1, 'has 1 reported error')
-      t.equals(errors[0][2], 'route handler error', 'has correct error message')
-      t.equals(statusCode, 400, 'has expected 400 status code')
+      t.equal(errors.length, 1, 'has 1 reported error')
+      t.equal(errors[0][2], 'route handler error', 'has correct error message')
+      t.equal(statusCode, 400, 'has expected 400 status code')
       t.end()
     })
   })
@@ -162,9 +162,9 @@ tap.test('Hapi error handling', function (t) {
     })
 
     runTest(t, (errors, statusCode) => {
-      t.equals(errors.length, 1, 'has 1 reported error')
-      t.equals(errors[0][2], 'route handler error', 'has correct error message')
-      t.equals(statusCode, 500, 'has expected 500 status code')
+      t.equal(errors.length, 1, 'has 1 reported error')
+      t.equal(errors[0][2], 'route handler error', 'has correct error message')
+      t.equal(statusCode, 500, 'has expected 500 status code')
       t.end()
     })
   })
@@ -184,7 +184,7 @@ tap.test('Hapi error handling', function (t) {
     })
 
     runTest(t, (errors, statusCode) => {
-      t.equals(errors.length, 0, 'has no reported errors')
+      t.equal(errors.length, 0, 'has no reported errors')
       t.ok([200, 204].includes(statusCode), 'has expected 200 or 204 status code')
       t.end()
     })

--- a/test/versioned/ioredis/ioredis-3.tap.js
+++ b/test/versioned/ioredis/ioredis-3.tap.js
@@ -60,16 +60,16 @@ tap.test('ioredis instrumentation', function (t) {
 
     agent.on('transactionFinished', function (tx) {
       const root = tx.trace.root
-      t.equals(root.children.length, 2, 'root has two children')
+      t.equal(root.children.length, 2, 'root has two children')
 
       const setSegment = root.children[0]
-      t.equals(setSegment.name, 'Datastore/operation/Redis/set')
+      t.equal(setSegment.name, 'Datastore/operation/Redis/set')
 
       // ioredis operations return promise, any 'then' callbacks will be sibling segments
       // of the original redis call
       const getSegment = root.children[1]
-      t.equals(getSegment.name, 'Datastore/operation/Redis/get')
-      t.equals(getSegment.children.length, 0, 'should not contain any segments')
+      t.equal(getSegment.name, 'Datastore/operation/Redis/get')
+      t.equal(getSegment.children.length, 0, 'should not contain any segments')
 
       t.end()
     })

--- a/test/versioned/ioredis/ioredis.tap.js
+++ b/test/versioned/ioredis/ioredis.tap.js
@@ -71,16 +71,16 @@ tap.test('ioredis instrumentation', (t) => {
 
     agent.on('transactionFinished', function (tx) {
       const root = tx.trace.root
-      t.equals(root.children.length, 2, 'root has two children')
+      t.equal(root.children.length, 2, 'root has two children')
 
       const setSegment = root.children[0]
-      t.equals(setSegment.name, 'Datastore/operation/Redis/set')
+      t.equal(setSegment.name, 'Datastore/operation/Redis/set')
 
       // ioredis operations return promise, any 'then' callbacks will be sibling segments
       // of the original redis call
       const getSegment = root.children[1]
-      t.equals(getSegment.name, 'Datastore/operation/Redis/get')
-      t.equals(getSegment.children.length, 0, 'should not contain any segments')
+      t.equal(getSegment.name, 'Datastore/operation/Redis/get')
+      t.equal(getSegment.children.length, 0, 'should not contain any segments')
 
       t.end()
     })

--- a/test/versioned/redis/redis.tap.js
+++ b/test/versioned/redis/redis.tap.js
@@ -74,27 +74,27 @@ test('Redis instrumentation', { timeout: 20000 }, function (t) {
           }
 
           t.ok(agent.getTransaction(), 'transaction should still still be visible')
-          t.equals(value, 'arglbargle', 'memcached client should still work')
+          t.equal(value, 'arglbargle', 'memcached client should still work')
 
           const trace = transaction.trace
           t.ok(trace, 'trace should exist')
           t.ok(trace.root, 'root element should exist')
-          t.equals(trace.root.children.length, 1, 'there should be only one child of the root')
+          t.equal(trace.root.children.length, 1, 'there should be only one child of the root')
 
           const setSegment = trace.root.children[0]
           const setAttributes = setSegment.getAttributes()
           t.ok(setSegment, 'trace segment for set should exist')
-          t.equals(setSegment.name, 'Datastore/operation/Redis/set', 'should register the set')
-          t.equals(setAttributes.key, '"testkey"', 'should have the set key as a attribute')
-          t.equals(setSegment.children.length, 1, 'set should have an only child')
+          t.equal(setSegment.name, 'Datastore/operation/Redis/set', 'should register the set')
+          t.equal(setAttributes.key, '"testkey"', 'should have the set key as a attribute')
+          t.equal(setSegment.children.length, 1, 'set should have an only child')
 
           const getSegment = setSegment.children[0].children[0]
           const getAttributes = getSegment.getAttributes()
           t.ok(getSegment, 'trace segment for get should exist')
 
-          t.equals(getSegment.name, 'Datastore/operation/Redis/get', 'should register the get')
+          t.equal(getSegment.name, 'Datastore/operation/Redis/get', 'should register the get')
 
-          t.equals(getAttributes.key, '"testkey"', 'should have the get key as a attribute')
+          t.equal(getAttributes.key, '"testkey"', 'should have the get key as a attribute')
 
           t.ok(getSegment.children.length >= 1, 'get should have a callback segment')
 
@@ -194,7 +194,7 @@ test('Redis instrumentation', { timeout: 20000 }, function (t) {
         t.error(error)
 
         const segment = agent.tracer.getSegment().parent
-        t.equals(segment.getAttributes().key, '"saveme"', 'should have `key` attribute')
+        t.equal(segment.getAttributes().key, '"saveme"', 'should have `key` attribute')
         t.end()
       })
     })
@@ -232,14 +232,14 @@ test('Redis instrumentation', { timeout: 20000 }, function (t) {
         const trace = transaction.trace
         const setSegment = trace.root.children[0]
         const attributes = setSegment.getAttributes()
-        t.equals(attributes.host, METRIC_HOST_NAME, 'should have host as attribute')
-        t.equals(
+        t.equal(attributes.host, METRIC_HOST_NAME, 'should have host as attribute')
+        t.equal(
           attributes.port_path_or_id,
           String(params.redis_port),
           'should have port as attribute'
         )
-        t.equals(attributes.database_name, String(DB_INDEX), 'should have database id as attribute')
-        t.equals(attributes.product, 'Redis', 'should have product attribute')
+        t.equal(attributes.database_name, String(DB_INDEX), 'should have database id as attribute')
+        t.equal(attributes.product, 'Redis', 'should have product attribute')
       })
     })
   })
@@ -260,13 +260,13 @@ test('Redis instrumentation', { timeout: 20000 }, function (t) {
 
         const setSegment = transaction.trace.root.children[0]
         const attributes = setSegment.getAttributes()
-        t.equals(attributes.host, undefined, 'should not have host attribute')
-        t.equals(attributes.port_path_or_id, undefined, 'should not have port attribute')
-        t.equals(attributes.database_name, undefined, 'should not have db name attribute')
+        t.equal(attributes.host, undefined, 'should not have host attribute')
+        t.equal(attributes.port_path_or_id, undefined, 'should not have port attribute')
+        t.equal(attributes.database_name, undefined, 'should not have db name attribute')
 
         transaction.end()
         const unscoped = transaction.metrics.unscoped
-        t.equals(
+        t.equal(
           unscoped['Datastore/instance/Redis/' + HOST_ID],
           undefined,
           'should not have instance metric'
@@ -304,20 +304,20 @@ test('Redis instrumentation', { timeout: 20000 }, function (t) {
       const selectSegment = setSegment1.children[0].children[0]
       const setSegment2 = selectSegment.children[0].children[0]
 
-      t.equals(setSegment1.name, 'Datastore/operation/Redis/set', 'should register the first set')
-      t.equals(
+      t.equal(setSegment1.name, 'Datastore/operation/Redis/set', 'should register the first set')
+      t.equal(
         setSegment1.getAttributes().database_name,
         String(DB_INDEX),
         'should have the starting database id as attribute for the first set'
       )
-      t.equals(selectSegment.name, 'Datastore/operation/Redis/select', 'should register the select')
-      t.equals(
+      t.equal(selectSegment.name, 'Datastore/operation/Redis/select', 'should register the select')
+      t.equal(
         selectSegment.getAttributes().database_name,
         String(DB_INDEX),
         'should have the starting database id as attribute for the select'
       )
-      t.equals(setSegment2.name, 'Datastore/operation/Redis/set', 'should register the second set')
-      t.equals(
+      t.equal(setSegment2.name, 'Datastore/operation/Redis/set', 'should register the second set')
+      t.equal(
         setSegment2.getAttributes().database_name,
         String(SELECTED_DB),
         'should have the selected database id as attribute for the second set'
@@ -330,7 +330,7 @@ function checkMetrics(t, metrics, expected) {
   Object.keys(expected).forEach(function (name) {
     t.ok(metrics[name], 'should have metric ' + name)
     if (metrics[name]) {
-      t.equals(
+      t.equal(
         metrics[name].callCount,
         expected[name],
         'should have ' + expected[name] + ' calls for ' + name


### PR DESCRIPTION
## Description

Replaced deprecated t.equals assertions in tests with t.equal.

## Related Issues

Closes NR-140242
Closes #1710 