### PR TITLE
fix: updated isSimpleObject util to only check plain objects not arrays

### DIFF
--- a/lib/instrumentation/@elastic/elasticsearch.js
+++ b/lib/instrumentation/@elastic/elasticsearch.js
@@ -67,7 +67,7 @@ function queryParser(params) {
   // let body or bulkBody override querystring, as some requests have both
   if (isNotEmpty(params.body)) {
     queryParam = params.body
-  } else if (isNotEmpty(params.bulkBody)) {
+  } else if (Array.isArray(params.bulkBody) && params.bulkBody.length) {
     queryParam = params.bulkBody
   }
 

--- a/lib/util/objects.js
+++ b/lib/util/objects.js
@@ -13,7 +13,7 @@ exports = module.exports = { isSimpleObject, isNotEmpty }
  * @returns {boolean} whether or not the value is an object and not null
  */
 function isSimpleObject(thing) {
-  return 'object' === typeof thing && thing !== null
+  return Object.prototype.toString.call(thing) === '[object Object]' && thing !== null
 }
 
 /**

--- a/test/unit/util/objects.test.js
+++ b/test/unit/util/objects.test.js
@@ -10,10 +10,11 @@ const { isSimpleObject, isNotEmpty } = require('../../../lib/util/objects')
 const fixtures = [
   { name: 'populated object', value: { a: 1, b: 2, c: 3 }, simple: true, nonEmpty: true },
   { name: 'empty object', value: {}, simple: true, nonEmpty: false },
+  { name: 'object', value: { key: 'value' }, simple: true, nonEmpty: true },
   { name: 'null', value: null, simple: false, nonEmpty: false },
   { name: 'undefined', value: undefined, simple: false, nonEmpty: false },
-  { name: 'array', value: [1, 2, 3, 4], simple: true, nonEmpty: true },
-  { name: 'empty array', value: [], simple: true, nonEmpty: false },
+  { name: 'array', value: [1, 2, 3, 4], simple: false, nonEmpty: false },
+  { name: 'empty array', value: [], simple: false, nonEmpty: false },
   { name: 'string', value: 'a string', simple: false, nonEmpty: false },
   { name: 'empty string', value: '', simple: false, nonEmpty: false },
   { name: 'number', value: 42, simple: false, nonEmpty: false },


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

The `isSimpleObject` utility was returning the incorrect boolean value when passing in an array.  The intention of this utility was to only assert if it was a plain object `{ key: 'value'}`.

## Related Issues

Closes #1864
