### PR TITLE
fix(deps): Updated @newrelic/aws-sdk to 7.0.3

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -510,7 +510,7 @@ This product includes source derived from [@grpc/proto-loader](https://github.co
 
 ### @newrelic/aws-sdk
 
-This product includes source derived from [@newrelic/aws-sdk](https://github.com/newrelic/node-newrelic-aws-sdk) ([v7.0.2](https://github.com/newrelic/node-newrelic-aws-sdk/tree/v7.0.2)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-aws-sdk/blob/v7.0.2/LICENSE):
+This product includes source derived from [@newrelic/aws-sdk](https://github.com/newrelic/node-newrelic-aws-sdk) ([v7.0.3](https://github.com/newrelic/node-newrelic-aws-sdk/tree/v7.0.3)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-aws-sdk/blob/v7.0.3/LICENSE):
 
 ```
                                  Apache License

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.9.4",
         "@grpc/proto-loader": "^0.7.5",
-        "@newrelic/aws-sdk": "^7.0.2",
+        "@newrelic/aws-sdk": "^7.0.3",
         "@newrelic/koa": "^8.0.1",
         "@newrelic/security-agent": "0.5.0",
         "@newrelic/superagent": "^7.0.1",
@@ -1355,9 +1355,9 @@
       }
     },
     "node_modules/@newrelic/aws-sdk": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-7.0.2.tgz",
-      "integrity": "sha512-nT19hzId0MbjR3v1ks5YetvNfrwIEgMfeai+T2pQkuWkjCsYm3z+OybLOYMCN66gueqOOqGTq60qhM4dFu5s5w==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-7.0.3.tgz",
+      "integrity": "sha512-oafBFD+DEAqXTg0w15eEu2rfoedWMS7abyW5CuOJxSb+7OWiFUx9jZPpdFblsYPVNWBehxFdws6/JEio3GklyA==",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -17365,9 +17365,9 @@
       }
     },
     "@newrelic/aws-sdk": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-7.0.2.tgz",
-      "integrity": "sha512-nT19hzId0MbjR3v1ks5YetvNfrwIEgMfeai+T2pQkuWkjCsYm3z+OybLOYMCN66gueqOOqGTq60qhM4dFu5s5w=="
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-7.0.3.tgz",
+      "integrity": "sha512-oafBFD+DEAqXTg0w15eEu2rfoedWMS7abyW5CuOJxSb+7OWiFUx9jZPpdFblsYPVNWBehxFdws6/JEio3GklyA=="
     },
     "@newrelic/eslint-config": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.9.4",
     "@grpc/proto-loader": "^0.7.5",
-    "@newrelic/aws-sdk": "^7.0.2",
+    "@newrelic/aws-sdk": "^7.0.3",
     "@newrelic/koa": "^8.0.1",
     "@newrelic/security-agent": "0.5.0",
     "@newrelic/superagent": "^7.0.1",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Fri Nov 17 2023 14:06:10 GMT+0530 (India Standard Time)",
+  "lastUpdated": "Thu Dec 07 2023 10:54:24 GMT-0500 (Eastern Standard Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -68,15 +68,15 @@
       "licenseTextSource": "file",
       "publisher": "Google Inc."
     },
-    "@newrelic/aws-sdk@7.0.2": {
+    "@newrelic/aws-sdk@7.0.3": {
       "name": "@newrelic/aws-sdk",
-      "version": "7.0.2",
-      "range": "^7.0.2",
+      "version": "7.0.3",
+      "range": "^7.0.3",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic-aws-sdk",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-aws-sdk/tree/v7.0.2",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-aws-sdk/tree/v7.0.3",
       "licenseFile": "node_modules/@newrelic/aws-sdk/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic-aws-sdk/blob/v7.0.2/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic-aws-sdk/blob/v7.0.3/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
## Description

Updated @newrelic/aws-sdk to 7.0.3, to call shim.setLibrary and shim.setDatastore only once instead of on every call to sqs/sns/dyanmodb. 

## Related Issues

https://github.com/newrelic/node-newrelic-aws-sdk/issues/218