### PR TITLE
fix: updated agent to create a stub api when running in a worker thread

### DIFF
--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -308,9 +308,10 @@ test('index tests', (t) => {
     processVersionStub.satisfies.onCall(0).returns(true)
     processVersionStub.satisfies.onCall(1).returns(true)
     processVersionStub.satisfies.onCall(2).returns(false)
-    loadIndex()
+    const api = loadIndex()
     t.equal(loggerMock.info.callCount, 2, 'should log info logs')
     t.equal(loggerMock.info.args[1][0], 'No configuration detected. Not starting.')
+    t.equal(api.constructor.name, 'Stub')
     t.end()
   })
 
@@ -319,9 +320,10 @@ test('index tests', (t) => {
     processVersionStub.satisfies.onCall(0).returns(true)
     processVersionStub.satisfies.onCall(1).returns(true)
     processVersionStub.satisfies.onCall(2).returns(false)
-    loadIndex()
+    const api = loadIndex()
     t.equal(loggerMock.info.callCount, 2, 'should log info logs')
     t.equal(loggerMock.info.args[1][0], 'Module disabled in configuration. Not starting.')
+    t.equal(api.constructor.name, 'Stub')
     t.end()
   })
 
@@ -362,15 +364,16 @@ test('index tests', (t) => {
     t.end()
   })
 
-  t.test('should log warning if not in main thread', (t) => {
+  t.test('should log warning if not in main thread and make a stub api', (t) => {
     workerThreadsStub.isMainThread = false
-    loadIndex()
+    const api = loadIndex()
     t.equal(loggerMock.warn.callCount, 1)
     t.equal(
       loggerMock.warn.args[0][0],
       'Using New Relic for Node.js in worker_threads is not supported. Not starting!'
     )
     t.equal(loggerMock.info.callCount, 0, 'should not attempt to initialize agent')
+    t.equal(api.constructor.name, 'Stub')
     t.end()
   })
 })


### PR DESCRIPTION
## Description

Apparently Next.js does not like early returns in CommonJS files, even though it's valid syntax.  This PR updates it to return a stub API in that case, effectively doing nothing but without an early return

## Links
Closes #1783 