### PR TITLE
test: pin prisma to < 5 when running on node 14

### DIFF
--- a/test/versioned/prisma/package.json
+++ b/test/versioned/prisma/package.json
@@ -8,10 +8,22 @@
   "tests": [
     {
       "engines": {
-        "node": ">=14"
+        "node": "14"
       },
       "dependencies": {
-        "@prisma/client": ">=4.0.0",
+        "@prisma/client": ">=4.0.0 <5.0.0",
+        "prisma": "4.16.2"
+      },
+      "files": [
+        "prisma.tap.js"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=16"
+      },
+      "dependencies": {
+        "@prisma/client": ">=5.0.0",
         "prisma": "latest"
       },
       "files": [


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Prisma dropped Node 14 in version 5.  Until we drop 14, we need to prevent our versioned tests from running >=5 on Node 14.  #1715 is also testing if the instrumentation crashes and if we have to do a semver check in instrumentation.  This is just to unblock CI.
