### PR TITLE
chore: Added free space display to versioned coverage run

### DIFF
--- a/.github/workflows/versioned-coverage.yml
+++ b/.github/workflows/versioned-coverage.yml
@@ -25,6 +25,8 @@ jobs:
       run: npm ci
     - name: Run Docker Services
       run: npm run services
+    - name: Check Available Space
+      run: df -h
     - name: Run Legacy Context Versioned Tests
       run: TEST_CHILD_TIMEOUT=600000 npm run versioned:legacy-context
       env:


### PR DESCRIPTION
## Description

Versioned test runs are exceeding available space. This is a diagnostic step.

## Related Issues

NR-166791
#1789 