### PR TITLE
fix: updated prisma instrumentation to parse prisma datamodel with internal package

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -16,7 +16,6 @@ code, the source code can be found at [https://github.com/newrelic/node-newrelic
 
 * [@grpc/grpc-js](#grpcgrpc-js)
 * [@grpc/proto-loader](#grpcproto-loader)
-* [@mrleebo/prisma-ast](#mrleeboprisma-ast)
 * [@newrelic/aws-sdk](#newrelicaws-sdk)
 * [@newrelic/koa](#newrelickoa)
 * [@newrelic/security-agent](#newrelicsecurity-agent)
@@ -81,6 +80,7 @@ code, the source code can be found at [https://github.com/newrelic/node-newrelic
 
 * [@contrast/fn-inspect](#contrastfn-inspect)
 * [@newrelic/native-metrics](#newrelicnative-metrics)
+* [@prisma/prisma-fmt-wasm](#prismaprisma-fmt-wasm)
 
 **[Additional Licenses](#additional-licenses)**
 
@@ -505,34 +505,6 @@ This product includes source derived from [@grpc/proto-loader](https://github.co
    See the License for the specific language governing permissions and
    limitations under the License.
 
-```
-
-### @mrleebo/prisma-ast
-
-This product includes source derived from [@mrleebo/prisma-ast](https://github.com/MrLeebo/prisma-ast) ([v0.5.2](https://github.com/MrLeebo/prisma-ast/tree/v0.5.2)), distributed under the [MIT License](https://github.com/MrLeebo/prisma-ast/blob/v0.5.2/LICENSE):
-
-```
-MIT License
-
-Copyright (c) 2021 Jeremy Liberman
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 ```
 
 ### @newrelic/aws-sdk
@@ -9784,6 +9756,86 @@ This product includes source derived from [@newrelic/native-metrics](https://git
    See the License for the specific language governing permissions and
    limitations under the License.
 
+```
+
+### @prisma/prisma-fmt-wasm
+
+This product includes source derived from [@prisma/prisma-fmt-wasm](https://github.com/prisma/prisma-engines) ([v4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085](https://github.com/prisma/prisma-engines/tree/v4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085)), distributed under the [Apache-2.0 License](https://github.com/prisma/prisma-engines/blob/v4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085/README.md):
+
+```
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 ```
 
 ## Additional Licenses

--- a/lib/instrumentation/@prisma/client.js
+++ b/lib/instrumentation/@prisma/client.js
@@ -13,41 +13,6 @@ const parseSql = require('../../db/query-parsers/sql')
 const RAW_COMMANDS = ['executeRaw', 'queryRaw']
 
 const semver = require('semver')
-const { getSchema } = require('@mrleebo/prisma-ast')
-
-/**
- * The library we use to parse the prisma schema retains double quotes around
- * strings, and they need to be stripped
- *
- * @param {string} [str=''] string to strip double-quotes from
- * @returns {string} stripped string
- */
-function trimQuotes(str = '') {
-  return str.match(/"(.*)"/)[1]
-}
-
-/**
- * You can set the connection string in schema as raw string,
- * env var mapping, or an override at client instantiation time.
- *
- * @param {*} url string/object value of url in datsource stanza of schema
- * @param {string} overrideUrl value of url in overrides at client instantiation
- * @returns {string} properly parsed connection url
- */
-function parseDataModelUrl(url, overrideUrl) {
-  let parsedUrl = ''
-
-  if (overrideUrl) {
-    parsedUrl = overrideUrl
-  } else if (typeof url === 'string') {
-    parsedUrl = trimQuotes(url)
-  } else if (url.name && url.name === 'env') {
-    const envVar = trimQuotes(url.params[0])
-    parsedUrl = process.env[envVar]
-  }
-
-  return parsedUrl
-}
 
 /**
  * Parses a connection string. Most database engines in prisma are SQL and all
@@ -148,22 +113,34 @@ function queryParser(query) {
 }
 
 /**
- * Extracts the prisma connection information from the engine. This used to use
- * prisma functions available on engine `getConfig` but that's no longer accessible.
- * Instead we went the route of parsing the schema DSL.
+ * Extracts connection string from parse datasource config
+ *
+ * @param {object} datasource active datasource
+ * @returns {string} connection string
+ */
+function extractConnectionString(datasource = {}) {
+  return process.env[datasource?.url?.fromEnvVar] || datasource?.url?.value
+}
+
+/**
+ * Extracts the prisma connection information from the engine. This calls an internal
+ * package used to parse the prisma schema config.
  *
  * @param {object} client prisma client instance
- * @returns {Promise} returns prisma datasource connection configuration { provider, url }
+ * @returns {object} returns prisma datasource connection configuration { provider, url }
  */
 function extractPrismaDatasource(client) {
-  const { datamodel, datasourceOverrides: overrides } = client._engine
-  const schema = getSchema(datamodel)
-  const datasource = schema.list.filter(({ type }) => type === 'datasource')[0]
-  const urlData = datasource.assignments.filter(({ key }) => key === 'url')[0].value
-  const url = parseDataModelUrl(urlData, overrides[datasource.name])
+  const { get_config: getConfig } = require('@prisma/prisma-fmt-wasm')
+  const options = JSON.stringify({
+    prismaSchema: client?._engine?.datamodel,
+    ignoreEnvVarErrors: true
+  })
+  const config = JSON.parse(getConfig(options))
+  const activeDatasource = config?.datasources?.[0]
+
   return {
-    provider: trimQuotes(datasource.assignments.filter(({ key }) => key === 'provider')[0].value),
-    url
+    provider: activeDatasource.provider,
+    url: extractConnectionString(activeDatasource)
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,11 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.8.10",
         "@grpc/proto-loader": "^0.7.5",
-        "@mrleebo/prisma-ast": "^0.5.2",
         "@newrelic/aws-sdk": "^6.0.0",
         "@newrelic/koa": "^7.1.1",
         "@newrelic/security-agent": "0.2.1",
         "@newrelic/superagent": "^6.0.0",
+        "@prisma/prisma-fmt-wasm": "^4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085",
         "@tyriar/fibonacci-heap": "^2.0.7",
         "concat-stream": "^2.0.0",
         "https-proxy-agent": "^7.0.1",
@@ -75,7 +75,7 @@
         "when": "*"
       },
       "engines": {
-        "node": ">=14",
+        "node": ">=16",
         "npm": ">=6.0.0"
       },
       "optionalDependencies": {
@@ -991,35 +991,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
-      "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
-      "dependencies": {
-        "@chevrotain/gast": "10.5.0",
-        "@chevrotain/types": "10.5.0",
-        "lodash": "4.17.21"
-      }
-    },
-    "node_modules/@chevrotain/gast": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
-      "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
-      "dependencies": {
-        "@chevrotain/types": "10.5.0",
-        "lodash": "4.17.21"
-      }
-    },
-    "node_modules/@chevrotain/types": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
-      "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A=="
-    },
-    "node_modules/@chevrotain/utils": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
-      "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ=="
-    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -1402,17 +1373,6 @@
       },
       "engines": {
         "node": ">=v12.0.0"
-      }
-    },
-    "node_modules/@mrleebo/prisma-ast": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.5.2.tgz",
-      "integrity": "sha512-v2jwtrLt/x5/MaF7Sucsz/do8tDUmiq3KA+UYdyZfr3OQ2IGXUtpNSXmdlvyRM+vQ7Abn/FxpLW/qqhZGB9vhQ==",
-      "dependencies": {
-        "chevrotain": "^10.4.2"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@newrelic/aws-sdk": {
@@ -4051,6 +4011,11 @@
         "@octokit/openapi-types": "^12.11.0"
       }
     },
+    "node_modules/@prisma/prisma-fmt-wasm": {
+      "version": "4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085.tgz",
+      "integrity": "sha512-zYz3rFwPB82mVlHGknAPdnSY/a308dhPOblxQLcZgZTDRtDXOE1MgxoRAys+jekwR4/bm3+rZDPs1xsFMsPZig=="
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -6063,19 +6028,6 @@
       "dev": true,
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/chevrotain": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
-      "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
-      "dependencies": {
-        "@chevrotain/cst-dts-gen": "10.5.0",
-        "@chevrotain/gast": "10.5.0",
-        "@chevrotain/types": "10.5.0",
-        "@chevrotain/utils": "10.5.0",
-        "lodash": "4.17.21",
-        "regexp-to-ast": "0.5.0"
       }
     },
     "node_modules/chokidar": {
@@ -12757,11 +12709,6 @@
         "esprima": "~4.0.0"
       }
     },
-    "node_modules/regexp-to-ast": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
-      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
@@ -17453,35 +17400,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "@chevrotain/cst-dts-gen": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
-      "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
-      "requires": {
-        "@chevrotain/gast": "10.5.0",
-        "@chevrotain/types": "10.5.0",
-        "lodash": "4.17.21"
-      }
-    },
-    "@chevrotain/gast": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
-      "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
-      "requires": {
-        "@chevrotain/types": "10.5.0",
-        "lodash": "4.17.21"
-      }
-    },
-    "@chevrotain/types": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
-      "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A=="
-    },
-    "@chevrotain/utils": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
-      "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ=="
-    },
     "@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -17767,14 +17685,6 @@
       "dev": true,
       "requires": {
         "lodash": "^4.17.21"
-      }
-    },
-    "@mrleebo/prisma-ast": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.5.2.tgz",
-      "integrity": "sha512-v2jwtrLt/x5/MaF7Sucsz/do8tDUmiq3KA+UYdyZfr3OQ2IGXUtpNSXmdlvyRM+vQ7Abn/FxpLW/qqhZGB9vhQ==",
-      "requires": {
-        "chevrotain": "^10.4.2"
       }
     },
     "@newrelic/aws-sdk": {
@@ -19824,6 +19734,11 @@
         "@octokit/openapi-types": "^12.11.0"
       }
     },
+    "@prisma/prisma-fmt-wasm": {
+      "version": "4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085.tgz",
+      "integrity": "sha512-zYz3rFwPB82mVlHGknAPdnSY/a308dhPOblxQLcZgZTDRtDXOE1MgxoRAys+jekwR4/bm3+rZDPs1xsFMsPZig=="
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -21454,19 +21369,6 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true
-    },
-    "chevrotain": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
-      "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
-      "requires": {
-        "@chevrotain/cst-dts-gen": "10.5.0",
-        "@chevrotain/gast": "10.5.0",
-        "@chevrotain/types": "10.5.0",
-        "@chevrotain/utils": "10.5.0",
-        "lodash": "4.17.21",
-        "regexp-to-ast": "0.5.0"
-      }
     },
     "chokidar": {
       "version": "3.5.3",
@@ -26497,11 +26399,6 @@
       "requires": {
         "esprima": "~4.0.0"
       }
-    },
-    "regexp-to-ast": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
-      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="
     },
     "regexp.prototype.flags": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,6 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.8.10",
     "@grpc/proto-loader": "^0.7.5",
