### PR TITLE
perf(Trace): use faster way to copy one array into another

### DIFF
--- a/lib/transaction/trace/index.js
+++ b/lib/transaction/trace/index.js
@@ -224,7 +224,7 @@ Trace.prototype.getTotalTimeDurationInMillis = function getTotalTimeDurationInMi
   while (segments.length !== 0) {
     const segment = segments.pop()
     totalTimeInMillis += segment.getExclusiveDurationInMillis()
-    segment.getChildren().forEach((childSegment) => segments.push(childSegment))
+    segments.push(...segment.getChildren())
   }
 
   if (!this.transaction.isActive()) {


### PR DESCRIPTION
## Description

This is a follow-up to https://github.com/newrelic/node-newrelic/pull/1774, optimizing the solution further. This is the fastest way to copy values from one array into another array, see https://github.com/kibertoad/nodejs-benchmark-tournament/blob/master/add-array/_results/results.md for benchmarking results (pushDestruct method, while currently `pushForEach` is used, which is the slowest way to do so)

This retains the same logic as is currently used, but works faster (rougly 25% speed-up for the copying operation).

## How to Test

I've benchmarked the algorithm to ensure that this is the fastest possible option. See https://github.com/kibertoad/nodejs-benchmark-tournament/blob/master/add-array/contestants/pushDestruct.js for how this was implemented in benchmark.

## Related Issues

https://github.com/newrelic/node-newrelic/pull/1774