### PR TITLE
refactor: Updated LLM events to no longer serialize and just return object

### DIFF
--- a/lib/llm-events/openai/chat-completion-message.js
+++ b/lib/llm-events/openai/chat-completion-message.js
@@ -11,7 +11,7 @@ module.exports = class LlmChatCompletionMessage extends LlmEvent {
   constructor({ agent, segment, request = {}, response = {}, index = 0 }) {
     super({ agent, segment, request, response })
     this.id = `${response.id}-${index}`
-    this.conversation_id = this.conversationId()
+    this.conversation_id = this.conversationId(agent)
     this.content = request?.messages?.[index]?.content
     this.role = request?.messages?.[index]?.role
     this.sequence = index

--- a/lib/llm-events/openai/chat-completion-summary.js
+++ b/lib/llm-events/openai/chat-completion-summary.js
@@ -9,7 +9,7 @@ const LlmEvent = require('./event')
 module.exports = class LlmChatCompletionSummary extends LlmEvent {
   constructor({ agent, segment, request = {}, response = {} }) {
     super({ agent, segment, request, response, responseAttrs: true })
-    this.conversation_id = this.conversationId()
+    this.conversation_id = this.conversationId(agent)
     this['request.max_tokens'] = request.max_tokens
     this['request.temperature'] = request.temperature
     this['response.number_of_messages'] = request?.messages?.length + response?.choices?.length

--- a/lib/llm-events/openai/error-message.js
+++ b/lib/llm-events/openai/error-message.js
@@ -18,8 +18,4 @@ module.exports = class LlmErrorMessage {
     this['error.code'] = response.code
     this['error.param'] = response.param
   }
-
-  serialize() {
-    return JSON.parse(JSON.stringify(this, (_, v) => v || ''))
-  }
 }

--- a/lib/llm-events/openai/event.js
+++ b/lib/llm-events/openai/event.js
@@ -9,7 +9,6 @@ const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
 
 module.exports = class LlmEvent {
   constructor({ agent, segment, request, response, responseAttrs = false }) {
-    this.agent = agent
     this.id = makeId(36)
     this.appName = agent.config.applications()[0]
     this.request_id = response?.headers?.['x-request-id']
@@ -50,14 +49,9 @@ module.exports = class LlmEvent {
       response?.headers?.['x-ratelimit-remaining-requests']
   }
 
-  conversationId() {
-    const transaction = this.agent.tracer.getTransaction()
+  conversationId(agent) {
+    const transaction = agent.tracer.getTransaction()
     const attrs = transaction?.trace?.custom.get(DESTINATIONS.TRANS_SCOPE)
     return attrs?.conversation_id
-  }
-
-  serialize() {
-    delete this.agent
-    return JSON.parse(JSON.stringify(this, (_, v) => v || ''))
   }
 }

--- a/lib/llm-events/openai/feedback-message.js
+++ b/lib/llm-events/openai/feedback-message.js
@@ -17,8 +17,4 @@ module.exports = class LlmFeedbackMessage {
     this.message = opts.message
     this.ingest_source = 'Node'
   }
-
-  serialize() {
-    return JSON.parse(JSON.stringify(this, (_, v) => v || ''))
-  }
 }

--- a/test/unit/llm-events/openai/chat-completion-message.test.js
+++ b/test/unit/llm-events/openai/chat-completion-message.test.js
@@ -22,7 +22,7 @@ tap.test('LlmChatCompletionMessage', (t) => {
     helper.unloadAgent(agent)
   })
 
-  t.test('should properly serialize a LlmChatCompletionMessage event', (t) => {
+  t.test('should create a LlmChatCompletionMessage event', (t) => {
     const api = helper.getAgentApi()
     helper.runInTransaction(agent, (tx) => {
       api.startSegment('fakeSegment', false, () => {
@@ -34,14 +34,13 @@ tap.test('LlmChatCompletionMessage', (t) => {
           response: chatRes,
           index: 0
         })
-        const serialized = chatMessageEvent.serialize()
         const expected = getExpectedResult(
           tx,
           { id: 'res-id-0' },
           'message',
           chatMessageEvent.completion_id
         )
-        t.same(serialized, expected)
+        t.same(chatMessageEvent, expected)
         t.end()
       })
     })

--- a/test/unit/llm-events/openai/chat-completion-summary.test.js
+++ b/test/unit/llm-events/openai/chat-completion-summary.test.js
@@ -22,7 +22,7 @@ tap.test('LlmChatCompletionSummary', (t) => {
     helper.unloadAgent(agent)
   })
 
-  t.test('should properly serialize a LlmChatCompletionSummary event', (t) => {
+  t.test('should properly create a LlmChatCompletionSummary event', (t) => {
     const api = helper.getAgentApi()
     helper.runInTransaction(agent, (tx) => {
       api.startSegment('fakeSegment', false, () => {
@@ -33,9 +33,8 @@ tap.test('LlmChatCompletionSummary', (t) => {
           request: req,
           response: chatRes
         })
-        const serialized = chatSummaryEvent.serialize()
         const expected = getExpectedResult(tx, chatSummaryEvent, 'summary')
-        t.same(serialized, expected)
+        t.same(chatSummaryEvent, expected)
         t.end()
       })
     })

--- a/test/unit/llm-events/openai/common.js
+++ b/test/unit/llm-events/openai/common.js
@@ -46,24 +46,62 @@ const req = {
 
 function getExpectedResult(tx, event, type, completionId) {
   const trace = tx.trace.root
-  let serialized = `{"id":"${event.id}","appName":"New Relic for Node.js tests","request_id":"req-id","trace_id":"${tx.traceId}","span_id":"${trace.children[0].id}","transaction_id":"${tx.id}","metadata":"","response.model":"gpt-3.5-turbo-0613","vendor":"openAI","ingest_source":"Node",`
-  const resKeys = `"duration":${trace.children[0].getExclusiveDurationInMillis()},"request.model":"gpt-3.5-turbo-0613","api_key_last_four_digits":"sk-7890","response.organization":"new-relic","response.usage.total_tokens":"100","response.usage.prompt_tokens":"10","response.headers.llmVersion":"1.0.0","response.headers.ratelimitLimitRequests":"100","response.headers.ratelimitLimitTokens":"100","response.headers.ratelimitResetTokens":"100","response.headers.ratelimitRemainingTokens":"10","response.headers.ratelimitRemainingRequests":"10",`
+  let expected = {
+    'id': event.id,
+    'appName': 'New Relic for Node.js tests',
+    'request_id': 'req-id',
+    'trace_id': tx.traceId,
+    'span_id': trace.children[0].id,
+    'transaction_id': tx.id,
+    'metadata': undefined,
+    'response.model': 'gpt-3.5-turbo-0613',
+    'vendor': 'openAI',
+    'ingest_source': 'Node'
+  }
+  const resKeys = {
+    'duration': trace.children[0].getExclusiveDurationInMillis(),
+    'request.model': 'gpt-3.5-turbo-0613',
+    'api_key_last_four_digits': 'sk-7890',
+    'response.organization': 'new-relic',
+    'response.usage.total_tokens': '100',
+    'response.usage.prompt_tokens': '10',
+    'response.headers.llmVersion': '1.0.0',
+    'response.headers.ratelimitLimitRequests': '100',
+    'response.headers.ratelimitLimitTokens': '100',
+    'response.headers.ratelimitResetTokens': '100',
+    'response.headers.ratelimitRemainingTokens': '10',
+    'response.headers.ratelimitRemainingRequests': '10'
+  }
 
   switch (type) {
     case 'embedding':
-      serialized += resKeys
-      serialized += `"input":"This is my test input"}`
+      expected = { ...expected, ...resKeys }
+      expected.input = 'This is my test input'
       break
     case 'summary':
-      serialized += resKeys
-      serialized +=
-        '"conversation_id":"","request.max_tokens":"1000000","request.temperature":"medium-rare","response.number_of_messages":3,"response.usage.completion_tokens":10,"response.choices.finish_reason":"stop"}'
+      expected = {
+        ...expected,
+        ...resKeys,
+        conversation_id: undefined,
+        ['request.max_tokens']: '1000000',
+        ['request.temperature']: 'medium-rare',
+        ['response.number_of_messages']: 3,
+        ['response.usage.completion_tokens']: 10,
+        ['response.choices.finish_reason']: 'stop'
+      }
       break
     case 'message':
-      serialized += `"conversation_id":"","content":"What is a woodchuck?","role":"inquisitive-kid","sequence":"","completion_id":"${completionId}"}`
+      expected = {
+        ...expected,
+        conversation_id: undefined,
+        content: 'What is a woodchuck?',
+        role: 'inquisitive-kid',
+        sequence: 0,
+        completion_id: completionId
+      }
   }
 
-  return JSON.parse(serialized)
+  return expected
 }
 
 module.exports = {

--- a/test/unit/llm-events/openai/embedding.test.js
+++ b/test/unit/llm-events/openai/embedding.test.js
@@ -22,7 +22,7 @@ tap.test('LlmEmbedding', (t) => {
     helper.unloadAgent(agent)
   })
 
-  t.test('should properly serialize a LlmEmbedding event', (t) => {
+  t.test('should properly create a LlmEmbedding event', (t) => {
     const req = {
       input: 'This is my test input',
       model: 'gpt-3.5-turbo-0613'
@@ -33,9 +33,8 @@ tap.test('LlmEmbedding', (t) => {
       api.startSegment('fakeSegment', false, () => {
         const segment = api.shim.getActiveSegment()
         const embeddingEvent = new LlmEmbedding({ agent, segment, request: req, response: res })
-        const serialized = embeddingEvent.serialize()
         const expected = getExpectedResult(tx, embeddingEvent, 'embedding')
-        t.same(serialized, expected)
+        t.same(embeddingEvent, expected)
         t.end()
       })
     })

--- a/test/unit/llm-events/openai/error.test.js
+++ b/test/unit/llm-events/openai/error.test.js
@@ -12,9 +12,19 @@ const { req, chatRes } = require('./common')
 tap.test('LlmErrorMessage', (t) => {
   const res = { ...chatRes, code: 'insufficient_quota', param: 'test-param', status: 429 }
   const errorMsg = new LlmErrorMessage(req, res)
-  const serialized = errorMsg.serialize()
-  const expected =
-    '{"api_key_last_four_digits":"sk-7890","request.model":"gpt-3.5-turbo-0613","request.temperature":"medium-rare","request.max_tokens":"1000000","vendor":"openAI","ingest_source":"Node","response.number_of_messages":2,"http.statusCode":429,"response.organization":"new-relic","error.code":"insufficient_quota","error.param":"test-param"}'
-  t.same(serialized, JSON.parse(expected))
+  const expected = {
+    'api_key_last_four_digits': 'sk-7890',
+    'request.model': 'gpt-3.5-turbo-0613',
+    'request.temperature': 'medium-rare',
+    'request.max_tokens': '1000000',
+    'vendor': 'openAI',
+    'ingest_source': 'Node',
+    'response.number_of_messages': 2,
+    'http.statusCode': 429,
+    'response.organization': 'new-relic',
+    'error.code': 'insufficient_quota',
+    'error.param': 'test-param'
+  }
+  t.same(errorMsg, expected)
   t.end()
 })

--- a/test/unit/llm-events/openai/feedback-message.test.js
+++ b/test/unit/llm-events/openai/feedback-message.test.js
@@ -18,8 +18,16 @@ tap.test('LlmFeedbackMessage', (t) => {
     message: 'This answer was amazing'
   }
   const feedbackMsg = new LlmFeedbackMessage(opts)
-  const serialized = feedbackMsg.serialize()
-  const expected = `{"id":"${feedbackMsg.id}","conversation_id":"convo-id","request_id":"request-id","message_id":"msg-id","category":"informative","rating":"informative","message":"This answer was amazing","ingest_source":"Node"}`
-  t.same(serialized, JSON.parse(expected))
+  const expected = {
+    id: feedbackMsg.id,
+    conversation_id: 'convo-id',
+    request_id: 'request-id',
+    message_id: 'msg-id',
+    category: 'informative',
+    rating: 'informative',
+    message: 'This answer was amazing',
+    ingest_source: 'Node'
+  }
+  t.same(feedbackMsg, expected)
   t.end()
 })


### PR DESCRIPTION
The initial attempt at creating LLM events was overengineered and created a perf hit around serialization with `JSON.parse(JSON.stringify(event))`. This PR updates that to just return the instance of the event and refactors it so we no longer have to store the agent as an instance property.
