### PR TITLE
fix: added defensive code around JSON.parse in formatting pino log lines because pino can return invalid json

### DIFF
--- a/lib/aggregators/log-aggregator.js
+++ b/lib/aggregators/log-aggregator.js
@@ -41,13 +41,21 @@ class LogAggregator extends EventAggregator {
      *  some "log lines" are a function that formats the
      *  data accordingly into an Object, I know, this sucks.
      */
-    const formattedLogs = logs.map((logLine) => {
-      if (typeof logLine === 'function') {
-        return logLine()
-      }
+    const formattedLogs = logs
+      .map((logLine) => {
+        if (typeof logLine === 'function') {
+          return logLine()
+        }
 
-      return logLine
-    })
+        return logLine
+      })
+      .filter(Boolean)
+
+    if (!formattedLogs.length) {
+      logger.debug('No log events to send after formatting.')
+      return
+    }
+
     return [{ logs: formattedLogs }]
   }
 

--- a/lib/instrumentation/pino/pino.js
+++ b/lib/instrumentation/pino/pino.js
@@ -81,7 +81,14 @@ module.exports = function instrument(shim) {
 
       if (isLogForwardingEnabled(config, agent)) {
         const chindings = this[symbols.chindingsSym]
-        const formatLogLine = reformatLogLine({ msg: args[1], logLine, agent, chindings, levelMap })
+        const formatLogLine = reformatLogLine({
+          msg: args[1],
+          logLine,
+          agent,
+          chindings,
+          levelMap,
+          logger: shim.logger
+        })
 
         agent.logs.add(formatLogLine)
       }
@@ -104,8 +111,9 @@ module.exports = function instrument(shim) {
  * @param logLine.chindings
  * @param logLine.msg
  * @param logLine.levelMap
+ * @param logLine.logger
  */
-function reformatLogLine({ logLine, msg, agent, chindings = '', levelMap }) {
+function reformatLogLine({ logLine, msg, agent, chindings = '', levelMap, logger }) {
   const metadata = agent.getLinkingMetadata()
 
   /**
@@ -125,7 +133,14 @@ function reformatLogLine({ logLine, msg, agent, chindings = '', levelMap }) {
    * context metadata and rename the time/msg keys to timestamp/message
    */
   return function formatLogLine() {
-    const formattedLog = JSON.parse(logLine)
+    let formattedLog
+    try {
+      formattedLog = JSON.parse(logLine)
+    } catch (err) {
+      logger.error('Failed to parse log line as json: %s', err.message)
+      return
+    }
+
     if (formattedLog.err) {
       reformatError(formattedLog)
     }

--- a/test/unit/aggregators/log-aggregator.test.js
+++ b/test/unit/aggregators/log-aggregator.test.js
@@ -98,9 +98,35 @@ test('Log Aggregator', (t) => {
     }
   )
 
+  t.test('toPayload() should only return logs that have data', (t) => {
+    const log2 = JSON.stringify(log)
+    function formatLog() {
+      return JSON.parse(log2)
+    }
+    function formatLog2() {
+      return
+    }
+    logEventAggregator.add(log)
+    logEventAggregator.add(formatLog)
+    logEventAggregator.add(formatLog2)
+    const payload = logEventAggregator._toPayloadSync()
+    t.same(payload, [{ logs: [log, JSON.parse(log2)] }])
+    t.end()
+  })
+
   t.test('toPayload() should return nothing with no log event data', (t) => {
     const payload = logEventAggregator._toPayloadSync()
 
+    t.notOk(payload)
+    t.end()
+  })
+
+  t.test('toPayload() should return nothing when log functions return no data', (t) => {
+    function formatLog() {
+      return
+    }
+    logEventAggregator.add(formatLog)
+    const payload = logEventAggregator._toPayloadSync()
     t.notOk(payload)
     t.end()
   })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Because pino does not always return valid JSON when serializing to json(see https://github.com/pinojs/pino/issues/1767), we have to add some defensive code to return a null record if we cannot parse the json to an object.  This also required some filtering logic in the log aggregator to not send empty logs to the collector.


Closes #1744 