### PR TITLE
fix: Updated intialization to properly return the api on start up to the security agent

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ function initApi({ agent, apiPath }) {
 
   const api = new API(agent)
   require.cache.__NR_cache = module.exports = api
+  return api
 }
 
 function initialize() {

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -269,8 +269,9 @@ test('index tests', (t) => {
 
   t.test('should load k2 agent if config.security.agent.enabled', (t) => {
     mockConfig.security.agent.enabled = true
-    loadIndex()
+    const api = loadIndex()
     t.equal(k2Stub.start.callCount, 1, 'should register security agent')
+    t.same(k2Stub.start.args[0][0], api, 'should call start on security agent with proper args')
     t.end()
   })
 


### PR DESCRIPTION
In #1800 we updated the early return and abstracted common initialization code.  It properly assigns the API to module.exports but forgets to return the value used for security agent.  This fixes that and updates the unit test to assert that the security agent is called with the agent.
