### PR TITLE
chore: Improve OpenAI mock server streams

### DIFF
--- a/test/versioned/openai/chat-completions.tap.js
+++ b/test/versioned/openai/chat-completions.tap.js
@@ -233,7 +233,7 @@ tap.test('OpenAI instrumentation - chat completions', (t) => {
           // are asserted in other tests
           t.match(tx.exceptions[0], {
             customAttributes: {
-              'error.message': '"exceeded count"',
+              'error.message': 'Premature close',
               'completion_id': /\w{32}/
             }
           })


### PR DESCRIPTION
The OpenAI folks [helped me realize](https://github.com/openai/openai-node/issues/537) that I didn't quite design the error stream case in our mock server. This PR refactors the mock server to induce an error at the client side that will be handled correctly by the OpenAI client, and in turn bubbled up to our code as a legitimate connection error.