### PR TITLE
ci: Disable fail-fast on nightly versioned test runs

### DIFF
--- a/.github/workflows/versioned-coverage.yml
+++ b/.github/workflows/versioned-coverage.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         node-version: [16.x, 18.x, 20.x]
 

--- a/.github/workflows/versioned-security-agent.yml
+++ b/.github/workflows/versioned-security-agent.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         node-version: [16.x, 18.x, 20.x]
 


### PR DESCRIPTION
We sometimes get failures on nightly runs. Usually they are flappy tests and all other running versioned are stopped. This will prevent that from happening