### PR TITLE
test: removed access to deprecated req._headers and instead use req.headers

### DIFF
--- a/test/integration/distributed-tracing/dt.tap.js
+++ b/test/integration/distributed-tracing/dt.tap.js
@@ -411,7 +411,7 @@ function get(uri, options, cb) {
     res.on('data', (data) => (body += data.toString('utf8')))
     res.on('error', (err) => cb(err))
     res.on('end', () => {
-      cb(null, { body: JSON.parse(body), reqHeaders: res.req._headers })
+      cb(null, { body: JSON.parse(body), reqHeaders: res.req.headers })
     })
   })
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
I was refactoring promise-shim and verifying I didn't break anything and noticed in this test we were using a deprecated `_headers` property on a request message.  The preferred way to access is via `.headers`.
