### PR TITLE
feat: Removed undici feature flag. This will not instrument undici by default

### DIFF
--- a/documentation/feature-flags.md
+++ b/documentation/feature-flags.md
@@ -20,12 +20,6 @@ Any prerelease flags can be enabled or disabled in your agent config by adding a
 * Environment Variable: `NEW_RELIC_FEATURE_FLAG_REVERSE_NAMING_RULES`
 * Description: Naming rules are in forward order by default.  
 
-#### undici_instrumentation
-* Enabled by default: `false`
-* Configuration: `{ feature_flag: { undici_instrumentation: true|false }}`
-* Environment Variable: `NEW_RELIC_FEATURE_FLAG_UNDICI_INSTRUMENTATION`
-* Description: Enable experimental instrumentation for the [undici](https://github.com/nodejs/undici) http client. Note that support for undici client is Node.js 16.x minimum, and requires at minimum [v4.7.0+](https://github.com/nodejs/undici/releases/tag/v4.7.0) of the undici client.
-
 #### undici_async_tracking
 * Enabled by default: `true`
 * Configuration: `{ feature_flag: { undici_async_tracking: true|false }}`

--- a/lib/feature_flags.js
+++ b/lib/feature_flags.js
@@ -10,7 +10,6 @@ exports.prerelease = {
   express5: false,
   promise_segments: false,
   reverse_naming_rules: false,
-  undici_instrumentation: false,
   undici_async_tracking: true,
   unresolved_promise_cleanup: true,
   legacy_context_manager: false
@@ -33,7 +32,8 @@ exports.released = [
   'fastify_instrumentation',
   'await_support',
   'certificate_bundle',
-  'async_local_context'
+  'async_local_context',
+  'undici_instrumentation'
 ]
 
 // flags that are no longer used for unreleased features

--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -12,22 +12,9 @@ const NAMES = require('../metrics/names')
 const NEWRELIC_SYNTHETICS_HEADER = 'x-newrelic-synthetics'
 const symbols = require('../symbols')
 const { executionAsyncResource } = require('async_hooks')
-let diagnosticsChannel = null
-try {
-  diagnosticsChannel = require('diagnostics_channel')
-} catch (e) {
-  // quick check to see if module exists
-  // module was not added until v15.x
-}
+const diagnosticsChannel = require('diagnostics_channel')
 
 module.exports = function addUndiciChannels(agent, _undici, _modName, shim) {
-  if (!diagnosticsChannel || !agent.config.feature_flag.undici_instrumentation) {
-    logger.warn(
-      'diagnostics_channel or feature_flag.undici_instrumentation = false. Skipping undici instrumentation.'
-    )
-    return
-  }
-
   registerHookPoints(shim)
 }
 

--- a/test/unit/instrumentation/undici.test.js
+++ b/test/unit/instrumentation/undici.test.js
@@ -38,7 +38,6 @@ tap.test('undici instrumentation', function (t) {
     agent.config.distributed_tracing.enabled = false
     agent.config.cross_application_tracer.enabled = false
     agent.config.feature_flag = {
-      undici_instrumentation: true,
       undici_async_tracking: true
     }
     shim = new TransactionShim(agent, 'undici')
@@ -58,15 +57,6 @@ tap.test('undici instrumentation', function (t) {
     agent.config.feature_flag.undici_async_tracking = true
     helper.unloadAgent(agent)
   }
-
-  t.test('should log warning if feature flag is not enabled', function (t) {
-    agent.config.feature_flag.undici_instrumentation = false
-    undiciInstrumentation(agent)
-    t.same(loggerMock.warn.args[0], [
-      'diagnostics_channel or feature_flag.undici_instrumentation = false. Skipping undici instrumentation.'
-    ])
-    t.end()
-  })
 
   t.test('request:create', function (t) {
     t.autoend()

--- a/test/versioned/undici/requests.tap.js
+++ b/test/versioned/undici/requests.tap.js
@@ -49,11 +49,7 @@ tap.test('Undici request tests', (t) => {
   }
 
   t.before(() => {
-    agent = helper.instrumentMockedAgent({
-      feature_flag: {
-        undici_instrumentation: true
-      }
-    })
+    agent = helper.instrumentMockedAgent()
 
     undici = require('undici')
     server = createServer()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

I was hoping to remove the `undici_async_tracking` feature flag but there is still some inconsistency with async context propagation.  This will need to be addressed in undici itself.  I think I plan on PRing that shortly so that we can remove this feature flag at a later date.


## Links
Closes #1771
