### PR TITLE
chore: Capitalize release PR title

### DIFF
--- a/bin/prepare-release.js
+++ b/bin/prepare-release.js
@@ -166,7 +166,7 @@ async function prepareReleaseNotes() {
     let body
 
     if (options.useNewRelease) {
-      title = `chore: release ${version}`
+      title = `chore: Release ${version}`
       body = releaseData
     } else {
       title = `Release ${version}`


### PR DESCRIPTION
## Description

Yesterday during release, the validate-pr job hung without feedback until the title was capitalized. This capitalizes the title in our automation. 
