### PR TITLE
chore(deps): Updated aws-sdk, koa, superagent

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -92,7 +92,7 @@ code, the source code can be found at [https://github.com/newrelic/node-newrelic
 
 ### @grpc/grpc-js
 
-This product includes source derived from [@grpc/grpc-js](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js) ([v1.9.2](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js/tree/v1.9.2)), distributed under the [Apache-2.0 License](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js/blob/v1.9.2/LICENSE):
+This product includes source derived from [@grpc/grpc-js](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js) ([v1.9.4](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js/tree/v1.9.4)), distributed under the [Apache-2.0 License](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js/blob/v1.9.4/LICENSE):
 
 ```
                                  Apache License
@@ -510,7 +510,7 @@ This product includes source derived from [@grpc/proto-loader](https://github.co
 
 ### @newrelic/aws-sdk
 
-This product includes source derived from [@newrelic/aws-sdk](https://github.com/newrelic/node-newrelic-aws-sdk) ([v7.0.0](https://github.com/newrelic/node-newrelic-aws-sdk/tree/v7.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-aws-sdk/blob/v7.0.0/LICENSE):
+This product includes source derived from [@newrelic/aws-sdk](https://github.com/newrelic/node-newrelic-aws-sdk) ([v7.0.2](https://github.com/newrelic/node-newrelic-aws-sdk/tree/v7.0.2)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-aws-sdk/blob/v7.0.2/LICENSE):
 
 ```
                                  Apache License
@@ -718,7 +718,7 @@ This product includes source derived from [@newrelic/aws-sdk](https://github.com
 
 ### @newrelic/koa
 
-This product includes source derived from [@newrelic/koa](https://github.com/newrelic/node-newrelic-koa) ([v8.0.0](https://github.com/newrelic/node-newrelic-koa/tree/v8.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-koa/blob/v8.0.0/LICENSE):
+This product includes source derived from [@newrelic/koa](https://github.com/newrelic/node-newrelic-koa) ([v8.0.1](https://github.com/newrelic/node-newrelic-koa/tree/v8.0.1)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-koa/blob/v8.0.1/LICENSE):
 
 ```
 Apache License
@@ -978,7 +978,7 @@ This license terminates when the Pre-Release Software stops being provided by Ne
 
 ### @newrelic/superagent
 
-This product includes source derived from [@newrelic/superagent](https://github.com/newrelic/node-newrelic-superagent) ([v7.0.0](https://github.com/newrelic/node-newrelic-superagent/tree/v7.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-superagent/blob/v7.0.0/LICENSE):
+This product includes source derived from [@newrelic/superagent](https://github.com/newrelic/node-newrelic-superagent) ([v7.0.1](https://github.com/newrelic/node-newrelic-superagent/tree/v7.0.1)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-superagent/blob/v7.0.1/LICENSE):
 
 ```
                                  Apache License

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.9.4",
         "@grpc/proto-loader": "^0.7.5",
-        "@newrelic/aws-sdk": "^7.0.0",
-        "@newrelic/koa": "^8.0.0",
+        "@newrelic/aws-sdk": "^7.0.2",
+        "@newrelic/koa": "^8.0.1",
         "@newrelic/security-agent": "0.3.0",
-        "@newrelic/superagent": "^7.0.0",
+        "@newrelic/superagent": "^7.0.1",
         "@tyriar/fibonacci-heap": "^2.0.7",
         "concat-stream": "^2.0.0",
         "https-proxy-agent": "^7.0.1",
@@ -1316,14 +1316,11 @@
       }
     },
     "node_modules/@newrelic/aws-sdk": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-7.0.0.tgz",
-      "integrity": "sha512-/14Y9qYomDEzFrdXogqms2CGMI9hEJECzNBSqBLT53FY/uZh6SdI4Tr5u0sEOghjCdNyF2rseW7u63bAn09Pxw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-7.0.2.tgz",
+      "integrity": "sha512-nT19hzId0MbjR3v1ks5YetvNfrwIEgMfeai+T2pQkuWkjCsYm3z+OybLOYMCN66gueqOOqGTq60qhM4dFu5s5w==",
       "engines": {
         "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "newrelic": ">=10.0.0"
       }
     },
     "node_modules/@newrelic/eslint-config": {
@@ -1345,14 +1342,11 @@
       }
     },
     "node_modules/@newrelic/koa": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-8.0.0.tgz",
