### PR TITLE
ci: add steps to zip up container logs on versioned test failure

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -142,6 +142,20 @@ jobs:
       with:
         name: versioned-tests-${{ matrix.node-version }}
         path: ./coverage/versioned/lcov.info
+    - name: Collect docker logs on failure
+      if: failure()
+      uses: jwalton/gh-docker-logs@v2
+      with:
+        dest: ./logs-${{ matrix.node-version }}
+    - name: Tar logs
+      if: failure()
+      run: tar cvzf ./logs-${{ matrix.node-version }}.tgz ./logs-${{ matrix.node-version }}
+    - name: Upload logs to GitHub
+      if: failure()
+      uses: actions/upload-artifact@master
+      with:
+        name: logs-${{ matrix.node-version }}.tgz
+        path: ./logs-${{ matrix.node-version }}.tgz
   
   # There is no coverage for external as that's tracked in their respective repos
   versioned-external:


### PR DESCRIPTION
I would've been able to triage the elastic search issues faster if we had logs for the container.  This PR uploads all docker logs if a versioned test run fails.

You can see links [here](https://github.com/bizob2828/node-newrelic/actions/runs/6474022463).  I had a commit that replaced `failure()` with `always()`, but this will work on failures.


You can see there is a .gz for every version.


<img width="902" alt="screenshot 2023-10-10 at 5 05 32 PM" src="https://github.com/newrelic/node-newrelic/assets/1874937/ab7d923b-e409-4010-9b6d-3ad48a01f536">
