### PR TITLE
refactor: updated how completion_id is assigned to LlmCompletionMessage

### DIFF
--- a/lib/instrumentation/openai.js
+++ b/lib/instrumentation/openai.js
@@ -68,6 +68,7 @@ module.exports = function initialize(agent, openai, moduleName, shim) {
    * @param {object} msg LLM event
    */
   function recordEvent(type, msg) {
+    msg = agent?.llm?.metadata ? { ...agent.llm.metadata, ...msg } : msg
     agent.customEventAggregator.add([{ type, timestamp: Date.now() }, msg])
   }
 
@@ -95,6 +96,69 @@ module.exports = function initialize(agent, openai, moduleName, shim) {
   })
 
   /**
+   * Assigns requestId, conversationId and messageIds for a given
+   * chat completion response on the active transaction.
+   * This is used for generating LlmFeedbackEvent via `api.recordLlmFeedbackEvent`
+   *
+   * @param {object} params input params
+   * @param {Transaction} params.tx active transaction
+   * @param {LlmChatCompletionMessage} params.completionMsg chat completion message
+   * @param {string} params.responseId id of response
+   */
+  function assignIdsToTx({ tx, completionMsg, responseId }) {
+    const tracker = tx.llm.responses
+    const trackedIds =
+      tracker.get(responseId) ??
+      new LlmTrackedIds({
+        requestId: completionMsg.request_id,
+        conversationId: completionMsg.conversation_id
+      })
+    trackedIds.message_ids.push(completionMsg.id)
+    tracker.set(responseId, trackedIds)
+  }
+
+  /**
+   * Generates LlmChatCompletionSummary for a chat completion creation.
+   * Also iterates over both input messages and the first response message
+   * and creates LlmChatCompletionMessage.
+   *
+   * Also assigns relevant ids by response id for LlmFeedbackEvent creation
+   *
+   * @param {object} params input params
+   * @param {TraceSegment} params.segment active segment from chat completion
+   * @param {object} params.request chat completion params
+   * @param {object} params.response chat completion response
+   */
+  function recordChatCompletionMessages({ segment, request, response }) {
+    const tx = segment.transaction
+    const completionSummary = new LlmChatCompletionSummary({
+      agent,
+      segment,
+      request,
+      response
+    })
+
+    // Only take the first response message and append to input messages
+    const messages = [...request.messages, response?.choices?.[0]?.message]
+    messages.forEach((message, index) => {
+      const completionMsg = new LlmChatCompletionMessage({
+        agent,
+        segment,
+        request,
+        response,
+        index,
+        completionId: completionSummary.id,
+        message
+      })
+
+      assignIdsToTx({ tx, completionMsg, responseId: response.id })
+      recordEvent('LlmChatCompletionMessage', completionMsg)
+    })
+
+    recordEvent('LlmChatCompletionSummary', completionSummary)
+  }
+
+  /**
    * Instruments chat completion creation
    * and creates the LLM events
    *
@@ -108,7 +172,6 @@ module.exports = function initialize(agent, openai, moduleName, shim) {
       return {
         name: `${AI.OPEN_AI}/Chat/Completions/Create`,
         promise: true,
-        opaque: true,
         // eslint-disable-next-line max-params
         after(_shim, _fn, _name, err, response, segment) {
           response.headers = segment[openAiHeaders]
@@ -119,38 +182,11 @@ module.exports = function initialize(agent, openai, moduleName, shim) {
           // See: https://github.com/newrelic/node-newrelic/issues/1845
           // if (err) {}
 
-          const completionSummary = new LlmChatCompletionSummary({
-            agent,
+          recordChatCompletionMessages({
             segment,
             request,
             response
           })
-
-          request.messages.forEach((_msg, index) => {
-            const completionMsg = new LlmChatCompletionMessage({
-              agent,
-              segment,
-              request,
-              response,
-              index
-            })
-
-            // Track information for the feedback message API.
-            const tracker = segment.transaction.llm.responses
-            const trackedIds =
-              tracker.get(response.id) ??
-              new LlmTrackedIds({
-                requestId: completionMsg.request_id,
-                conversationId: completionMsg.conversation_id
-              })
-            trackedIds.message_ids.push(completionMsg.id)
-            tracker.set(response.id, trackedIds)
-
-            recordEvent('LlmChatCompletionMessage', completionMsg)
-          })
-
-          recordEvent('LlmChatCompletionSummary', completionSummary)
-
           // cleanup keys on response before returning to user code
           delete response.api_key
           delete response.headers

--- a/lib/llm-events/openai/chat-completion-message.js
+++ b/lib/llm-events/openai/chat-completion-message.js
@@ -5,16 +5,16 @@
 
 'use strict'
 const LlmEvent = require('./event')
-const { makeId } = require('../../util/hashes')
 
 module.exports = class LlmChatCompletionMessage extends LlmEvent {
-  constructor({ agent, segment, request = {}, response = {}, index = 0 }) {
+  constructor({ agent, segment, request = {}, response = {}, index = 0, message, completionId }) {
     super({ agent, segment, request, response })
     this.id = `${response.id}-${index}`
     this.conversation_id = this.conversationId(agent)
-    this.content = request?.messages?.[index]?.content
-    this.role = request?.messages?.[index]?.role
+    this.content = message?.content
+    this.role = message?.role
     this.sequence = index
-    this.completion_id = makeId(36)
+    this.completion_id = completionId
+    this.is_response = response?.choices?.[0]?.message?.content === this.content
   }
 }

--- a/lib/llm-events/openai/event.js
+++ b/lib/llm-events/openai/event.js
@@ -15,7 +15,6 @@ module.exports = class LlmEvent {
     this.trace_id = segment?.transaction?.traceId
     this.span_id = segment?.id
     this.transaction_id = segment?.transaction?.id
-    this.metadata = agent?.llm?.metadata
     this['response.model'] = response.model
     this.vendor = 'openAI'
     this.ingest_source = 'Node'

--- a/test/unit/llm-events/openai/common.js
+++ b/test/unit/llm-events/openai/common.js
@@ -53,7 +53,6 @@ function getExpectedResult(tx, event, type, completionId) {
     'trace_id': tx.traceId,
     'span_id': trace.children[0].id,
     'transaction_id': tx.id,
-    'metadata': undefined,
     'response.model': 'gpt-3.5-turbo-0613',
     'vendor': 'openAI',
     'ingest_source': 'Node'
@@ -97,7 +96,8 @@ function getExpectedResult(tx, event, type, completionId) {
         content: 'What is a woodchuck?',
         role: 'inquisitive-kid',
         sequence: 0,
-        completion_id: completionId
+        completion_id: completionId,
+        is_response: false
       }
   }
 

--- a/test/unit/llm-events/openai/embedding.test.js
+++ b/test/unit/llm-events/openai/embedding.test.js
@@ -39,20 +39,6 @@ tap.test('LlmEmbedding', (t) => {
       })
     })
   })
-
-  t.test('should assign metadata if available on agent.llm.metadata', (t) => {
-    const api = helper.getAgentApi()
-    const metadata = { key: 'value', meta: 'data', test: true, data: [1, 2, 3] }
-    api.setLlmMetadata(metadata)
-    const embeddingEvent = new LlmEmbedding({
-      agent,
-      segment: null,
-      request: {},
-      response: {}
-    })
-    t.same(embeddingEvent.metadata, metadata)
-    t.end()
-  })
   ;[
     { type: 'string', value: 'test input', expected: 'test input' },
     {
@@ -71,7 +57,7 @@ tap.test('LlmEmbedding', (t) => {
       expected: '1,2,3,4,5,6'
     }
   ].forEach(({ type, value, expected }) => {
-    t.test(`should properly seriaize input when it is a ${type}`, (t) => {
+    t.test(`should properly serialize input when it is a ${type}`, (t) => {
       const embeddingEvent = new LlmEmbedding({
         agent,
         segment: null,


### PR DESCRIPTION
## Description

This PR addresses a few items after reviewing approach with AI O11y team.

 * removed `opaque: true` on recording of chat completions(embeddings was done in #1872) because we do in fact want to create spans for the external http call separately.
 * `completion_id` should be the summary id for every message within a chat completion
 * it was discovered that we were lacking creating a LlmChatCompletionMessage for the response choices
    * it will only create a message for the first message(this is how python agent does as well as other vendors)
 * metadata is spread across all LLM events instead of assigned to a key of `metadata`. 
 * operations within chat completions were extracted to better convey what is occurring 
 * added an `is_response` boolean to LlmChatCompletionMessages when it is the `response.choices[0].message.content`

## How to Test


## Related Issues

Closes #1867 