### PR TITLE
chore: fixed typos in lib/config/index.js comments

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -833,7 +833,7 @@ Config.prototype.logUnknown = function logUnknown(json, key) {
 /**
  * Gets the user set host display name. If not provided, it returns the default value.
  *
- * This function is written is this strange way becauase of the use of caching variables.
+ * This function is written is this strange way because of the use of caching variables.
  * I wanted to cache the DisplayHost, but if I attached the variable to the config object,
  * it sends the extra variable to New Relic, which is not desired.
  *
@@ -869,9 +869,9 @@ function getDisplayHost() {
 
 /**
  * Gets the system's host name. If that fails, it just returns ipv4/6 based on the user's
- * process_host.ipv_preferenece setting.
+ * process_host.ipv_preference setting.
  *
- * This function is written is this strange way becauase of the use of caching variables.
+ * This function is written is this strange way because of the use of caching variables.
  * I wanted to cache the Hostname, but if I attached the variable to the config object,
  * it sends the extra variable to New Relic, which is not desired.
  *
@@ -1235,7 +1235,7 @@ Config.prototype._serverlessDT = function _serverlessDT() {
 /**
  * In serverless mode we allow defer auth to the downstream serverless entities.
  * This means we set account_id, primary_application_id, and trusted_account_key in configuration.
- * This function sets all those to null because this.serverles_mode.enabled is falsey.
+ * This function sets all those to null because this.serverless_mode.enabled is falsey.
  *
  * @returns {void}
  */
@@ -1654,7 +1654,7 @@ Config.prototype._warnDeprecations = function _warnDeprecations() {
  *   5. If this module is installed as a dependency, the directory above the
  *      node_modules folder in which newrelic is installed.
  *
- * When node process environment varaibles and a config file are used,
+ * When node process environment variables and a config file are used,
  * the environment variables will override their corresponding
  * configuration file settings.
  *
@@ -1711,7 +1711,7 @@ function initialize(config) {
         `Unable to read existing configuration file "${filepath}".`,
         'To allow reading of the file (if desired),',
         'please ensure the application has read access and the file is exporting valid JSON.',
-        'Attempting to start agent using enviornment variables.'
+        'Attempting to start agent using environment variables.'
       ].join(' ')
     )
   }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This is nothing but typo corrections. Only one in a log line, the rest in code comments. There are no functional changes.

I checked that the two typos that directly reference the code (`process_host.ipv_preference` and `this.serverless_mode`) are only misspelled in the comment, the code itself is using the correct spelling I changed them to.

I was temped to rename `_laspReponse` to `_laspResponse`, but I didn't want to step on any toes. Though it looks like it's only in the repo in this file and would be a safe change.