### PR TITLE
security: Set log file permissions to read/write for Node process only

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -47,7 +47,7 @@ if (config) {
         break
 
       default:
-        stream = fs.createWriteStream(config.logging.filepath, { flags: 'a+' })
+        stream = fs.createWriteStream(config.logging.filepath, { flags: 'a+', mode: 0o600 })
         stream.on('error', function logStreamOnError(err) {
           /* eslint-disable no-console */
           // Since our normal logging didn't work, dump this to stderr.

--- a/test/unit/lib/logger.test.js
+++ b/test/unit/lib/logger.test.js
@@ -80,7 +80,7 @@ tap.test('Bootstrapped Logger', (t) => {
     )
 
     t.ok(
-      fakeFS.createWriteStream.calledOnceWithExactly('/foo/bar/baz', { flags: 'a+' }),
+      fakeFS.createWriteStream.calledOnceWithExactly('/foo/bar/baz', { flags: 'a+', mode: 0o600 }),
       'should create a new write stream to specific file'
     )
 


### PR DESCRIPTION
## Description
Set log file permissions to read/write for Node process only to prevent unauthorized access to the log.

## How to Test
`sudo -u nobody cat newrelic_agent.log` to simulate an unauthorized user should return `cat: newrelic_agent.log: Permission denied`.

`npm run unit` verifies that the agent can write the log as expected. 

## Related Issues

Closes NR-175304