### PR TITLE
feat: Added instrumentation for Restify async handlers 

### DIFF
--- a/lib/instrumentation/restify.js
+++ b/lib/instrumentation/restify.js
@@ -55,12 +55,20 @@ module.exports = function initialize(agent, restify, moduleName, shim) {
         if (shim.isWrapped(middleware)) {
           return middleware
         }
-        return shim.recordMiddleware(middleware, {
+        const spec = {
           matchArity: true,
           route,
           req: shim.FIRST,
           next: shim.LAST
-        })
+        }
+
+        const wrappedMw = shim.recordMiddleware(middleware, spec)
+        if (middleware.constructor.name === 'AsyncFunction') {
+          return async function asyncShim() {
+            return wrappedMw.apply(this, arguments)
+          }
+        }
+        return wrappedMw
       }
     })
 
@@ -70,11 +78,18 @@ module.exports = function initialize(agent, restify, moduleName, shim) {
       if (shim.isWrapped(middleware)) {
         return middleware
       }
-      return shim.recordMiddleware(middleware, {
+      const spec = {
         matchArity: true,
         req: shim.FIRST,
         next: shim.LAST
-      })
+      }
+      const wrappedMw = shim.recordMiddleware(middleware, spec)
+      if (middleware.constructor.name === 'AsyncFunction') {
+        return async function asyncShim() {
+          return wrappedMw.apply(this, arguments)
+        }
+      }
+      return wrappedMw
     })
   }
 }

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -261,7 +261,7 @@ Logger.prototype.write = function write(level, args, extra) {
     data = stringify(entry) + '\n'
   } catch (err) {
     // eslint-disable-line no-unused-vars
-    this.debug('Unabled to stringify log message')
+    this.debug('Unable to stringify log message')
   }
 
   if (this.reading) {

--- a/test/versioned/restify/restify-post-7/async-handlers.tap.js
+++ b/test/versioned/restify/restify-post-7/async-handlers.tap.js
@@ -9,6 +9,7 @@ const tap = require('tap')
 
 const helper = require('../../../lib/agent_helper')
 const { assertMetrics } = require('../../../lib/metrics_helper')
+const { runTest } = require('./common')
 
 const simulateAsyncWork = async () => {
   const delay = Math.floor(Math.random() * 100)
@@ -50,7 +51,7 @@ tap.test('Restify with async handlers should work the same as with sync', (t) =>
       res.send()
     })
 
-    runTest({ t, endpoint: '/path1', expectedName: 'GET//path1' })
+    runTest({ agent, server, t, endpoint: '/path1', expectedName: 'GET//path1' })
   })
 
   t.test('transaction name for async route with sync middleware', (t) => {
@@ -63,7 +64,7 @@ tap.test('Restify with async handlers should work the same as with sync', (t) =>
       res.send()
     })
 
-    runTest({ t, endpoint: '/path1', expectedName: 'GET//path1' })
+    runTest({ agent, server, t, endpoint: '/path1', expectedName: 'GET//path1' })
   })
 
   t.test('transaction name for async route with async middleware', (t) => {
@@ -76,7 +77,7 @@ tap.test('Restify with async handlers should work the same as with sync', (t) =>
       res.send()
     })
 
-    runTest({ t, endpoint: '/path1', expectedName: 'GET//path1' })
+    runTest({ agent, server, t, endpoint: '/path1', expectedName: 'GET//path1' })
   })
 
   t.test('transaction name for async route with multiple async middleware', (t) => {
@@ -96,36 +97,8 @@ tap.test('Restify with async handlers should work the same as with sync', (t) =>
       res.send()
     })
 
-    runTest({ t, endpoint: '/path1', expectedName: 'GET//path1' })
+    runTest({ agent, server, t, endpoint: '/path1', expectedName: 'GET//path1' })
   })
