### PR TITLE
test: update smoke tests versioned matrix in CI to 16, 18, and 20.

### DIFF
--- a/.github/workflows/smoke-test-workflow.yml
+++ b/.github/workflows/smoke-test-workflow.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
We missed updating smoke test to test only on 16, 18 and 20. This PR fixes that
