### PR TITLE
ci: Updated CI workflow to use larger runners on versioned tests but only when running against the main branch

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -115,7 +115,7 @@ jobs:
   versioned-internal:
     needs: skip_if_release
     if: needs.skip_if_release.outputs.should_skip != 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER || 'ubuntu-latest' }}
 
     strategy:
       matrix:
@@ -135,7 +135,8 @@ jobs:
       run: TEST_CHILD_TIMEOUT=600000 npm run versioned:internal
       env:
         VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}
-        JOBS: 4 # 2 per CPU seems to be the sweet spot in GHA (July 2022)
+        # Run more jobs when using larger runner, otherwise 2 per CPU seems to be the sweet spot in GHA default runners(July 2022)
+        JOBS: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER && 16 ||  4 }}
         C8_REPORTER: lcovonly
     - name: Archive Versioned Test Coverage
       uses: actions/upload-artifact@v3
@@ -161,7 +162,7 @@ jobs:
   versioned-external:
     needs: skip_if_release
     if: needs.skip_if_release.outputs.should_skip != 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER || 'ubuntu-latest' }}
 
     strategy:
       matrix:
@@ -179,7 +180,8 @@ jobs:
       run: TEST_CHILD_TIMEOUT=600000 npm run versioned:external
       env:
         VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}
-        JOBS: 4 # 2 per CPU seems to be the sweet spot in GHA (July 2022)
+        # Run more jobs when using larger runner, otherwise 2 per CPU seems to be the sweet spot in GHA default runners(July 2022)
+        JOBS: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER && 16 ||  4 }}
   codecov:
     needs: [unit, integration, versioned-internal]
     runs-on: ubuntu-latest


### PR DESCRIPTION
We were running up against a constrained CI environment when running versioned tests.  We split out internal and external versioned tests in #1792, this helped speed up runs significantly from 1hr 15 mins to 45 mins.  We were still towards the upper limit on disk space and when running coverage on versioned tests it took up over 40% of the disk.  When we added elasticsearch container it was causing failures because the disk was too high for the watermark, which we disabled in #1803.    We also had to limit the number of concurrent versioned tests job to 2 which also slowed it down.  We got approval for a larger 16 core runner and now can run 16 concurrent jobs on main.

This PR will only use larger runner when the branch is main and the `vars.NR_RUNNER` which is set to our larger runner of `node_16_cores_ubuntu`.  A few test jobs showed significant speed ups:  [running with major flag](https://github.com/newrelic/node-newrelic/actions/runs/6537300774), and [running with minor flag](https://github.com/newrelic/node-newrelic/actions/runs/6537549247)