### PR TITLE
fix: Ensure opts.headers is defined in request instrumenting

### DIFF
--- a/lib/instrumentation/core/http-outbound.js
+++ b/lib/instrumentation/core/http-outbound.js
@@ -138,6 +138,8 @@ function instrumentRequest(agent, opts, makeRequest, hostname, segment) {
   const transaction = segment.transaction
   const outboundHeaders = Object.create(null)
 
+  opts.headers = opts.headers || {};
+
   synthetics.assignHeadersToOutgoingRequest(agent.config, transaction, outboundHeaders)
   maybeAddDtCatHeaders(agent, transaction, outboundHeaders, opts?.headers)
   opts.headers = assignOutgoingHeaders(opts.headers, outboundHeaders)

--- a/lib/instrumentation/core/http-outbound.js
+++ b/lib/instrumentation/core/http-outbound.js
@@ -138,7 +138,7 @@ function instrumentRequest(agent, opts, makeRequest, hostname, segment) {
   const transaction = segment.transaction
   const outboundHeaders = Object.create(null)
 
-  opts.headers = opts.headers || {};
+  opts.headers = opts.headers || {}
 
   synthetics.assignHeadersToOutgoingRequest(agent.config, transaction, outboundHeaders)
   maybeAddDtCatHeaders(agent, transaction, outboundHeaders, opts?.headers)

--- a/test/unit/instrumentation/http/outbound.test.js
+++ b/test/unit/instrumentation/http/outbound.test.js
@@ -275,15 +275,15 @@ tap.test('instrumentOutbound', (t) => {
 
   t.test('should not crash when req.headers is null', (t) => {
     const req = new events.EventEmitter()
-    helper.runInTransaction(agent, function (transaction) {
+    helper.runInTransaction(agent, function () {
       const path = '/asdf'
-      const name = NAMES.EXTERNAL.PREFIX + HOSTNAME + ':' + PORT + path
 
       instrumentOutbound(agent, { headers: null, host: HOSTNAME, port: PORT }, makeFakeRequest)
-      t.equal(transaction.trace.root.children[0].name, name)
 
-      function makeFakeRequest() {
-        req.path = '/asdf?a=b&another=yourself&thing&grownup=true'
+      function makeFakeRequest(opts) {
+        t.ok(opts.headers, 'should assign headers when null')
+        t.ok(opts.headers.traceparent, 'traceparent should exist')
+        req.path = path
         return req
       }
     })

--- a/test/unit/instrumentation/http/outbound.test.js
+++ b/test/unit/instrumentation/http/outbound.test.js
@@ -272,6 +272,24 @@ tap.test('instrumentOutbound', (t) => {
     }
     t.end()
   })
+
+  t.test('should not crash when req.headers is null', (t) => {
+    const req = new events.EventEmitter()
+    helper.runInTransaction(agent, function (transaction) {
+      const path = '/asdf'
+      const name = NAMES.EXTERNAL.PREFIX + HOSTNAME + ':' + PORT + path
+
+      instrumentOutbound(agent, { headers: null, host: HOSTNAME, port: PORT }, makeFakeRequest)
+      t.equal(transaction.trace.root.children[0].name, name)
+
+      function makeFakeRequest() {
+        req.path = '/asdf?a=b&another=yourself&thing&grownup=true'
+        return req
+      }
+    })
+    t.end()
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
This fixes a bug where if `opts.headers` is `null`, it is not handled by further down functions and causes a crash.

## How to Test
Unfortunately, the situations in which this is reproduced are very specific to a flow that I have difficulty artificially reproducing. I am applying this fix as a technical code fix purely based on the way that it is crashing.

## Related Issues
Fixes #1925 