### PR TITLE
fix: Add missing configuration check in OpenAI implementation

### DIFF
--- a/api.js
+++ b/api.js
@@ -1551,9 +1551,15 @@ API.prototype.getLlmMessageIds = function getLlmMessageIds({ responseId } = {}) 
     .getOrCreateMetric(`${NAMES.SUPPORTABILITY.API}/getLlmMessageIds`)
     .incrementCallCount()
 
+  if (this.agent.config?.ai_monitoring?.enabled !== true) {
+    logger.warn('getLlmMessageIds invoked but ai_monitoring is disabled.')
+    return
+  }
+
   const tx = this.agent.tracer.getTransaction()
   if (!tx) {
-    return logger.warn('getLlmMessageIds must be called within the scope of a transaction.')
+    logger.warn('getLlmMessageIds must be called within the scope of a transaction.')
+    return
   }
   return tx.llm.responses.get(responseId)
 }
@@ -1587,11 +1593,17 @@ API.prototype.recordLlmFeedbackEvent = function recordLlmFeedbackEvent({
     .getOrCreateMetric(`${NAMES.SUPPORTABILITY.API}/recordLlmFeedbackEvent`)
     .incrementCallCount()
 
+  if (this.agent.config?.ai_monitoring?.enabled !== true) {
+    logger.warn('recordLlmFeedbackEvent invoked but ai_monitoring is disabled.')
+    return
+  }
+
   const tx = this.agent.tracer.getTransaction()
   if (!tx) {
-    return logger.warn(
+    logger.warn(
       'No message feedback events will be recorded. recordLlmFeedbackEvent must be called within the scope of a transaction.'
     )
+    return
   }
 
   const feedback = new LlmFeedbackMessage({

--- a/lib/instrumentation/openai.js
+++ b/lib/instrumentation/openai.js
@@ -18,7 +18,7 @@ const semver = require('semver')
 
 /**
  * Checks if we should skip instrumentation.
- * Currently it checks if `feature_flag.openai_instrumentation` is true
+ * Currently it checks if `ai_monitoring.enabled` is true
  * and the package version >= 4.0.0
  *
  * @param {object} config agent config
@@ -26,9 +26,8 @@ const semver = require('semver')
  * @returns {boolean} flag if instrumentation should be skipped
  */
 function shouldSkipInstrumentation(config, shim) {
-  // TODO: Remove when we release full support for OpenAI
   if (config?.ai_monitoring?.enabled !== true) {
-    shim.logger.debug('config.feature_flag.openai_instrumentation is disabled.')
+    shim.logger.debug('config.ai_monitoring.enabled is set to false.')
     return true
   }
 

--- a/lib/instrumentation/openai.js
+++ b/lib/instrumentation/openai.js
@@ -27,7 +27,7 @@ const semver = require('semver')
  */
 function shouldSkipInstrumentation(config, shim) {
   // TODO: Remove when we release full support for OpenAI
-  if (!config?.feature_flag?.openai_instrumentation) {
+  if (config?.ai_monitoring?.enabled !== true) {
     shim.logger.debug('config.feature_flag.openai_instrumentation is disabled.')
     return true
   }

--- a/test/unit/api/api-llm.test.js
+++ b/test/unit/api/api-llm.test.js
@@ -58,4 +58,31 @@ tap.test('Agent API LLM methods', (t) => {
       t.end()
     })
   })
+
+  t.test('getLlmMessageIds is no-op when ai_monitoring is disabled', async (t) => {
+    const { api } = t.context
+    api.agent.config.ai_monitoring.enabled = false
+
+    const trackedIds = api.getLlmMessageIds({ responseId: 'test' })
+    t.equal(trackedIds, undefined)
+    t.equal(loggerMock.warn.callCount, 1)
+    t.equal(loggerMock.warn.args[0][0], 'getLlmMessageIds invoked but ai_monitoring is disabled.')
+  })
+
+  t.test('recordLlmFeedbackEvent is no-op when ai_monitoring is disabled', async (t) => {
+    const { api } = t.context
+    api.agent.config.ai_monitoring.enabled = false
+
+    const result = api.recordLlmFeedbackEvent({
+      messageId: 'test',
+      category: 'test',
+      rating: 'test'
+    })
+    t.equal(result, undefined)
+    t.equal(loggerMock.warn.callCount, 1)
+    t.equal(
+      loggerMock.warn.args[0][0],
+      'recordLlmFeedbackEvent invoked but ai_monitoring is disabled.'
+    )
+  })
 })

--- a/test/unit/instrumentation/openai.test.js
+++ b/test/unit/instrumentation/openai.test.js
@@ -76,7 +76,7 @@ test('openai unit tests', (t) => {
 
     initialize(agent, MockOpenAi, 'openai', shim)
     t.equal(shim.logger.debug.callCount, 2, 'should log 2 debug messages')
-    t.equal(shim.logger.debug.args[0][0], 'config.feature_flag.openai_instrumentation is disabled.')
+    t.equal(shim.logger.debug.args[0][0], 'config.ai_monitoring.enabled is set to false.')
     t.equal(
       shim.logger.debug.args[1][0],
       'openai instrumentation support is for versions >=4.0.0. Skipping instrumentation.'

--- a/test/unit/instrumentation/openai.test.js
+++ b/test/unit/instrumentation/openai.test.js
@@ -16,7 +16,7 @@ test('openai unit tests', (t) => {
   t.beforeEach(function (t) {
     const sandbox = sinon.createSandbox()
     const agent = helper.loadMockedAgent()
-    agent.config.feature_flag = { openai_instrumentation: true }
+    agent.config.ai_monitoring = { enabled: true }
     const shim = new GenericShim(agent, 'openai')
     sandbox.stub(shim, 'require')
     shim.require.returns({ version: '4.0.0' })
@@ -69,26 +69,20 @@ test('openai unit tests', (t) => {
     t.end()
   })
 
-  t.test(
-    'should not register instrumentation if feature_flag.openai_instrumentation is false',
-    (t) => {
-      const { shim, agent, initialize } = t.context
-      const MockOpenAi = getMockModule()
-      agent.config.feature_flag = { openai_instrumentation: false }
+  t.test('should not register instrumentation if ai_monitoring.enabled is false', (t) => {
+    const { shim, agent, initialize } = t.context
+    const MockOpenAi = getMockModule()
+    agent.config.ai_monitoring = { enabled: false }
 
-      initialize(agent, MockOpenAi, 'openai', shim)
-      t.equal(shim.logger.debug.callCount, 2, 'should log 2 debug messages')
-      t.equal(
-        shim.logger.debug.args[0][0],
-        'config.feature_flag.openai_instrumentation is disabled.'
-      )
-      t.equal(
-        shim.logger.debug.args[1][0],
-        'openai instrumentation support is for versions >=4.0.0. Skipping instrumentation.'
-      )
-      const isWrapped = shim.isWrapped(MockOpenAi.Chat.Completions.prototype.create)
-      t.equal(isWrapped, false, 'should not wrap chat completions create')
-      t.end()
-    }
-  )
+    initialize(agent, MockOpenAi, 'openai', shim)
+    t.equal(shim.logger.debug.callCount, 2, 'should log 2 debug messages')
+    t.equal(shim.logger.debug.args[0][0], 'config.feature_flag.openai_instrumentation is disabled.')
+    t.equal(
+      shim.logger.debug.args[1][0],
+      'openai instrumentation support is for versions >=4.0.0. Skipping instrumentation.'
+    )
+    const isWrapped = shim.isWrapped(MockOpenAi.Chat.Completions.prototype.create)
+    t.equal(isWrapped, false, 'should not wrap chat completions create')
+    t.end()
+  })
 })

--- a/test/versioned/openai/openai.tap.js
+++ b/test/versioned/openai/openai.tap.js
@@ -9,7 +9,7 @@ const tap = require('tap')
 const helper = require('../../lib/agent_helper')
 const createOpenAIMockServer = require('../../lib/openai-mock-server')
 const { assertSegments } = require('../../lib/metrics_helper')
-// TODO: remove config once we fully release OpenAI instrumentation
+
 const config = {
   ai_monitoring: {
     enabled: true

--- a/test/versioned/openai/openai.tap.js
+++ b/test/versioned/openai/openai.tap.js
@@ -11,8 +11,8 @@ const createOpenAIMockServer = require('../../lib/openai-mock-server')
 const { assertSegments } = require('../../lib/metrics_helper')
 // TODO: remove config once we fully release OpenAI instrumentation
 const config = {
-  feature_flag: {
-    openai_instrumentation: true
+  ai_monitoring: {
+    enabled: true
   }
 }
 


### PR DESCRIPTION
In #1868 we forgot to update the instrumentation's check for enablement. This PR fixes that oversight. It also improves the check to be an explicit check, which should cause future tests to fail if the configuration is removed or refactored again.
