### PR TITLE
test: pin undici versioned to <6.0.0 on Node 16

### DIFF
--- a/test/versioned/undici/package.json
+++ b/test/versioned/undici/package.json
@@ -5,7 +5,18 @@
   "tests": [
     {
       "engines": {
-        "node": ">=16"
+        "node": "16"
+      },
+      "dependencies": {
+        "undici": ">=4.7.0 <6.0.0"
+      },
+      "files": [
+        "requests.tap.js"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=18"
       },
       "dependencies": {
         "undici": ">=4.7.0"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Undici EOLd Node 16 in [6.0.0](https://github.com/nodejs/undici/releases/tag/v6.0.0). This PR skips running >=6.0.0 on Node 16.
