### PR TITLE
feat: Added setLlmMetadata API to allow users to specify metadata for LLM events

### DIFF
--- a/api.js
+++ b/api.js
@@ -1788,4 +1788,28 @@ API.prototype.setErrorGroupCallback = function setErrorGroupCallback(callback) {
   this.agent.errors.errorGroupCallback = callback
 }
 
+/**
+ * Function for assigning metadata to all LLM events. This should only
+ * be called once in your application and before executing any openai, bedrock,
+ * langchain, generative AI methods.
+ *
+ * If passing in metadata via `api.recordLlmFeedbackEvent`, it will take precedence
+ * over what is assigned wit this method.
+ *
+ * @param {object} metadata key/value metadata to be assigned to all LLM Events on creation
+ * @example
+ * newrelic.setLlmMetadata({ type: 'openai', framework: 'express', region: 'us' })
+ */
+API.prototype.setLlmMetadata = function setLlmMetadata(metadata) {
+  const metric = this.agent.metrics.getOrCreateMetric(NAMES.SUPPORTABILITY.API + '/setLlmMetadata')
+  metric.incrementCallCount()
+
+  if (!(metadata?.constructor === Object)) {
+    logger.warn('metadata must be an object, not assigning LLM metadata.')
+    return
+  }
+
+  this.agent.llm.metadata = metadata
+}
+
 module.exports = API

--- a/api.js
+++ b/api.js
@@ -30,6 +30,7 @@ const NAMES = require('./lib/metrics/names')
 const obfuscate = require('./lib/util/sql/obfuscate')
 const { DESTINATIONS } = require('./lib/config/attribute-filter')
 const parse = require('module-details-from-path')
+const { isSimpleObject } = require('./lib/util/objects')
 
 /*
  *
@@ -1804,7 +1805,7 @@ API.prototype.setLlmMetadata = function setLlmMetadata(metadata) {
   const metric = this.agent.metrics.getOrCreateMetric(NAMES.SUPPORTABILITY.API + '/setLlmMetadata')
   metric.incrementCallCount()
 
-  if (!(metadata?.constructor === Object)) {
+  if (!isSimpleObject(metadata)) {
     logger.warn('metadata must be an object, not assigning LLM metadata.')
     return
   }

--- a/api.js
+++ b/api.js
@@ -1794,7 +1794,7 @@ API.prototype.setErrorGroupCallback = function setErrorGroupCallback(callback) {
  * langchain, generative AI methods.
  *
  * If passing in metadata via `api.recordLlmFeedbackEvent`, it will take precedence
- * over what is assigned wit this method.
+ * over what is assigned via this method.
  *
  * @param {object} metadata key/value metadata to be assigned to all LLM Events on creation
  * @example

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -197,6 +197,8 @@ function Agent(config) {
   // Used by shutdown code as well as entity tracking stats
   this.activeTransactions = 0
 
+  this.llm = {}
+
   // Finally, add listeners for the agent's own events.
   this.on('transactionFinished', this._transactionFinished.bind(this))
 }

--- a/test/unit/agent/agent.test.js
+++ b/test/unit/agent/agent.test.js
@@ -1239,6 +1239,11 @@ tap.test('logging supportability on connect', (t) => {
       t.end()
     })
   })
+
+  t.test('should default llm to an object', (t) => {
+    t.same(agent.llm, {})
+    t.end()
+  })
 })
 
 tap.test('getNRLinkingMetadata', (t) => {

--- a/test/unit/api/api-llm.test.js
+++ b/test/unit/api/api-llm.test.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+const helper = require('../../lib/agent_helper')
+const NAMES = require('../../../lib/metrics/names')
+
+tap.test('Agent API LLM methods', (t) => {
+  t.autoend()
+  let loggerMock
+  let API
+
+  t.before(() => {
+    loggerMock = require('../mocks/logger')()
+    API = proxyquire('../../../api', {
+      './lib/logger': {
+        child: sinon.stub().callsFake(() => loggerMock)
+      }
+    })
+  })
+
+  t.beforeEach((t) => {
+    loggerMock.warn.reset()
+    const agent = helper.loadMockedAgent()
+    t.context.api = new API(agent)
+  })
+
+  t.afterEach((t) => {
+    helper.unloadAgent(t.context.api.agent)
+  })
+
+  t.test('should assign llm metadata when it is an object', (t) => {
+    const { api } = t.context
+    const meta = { user: 'bob', env: 'prod', random: 'data' }
+    api.setLlmMetadata(meta)
+
+    t.equal(loggerMock.warn.callCount, 0, 'should not log warnings when successful')
+    t.equal(
+      api.agent.metrics.getOrCreateMetric(NAMES.SUPPORTABILITY.API + '/setLlmMetadata').callCount,
+      1,
+      'should increment the API tracking metric'
+    )
+    t.same(api.agent.llm.metadata, meta)
+    t.end()
+  })
+  ;['string', 10, true, null, undefined, [1, 2, 3, 4], [{ collection: true }]].forEach((meta) => {
+    t.test(`should not assign llm metadata when ${meta} is not an object`, (t) => {
+      const { api } = t.context
+      api.setLlmMetadata(meta)
+      t.equal(loggerMock.warn.callCount, 1, 'should log warning when metadata is not an object')
+      t.same(api.agent.llm, {})
+      t.end()
+    })
+  })
+})

--- a/test/unit/api/stub.test.js
+++ b/test/unit/api/stub.test.js
@@ -8,7 +8,7 @@
 const tap = require('tap')
 const API = require('../../../stub_api')
 
-const EXPECTED_API_COUNT = 33
+const EXPECTED_API_COUNT = 34
 
 tap.test('Agent API - Stubbed Agent API', (t) => {
   t.autoend()

--- a/test/unit/llm-events/openai/embedding.test.js
+++ b/test/unit/llm-events/openai/embedding.test.js
@@ -42,8 +42,9 @@ tap.test('LlmEmbedding', (t) => {
   })
 
   t.test('should assign metadata if available on agent.llm.metadata', (t) => {
+    const api = helper.getAgentApi()
     const metadata = { key: 'value', meta: 'data', test: true, data: [1, 2, 3] }
-    agent.llm = { metadata }
+    api.setLlmMetadata(metadata)
     const embeddingEvent = new LlmEmbedding({ agent, segment: null, request: {}, response: {} })
     t.same(embeddingEvent.metadata, metadata)
     t.end()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This API endpoint checks if the metadata is a plain object and if so assigns to agent.llm.metadata.

## Related Issues

Closes #1850
