### PR TITLE
ci: Make release note date always in pacific time

### DIFF
--- a/bin/prepare-release.js
+++ b/bin/prepare-release.js
@@ -375,8 +375,7 @@ function updateReleaseNotesFile(file, version, newNotes) {
         reject(new Error(errMessage))
       }
 
-      // toISOString() will always return UTC time
-      const todayFormatted = new Date().toISOString().split('T')[0]
+      const todayFormatted = getReleaseDate()
       const newVersionHeader = `### ${version} (${todayFormatted})`
 
       const newContent = [newVersionHeader, newNotes, '\n\n', data].join('')
@@ -392,6 +391,22 @@ function updateReleaseNotesFile(file, version, newNotes) {
       })
     })
   })
+}
+
+/**
+ * Returns an RFC3339 date-string for the current day in the Pacific
+ * (Los Angeles) time zone.
+ *
+ * @returns {string} The date string.
+ */
+function getReleaseDate() {
+  const tz = process.env.TZ
+  process.env.TZ = 'America/Los_Angeles'
+  const today = new Date(Date.now()).toLocaleDateString()
+  process.env.TZ = tz
+
+  const parts = today.split('/')
+  return `${parts[2]}-${parts[0].padStart(2, '0')}-${parts[1].padStart(2, '0')}`
 }
 
 function getFormattedPrBody(data) {
@@ -416,6 +431,7 @@ if (require.main === module) {
 } else {
   module.exports = {
     generateConventionalReleaseNotes,
+    getReleaseDate,
     isValid
   }
 }

--- a/bin/test/prepare-release.test.js
+++ b/bin/test/prepare-release.test.js
@@ -8,6 +8,7 @@
 const tap = require('tap')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
+const { getReleaseDate } = require('../prepare-release')
 
 tap.test('Prepare Release script', (testHarness) => {
   testHarness.autoend()
@@ -150,5 +151,24 @@ tap.test('Prepare Release script', (testHarness) => {
       t.equal(result, false)
       t.end()
     })
+  })
+})
+
+tap.test('getReleaseDate', async (t) => {
+  t.beforeEach(async (t) => {
+    t.context.now = Date.now
+    Date.now = function now() {
+      return new Date('2023-11-08T22:45:00.000-05:00').getTime()
+    }
+  })
+
+  t.afterEach(async (t) => {
+    Date.now = t.context.now
+  })
+
+  t.test('returns the correct string', async (t) => {
+    const expected = '2023-11-08'
+    const found = getReleaseDate()
+    t.equal(found, expected)
   })
 })


### PR DESCRIPTION
This PR resolves issue #632 by always returning a date-string local to the `America/Los_Angeles` time zone.