-    "@mrleebo/prisma-ast": "^0.5.2",
     "@newrelic/aws-sdk": "^6.0.0",
     "@newrelic/koa": "^7.1.1",
     "@newrelic/security-agent": "0.2.1",
@@ -197,7 +196,8 @@
   },
   "optionalDependencies": {
     "@contrast/fn-inspect": "^3.3.0",
-    "@newrelic/native-metrics": "^9.0.1"
+    "@newrelic/native-metrics": "^9.0.1",
+    "@prisma/prisma-fmt-wasm": "^4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085"
   },
   "devDependencies": {
     "@newrelic/eslint-config": "^0.3.0",

--- a/test/unit/instrumentation/prisma-client.test.js
+++ b/test/unit/instrumentation/prisma-client.test.js
@@ -11,7 +11,6 @@ const helper = require('../../lib/agent_helper')
 const DatastoreShim = require('../../../lib/shim/datastore-shim.js')
 const symbols = require('../../../lib/symbols')
 const sinon = require('sinon')
-const proxyquire = require('proxyquire')
 
 let agent = null
 let initialize = null
@@ -19,17 +18,12 @@ let shim = null
 
 test('PrismaClient unit tests', (t) => {
   t.autoend()
-  let getSchemaSpy
   let sandbox
 
   t.beforeEach(function () {
     sandbox = sinon.createSandbox()
     agent = helper.loadMockedAgent()
-    const prismaAst = require('@mrleebo/prisma-ast')
-    getSchemaSpy = sandbox.spy(prismaAst, 'getSchema')
-    initialize = proxyquire('../../../lib/instrumentation/@prisma/client', {
-      '@mrleebo/prisma-ast': prismaAst
-    })
+    initialize = require('../../../lib/instrumentation/@prisma/client')
     shim = new DatastoreShim(agent, 'prisma')
     sandbox.stub(shim, 'require')
     shim.require.returns({ version: '4.0.0' })
@@ -99,58 +93,6 @@ test('PrismaClient unit tests', (t) => {
     })
   })
 
-  t.test('should parse connection string client override', (t) => {
-    const MockPrismaClient = getMockModule()
-    const prisma = { PrismaClient: MockPrismaClient }
-
-    initialize(agent, prisma, '@prisma/client', shim)
-    const client = new prisma.PrismaClient()
-    client._engine.datasourceOverrides = {
-      db: 'postgresql://postgres:prisma@localhost:5433/override-db'
-    }
-    client._engine.datamodel = `
-      datasource db {
-        provider = "postgres"
-        url = "postgresql://postgres:prisma@localhost:5436/db"
-      }
-    `
-    helper.runInTransaction(agent, async () => {
-      await client._executeRequest({ clientMethod: 'user.create' })
-      t.same(client[symbols.prismaConnection], {
-        host: 'localhost',
-        port: '5433',
-        dbName: 'override-db'
-      })
-      t.end()
-    })
-  })
-
-  t.test('should not override with client override when datasource name does not match', (t) => {
-    const MockPrismaClient = getMockModule()
-    const prisma = { PrismaClient: MockPrismaClient }
-
-    initialize(agent, prisma, '@prisma/client', shim)
-    const client = new prisma.PrismaClient()
-    client._engine.datasourceOverrides = {
-      temp_db: 'postgresql://postgres:prisma@localhost:5433/override-db'
-    }
-    client._engine.datamodel = `
-      datasource db {
-        provider = "postgres"
-        url = "postgresql://postgres:prisma@localhost:5436/db"
-      }
-    `
-    helper.runInTransaction(agent, async () => {
-      await client._executeRequest({ clientMethod: 'user.create' })
-      t.same(client[symbols.prismaConnection], {
-        host: 'localhost',
-        port: '5436',
-        dbName: 'db'
-      })
-      t.end()
-    })
-  })
-
   t.test('should only try to parse the schema once per connection', (t) => {
     const MockPrismaClient = getMockModule()
     const prisma = { PrismaClient: MockPrismaClient }
@@ -170,8 +112,6 @@ test('PrismaClient unit tests', (t) => {
         args: { query: 'select test from unit-test;' },
         action: 'executeRaw'
       })
-
-      t.equal(getSchemaSpy.callCount, 1, 'should only parse schema once')
 
       t.end()
     })

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Fri Aug 18 2023 12:19:49 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Mon Aug 28 2023 12:39:43 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -28,6 +28,18 @@
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"
+    },
+    "@prisma/prisma-fmt-wasm@4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085": {
+      "name": "@prisma/prisma-fmt-wasm",
+      "version": "4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085",
+      "range": "^4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085",
+      "licenses": "Apache-2.0",
+      "repoUrl": "https://github.com/prisma/prisma-engines",
+      "versionedRepoUrl": "https://github.com/prisma/prisma-engines/tree/v4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085",
+      "licenseFile": "node_modules/@prisma/prisma-fmt-wasm/README.md",
+      "licenseUrl": "https://github.com/prisma/prisma-engines/blob/v4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085/README.md",
+      "licenseTextSource": "spdx",
+      "publisher": "Prisma"
     }
   },
   "includeDev": true,
@@ -55,18 +67,6 @@
       "licenseUrl": "https://github.com/grpc/grpc-node/blob/v0.7.7/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Google Inc."
-    },
-    "@mrleebo/prisma-ast@0.5.2": {
-      "name": "@mrleebo/prisma-ast",
-      "version": "0.5.2",
-      "range": "^0.5.2",
-      "licenses": "MIT",
-      "repoUrl": "https://github.com/MrLeebo/prisma-ast",
-      "versionedRepoUrl": "https://github.com/MrLeebo/prisma-ast/tree/v0.5.2",
-      "licenseFile": "node_modules/@mrleebo/prisma-ast/LICENSE",
-      "licenseUrl": "https://github.com/MrLeebo/prisma-ast/blob/v0.5.2/LICENSE",
-      "licenseTextSource": "file",
-      "publisher": "Jeremy Liberman"
     },
     "@newrelic/aws-sdk@6.0.0": {
       "name": "@newrelic/aws-sdk",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We had issues in the past with parsing the prisma connection string and provider.  In #1634 I moved it to parsing the schema with a 3rd party DSL parser.  I reached out to the prisma contributors and asked to re-expose getConfig. But they mentioned just trying out the [wasm package](https://github.com/prisma/prisma/pull/17455#issuecomment-1553402985).  I made this dep optional because not everyone uses prisma and it requires your build system to be configured to build node packages.
