### PR TITLE
fix: Dropped query params when obfuscating

### DIFF
--- a/lib/instrumentation/core/http.js
+++ b/lib/instrumentation/core/http.js
@@ -86,7 +86,7 @@ function wrapEmitWithTransaction(agent, emit, isHTTPS) {
 
     // the error tracer needs a URL for tracing, even though naming overwrites
     transaction.parsedUrl = url.parse(request.url, true)
-    transaction.url = urltils.obfuscatePath(agent.config, transaction.parsedUrl.path)
+    transaction.url = urltils.obfuscatePath(agent.config, transaction.parsedUrl.pathname)
     transaction.verb = request.method
 
     // URL is sent as an agent attribute with transaction events

--- a/test/unit/instrumentation/http/http.test.js
+++ b/test/unit/instrumentation/http/http.test.js
@@ -351,6 +351,28 @@ test('built-in http module instrumentation', (t) => {
       }
     })
 
+    t.test('request.uri should not contain request params', (t) => {
+      transaction = null
+      makeRequest(
+        {
+          port: 8123,
+          host: 'localhost',
+          path: '/foo5/bar5?region=here&auth=secretString',
+          method: 'GET'
+        },
+        finish
+      )
+
+      function finish() {
+        const segment = transaction.baseSegment
+        const spanAttributes = segment.attributes.get(DESTINATIONS.SPAN_EVENT)
+
+        t.equal(spanAttributes['request.uri'], '/foo5/bar5')
+
+        t.end()
+      }
+    })
+
     t.test('successful request', (t) => {
       transaction = null
       const refererUrl = 'https://www.google.com/search/cats?scrubbed=false'


### PR DESCRIPTION
Changed http to use pathname instead of path, avoiding exposure of query params

## How to Test

Test for this case has been added to tests/unit/instrumentation/http/http.test.js 

## Related Issues

Fixes #1718 
Closes NR-141506