### PR TITLE
chore: fix bool -> boolean in jsdoc

### DIFF
--- a/lib/adaptive-sampler.js
+++ b/lib/adaptive-sampler.js
@@ -79,7 +79,7 @@ class AdaptiveSampler {
    * the number of objects sampled in this window.
    *
    * @param {number} roll - The number to compare against the threshold
-   * @returns {bool} True if the object should be sampled.
+   * @returns {boolean} True if the object should be sampled.
    */
   shouldSample(roll) {
     ++this._seen

--- a/lib/collector/remote-method.js
+++ b/lib/collector/remote-method.js
@@ -360,7 +360,7 @@ RemoteMethod.prototype._path = function _path() {
  * @param {object} options
  * @param {number} options.body       - Data to be sent.
  * @param {object} options.nrHeaders  - NR request headers from the connect response.
- * @param {bool}   options.compressed - The compression method used, if any.
+ * @param {boolean}   options.compressed - The compression method used, if any.
  */
 RemoteMethod.prototype._headers = function _headers(options) {
   const agent = this._userAgent()

--- a/lib/metrics/normalizer.js
+++ b/lib/metrics/normalizer.js
@@ -70,8 +70,8 @@ util.inherits(MetricNormalizer, EventEmitter)
 
 /**
  * @typedef {object} NormalizationResults
- * @property {bool}   matched - True if a rule was found that matched.
- * @property {bool}   ignore  - True if the given input should be ignored.
+ * @property {boolean}   matched - True if a rule was found that matched.
+ * @property {boolean}   ignore  - True if the given input should be ignored.
  * @property {string} value   - The normalized input value.
  */
 

--- a/lib/metrics/normalizer/rule.js
+++ b/lib/metrics/normalizer/rule.js
@@ -76,7 +76,7 @@ NormalizerRule.prototype.getSegments = function getSegments(input) {
  * Does not set {NormalizerRule#matched}.
  *
  * @param {string} input - URL to match.
- * @returns {bool} - True if this rule matches the given input, otherwise false.
+ * @returns {boolean} - True if this rule matches the given input, otherwise false.
  */
 NormalizerRule.prototype.matches = function matches(input) {
   const segments = this.getSegments(input)

--- a/lib/shim/promise-shim.js
+++ b/lib/shim/promise-shim.js
@@ -59,7 +59,7 @@ class PromiseShim extends Shim {
    * library being wrapped.
    *
    * @param {*} obj - The object to check the instance type of.
-   * @returns {bool} True if the provided object is an instance of a promise from
+   * @returns {boolean} True if the provided object is an instance of a promise from
    *  this promise library.
    * @see PromiseShim#setClass
    */

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -295,7 +295,7 @@ Shim.prototype[symbols.unwrap] = unwrapAll
  *  ```js
  *  shim.wrap(Object.getPrototypeOf(context), spec.$proto)
  *  ```
- * @property {bool} $once
+ * @property {boolean} $once
  *  Ensures that the parent spec will only be executed one time if the value is
  *  `true`. Good for preventing double wrapping of prototype methods.
  *
@@ -416,7 +416,7 @@ Shim.prototype[symbols.unwrap] = unwrapAll
  *  value is truthy then the recording will extend to the `end` event of the
  *  stream. If the value is a string it is assumed to be the name of an event to
  *  measure. A segment will be created to record emissions of the event.
- * @property {bool} [promise]
+ * @property {boolean} [promise]
  *  Indicates if the return value from the wrapped function is a Promise. If the
  *  value is truthy then the recording will extend to the completion of the
  *  Promise.
@@ -430,7 +430,7 @@ Shim.prototype[symbols.unwrap] = unwrapAll
  *  one segment for all calls to the callback. This is mostly useful for
  *  functions which will be called repeatedly, such as once for each item in a
  *  result set.
- * @property {bool} [internal=false]
+ * @property {boolean} [internal=false]
  *  Marks this as the boundary point into the instrumented library. If `true`
  *  and the current segment is _also_ marked as `internal` by the same shim,
  *  then we will not record this inner activity.
@@ -443,7 +443,7 @@ Shim.prototype[symbols.unwrap] = unwrapAll
  *  A function to call after the synchronous execution of the recorded method.
  *  If the function synchronously threw an error, that error will be handed to
  *  this function.
- * @property {bool} [callbackRequired]
+ * @property {boolean} [callbackRequired]
  *  When `true`, a recorded method must be called with a callback for a segment
  *  to be created. Does not apply if a custom callback method has been assigned
  *  via {@link callback}.
@@ -455,7 +455,7 @@ Shim.prototype[symbols.unwrap] = unwrapAll
  * @interface ClassWrapSpec
  * @description
  *  Specifies the style of wrapping and construction hooks for wrapping classes.
- * @property {bool} [es6=false]
+ * @property {boolean} [es6=false]
  * @property {ConstructorHookFunction} [pre=null]
  *  A function called with the constructor's arguments before the base class'
  *  constructor is executed. The `this` value will be `null`.
@@ -797,7 +797,7 @@ function getExport(defaultExport) {
  * @param {string} [property]
  *  The property to check. If omitted, the `nodule` parameter is assumed to be
  *  the function to check.
- * @returns {bool} True if the item exists and has been wrapped.
+ * @returns {boolean} True if the item exists and has been wrapped.
  * @see Shim#wrap
  * @see Shim#bindSegment
  */
@@ -1090,7 +1090,7 @@ function getOriginalOnce(nodule, property) {
  * @param {?TraceSegment} [segment=null]
  *  The segment to bind the execution of the function to. If omitted or `null`
  *  the currently active segment will be bound instead.
- * @param {bool} [full=false]
+ * @param {boolean} [full=false]
  *  Indicates if the full lifetime of the segment is bound to this function.
  * @returns {object | Function} The first parameter after wrapping.
  */
@@ -1286,7 +1286,7 @@ function storeSegment(obj, segment) {
  * @memberof Shim.prototype
  * @param {Function} func The function to execute in the context of the given segment.
  * @param {TraceSegment} segment The segment to make active for the duration of the function.
- * @param {bool} full Indicates if the full lifetime of the segment is bound to this function.
+ * @param {boolean} full Indicates if the full lifetime of the segment is bound to this function.
  * @param {*} context The `this` argument for the function.
  * @param {Array.<*>} args The arguments to be passed into the function.
  * @param {Function} [inContextCB] The function used to do more instrumentation work. This function is
@@ -1425,7 +1425,7 @@ function getName(obj) {
  *
  * @memberof Shim.prototype
  * @param {*} obj - The object to check.
- * @returns {bool} True if the object is an Object, else false.
+ * @returns {boolean} True if the object is an Object, else false.
  */
 function isObject(obj) {
   return obj instanceof Object
@@ -1436,7 +1436,7 @@ function isObject(obj) {
  *
  * @memberof Shim.prototype
  * @param {*} obj - The object to check.
- * @returns {bool} True if the object is a function, else false.
+ * @returns {boolean} True if the object is a function, else false.
  */
 function isFunction(obj) {
   return typeof obj === 'function'
@@ -1447,7 +1447,7 @@ function isFunction(obj) {
  *
  * @memberof Shim.prototype
  * @param {*} obj - The object to check.
- * @returns {bool} True if the object is a string, else false.
+ * @returns {boolean} True if the object is a string, else false.
  */
 function isString(obj) {
   return typeof obj === 'string' || obj instanceof String
@@ -1458,7 +1458,7 @@ function isString(obj) {
  *
  * @memberof Shim.prototype
  * @param {*} obj - The object to check.
- * @returns {bool} True if the object is a number literal, else false.
+ * @returns {boolean} True if the object is a number literal, else false.
  */
 function isNumber(obj) {
   return typeof obj === 'number'
@@ -1469,7 +1469,7 @@ function isNumber(obj) {
  *
  * @memberof Shim.prototype
  * @param {*} obj - The object to check.
- * @returns {bool} True if the object is a boolean literal, else false.
+ * @returns {boolean} True if the object is a boolean literal, else false.
  */
 function isBoolean(obj) {
   return typeof obj === 'boolean'
@@ -1480,7 +1480,7 @@ function isBoolean(obj) {
  *
  * @memberof Shim.prototype
  * @param {*} obj - The object to check.
- * @returns {bool} True if the object is an array, else false.
+ * @returns {boolean} True if the object is an array, else false.
  */
 function isArray(obj) {
   return obj instanceof Array
@@ -1491,7 +1491,7 @@ function isArray(obj) {
  *
  * @memberof Shim.prototype
  * @param {*} obj - The object to check.
- * @returns {bool} True if the object is a promise, else false.
+ * @returns {boolean} True if the object is a promise, else false.
  */
 function isPromise(obj) {
   return obj && typeof obj.then === 'function'
@@ -1502,7 +1502,7 @@ function isPromise(obj) {
  *
  * @memberof Shim.prototype
  * @param {*} val - The value to check.
- * @returns {bool} True if the value is null, else false.
+ * @returns {boolean} True if the value is null, else false.
  */
 function isNull(val) {
   return val === null
@@ -1923,7 +1923,7 @@ function _makeBindWrapper(shim, fn, segment, full) {
  * @param {TraceSegment} spec.segment
  *  The segment measuring the function which will be the parent of any callback
  *  segments that may be created.
- * @param {bool} spec.shouldCreateSegment
+ * @param {boolean} spec.shouldCreateSegment
  *  Flag indicating if we should create segments for the callbacks. We almost
  *  always do, but in the special case of nested internal methods we do not.
  */
@@ -1981,7 +1981,7 @@ function _bindAllCallbacks(shim, fn, name, args, spec) {
  * @param {string} [spec.event]
  *  The name of an event to record. If provided, a new segment will be created
  *  for this event and will measure each time the event is emitted.
- * @param {bool} spec.shouldCreateSegment
+ * @param {boolean} spec.shouldCreateSegment
  *  Indicates if any child segments should be created. This should always be
  *  true unless this segment and its parent are both internal segments.
  */

--- a/lib/shim/transaction-shim.js
+++ b/lib/shim/transaction-shim.js
@@ -80,7 +80,7 @@ TransactionShim.prototype.insertCATRequestHeaders = insertCATRequestHeaders
  * @property {string} type
  *  The type of transaction to create. Must be one of the values from
  *  {@link Shim#TRANSACTION_TYPES}.
- * @property {bool} [nest=false]
+ * @property {boolean} [nest=false]
  *  Indicates if the transaction being created is allowed to be nested within
  *  another transaction of the same type. If `false`, the default, the transaction
  *  will only be created if there is no existing transaction, or the current
@@ -269,7 +269,7 @@ function handleMqTracingHeaders(headers, segment, transportType) {
  * @memberof TransactionShim.prototype
  * @param {object} headers
  *  The outbound request headers object to inject our CAT headers into.
- * @param {bool} [useAlternateHeaderNames=false]
+ * @param {boolean} [useAlternateHeaderNames=false]
  *  Indicates if HTTP-style headers should be used or alternate style. Some
  *  transport protocols are more strict on the characters allowed in headers
  *  and this option can be used to toggle use of pure-alpha header names.
@@ -312,7 +312,7 @@ function insertCATRequestHeaders(headers, useAlternateHeaderNames) {
  * @memberof TransactionShim.prototype
  * @param {object} headers
  *  The outbound response headers object to inject our CAT headers into.
- * @param {bool} [useAlternateHeaderNames=false]
+ * @param {boolean} [useAlternateHeaderNames=false]
  *  Indicates if HTTP-style headers should be used or alternate style. Some
  *  transport protocols are more strict on the characters allowed in headers
  *  and this option can be used to toggle use of pure-alpha header names.

--- a/lib/shim/webframework-shim.js
+++ b/lib/shim/webframework-shim.js
@@ -641,7 +641,7 @@ function _defaultRouteParser(shim, fn, fnName, route) {
  * Default error predicate just returns true.
  *
  * @private
- * @returns {bool} True. Always.
+ * @returns {boolean} True. Always.
  */
 function _defaultErrorPredicate() {
   return true
@@ -651,7 +651,7 @@ function _defaultErrorPredicate() {
  * Default response predicate just returns false.
  *
  * @private
- * @returns {bool} False. Always.
+ * @returns {boolean} False. Always.
  */
 function _defaultResponsePredicate() {
   return false
@@ -1074,7 +1074,7 @@ function _noticeError(shim, txInfo, err) {
  *  The shim used for this web framework.
  * @param {?*} err
  *  The object to check for error-ness.
- * @returns {bool} True if the given object is an error according to the shim.
+ * @returns {boolean} True if the given object is an error according to the shim.
  */
 function _isError(shim, err) {
   return err && shim._errorPredicate(err)

--- a/lib/spans/streaming-span-event-aggregator.js
+++ b/lib/spans/streaming-span-event-aggregator.js
@@ -77,7 +77,7 @@ class StreamingSpanEventAggregator extends Aggregator {
    * @param {TraceSegment}  segment         - The segment to add.
    * @param {string}        [parentId=null] - The GUID of the parent span.
    * @param isRoot
-   * @returns {bool} True if the segment was added, or false if it was discarded.
+   * @returns {boolean} True if the segment was added, or false if it was discarded.
    */
   addSegment(segment, parentId, isRoot) {
     if (!this.started) {

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -106,21 +106,21 @@ Timer.prototype.softEnd = function softEnd() {
 }
 
 /**
- * @returns {bool} Is this timer currently running?
+ * @returns {boolean} Is this timer currently running?
  */
 Timer.prototype.isRunning = function isRunning() {
   return this.state === RUNNING
 }
 
 /**
- * @returns {bool} Is this timer still alive?
+ * @returns {boolean} Is this timer still alive?
  */
 Timer.prototype.isActive = function isActive() {
   return this.state < STOPPED
 }
 
 /**
- * @returns {bool} Has the timer been touched or ended?
+ * @returns {boolean} Has the timer been touched or ended?
  */
 Timer.prototype.hasEnd = function hasEnd() {
   return !!this.hrDuration

--- a/lib/util/flatten.js
+++ b/lib/util/flatten.js
@@ -46,7 +46,7 @@ function flatten(result, prefix, obj, seen) {
  * @param {object}  obj       - The object to get the flat keys of.
  * @param {string}  prefix    - A prefix for the keys, usually `''`.
  * @param arrayIdxs
- * @param {bool}    arrayIdx  - Flag indicating if array indexes should be iterated.
+ * @param {boolean}    arrayIdx  - Flag indicating if array indexes should be iterated.
  * @returns {Array.<string>} An array of keys names.
  */
 function flatKeys(obj, prefix, arrayIdxs) {

--- a/lib/util/process-version.js
+++ b/lib/util/process-version.js
@@ -17,7 +17,7 @@ exports.prerelease = prerelease
  * Safely checks if the process version satisfies the given semver range.
  *
  * @param {string} check - The semantic version range to check.
- * @returns {bool} True if the process version satisfies the given version, false
+ * @returns {boolean} True if the process version satisfies the given version, false
  *  otherwise.
  */
 function satisfies(check) {
@@ -32,7 +32,7 @@ function satisfies(check) {
 /**
  * Safely checks if the process version is a pre-release version.
  *
- * @returns {bool} True if the process version is pre-release, false otherwise.
+ * @returns {boolean} True if the process version is pre-release, false otherwise.
  */
 function prerelease() {
   try {

--- a/lib/util/properties.js
+++ b/lib/util/properties.js
@@ -18,7 +18,7 @@ const hasOwnProperty = Object.hasOwnProperty
  * @private
  * @param {*}       obj - The item to check for the property on.
  * @param {string}  key - The name of the property to look for.
- * @returns {bool} True if the given object has its own property with the given
+ * @returns {boolean} True if the given object has its own property with the given
  *  key.
  */
 exports.hasOwn = function hasOwn(obj, key) {
@@ -29,7 +29,7 @@ exports.hasOwn = function hasOwn(obj, key) {
  * Checks if a given object is empty.
  *
  * @param {*} obj - The object to check for properties on.
- * @returns {bool} True if the object has no keys of its own.
+ * @returns {boolean} True if the object has no keys of its own.
  */
 exports.isEmpty = function isEmpty(obj) {
   // Use this case for null prototyped objects.

--- a/lib/util/urltils.js
+++ b/lib/util/urltils.js
@@ -34,7 +34,7 @@ module.exports = {
    * Checks if the given name is in the dictionary of localhost names.
    *
    * @param {string} host - The hostname to lookup.
-   * @returns {bool} - True if the given hostname is a synonym for localhost.
+   * @returns {boolean} - True if the given hostname is a synonym for localhost.
    */
   isLocalhost: function isLocahost(host) {
     return LOCALHOST_NAMES[host] != null
@@ -47,7 +47,7 @@ module.exports = {
    *
    * @param {Config} config The configuration containing the error list.
    * @param {string} code   The HTTP status code to check.
-   * @returns {bool} Whether the status code should be ignored.
+   * @returns {boolean} Whether the status code should be ignored.
    */
   isError: function isError(config, code) {
     return code >= 400 && !isIgnoredStatusCodeForErrors(config, code)
@@ -58,7 +58,7 @@ module.exports = {
    *
    * @param {Config} config The configuration containing the error list.
    * @param {string} code   The HTTP status code to check.
-   * @returns {bool} Whether the status code should be ignored.
+   * @returns {boolean} Whether the status code should be ignored.
    */
   isIgnoredError: function isIgnoredError(config, code) {
     return code >= 400 && isIgnoredStatusCodeForErrors(config, code)
@@ -69,7 +69,7 @@ module.exports = {
    *
    * @param {Config} config The configuration containing the error list.
    * @param {string} code   The HTTP status code to check.
-   * @returns {bool} Whether the status code is expected.
+   * @returns {boolean} Whether the status code is expected.
    */
   isExpectedError: function isExpectedError(config, code) {
     return isExpectedStatusCodeForErrors(config, code)


### PR DESCRIPTION
JSDoc doesn't recognize "bool" as a valid type. It should be written as "boolean". This PR adjusts all instances such that `npm run lint` does not report any "unknown type bool" errors.