### PR TITLE
chore: included changelog entry for removing ability to run in worker threads to 11.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,7 @@
 * Updated agent to use require-in-the-middle to register CommonJS instrumentation. You can no longer use an onResolved hook to register custom instrumentation.
 * Updated the default context manager to be AsyncLocalContextManager.
 * Renamed `shim.handleCATHeaders` to `shim.handleMqTracingHeaders`.
+* Updated agent to only run in the main thread. This is because running in a worker thread does not completely function out of the box. This will reduce the overhead for customers that are naively trying to load this into worker threads.
 
 #### Features
 


### PR DESCRIPTION
This was missed when creating the changelog for 11.0.0.  The GitHub release has already been updated and PR to the release notes on docs-website will be coming shortly.  
