### PR TITLE
test: Updated openai versioned tests to properly work with the legacy context manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "versioned:major": "VERSIONED_MODE=--major npm run versioned",
     "versioned": "npm run checkout-external-versioned && npm run prepare-test && time ./bin/run-versioned-tests.sh",
     "versioned:legacy-context": "NEW_RELIC_FEATURE_FLAG_LEGACY_CONTEXT_MANAGER=1 npm run versioned",
-    "versioned:legacy_context:major": "NEW_RELIC_FEATURE_FLAG_LEGACY_CONTEXT_MANAGER=1 npm run versioned:major",
+    "versioned:legacy-context:major": "NEW_RELIC_FEATURE_FLAG_LEGACY_CONTEXT_MANAGER=1 npm run versioned:major",
     "versioned:security": "NEW_RELIC_SECURITY_AGENT_ENABLED=true npm run versioned",
     "versioned:security:major": "NEW_RELIC_SECURITY_AGENT_ENABLED=true npm run versioned:major",
     "prepare": "husky install"

--- a/test/versioned/openai/openai.tap.js
+++ b/test/versioned/openai/openai.tap.js
@@ -59,6 +59,7 @@ tap.test('OpenAI instrumentation', (t) => {
           { exact: false }
         )
       }, 'should have expected segments')
+      tx.end()
       test.end()
     })
   })
@@ -144,6 +145,7 @@ tap.test('OpenAI instrumentation', (t) => {
         'response.choices.finish_reason': 'stop'
       }
       test.match(chatSummary[1], expectedChatSummary, 'should match chat summary message')
+      tx.end()
       test.end()
     })
   })
@@ -153,7 +155,7 @@ tap.test('OpenAI instrumentation', (t) => {
     (test) => {
       const { client, agent } = t.context
       const api = helper.getAgentApi()
-      helper.runInTransaction(agent, async () => {
+      helper.runInTransaction(agent, async (tx) => {
         const meta = { key: 'value', extended: true, vendor: 'overwriteMe', id: 'bogus' }
         api.setLlmMetadata(meta)
 
@@ -172,6 +174,7 @@ tap.test('OpenAI instrumentation', (t) => {
           )
           test.not(testEvent.id, 'bogus', 'should not override properties of message with metadata')
         })
+        tx.end()
         test.end()
       })
     }
@@ -189,7 +192,7 @@ tap.test('OpenAI instrumentation', (t) => {
 
   t.test('should make tracked ids available', (test) => {
     const { client, agent } = t.context
-    helper.runInTransaction(agent, async () => {
+    helper.runInTransaction(agent, async (tx) => {
       const results = await client.chat.completions.create({
         messages: [
           { role: 'user', content: 'You are a mathematician.' },
@@ -208,6 +211,7 @@ tap.test('OpenAI instrumentation', (t) => {
           'chatcmpl-87sb95K4EF2nuJRcTs43Tm9ntTeat-2'
         ]
       })
+      tx.end()
       test.end()
     })
   })
@@ -215,7 +219,7 @@ tap.test('OpenAI instrumentation', (t) => {
   t.test('can send feedback events', (test) => {
     const { client, agent } = t.context
     const api = helper.getAgentApi()
-    helper.runInTransaction(agent, async () => {
+    helper.runInTransaction(agent, async (tx) => {
       const results = await client.chat.completions.create({
         messages: [{ role: 'user', content: 'You are a mathematician.' }]
       })
@@ -252,6 +256,7 @@ tap.test('OpenAI instrumentation', (t) => {
           })
         })
       )
+      tx.end()
       test.end()
     })
   })
@@ -275,6 +280,7 @@ tap.test('OpenAI instrumentation', (t) => {
           { exact: false }
         )
       }, 'should have expected segments')
+      tx.end()
       test.end()
     })
   })
@@ -316,6 +322,7 @@ tap.test('OpenAI instrumentation', (t) => {
 
       test.equal(embedding[0].type, 'LlmEmbedding')
       test.match(embedding[1], expectedEmbedding, 'should match embedding message')
+      tx.end()
       test.end()
     })
   })
@@ -325,7 +332,7 @@ tap.test('OpenAI instrumentation', (t) => {
     (test) => {
       const { client, agent } = t.context
       const api = helper.getAgentApi()
-      helper.runInTransaction(agent, async () => {
+      helper.runInTransaction(agent, async (tx) => {
         const meta = { key: 'value', extended: true, vendor: 'overwriteMe', id: 'bogus' }
         api.setLlmMetadata(meta)
 
@@ -344,6 +351,7 @@ tap.test('OpenAI instrumentation', (t) => {
           'should not override properties of message with metadata'
         )
         test.not(testEvent.id, 'bogus', 'should not override properties of message with metadata')
+        tx.end()
         test.end()
       })
     }

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Fri Oct 27 2023 18:35:37 GMT+0530 (India Standard Time)",
+  "lastUpdated": "Thu Nov 16 2023 14:05:45 GMT-0500 (Eastern Standard Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

The nightly legacy context manager versioned tests were failing on [openai](https://github.com/newrelic/node-newrelic/actions/runs/6888474698).  This PR addresses those failures by ending every transaction.  It turns out the async local context manager does not require you to end the transaction because that implicitly happens with the ctx manager.  However, the legacy context manager requires you to end transactions if you want to properly sandbox every test.

## How to Test

`npm run versioned:legacy-context openai`