-
-  /**
-   * @param {Object} cfg
-   * @property {Object} cfg.t
-   * @property {string} cfg.endpoint
-   * @property {string} [cfg.prefix='Restify']
-   * @property {string} cfg.expectedName
-   * @property {Function} [cfg.cb=t.end]
-   * @property {Object} [cfg.requestOpts=null]
-   */
-  function runTest(cfg) {
-    const t = cfg.t
-    const endpoint = cfg.endpoint
-    const prefix = cfg.prefix || 'Restify'
-    const expectedName = `WebTransaction/${prefix}/${cfg.expectedName}`
-
-    agent.on('transactionFinished', (tx) => {
-      t.equal(tx.name, expectedName, `should have correct name ${expectedName}`)
-
-      console.log('attr', tx.trace.attributes)
-      ;(cfg.cb && cfg.cb()) || t.end()
-    })
-
-    server.listen(() => {
-      const port = server.address().port
-      helper.makeGetRequest(`http://localhost:${port}${endpoint}`, cfg.requestOpts || null)
-    })
-  }
 })
 
 tap.test('Restify metrics for async handlers', (t) => {

--- a/test/versioned/restify/restify-post-7/async-handlers.tap.js
+++ b/test/versioned/restify/restify-post-7/async-handlers.tap.js
@@ -36,30 +36,30 @@ tap.test('Restify instrumentation', (t) => {
       numbers[i] = randomNumber()
       i++
       const txn = agent.getTransaction()
-      t.ok(txn, `sync middleware should be in transaction context`)
+      t.ok(txn, `sync middleware should be in transaction context (${req.method} ${req.path()})`)
       return next()
     }
 
-    const useAsyncMiddleware = async () => {
+    const useAsyncMiddleware = async (req) => {
       const txn = agent.getTransaction()
-      t.ok(txn, 'async middleware should be in transaction context')
+      t.ok(txn, `async middleware should be in transaction context (${req.method} ${req.path()})`)
       numbers[i] = await getRandomNumber()
       i++
     }
 
     const handler = (req, res, next) => {
       const txn = agent.getTransaction()
-      t.ok(txn, 'sync handler should be in transaction context')
+      t.ok(txn, `sync handler should be in transaction context (${req.method} ${req.path()})`)
       res.send({ message: 'done with handler', numbers })
       return next()
     }
 
     const asyncHandler = async (req, res) => {
       const txn = agent.getTransaction()
-      t.ok(txn, 'async handler should be in transaction context')
+      t.ok(txn, `async handler should be in transaction context (${req.method} ${req.path()})`)
       numbers[i] = await getRandomNumber()
       i++
-      res.send(JSON.stringify({ message: 'done with handler', numbers }))
+      res.send({ message: 'done with handler', numbers })
     }
 
     server.use(useSyncMiddleware)
@@ -84,8 +84,8 @@ tap.test('Restify instrumentation', (t) => {
     const url = `http://localhost:${port}/sync/handler`
 
     helper.makeGetRequest(url, {}, function (error, res) {
-      t.notOk(error)
-      t.ok(res)
+      t.notOk(error, 'synchronous GET endpoint should not error')
+      t.ok(res, 'synchronous GET response should be ok')
       t.end()
     })
   })
@@ -95,8 +95,8 @@ tap.test('Restify instrumentation', (t) => {
 
     await new Promise((resolve) => {
       helper.makeGetRequest(url, {}, async function (error, res) {
-        t.notOk(error)
-        t.ok(res)
+        t.notOk(error, 'async GET endpoint should not error')
+        t.ok(res, 'async GET response should be ok')
         resolve()
       })
     })
@@ -110,8 +110,8 @@ tap.test('Restify instrumentation', (t) => {
       url,
       { method: 'PUT', body: JSON.stringify({ message: 'hi' }) },
       function (error, res) {
-        t.notOk(error)
-        t.ok(res)
+        t.notOk(error, 'synchronous PUT endpoint should not error')
+        t.ok(res, 'synchronous PUT response should be ok')
         t.end()
       }
     )
@@ -125,8 +125,8 @@ tap.test('Restify instrumentation', (t) => {
         url,
         { method: 'PUT', body: JSON.stringify({ message: 'hi' }) },
         function (error, res) {
-          t.notOk(error)
-          t.ok(res)
+          t.notOk(error, 'async PUT endpoint should not error')
+          t.ok(res, 'async PUT response should be ok')
           resolve()
         }
       )

--- a/test/versioned/restify/restify-post-7/async-handlers.tap.js
+++ b/test/versioned/restify/restify-post-7/async-handlers.tap.js
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+
+const helper = require('../../../lib/agent_helper')
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+const randomNumber = () => Math.floor(Math.random() * 1000)
+
+const getRandomNumber = async () => {
+  const number = randomNumber()
+  await wait(number / 10)
+  return number
+}
+
+tap.test('Restify instrumentation', (t) => {
+  t.autoend()
+
+  let agent = null
+  let restify = null
+  let server = null
+  const numbers = []
+  let i = 0
+
+  t.before(() => {
+    agent = helper.instrumentMockedAgent()
+    restify = require('restify')
+    server = restify.createServer()
+
+    const useSyncMiddleware = (req, res, next) => {
+      numbers[i] = randomNumber()
+      i++
+      const txn = agent.getTransaction()
+      t.ok(txn, `sync middleware should be in transaction context`)
+      return next()
+    }
+
+    const useAsyncMiddleware = async () => {
+      const txn = agent.getTransaction()
+      t.ok(txn, 'async middleware should be in transaction context')
+      numbers[i] = await getRandomNumber()
+      i++
+    }
+
+    const handler = (req, res, next) => {
+      const txn = agent.getTransaction()
+      t.ok(txn, 'sync handler should be in transaction context')
+      res.send({ message: 'done with handler', numbers })
+      return next()
+    }
+
+    const asyncHandler = async (req, res) => {
+      const txn = agent.getTransaction()
+      t.ok(txn, 'async handler should be in transaction context')
+      numbers[i] = await getRandomNumber()
+      i++
+      res.send(JSON.stringify({ message: 'done with handler', numbers }))
+    }
+
+    server.use(useSyncMiddleware)
+    server.use(useAsyncMiddleware)
+
+    server.get('/sync/:handler', handler)
+    server.put('/sync/:handler', handler)
+
+    server.get('/async/:handler', asyncHandler)
+    server.put('/async/:handler', asyncHandler)
+
+    server.listen(0, function () {})
+  })
+
+  t.teardown(() => {
+    server.close()
+    helper.unloadAgent(agent)
+  })
+
+  t.test('should instrument sync GET requests', (t) => {
+    const port = server.address().port
+    const url = `http://localhost:${port}/sync/handler`
+
+    helper.makeGetRequest(url, {}, function (error, res) {
+      t.notOk(error)
+      t.ok(res)
+      t.end()
+    })
+  })
+  t.test('Should instrument async GET requests', async (t) => {
+    const port = server.address().port
+    const url = `http://localhost:${port}/async/handler`
+
+    await new Promise((resolve) => {
+      helper.makeGetRequest(url, {}, async function (error, res) {
+        t.notOk(error)
+        t.ok(res)
+        resolve()
+      })
+    })
+    t.end()
+  })
+  t.test('Should instrument sync PUT requests', (t) => {
+    const port = server.address().port
+    const url = `http://localhost:${port}/sync/handler`
+
+    helper.makeRequest(
+      url,
+      { method: 'PUT', body: JSON.stringify({ message: 'hi' }) },
+      function (error, res) {
+        t.notOk(error)
+        t.ok(res)
+        t.end()
+      }
+    )
+  })
+  t.test('Should instrument async PUT requests', async (t) => {
+    const port = server.address().port
+    const url = `http://localhost:${port}/async/handler`
+
+    await new Promise((resolve) => {
+      helper.makeRequest(
+        url,
+        { method: 'PUT', body: JSON.stringify({ message: 'hi' }) },
+        function (error, res) {
+          t.notOk(error)
+          t.ok(res)
+          resolve()
+        }
+      )
+    })
+    t.end()
+  })
+})

--- a/test/versioned/restify/restify-post-7/capture-params.tap.js
+++ b/test/versioned/restify/restify-post-7/capture-params.tap.js
@@ -61,7 +61,7 @@ test('Restify capture params introspection', function (t) {
       port = server.address().port
       helper.makeGetRequest('http://localhost:' + port + '/test', function (error, res, body) {
         t.equal(res.statusCode, 200, 'nothing exploded')
-        t.same(body, { status: 'ok' }, 'got expected respose')
+        t.same(body, { status: 'ok' }, 'got expected response')
         t.end()
       })
     })

--- a/test/versioned/restify/restify-post-7/common.js
+++ b/test/versioned/restify/restify-post-7/common.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const common = module.exports
+const helper = require('../../../lib/agent_helper')
+
+/**
+ * @param {object} cfg
+ * @property {object} cfg.t
+ * @property {string} cfg.endpoint
+ * @property {string} [cfg.prefix='Restify']
+ * @property {string} cfg.expectedName
+ * @property {Function} [cfg.cb=t.end]
+ * @property {object} [cfg.requestOpts=null]
+ * @property {object} cfg.agent
+ * @property {object} cfg.server
+ */
+common.runTest = function runTest(cfg) {
+  const { t, endpoint, agent, prefix = 'Restify', requestOpts = null, server } = cfg
+  let { expectedName } = cfg
+  expectedName = `WebTransaction/${prefix}/${expectedName}`
+
+  agent.on('transactionFinished', (tx) => {
+    t.equal(tx.name, expectedName, 'should have correct name')
+    t.end()
+  })
+
+  server.listen(() => {
+    const port = server.address().port
+    helper.makeGetRequest(`http://localhost:${port}${endpoint}`, requestOpts)
+  })
+}

--- a/test/versioned/restify/restify-post-7/package.json
+++ b/test/versioned/restify/restify-post-7/package.json
@@ -32,6 +32,7 @@
         "restify-errors": "6.1"
       },
       "files": [
+        "async-handlers.tap.js",
         "capture-params.tap.js",
         "ignoring.tap.js",
         "restify.tap.js",

--- a/test/versioned/restify/restify-post-7/transaction-naming.tap.js
+++ b/test/versioned/restify/restify-post-7/transaction-naming.tap.js
@@ -8,6 +8,7 @@
 const helper = require('../../../lib/agent_helper')
 const tap = require('tap')
 const semver = require('semver')
+const { runTest } = require('./common')
 
 tap.test('Restify transaction naming', (t) => {
   t.autoend()
@@ -44,7 +45,7 @@ tap.test('Restify transaction naming', (t) => {
       next()
     })
 
-    runTest({ t, endpoint: '/path1', expectedName: 'GET//path1' })
+    runTest({ agent, server, t, endpoint: '/path1', expectedName: 'GET//path1' })
   })
 
   t.test('transaction name with async response middleware', (t) => {
@@ -67,6 +68,8 @@ tap.test('Restify transaction naming', (t) => {
     })
 
     runTest({
+      agent,
+      server,
       t,
       endpoint: '/path1',
       expectedName: 'GET//path1',
@@ -94,6 +97,8 @@ tap.test('Restify transaction naming', (t) => {
     })
 
     runTest({
+      agent,
+      server,
       t,
       endpoint: '/path1',
       expectedName: 'GET//path1',
@@ -124,6 +129,8 @@ tap.test('Restify transaction naming', (t) => {
       })
 
       runTest({
+        agent,
+        server,
         t,
         endpoint: '/path1',
         expectedName: 'GET//path1',
@@ -147,6 +154,8 @@ tap.test('Restify transaction naming', (t) => {
     })
 
     runTest({
+      agent,
+      server,
       t,
       endpoint: '/path1',
       expectedName: 'GET//path1',
@@ -163,7 +172,14 @@ tap.test('Restify transaction naming', (t) => {
       next()
     })
 
-    runTest({ t, endpoint: '/foobar', prefix: 'Nodejs', expectedName: 'GET/(not found)' })
+    runTest({
+      agent,
+      server,
+      t,
+      endpoint: '/foobar',
+      prefix: 'Nodejs',
+      expectedName: 'GET/(not found)'
+    })
   })
 
   t.test('transaction name contains trailing slash', (t) => {
@@ -175,7 +191,7 @@ tap.test('Restify transaction naming', (t) => {
       next()
     })
 
-    runTest({ t, endpoint: '/path/', expectedName: 'GET//path/' })
+    runTest({ agent, server, t, endpoint: '/path/', expectedName: 'GET//path/' })
   })
 
   t.test('transaction name does not contain trailing slash', (t) => {
@@ -187,7 +203,7 @@ tap.test('Restify transaction naming', (t) => {
       next()
     })
 
-    runTest({ t, endpoint: '/path', expectedName: 'GET//path' })
+    runTest({ agent, server, t, endpoint: '/path', expectedName: 'GET//path' })
   })
 
   t.test('transaction name with route that has multiple handlers', (t) => {
@@ -206,7 +222,7 @@ tap.test('Restify transaction naming', (t) => {
       }
     )
 
-    runTest({ t, endpoint: '/path1', expectedName: 'GET//path1' })
+    runTest({ agent, server, t, endpoint: '/path1', expectedName: 'GET//path1' })
   })
 
   t.test('transaction name with middleware', (t) => {
@@ -222,7 +238,7 @@ tap.test('Restify transaction naming', (t) => {
       next()
     })
 
-    runTest({ t, endpoint: '/path1', expectedName: 'GET//path1' })
+    runTest({ agent, server, t, endpoint: '/path1', expectedName: 'GET//path1' })
   })
 
   t.test('with error', (t) => {
@@ -234,7 +250,7 @@ tap.test('Restify transaction naming', (t) => {
       next(new errors.InternalServerError('foobar'))
     })
 
-    runTest({ t, endpoint: '/path1', expectedName: 'GET//path1' })
+    runTest({ agent, server, t, endpoint: '/path1', expectedName: 'GET//path1' })
   })
 
   t.test('with error while out of context', (t) => {
@@ -248,7 +264,7 @@ tap.test('Restify transaction naming', (t) => {
       })
     })
 
-    runTest({ t, endpoint: '/path1', expectedName: 'GET//path1' })
+    runTest({ agent, server, t, endpoint: '/path1', expectedName: 'GET//path1' })
   })
 
   t.test('when using a route variable', (t) => {
@@ -260,7 +276,7 @@ tap.test('Restify transaction naming', (t) => {
       next()
     })
 
-    runTest({ t, endpoint: '/foo/fizz', expectedName: 'GET//foo/:bar' })
+    runTest({ agent, server, t, endpoint: '/foo/fizz', expectedName: 'GET//foo/:bar' })
   })
 
   t.test('when using a regular expression in path', (t) => {
@@ -272,7 +288,7 @@ tap.test('Restify transaction naming', (t) => {
       next()
     })
 
-    runTest({ t, endpoint: '/foo/bar', expectedName: 'GET//foo/*' })
+    runTest({ agent, server, t, endpoint: '/foo/bar', expectedName: 'GET//foo/*' })
   })
 
   t.test('when next is called after transaction state loss', (t) => {
@@ -296,7 +312,7 @@ tap.test('Restify transaction naming', (t) => {
       next()
     })
 
-    runTest({ t, endpoint: '/path1', expectedName: 'GET//path1' })
+    runTest({ agent, server, t, endpoint: '/path1', expectedName: 'GET//path1' })
   })
 
   t.test('responding after transaction state loss', (t) => {
@@ -310,7 +326,7 @@ tap.test('Restify transaction naming', (t) => {
       })
     })
 
-    runTest({ t, endpoint: '/path1', expectedName: 'GET//path1' })
+    runTest({ agent, server, t, endpoint: '/path1', expectedName: 'GET//path1' })
   })
 
   t.test('responding with just a status code', (t) => {
@@ -321,7 +337,7 @@ tap.test('Restify transaction naming', (t) => {
       next()
     })
 
-    runTest({ t, endpoint: '/path1', expectedName: 'GET//path1' })
+    runTest({ agent, server, t, endpoint: '/path1', expectedName: 'GET//path1' })
   })
 
   t.test('responding with just a status code after state loss', (t) => {
@@ -334,32 +350,6 @@ tap.test('Restify transaction naming', (t) => {
       })
     })
 
-    runTest({ t, endpoint: '/path1', expectedName: 'GET//path1' })
+    runTest({ agent, server, t, endpoint: '/path1', expectedName: 'GET//path1' })
   })
-
-  /**
-   * @param {Object} cfg
-   * @property {Object} cfg.t
-   * @property {string} cfg.endpoint
-   * @property {string} [cfg.prefix='Restify']
-   * @property {string} cfg.expectedName
-   * @property {Function} [cfg.cb=t.end]
-   * @property {Object} [cfg.requestOpts=null]
-   */
-  function runTest(cfg) {
-    const t = cfg.t
-    const endpoint = cfg.endpoint
-    const prefix = cfg.prefix || 'Restify'
-    const expectedName = `WebTransaction/${prefix}/${cfg.expectedName}`
-
-    agent.on('transactionFinished', (tx) => {
-      t.equal(tx.name, expectedName, 'should have correct name')
-      ;(cfg.cb && cfg.cb()) || t.end()
-    })
-
-    server.listen(() => {
-      const port = server.address().port
-      helper.makeGetRequest(`http://localhost:${port}${endpoint}`, cfg.requestOpts || null)
-    })
-  }
 })


### PR DESCRIPTION
## Description

Restify checks handler type and the number of arguments. Our traditional wrapping would supply a synchronous wrapper around sync or async functions, and as a result was not passing the type checking. This change supplies an asynchronous wrapper for asynchronous Restify handlers and middleware.

## How to Test

`npm run versioned restify` will run the Restify versioned tests. This includes a new test for async and sync handlers: `async-handlers.tap.js`.

## Related Issues

Closes #1824 
Closes NR-171678