### PR TITLE
test: updated connect min version to 2.0

### DIFF
--- a/test/versioned/connect/package.json
+++ b/test/versioned/connect/package.json
@@ -8,7 +8,7 @@
         "node": ">=16"
       },
       "dependencies": {
-        "connect": ">=1.0.0"
+        "connect": ">=2.0.0"
       },
       "files": [
         "error-intercept.tap.js",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Versioned tests starting failing in connect.

```sh
added 16 packages in 596ms
TAP version 13
# Subtest: intercepting errors with connect 2
    1..3
    # Subtest: should wrap handlers with proxies
        not ok 1 - require() of ES Module /home/runner/work/node-newrelic/node-newrelic/test/versioned/connect/node_modules/mime/dist/src/index.js from /home/runner/work/node-newrelic/node-newrelic/test/versioned/connect/node_modules/connect/lib/middleware/static.js not supported. Instead change the require of index.js in /home/runner/work/node-newrelic/node-newrelic/test/versioned/connect/node_modules/connect/lib/middleware/static.js to a dynamic import() which is available in all CommonJS modules.
          ---
```

It turns out v1.0.0 of connect is permissive with MIME with `>=0.0.1`.  Version 2 of connect locks it down so this PR updates the minimum version of connect under test.
