### PR TITLE
feat: Added instrumentation for openai embedding creation

### DIFF
--- a/lib/instrumentation/openai.js
+++ b/lib/instrumentation/openai.js
@@ -7,11 +7,13 @@
 const { openAiHeaders, openAiApiKey } = require('../../lib/symbols')
 const {
   LlmChatCompletionMessage,
-  LlmChatCompletionSummary
+  LlmChatCompletionSummary,
+  LlmEmbedding
 } = require('../../lib/llm-events/openai')
 const LlmTrackedIds = require('../../lib/llm-events/tracked-ids')
 
 const MIN_VERSION = '4.0.0'
+const { AI } = require('../../lib/metrics/names')
 const semver = require('semver')
 
 /**
@@ -104,7 +106,7 @@ module.exports = function initialize(agent, openai, moduleName, shim) {
     function wrapCreate(shim, create, name, args) {
       const [request] = args
       return {
-        name: 'AI/OpenAI/Chat/Completions/Create',
+        name: `${AI.OPEN_AI}/Chat/Completions/Create`,
         promise: true,
         opaque: true,
         // eslint-disable-next-line max-params
@@ -149,6 +151,38 @@ module.exports = function initialize(agent, openai, moduleName, shim) {
 
           recordEvent('LlmChatCompletionSummary', completionSummary)
 
+          // cleanup keys on response before returning to user code
+          delete response.api_key
+          delete response.headers
+        }
+      }
+    }
+  )
+
+  /**
+   * Instruments embedding creation
+   * and creates LlmEmbedding event
+   */
+  shim.record(
+    openai.Embeddings.prototype,
+    'create',
+    function wrapEmbeddingCreate(shim, embeddingCreate, name, args) {
+      const [request] = args
+      return {
+        name: `${AI.OPEN_AI}/Embeddings/Create`,
+        promise: true,
+        // eslint-disable-next-line max-params
+        after(_shim, _fn, _name, err, response, segment) {
+          response.headers = segment[openAiHeaders]
+          response.api_key = segment[openAiApiKey]
+          const embedding = new LlmEmbedding({
+            agent,
+            segment,
+            request,
+            response
+          })
+
+          recordEvent('LlmEmbedding', embedding)
           // cleanup keys on response before returning to user code
           delete response.api_key
           delete response.headers

--- a/lib/metrics/names.js
+++ b/lib/metrics/names.js
@@ -164,6 +164,10 @@ const EXPRESS = {
   ERROR_HANDLER: MIDDLEWARE.PREFIX + `${EXPRESS_LITERAL}/`
 }
 
+const AI = {
+  OPEN_AI: 'AI/OpenAI'
+}
+
 const RESTIFY = {
   PREFIX: 'Restify/'
 }
@@ -314,6 +318,7 @@ const LOGGING = {
 
 module.exports = {
   ACTION_DELIMITER: '/',
+  AI,
   ALL: ALL,
   APDEX: 'Apdex',
   CASSANDRA: CASSANDRA,

--- a/test/unit/instrumentation/openai.test.js
+++ b/test/unit/instrumentation/openai.test.js
@@ -39,6 +39,8 @@ test('openai unit tests', (t) => {
     function OpenAI() {}
     OpenAI.prototype.makeRequest = function () {}
     OpenAI.Chat = { Completions }
+    OpenAI.Embeddings = function () {}
+    OpenAI.Embeddings.prototype.create = function () {}
     return OpenAI
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Adds instrumentation to create span for embedding creation and the LlmEmbedding event.  I omitted opaque: true. I will update the chat complietion in a different PR.  There is an ask to still capture the external http call to openai and this will do so. You can now see in the versioned tests that I'm asserting the child http external for embedding create.

## Related Issues

Closes #1842