-      "integrity": "sha512-aaqEVLnRk12DzChCGbWthVQR4PxomqeNVVxnBF3txfHCMhDL2rkOjjcu8VYVoLkhVXrNtY0M226sYN/uqzQ+bQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-8.0.1.tgz",
+      "integrity": "sha512-GyeZGKPllpUu6gWXRwVP/FlvE9+tU2lOprRiTdoXNM8jdVGL02IfHnvAzrIANoZoUdf3+Vev8NNeCup2Eojcvg==",
       "engines": {
         "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "newrelic": ">=6.11.0"
       }
     },
     "node_modules/@newrelic/native-metrics": {
@@ -1468,14 +1462,11 @@
       }
     },
     "node_modules/@newrelic/superagent": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-7.0.0.tgz",
-      "integrity": "sha512-fNB4NC+pJYYrFZRLcXaTb4Z7XFEfHi7fVQ3O9Qh10m/9CBM2W+Qc/6yyK9M1liRfgUGo5NOILRdjA23SS7720A==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-7.0.1.tgz",
+      "integrity": "sha512-QZlW0VxHSVOXcMAtlkg+Mth0Nz3vFku8rfzTEmoI/pXcckHXGEYuiVUhhboCTD3xTKVgnZRUp9BWF6SOggGUSw==",
       "engines": {
         "node": ">=16.0"
-      },
-      "peerDependencies": {
-        "newrelic": ">=6.11.0"
       }
     },
     "node_modules/@newrelic/test-utilities": {
@@ -10707,72 +10698,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "node_modules/newrelic": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-11.0.0.tgz",
-      "integrity": "sha512-uZEetgjfoscuuFNP7TH5BIKLv4vnfX27DV9y+Yb26ZrC3CNnVL+jBOAKY4+/vTxQiQHCi4uPfRyjw+1/3fOQXA==",
-      "peer": true,
-      "dependencies": {
-        "@grpc/grpc-js": "^1.8.10",
-        "@grpc/proto-loader": "^0.7.5",
-        "@newrelic/aws-sdk": "^7.0.0",
-        "@newrelic/koa": "^8.0.0",
-        "@newrelic/security-agent": "0.2.1",
-        "@newrelic/superagent": "^7.0.0",
-        "@tyriar/fibonacci-heap": "^2.0.7",
-        "concat-stream": "^2.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "import-in-the-middle": "^1.4.2",
-        "json-bigint": "^1.0.0",
-        "json-stringify-safe": "^5.0.0",
-        "readable-stream": "^3.6.1",
-        "require-in-the-middle": "^7.2.0",
-        "semver": "^7.5.2",
-        "winston-transport": "^4.5.0"
-      },
-      "bin": {
-        "newrelic-naming-rules": "bin/test-naming-rules.js"
-      },
-      "engines": {
-        "node": ">=16",
-        "npm": ">=6.0.0"
-      },
-      "optionalDependencies": {
-        "@contrast/fn-inspect": "^3.3.0",
-        "@newrelic/native-metrics": "^10.0.0",
-        "@prisma/prisma-fmt-wasm": "^4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085"
-      }
-    },
-    "node_modules/newrelic/node_modules/@newrelic/security-agent": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/security-agent/-/security-agent-0.2.1.tgz",
-      "integrity": "sha512-oFPnBO+BlJap/qC3r80NuiHmedXdjpWnVnzAlNjsSZoAT7qJM/29tip6ZX/Qmp17mZAIiOVJ2MkyQ5OXHXPdLw==",
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/client-lambda": "^3.363.0",
-        "axios": "0.21.4",
-        "check-disk-space": "3.3.1",
-        "content-type": "^1.0.5",
-        "fast-safe-stringify": "^2.1.1",
-        "find-package-json": "^1.2.0",
-        "hash.js": "^1.1.7",
-        "html-entities": "^2.3.6",
-        "is-invalid-path": "^1.0.2",
-        "js-yaml": "^4.1.0",
-        "jsonschema": "^1.4.1",
-        "lodash": "^4.17.21",
-        "log4js": "^6.9.1",
-        "pretty-bytes": "^5.6.0",
-        "request-ip": "^3.3.0",
-        "ringbufferjs": "^2.0.0",
-        "semver": "^7.5.4",
-        "sync-request": "^6.1.0",
-        "unescape": "^1.0.1",
-        "unescape-js": "^1.1.4",
-        "uuid": "^9.0.0",
-        "ws": "^7.5.9"
-      }
-    },
     "node_modules/nise": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
