### PR TITLE
chore: updated next js repo to use main now that the branch has landed

### DIFF
--- a/test/versioned-external/external-repos.js
+++ b/test/versioned-external/external-repos.js
@@ -25,7 +25,7 @@ const repos = [
   {
     name: 'next',
     repository: 'https://github.com/newrelic/newrelic-node-nextjs.git',
-    branch: 'ritm-update'
+    branch: 'main'
   },
   {
     name: 'superagent',


### PR DESCRIPTION
CI will fail without this as the `ritm-update` branch in Next.js repo has been merged/closed.
