### PR TITLE
feat!: Renamed shim.handleCATHeaders to shim.handleMqTracingHeaders

### DIFF
--- a/lib/shim/message-shim.js
+++ b/lib/shim/message-shim.js
@@ -736,7 +736,7 @@ function recordSubscribedConsume(nodule, properties, spec) {
             }
           }
           if (msgDesc.headers) {
-            shim.handleCATHeaders(msgDesc.headers, tx.baseSegment, shim._transportType)
+            shim.handleMqTracingHeaders(msgDesc.headers, tx.baseSegment, shim._transportType)
           }
 
           shim.logger.trace('Started message transaction %s named %s', tx.id, txName)

--- a/lib/shim/transaction-shim.js
+++ b/lib/shim/transaction-shim.js
@@ -219,7 +219,7 @@ function setTransactionName(name) {
  *  The transport type that brought the headers. Usually `HTTP` or `HTTPS`.
  */
 function handleMqTracingHeaders(headers, segment, transportType) {
-  // TODO: rename function or replace functionality when CAT fully removed.
+  // TODO: replace functionality when CAT fully removed.
 
   if (!headers) {
     this.logger.debug('No headers for CAT or DT processing.')

--- a/lib/shim/transaction-shim.js
+++ b/lib/shim/transaction-shim.js
@@ -66,7 +66,7 @@ TransactionShim.prototype.bindCreateTransaction = bindCreateTransaction
 TransactionShim.prototype.pushTransactionName = pushTransactionName
 TransactionShim.prototype.popTransactionName = popTransactionName
 TransactionShim.prototype.setTransactionName = setTransactionName
-TransactionShim.prototype.handleCATHeaders = handleCATHeaders
+TransactionShim.prototype.handleMqTracingHeaders = handleMqTracingHeaders
 TransactionShim.prototype.insertCATReplyHeader = insertCATReplyHeader
 TransactionShim.prototype.insertCATRequestHeaders = insertCATRequestHeaders
 
@@ -204,7 +204,7 @@ function setTransactionName(name) {
 /**
  * Retrieves whatever CAT headers may be in the given headers.
  *
- * - `handleCATHeaders(headers [, segment [, transportType]])`
+ * - `handleMqTracingHeaders(headers [, segment [, transportType]])`
  *
  * @memberof TransactionShim.prototype
  *
@@ -218,7 +218,7 @@ function setTransactionName(name) {
  * @param {string} [transportType='Unknown']
  *  The transport type that brought the headers. Usually `HTTP` or `HTTPS`.
  */
-function handleCATHeaders(headers, segment, transportType) {
+function handleMqTracingHeaders(headers, segment, transportType) {
   // TODO: rename function or replace functionality when CAT fully removed.
 
   if (!headers) {

--- a/test/unit/shim/transaction-shim.test.js
+++ b/test/unit/shim/transaction-shim.test.js
@@ -14,7 +14,7 @@ const notRunningStates = ['stopped', 'stopping', 'errored']
 tap.Test.prototype.addAssert('isNonWritable', 1, helper.isNonWritable)
 
 /**
- * Creates CAT headers to be used in handleCATHeaders
+ * Creates CAT headers to be used in handleMqTracingHeaders
  * tests below
  *
  * @param {Object} config agent config
@@ -427,7 +427,7 @@ tap.test('TransactionShim', function (t) {
     })
   })
 
-  t.test('#handleCATHeaders', function (t) {
+  t.test('#handleMqTracingHeaders', function (t) {
     t.autoend()
 
     t.beforeEach(() => {
@@ -450,7 +450,7 @@ tap.test('TransactionShim', function (t) {
         t.notOk(segment.catTransaction)
         t.notOk(segment.getAttributes().transaction_guid)
 
-        shim.handleCATHeaders(headers, segment)
+        shim.handleMqTracingHeaders(headers, segment)
 
         t.notOk(tx.incomingCatId)
         t.notOk(tx.referringTransactionGuid)
@@ -473,7 +473,7 @@ tap.test('TransactionShim', function (t) {
         t.notOk(segment.catTransaction)
         t.notOk(segment.getAttributes().transaction_guid)
 
-        shim.handleCATHeaders(headers, segment)
+        shim.handleMqTracingHeaders(headers, segment)
 
         t.notOk(tx.incomingCatId)
         t.notOk(tx.referringTransactionGuid)
@@ -495,7 +495,7 @@ tap.test('TransactionShim', function (t) {
         t.notOk(segment.getAttributes().transaction_guid)
 
         t.doesNotThrow(function () {
-          shim.handleCATHeaders(null, segment)
+          shim.handleMqTracingHeaders(null, segment)
         })
 
         t.notOk(tx.incomingCatId)
@@ -522,7 +522,7 @@ tap.test('TransactionShim', function (t) {
 
           helper.runInTransaction(agent, shim.BG, function (tx2) {
             t.not(tx2, tx)
-            shim.handleCATHeaders(headers, segment)
+            shim.handleMqTracingHeaders(headers, segment)
           })
 
           t.equal(tx.incomingCatId, '9876#id')
@@ -546,7 +546,7 @@ tap.test('TransactionShim', function (t) {
           t.notOk(tx.tripId)
           t.notOk(tx.referringPathHash)
 
-          shim.handleCATHeaders(headers)
+          shim.handleMqTracingHeaders(headers)
 
           t.equal(tx.incomingCatId, '9876#id')
           t.equal(tx.referringTransactionGuid, 'trans id')
@@ -572,7 +572,7 @@ tap.test('TransactionShim', function (t) {
 
           helper.runInTransaction(agent, shim.BG, function (tx2) {
             t.not(tx2, tx)
-            shim.handleCATHeaders(headers, segment)
+            shim.handleMqTracingHeaders(headers, segment)
           })
 
           t.equal(tx.incomingCatId, '9876#id')
@@ -595,7 +595,7 @@ tap.test('TransactionShim', function (t) {
         helper.runInTransaction(agent, function (tx) {
           const headers = { traceparent, tracestate }
           const segment = shim.getSegment()
-          shim.handleCATHeaders(headers, segment)
+          shim.handleMqTracingHeaders(headers, segment)
 
           const outboundHeaders = {}
           tx.insertDistributedTraceHeaders(outboundHeaders)
@@ -617,7 +617,7 @@ tap.test('TransactionShim', function (t) {
         helper.runInTransaction(agent, function (tx) {
           const headers = { traceparent }
           const segment = shim.getSegment()
-          shim.handleCATHeaders(headers, segment)
+          shim.handleMqTracingHeaders(headers, segment)
 
           const outboundHeaders = {}
           tx.insertDistributedTraceHeaders(outboundHeaders)
@@ -639,7 +639,7 @@ tap.test('TransactionShim', function (t) {
         helper.runInTransaction(agent, function (tx) {
           const headers = { traceparent, tracestate }
           const segment = shim.getSegment()
-          shim.handleCATHeaders(headers, segment)
+          shim.handleMqTracingHeaders(headers, segment)
 
           const outboundHeaders = {}
           tx.insertDistributedTraceHeaders(outboundHeaders)
@@ -660,7 +660,7 @@ tap.test('TransactionShim', function (t) {
       helper.runInTransaction(agent, function (tx) {
         const headers = { traceparent, tracestate }
         const segment = shim.getSegment()
-        shim.handleCATHeaders(headers, segment)
+        shim.handleMqTracingHeaders(headers, segment)
 
         const outboundHeaders = {}
         tx.insertDistributedTraceHeaders(outboundHeaders)
@@ -686,7 +686,7 @@ tap.test('TransactionShim', function (t) {
 
           helper.runInTransaction(agent, shim.BG, function (tx2) {
             t.not(tx2, tx)
-            shim.handleCATHeaders(headers, segment)
+            shim.handleMqTracingHeaders(headers, segment)
           })
 
           t.equal(segment.catId, '6789#app')
@@ -710,7 +710,7 @@ tap.test('TransactionShim', function (t) {
           t.notOk(segment.catTransaction)
           t.notOk(segment.getAttributes().transaction_guid)
 
-          shim.handleCATHeaders(headers)
+          shim.handleMqTracingHeaders(headers)
 
           t.equal(segment.catId, '6789#app')
           t.equal(segment.catTransaction, 'app data transaction name')
@@ -735,7 +735,7 @@ tap.test('TransactionShim', function (t) {
 
           helper.runInTransaction(agent, shim.BG, function (tx2) {
             t.not(tx2, tx)
-            shim.handleCATHeaders(headers, segment)
+            shim.handleMqTracingHeaders(headers, segment)
           })
 
           t.equal(segment.catId, '6789#app')
@@ -760,7 +760,7 @@ tap.test('TransactionShim', function (t) {
           t.notOk(segment.catTransaction)
           t.notOk(segment.getAttributes().transaction_guid)
 
-          shim.handleCATHeaders(headers)
+          shim.handleMqTracingHeaders(headers)
 
           t.notOk(segment.catId)
           t.notOk(segment.catTransaction)


### PR DESCRIPTION
## Description

Renamed handleCATHeaders to handleMqTracingHeaders. This function handles both distributed tracing and cross-application-tracing headers for message queues. CAT is going to be removed, leaving just the DT functionality. 

## How to Test

test/unit/ship/transaction-shim.test.js covers this file.

## Related Issues

Closes #903 
Closes NR-133499