@@ -17333,10 +17258,9 @@
       }
     },
     "@newrelic/aws-sdk": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-7.0.0.tgz",
-      "integrity": "sha512-/14Y9qYomDEzFrdXogqms2CGMI9hEJECzNBSqBLT53FY/uZh6SdI4Tr5u0sEOghjCdNyF2rseW7u63bAn09Pxw==",
-      "requires": {}
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-7.0.2.tgz",
+      "integrity": "sha512-nT19hzId0MbjR3v1ks5YetvNfrwIEgMfeai+T2pQkuWkjCsYm3z+OybLOYMCN66gueqOOqGTq60qhM4dFu5s5w=="
     },
     "@newrelic/eslint-config": {
       "version": "0.3.0",
@@ -17346,10 +17270,9 @@
       "requires": {}
     },
     "@newrelic/koa": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-8.0.0.tgz",
-      "integrity": "sha512-aaqEVLnRk12DzChCGbWthVQR4PxomqeNVVxnBF3txfHCMhDL2rkOjjcu8VYVoLkhVXrNtY0M226sYN/uqzQ+bQ==",
-      "requires": {}
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-8.0.1.tgz",
+      "integrity": "sha512-GyeZGKPllpUu6gWXRwVP/FlvE9+tU2lOprRiTdoXNM8jdVGL02IfHnvAzrIANoZoUdf3+Vev8NNeCup2Eojcvg=="
     },
     "@newrelic/native-metrics": {
       "version": "10.0.0",
@@ -17446,10 +17369,9 @@
       }
     },
     "@newrelic/superagent": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-7.0.0.tgz",
