### PR TITLE
test: skip Elasticsearch tests on Node 20

### DIFF
--- a/test/versioned/elastic/package.json
+++ b/test/versioned/elastic/package.json
@@ -5,7 +5,7 @@
   "tests": [
     {
       "engines": {
-        "node": ">=16"
+        "node": ">=16 <20"
       },
       "dependencies": {
         "@elastic/elasticsearch": ">=8"


### PR DESCRIPTION
For some reason the versioned tests for elasticsearch are timing out but only run on main.  They work just fine in branches.  I spent a lot of time trying to track it down and do not want to block the main line any longer.  I plan on continuing triage but will do so async.  
