### PR TITLE
feat: Updated undici instrumentation to create segment on request create instead of after connection and opening socket to more accurately record time it takes to make an undici request.

### DIFF
--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -12,9 +12,6 @@ const NAMES = require('../metrics/names')
 const NEWRELIC_SYNTHETICS_HEADER = 'x-newrelic-synthetics'
 const symbols = require('../symbols')
 const { executionAsyncResource } = require('async_hooks')
-const tls = require('tls')
-const net = require('net')
-
 let diagnosticsChannel = null
 try {
   diagnosticsChannel = require('diagnostics_channel')
@@ -41,19 +38,14 @@ module.exports = function addUndiciChannels(agent, _undici, _modName, shim) {
  * @param {Shim} shim instance of shim
  */
 function registerHookPoints(shim) {
-  diagnosticsChannel.channel('undici:request:create').subscribe(requestCreateHook.bind(null, shim))
-  diagnosticsChannel
-    .channel('undici:client:sendHeaders')
-    .subscribe(responseHeadersHook.bind(null, shim))
-  diagnosticsChannel
-    .channel('undici:request:headers')
-    .subscribe(requestHeadersHook.bind(null, shim))
-  diagnosticsChannel
-    .channel('undici:request:trailers')
-    .subscribe(endAndRestoreSegment.bind(null, shim))
-  diagnosticsChannel
-    .channel('undici:request:error')
-    .subscribe(endAndRestoreSegment.bind(null, shim))
+  const requestCreate = diagnosticsChannel.channel('undici:request:create')
+  requestCreate.subscribe(requestCreateHook.bind(null, shim))
+  const requestHeaders = diagnosticsChannel.channel('undici:request:headers')
+  requestHeaders.subscribe(requestHeadersHook.bind(null, shim))
+  const requestTrailers = diagnosticsChannel.channel('undici:request:trailers')
+  requestTrailers.subscribe(endAndRestoreSegment.bind(null, shim))
+  const requestError = diagnosticsChannel.channel('undici:request:error')
+  requestError.subscribe(endAndRestoreSegment.bind(null, shim))
 }
 
 /**
@@ -130,41 +122,10 @@ function requestCreateHook(shim, { request }) {
   for (const key in outboundHeaders) {
     request.addHeader(key, outboundHeaders[key])
   }
-}
 
-/**
- * This event occurs right before the data is written to the socket.
- * Undici has some abstracted headers that are only created at this time, one
- * is the `host` header which we need to name the Undici segment. So in this
- * handler we create, start and set the segment active, name it, and
- * attach the url/procedure/request.parameters
- *
- * @param {Shim} shim instance of shim
- * @param {object} params object from undici hook
- * @param {object} params.request undici request object
- * @param {tls.TLSSocket | net.Socket} params.socket active socket connection
- */
-function responseHeadersHook(shim, { request, socket }) {
-  const parentSegment = request[symbols.parentSegment]
-  if (!parentSegment || (parentSegment && parentSegment.opaque)) {
-    return
-  }
-
-  const port = socket.remotePort
-  const isHttps = socket.servername
-  let urlString
-  if (isHttps) {
-    urlString = `https://${socket.servername}`
-    urlString += port === 443 ? request.path : `:${port}${request.path}`
-  } else {
-    urlString = `http://${socket._host}`
-    urlString += port === 80 ? request.path : `:${port}${request.path}`
-  }
-
-  const url = new URL(urlString)
-
+  const url = new URL(request.origin + request.path)
   const name = NAMES.EXTERNAL.PREFIX + url.host + url.pathname
-  const segment = shim.createSegment(name, recordExternal(url.host, 'undici'), parentSegment)
+  const segment = shim.createSegment(name, recordExternal(url.host, 'undici'), parent)
   if (segment) {
     segment.start()
     shim.setActiveSegment(segment)

--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -82,29 +82,14 @@ function getParentSegment(shim) {
 }
 
 /**
- * This event occurs after the Undici Request is created
- * We will check current segment for opaque and also attach
- * relevant headers to outgoing http request
+ * Injects relevant DT headers for the external request
  *
- * @param {Shim} shim instance of shim
- * @param {object} params object from undici hook
+ * @param {object} params
+ * @param {Shim} params.transaction current transaction
  * @param {object} params.request undici request object
+ * @param {object} params.config agent config
  */
-function requestCreateHook(shim, { request }) {
-  const { config } = shim.agent
-  const parent = getParentSegment(shim)
-  request[symbols.parentSegment] = parent
-  if (!parent || (parent && parent.opaque)) {
-    logger.trace(
-      'Not capturing data for outbound request (%s) because parent segment opaque (%s)',
-      request.path,
-      parent && parent.name
-    )
-
-    return
-  }
-
-  const transaction = parent.transaction
+function addDTHeaders({ transaction, config, request }) {
   const outboundHeaders = Object.create(null)
   if (config.encoding_key && transaction.syntheticsHeader) {
     outboundHeaders[NEWRELIC_SYNTHETICS_HEADER] = transaction.syntheticsHeader
@@ -122,10 +107,20 @@ function requestCreateHook(shim, { request }) {
   for (const key in outboundHeaders) {
     request.addHeader(key, outboundHeaders[key])
   }
+}
 
+/**
+ * Creates the external segment with url, procedure and request.parameters attributes
+ *
+ * @param {object} params
+ * @param {Shim} params.shim instance of shim
+ * @param {object} params.request undici request object
+ * @param {object} params.parentSegment current active, about to be parent of external segment
+ */
+function createExternalSegment({ shim, request, parentSegment }) {
   const url = new URL(request.origin + request.path)
   const name = NAMES.EXTERNAL.PREFIX + url.host + url.pathname
-  const segment = shim.createSegment(name, recordExternal(url.host, 'undici'), parent)
+  const segment = shim.createSegment(name, recordExternal(url.host, 'undici'), parentSegment)
   if (segment) {
     segment.start()
     shim.setActiveSegment(segment)
@@ -137,6 +132,34 @@ function requestCreateHook(shim, { request }) {
     segment.addAttribute('procedure', request.method || 'GET')
     request[symbols.segment] = segment
   }
+}
+
+/**
+ * This event occurs after the Undici Request is created.
+ * We will check current segment for opaque before creating the
+ * external segment with the standard url/procedure/request.parameters
+ * attributes.  We will also attach relevant DT headers to outgoing http request.
+ *
+ * @param {Shim} shim instance of shim
+ * @param {object} params object from undici hook
+ * @param {object} params.request undici request object
+ */
+function requestCreateHook(shim, { request }) {
+  const { config } = shim.agent
+  const parentSegment = getParentSegment(shim)
+  request[symbols.parentSegment] = parentSegment
+  if (!parentSegment || (parentSegment && parentSegment.opaque)) {
+    logger.trace(
+      'Not capturing data for outbound request (%s) because parent segment opaque (%s)',
+      request.path,
+      parentSegment && parentSegment.name
+    )
+
+    return
+  }
+
+  addDTHeaders({ transaction: parentSegment.transaction, config, request })
+  createExternalSegment({ shim, request, parentSegment })
 }
 
 /**

--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -84,7 +84,7 @@ function getParentSegment(shim) {
 /**
  * Injects relevant DT headers for the external request
  *
- * @param {object} params
+ * @param {object} params object to fn
  * @param {Shim} params.transaction current transaction
  * @param {object} params.request undici request object
  * @param {object} params.config agent config
@@ -112,7 +112,7 @@ function addDTHeaders({ transaction, config, request }) {
 /**
  * Creates the external segment with url, procedure and request.parameters attributes
  *
- * @param {object} params
+ * @param {object} params object to fn
  * @param {Shim} params.shim instance of shim
  * @param {object} params.request undici request object
  * @param {object} params.parentSegment current active, about to be parent of external segment
@@ -158,8 +158,12 @@ function requestCreateHook(shim, { request }) {
     return
   }
 
-  addDTHeaders({ transaction: parentSegment.transaction, config, request })
-  createExternalSegment({ shim, request, parentSegment })
+  try {
+    addDTHeaders({ transaction: parentSegment.transaction, config, request })
+    createExternalSegment({ shim, request, parentSegment })
+  } catch (err) {
+    logger.warn(err, 'Unable to create external segment')
+  }
 }
 
 /**

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -18,6 +18,7 @@ module.exports = {
   offTheRecord: Symbol('offTheRecord'),
   original: Symbol('original'),
   wrapped: Symbol('shimWrapped'),
+  parentSegment: Symbol('parentSegment'),
   prismaConnection: Symbol('prismaConnection'),
   prismaModelCall: Symbol('modelCall'),
   segment: Symbol('segment'),

--- a/test/integration/instrumentation/http.tap.js
+++ b/test/integration/instrumentation/http.tap.js
@@ -139,6 +139,15 @@ test('built-in http instrumentation should handle internal & external requests',
         'should associate outbound HTTP requests with the inbound transaction'
       )
 
+      stats = transaction.metrics.getOrCreateMetric('External/localhost:8321/all')
+      t.equal(stats.callCount, 1, 'should record unscoped outbound HTTP requests in metrics')
+
+      stats = transaction.metrics.getOrCreateMetric('External/allWeb')
+      t.equal(stats.callCount, 1, 'should record unscoped outbound HTTP requests in metrics')
+
+      stats = transaction.metrics.getOrCreateMetric('External/all')
+      t.equal(stats.callCount, 1, 'should record unscoped outbound HTTP requests in metrics')
+
       const attributes = transaction.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
 
       HTTP_ATTRS.forEach(function (key) {

--- a/test/unit/instrumentation/undici.test.js
+++ b/test/unit/instrumentation/undici.test.js
@@ -284,6 +284,24 @@ tap.test('undici instrumentation', function (t) {
         t.end()
       })
     })
+
+    t.test('should log warning if it fails to create external segment', function (t) {
+      helper.runInTransaction(agent, function (tx) {
+        const request = {
+          origin: 'blah',
+          method: 'POST',
+          path: '/port-http'
+        }
+        request[symbols.parentSegment] = shim.createSegment('parent')
+        channels.create.publish({ request })
+        t.not(shim.getSegment())
+        t.equal(loggerMock.warn.callCount, 1, 'logs warning')
+        t.equal(loggerMock.warn.args[0][0].message, 'Invalid URL')
+        t.equal(loggerMock.warn.args[0][1], 'Unable to create external segment')
+        tx.end()
+        t.end()
+      })
+    })
   })
 
   t.test('request:headers', function (t) {


### PR DESCRIPTION

## Description
I was able to get rid of a hook point because it turns out we do in fact have the host in the `request:create` hook. It just needs to be composed from `request.origin` + `request.path`.  I added some new tests around asserting the external metrics that were not there before.  Lastly, I changed the one versioned test that was written to appease the code but if you in fact have a malformed URL for undici we never tracked that as a segment.  Now we do.

## Links

Closes #947