-      "integrity": "sha512-fNB4NC+pJYYrFZRLcXaTb4Z7XFEfHi7fVQ3O9Qh10m/9CBM2W+Qc/6yyK9M1liRfgUGo5NOILRdjA23SS7720A==",
-      "requires": {}
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-7.0.1.tgz",
+      "integrity": "sha512-QZlW0VxHSVOXcMAtlkg+Mth0Nz3vFku8rfzTEmoI/pXcckHXGEYuiVUhhboCTD3xTKVgnZRUp9BWF6SOggGUSw=="
     },
     "@newrelic/test-utilities": {
       "version": "8.1.0",
@@ -24577,65 +24499,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
-    },
-    "newrelic": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-11.0.0.tgz",
-      "integrity": "sha512-uZEetgjfoscuuFNP7TH5BIKLv4vnfX27DV9y+Yb26ZrC3CNnVL+jBOAKY4+/vTxQiQHCi4uPfRyjw+1/3fOQXA==",
-      "peer": true,
-      "requires": {
-        "@contrast/fn-inspect": "^3.3.0",
-        "@grpc/grpc-js": "^1.8.10",
-        "@grpc/proto-loader": "^0.7.5",
-        "@newrelic/aws-sdk": "^7.0.0",
-        "@newrelic/koa": "^8.0.0",
-        "@newrelic/native-metrics": "^10.0.0",
-        "@newrelic/security-agent": "0.2.1",
-        "@newrelic/superagent": "^7.0.0",
-        "@prisma/prisma-fmt-wasm": "^4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085",
-        "@tyriar/fibonacci-heap": "^2.0.7",
-        "concat-stream": "^2.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "import-in-the-middle": "^1.4.2",
-        "json-bigint": "^1.0.0",
-        "json-stringify-safe": "^5.0.0",
-        "readable-stream": "^3.6.1",
-        "require-in-the-middle": "^7.2.0",
-        "semver": "^7.5.2",
-        "winston-transport": "^4.5.0"
-      },
-      "dependencies": {
-        "@newrelic/security-agent": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/@newrelic/security-agent/-/security-agent-0.2.1.tgz",
-          "integrity": "sha512-oFPnBO+BlJap/qC3r80NuiHmedXdjpWnVnzAlNjsSZoAT7qJM/29tip6ZX/Qmp17mZAIiOVJ2MkyQ5OXHXPdLw==",
-          "peer": true,
-          "requires": {
-            "@aws-sdk/client-lambda": "^3.363.0",
-            "axios": "0.21.4",
-            "check-disk-space": "3.3.1",
-            "content-type": "^1.0.5",
-            "fast-safe-stringify": "^2.1.1",
-            "find-package-json": "^1.2.0",
-            "hash.js": "^1.1.7",
-            "html-entities": "^2.3.6",
-            "is-invalid-path": "^1.0.2",
-            "js-yaml": "^4.1.0",
-            "jsonschema": "^1.4.1",
-            "lodash": "^4.17.21",
-            "log4js": "^6.9.1",
-            "pretty-bytes": "^5.6.0",
-            "request-ip": "^3.3.0",
-            "ringbufferjs": "^2.0.0",
-            "semver": "^7.5.4",
-            "sync-request": "^6.1.0",
-            "unescape": "^1.0.1",
-            "unescape-js": "^1.1.4",
-            "uuid": "^9.0.0",
-            "ws": "^7.5.9"
-          }
-        }
-      }
     },
     "nise": {
       "version": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -183,10 +183,10 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.9.4",
     "@grpc/proto-loader": "^0.7.5",
-    "@newrelic/aws-sdk": "^7.0.0",
-    "@newrelic/koa": "^8.0.0",
+    "@newrelic/aws-sdk": "^7.0.2",
+    "@newrelic/koa": "^8.0.1",
     "@newrelic/security-agent": "0.3.0",
-    "@newrelic/superagent": "^7.0.0",
+    "@newrelic/superagent": "^7.0.1",
     "@tyriar/fibonacci-heap": "^2.0.7",
     "concat-stream": "^2.0.0",
     "https-proxy-agent": "^7.0.1",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Mon Oct 23 2023 12:15:25 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Wed Oct 25 2023 14:53:27 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -44,15 +44,15 @@
   },
   "includeDev": true,
   "dependencies": {
-    "@grpc/grpc-js@1.9.2": {
+    "@grpc/grpc-js@1.9.4": {
       "name": "@grpc/grpc-js",
-      "version": "1.9.2",
-      "range": "^1.8.10",
+      "version": "1.9.4",
+      "range": "^1.9.4",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",
-      "versionedRepoUrl": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js/tree/v1.9.2",
+      "versionedRepoUrl": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js/tree/v1.9.4",
       "licenseFile": "node_modules/@grpc/grpc-js/LICENSE",
-      "licenseUrl": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js/blob/v1.9.2/LICENSE",
+      "licenseUrl": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js/blob/v1.9.4/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Google Inc."
     },
@@ -68,28 +68,28 @@
       "licenseTextSource": "file",
       "publisher": "Google Inc."
     },
-    "@newrelic/aws-sdk@7.0.0": {
+    "@newrelic/aws-sdk@7.0.2": {
       "name": "@newrelic/aws-sdk",
-      "version": "7.0.0",
-      "range": "^7.0.0",
+      "version": "7.0.2",
+      "range": "^7.0.2",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic-aws-sdk",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-aws-sdk/tree/v7.0.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-aws-sdk/tree/v7.0.2",
       "licenseFile": "node_modules/@newrelic/aws-sdk/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic-aws-sdk/blob/v7.0.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic-aws-sdk/blob/v7.0.2/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"
     },
-    "@newrelic/koa@8.0.0": {
+    "@newrelic/koa@8.0.1": {
       "name": "@newrelic/koa",
-      "version": "8.0.0",
-      "range": "^8.0.0",
+      "version": "8.0.1",
+      "range": "^8.0.1",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic-koa",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-koa/tree/v8.0.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-koa/tree/v8.0.1",
       "licenseFile": "node_modules/@newrelic/koa/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic-koa/blob/v8.0.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic-koa/blob/v8.0.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"
@@ -106,15 +106,15 @@
       "licenseTextSource": "file",
       "publisher": "newrelic"
     },
-    "@newrelic/superagent@7.0.0": {
+    "@newrelic/superagent@7.0.1": {
       "name": "@newrelic/superagent",
-      "version": "7.0.0",
-      "range": "^7.0.0",
+      "version": "7.0.1",
+      "range": "^7.0.1",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic-superagent",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-superagent/tree/v7.0.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-superagent/tree/v7.0.1",
       "licenseFile": "node_modules/@newrelic/superagent/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic-superagent/blob/v7.0.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic-superagent/blob/v7.0.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js Agent Team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
* Updated @newrelic/aws-sdk to v7.0.2
* Updated @newrelic/koa to v8.0.1
* Updated @newrelic/superagent to v7.0.1
* Removed this agent as a peer dependency, now that those packages are no longer standalone.
* Bumped @babel/traverse to v7.23.2 in dependencies.
