### PR TITLE
feat: Updated agent initialization to allow running in worker threads when config.worker_threads.enabled is true

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ function initialize() {
     } else {
       if (!isMainThread && config.worker_threads.enabled) {
         logger.warn(
-          'Attempting to load agent in worker thread. This is not officially supported, use at your own risk.'
+          'Attempting to load agent in worker thread. This is not officially supported. Use at your own risk.'
         )
       }
       agent = createAgent(config)

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1320,10 +1320,30 @@ defaultConfig.definition = () => ({
     }
   },
 
+  /**
+   * When enabled, it will use `process.env.DYNO`
+   * to set the hostname of the running application
+   */
   heroku: {
     use_dyno_names: {
       default: true,
       formatter: boolean
+    }
+  },
+
+  /**
+   * When enabled, it will allow loading of the agent
+   * in worker threads.
+   *
+   * In 11.0.0 we added code to prevent loading in worker threads
+   * to cut down on unnecessary overhead of the agent.  We have found
+   * in testing that traces and spans were useless unless work was
+   * completely self contained in the worker thread.
+   */
+  worker_threads: {
+    enabled: {
+      formatter: boolean,
+      default: false
     }
   }
 })

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -303,4 +303,9 @@ tap.test('with default properties', (t) => {
     t.equal(configuration.infinite_tracing.compression, true)
     t.end()
   })
+
+  t.test('should default worker_threads.enabled to false', (t) => {
+    t.equal(configuration.worker_threads.enabled, false)
+    t.end()
+  })
 })

--- a/test/unit/config/config-env.test.js
+++ b/test/unit/config/config-env.test.js
@@ -767,4 +767,11 @@ tap.test('when overriding configuration values via environment variables', (t) =
       t.end()
     })
   })
+
+  t.test('should convert NEW_RELIC_WORKER_THREADS_ENABLED accordingly', (t) => {
+    idempotentEnv({ NEW_RELIC_WORKER_THREADS_ENABLED: 'true' }, (config) => {
+      t.equal(config.worker_threads.enabled, true)
+      t.end()
+    })
+  })
 })

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -388,7 +388,7 @@ test('index tests', (t) => {
       t.equal(loggerMock.warn.callCount, 1)
       t.equal(
         loggerMock.warn.args[0][0],
-        'Attempting to load agent in worker thread. This is not officially supported, use at your own risk.'
+        'Attempting to load agent in worker thread. This is not officially supported. Use at your own risk.'
       )
       t.ok(api.agent)
       t.equal(api.agent.constructor.name, 'MockAgent', 'should initialize an agent')

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -210,7 +210,8 @@ test('index tests', (t) => {
       agent_enabled: true,
       logging: {},
       feature_flag: { flag_1: true, flag_2: false },
-      security: { agent: { enabled: false } }
+      security: { agent: { enabled: false } },
+      worker_threads: { enabled: false }
     }
     configMock = {
       getOrCreateInstance: sandbox.stub().returns(mockConfig)
@@ -371,10 +372,28 @@ test('index tests', (t) => {
     t.equal(loggerMock.warn.callCount, 1)
     t.equal(
       loggerMock.warn.args[0][0],
-      'Using New Relic for Node.js in worker_threads is not supported. Not starting!'
+      'New Relic for Node.js in worker_threads is not officially supported. Not starting! To bypass this, set `config.worker_threads.enabled` to true in configuration.'
     )
-    t.equal(loggerMock.info.callCount, 0, 'should not attempt to initialize agent')
+    t.not(api.agent, 'should not initialize an agent')
     t.equal(api.constructor.name, 'Stub')
     t.end()
   })
+
+  t.test(
+    'should log warning if not in main thread and worker_threads.enabled is true and init agent',
+    (t) => {
+      mockConfig.worker_threads.enabled = true
+      workerThreadsStub.isMainThread = false
+      const api = loadIndex()
+      t.equal(loggerMock.warn.callCount, 1)
+      t.equal(
+        loggerMock.warn.args[0][0],
+        'Attempting to load agent in worker thread. This is not officially supported, use at your own risk.'
+      )
+      t.ok(api.agent)
+      t.equal(api.agent.constructor.name, 'MockAgent', 'should initialize an agent')
+      t.equal(api.constructor.name, 'API')
+      t.end()
+    }
+  )
 })


### PR DESCRIPTION
To restore behavior for some customers wanting to run in worker threads, they can set `config.worker_threads.enabled` to true in config of set `NEW_RELIC_WORKER_THREADS_ENABLED` to `true`.  I tried to be clear and proivde warnings that running in worker threads is not officially supported.  It seems as though some customers may find it valuable but we want to default to disable running in worker threads and allow customers to opt-in.
