### PR TITLE
test: Removed skipping elasticsearch versioned tests on Node 20

### DIFF
--- a/test/versioned/elastic/package.json
+++ b/test/versioned/elastic/package.json
@@ -8,7 +8,7 @@
   "tests": [
     {
       "engines": {
-        "node": ">=16 <20"
+        "node": ">=16"
       },
       "dependencies": {
         "@elastic/elasticsearch": ">=8.0.0"


### PR DESCRIPTION
We skipped Node 20 elasticsearch tests while trying to triage issues with CI. This removes that flag.

