### PR TITLE
chore(docs): Updated links in documentation to https

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ To run the tests you need an openssl command-line binary, and some services:
 * Redis
 
 If you have these all running locally on the standard ports, then you are good
-to go. However, the suggested path is to use [Docker](http://www.docker.com).
+to go. However, the suggested path is to use [Docker](https://www.docker.com).
 If you use macOS or Windows, install [Docker Desktop]
 (https://www.docker.com/products/docker-desktop). Then, run `npm run services`
 to download and launch docker containers for each of the above services.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3673,7 +3673,7 @@ Special thanks to Ryan Copley (@RyanCopley) for the contribution.
     used for instrumenting web frameworks like `restify` or `express`.
 
   Documentation and tutorials for the new API can be found on our GitHub
-  documentation page: http://newrelic.github.io/node-newrelic/
+  documentation page: https://newrelic.github.io/node-newrelic/
 
 * Rewrote built-in instrumentation using the new `Shim` classes.
 
@@ -3762,7 +3762,7 @@ Special thanks to Ryan Copley (@RyanCopley) for the contribution.
   meaning every instrumentation will create Middleware metrics for your server.
 
   Tutorials on using the new instrumentation shim can be found on our API docs:
-  http://newrelic.github.io/node-newrelic/.
+  https://newrelic.github.io/node-newrelic/.
 
 * Removed `express_segments` feature flag.
 
@@ -4589,7 +4589,7 @@ Special thanks to Ryan Copley (@RyanCopley) for the contribution.
 
 * Advanced Analytics for APM Errors
 
-  With this release, the agent reports [TransactionError events](https://docs.newrelic.com/docs/insights/new-relic-insights/decorating-events/error-event-default-attributes-insights). These new events power the beta feature [Advanced Analytics for APM Errors](https://docs.newrelic.com/docs/apm/applications-menu/events/view-apm-errors-error-traces) (apply [here](https://discuss.newrelic.com/t/join-the-apm-errors-beta-of-real-time-analytics/31123) to participate). The error events are also available today through [New Relic Insights](http://newrelic.com/insights).
+  With this release, the agent reports [TransactionError events](https://docs.newrelic.com/docs/insights/new-relic-insights/decorating-events/error-event-default-attributes-insights). These new events power the beta feature [Advanced Analytics for APM Errors](https://docs.newrelic.com/docs/apm/applications-menu/events/view-apm-errors-error-traces) (apply [here](https://discuss.newrelic.com/t/join-the-apm-errors-beta-of-real-time-analytics/31123) to participate). The error events are also available today through [New Relic Insights](https://newrelic.com/insights).
 
   Advanced Analytics for APM Errors lets you see all of your errors with
   granular detail, filter and group by any attribute to analyze them, and take
@@ -5379,9 +5379,9 @@ Special thanks to Ryan Copley (@RyanCopley) for the contribution.
   10,000 per minute. After that events are statistically sampled. Event data
   includes transaction timing, transaction name, and any custom parameters. You
   can read what is sent in more detail
-  [here](http://docs.newrelic.com/docs/insights/basic-attributes#transaction-defaults).
+  [here](https://docs.newrelic.com/docs/insights/basic-attributes#transaction-defaults).
 
-  You can read more about Insights [here](http://newrelic.com/insights).
+  You can read more about Insights [here](https://newrelic.com/insights).
   Documentation for configuring this feature can be found
   [here](https://docs.newrelic.com/docs/nodejs/customizing-your-nodejs-config-file#tx_events).
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Here are some resources for learning more about the agent:
 
 - [New Relic's official Node.js agent documentation](https://docs.newrelic.com/docs/agents/nodejs-agent)
 
-- [Developer docs](http://newrelic.github.io/node-newrelic/)
+- [Developer docs](https://newrelic.github.io/node-newrelic/)
 
 - [Configuring the agent using `newrelic.js` or environment variables](https://docs.newrelic.com/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration)
 
@@ -242,7 +242,7 @@ To [all contributors](https://github.com/newrelic/node-newrelic/graphs/contribut
 
 ## License
 
-The Node.js agent is licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) License.
+The Node.js agent is licensed under the [Apache 2.0](https://apache.org/licenses/LICENSE-2.0.txt) License.
 
 The Node.js agent also uses source code from third-party libraries. You can find full details on which libraries are used and the terms under which they are licensed in [the third-party notices document](https://github.com/newrelic/node-newrelic/blob/main/THIRD_PARTY_NOTICES.md).
 

--- a/examples/shim/Datastore-Simple.md
+++ b/examples/shim/Datastore-Simple.md
@@ -298,11 +298,11 @@ there, please drop us a line on the [community forum](https://discuss.newrelic.c
 
 [1]: https://www.npmjs.com/package/cassandra-driver
 [2]: https://docs.newrelic.com/docs/apm/applications-menu/monitoring/databases-slow-queries-page
-[3]: http://docs.datastax.com/en/latest-nodejs-driver-api/Client.html
+[3]: https://github.com/datastax/nodejs-driver#basic-usage
 [4]: https://docs.newrelic.com/docs/apm/applications-menu/monitoring/transactions-page
 [5]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
-[6]: http://docs.datastax.com/en/latest-nodejs-driver-api/Client.html#eachRow
-[7]: http://docs.datastax.com/en/latest-nodejs-driver-api/Client.html#execute
-[8]: http://docs.datastax.com/en/latest-nodejs-driver-api/Client.html#stream
+[6]: https://github.com/datastax/nodejs-driver#row-streaming-and-pipes
+[7]: https://github.com/datastax/nodejs-driver#user-defined-types
+[8]: https://github.com/datastax/nodejs-driver#row-streaming-and-pipes
 [9]: https://github.com/datastax/nodejs-driver/blob/master/lib/client.js#L589
-[10]: http://docs.datastax.com/en/latest-nodejs-driver-api/Client.html#batch
+[10]: https://github.com/datastax/nodejs-driver#batch-multiple-statements

--- a/test/lib/cross_agent_tests/sql_obfuscation/README.md
+++ b/test/lib/cross_agent_tests/sql_obfuscation/README.md
@@ -25,12 +25,12 @@ Test cases may also contain the following properties:
 
 The following database documentation may be helpful in understanding these test
 cases:
-* [MySQL String Literals](http://dev.mysql.com/doc/refman/5.5/en/string-literals.html)
-* [PostgreSQL String Constants](http://www.postgresql.org/docs/8.2/static/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS)
+* [MySQL String Literals](https://dev.mysql.com/doc/refman/5.5/en/string-literals.html)
+* [PostgreSQL String Constants](https://www.postgresql.org/docs/8.2/static/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS)
 
 SQL Syntax Documentation:
-* [MySQL](http://dev.mysql.com/doc/refman/5.5/en/language-structure.html)
-* [PostgreSQL](http://www.postgresql.org/docs/8.4/static/sql-syntax.html)
-* [Cassandra](http://docs.datastax.com/en/cql/3.1/cql/cql_reference/cql_lexicon_c.html)
-* [Oracle](http://docs.oracle.com/cd/B28359_01/appdev.111/b28370/langelems.htm)
+* [MySQL](https://dev.mysql.com/doc/refman/5.5/en/language-structure.html)
+* [PostgreSQL](https://www.postgresql.org/docs/8.4/static/sql-syntax.html)
+* [Cassandra](https://docs.datastax.com/en/cql/3.1/cql/cql_reference/cql_lexicon_c.html)
+* [Oracle](https://docs.oracle.com/cd/B28359_01/appdev.111/b28370/langelems.htm)
 * [SQLite](https://www.sqlite.org/lang.html)


### PR DESCRIPTION
## Description

Update of links in documentation, to be consistent with use of `https` except for references to `localhost`.

## Related Issues

Closes NR-175309