### PR TITLE
test: Fix winston-esm versioned tests

### DIFF
--- a/test/versioned/winston-esm/package.json
+++ b/test/versioned/winston-esm/package.json
@@ -9,7 +9,7 @@
         "node": ">=16"
       },
       "dependencies": {
-        "winston": ">=3.4.0",
+        "winston": ">=3",
         "winston-transport": ">=4"
       },
       "files": [

--- a/test/versioned/winston-esm/package.json
+++ b/test/versioned/winston-esm/package.json
@@ -9,7 +9,7 @@
         "node": ">=16"
       },
       "dependencies": {
-        "winston": ">=3",
+        "winston": ">=3.4.0",
         "winston-transport": ">=4"
       },
       "files": [

--- a/test/versioned/winston-esm/winston.tap.mjs
+++ b/test/versioned/winston-esm/winston.tap.mjs
@@ -5,11 +5,16 @@
 
 import tap from 'tap'
 import { randomUUID } from 'node:crypto'
+import fs from 'node:fs/promises'
+import semver from 'semver'
 import helper from '../../lib/agent_helper.js'
 import names from '../../../lib/metrics/names.js'
 import { Sink } from './common.mjs'
 
 const { LOGGING } = names
+const winstonPkg = JSON.parse(await fs.readFile('./node_modules/winston/package.json'))
+
+tap.skip = true
 
 tap.beforeEach(async (t) => {
   t.context.test_id = randomUUID()
@@ -52,34 +57,38 @@ tap.test('named import issues logs correctly', async (t) => {
   t.equal(1, metric.callCount, 'winston log metric is recorded')
 })
 
-tap.test('alias import issues logs correctly', async (t) => {
-  const sink = new Sink()
-  const { agent } = t.context
-  agent.config.application_logging.forwarding.enabled = true
+tap.test(
+  'alias import issues logs correctly',
+  { skip: semver.lt(winstonPkg.version, '3.4.0') },
+  async (t) => {
+    const sink = new Sink()
+    const { agent } = t.context
+    agent.config.application_logging.forwarding.enabled = true
 
-  const { doLog } = await import('./fixtures/star-import.mjs?test=' + t.context.test_id)
-  doLog(sink)
-  t.equal(1, sink.loggedLines.length, 'log is written to the transport')
+    const { doLog } = await import('./fixtures/star-import.mjs?test=' + t.context.test_id)
+    doLog(sink)
+    t.equal(1, sink.loggedLines.length, 'log is written to the transport')
 
-  const log = sink.loggedLines[0]
-  const symbols = Object.getOwnPropertySymbols(log)
-  // Instrumented logs should still be decorated internally by Winston with
-  // a message symbol.
-  t.equal(
-    true,
-    symbols.some((s) => s.toString() === 'Symbol(message)'),
-    'log object has winston internal symbol'
-  )
+    const log = sink.loggedLines[0]
+    const symbols = Object.getOwnPropertySymbols(log)
+    // Instrumented logs should still be decorated internally by Winston with
+    // a message symbol.
+    t.equal(
+      true,
+      symbols.some((s) => s.toString() === 'Symbol(message)'),
+      'log object has winston internal symbol'
+    )
 
-  const agentLogs = agent.logs.getEvents()
-  t.equal(
-    true,
-    agentLogs.some((l) => {
-      return l?.message === 'import * as winston from winston'
-    }),
-    'log gets added to agent logs'
-  )
+    const agentLogs = agent.logs.getEvents()
+    t.equal(
+      true,
+      agentLogs.some((l) => {
+        return l?.message === 'import * as winston from winston'
+      }),
+      'log gets added to agent logs'
+    )
 
-  const metric = agent.metrics.getMetric(LOGGING.LIBS.WINSTON)
-  t.equal(1, metric.callCount, 'winston log metric is recorded')
-})
+    const metric = agent.metrics.getMetric(LOGGING.LIBS.WINSTON)
+    t.equal(1, metric.callCount, 'winston log metric is recorded')
+  }
+)


### PR DESCRIPTION
The tests from #1894 exhibited a failure case when the versioned sampling was expanded in the `main` CI suite (https://github.com/newrelic/node-newrelic/actions/runs/7091603183/job/19301106334). The issue is that Winston changes the way they export their API between v3.3.4 and v3.4.0 in https://github.com/winstonjs/winston/pull/2006. This PR narrows the test case to test against Winston >= 3.4.0.