### PR TITLE
test: updated chat-completions tests to properly assert segments

### DIFF
--- a/test/versioned/openai/chat-completions.tap.js
+++ b/test/versioned/openai/chat-completions.tap.js
@@ -212,16 +212,16 @@ tap.test('OpenAI instrumentation - chat completions', (t) => {
             res += chunk.choices[0]?.delta?.content
           }
         } catch (err) {
-          t.ok(res)
-          t.ok(err.message, 'exceeded count')
+          test.ok(res)
+          test.ok(err.message, 'exceeded count')
           const events = agent.customEventAggregator.events.toArray()
-          t.equal(events.length, 4)
+          test.equal(events.length, 4)
           const chatSummary = events.filter(([{ type }]) => type === 'LlmChatCompletionSummary')[0]
           test.llmSummary({ tx, model, chatSummary, error: true })
-          t.equal(tx.exceptions.length, 1)
+          test.equal(tx.exceptions.length, 1)
           // only asserting message and completion_id as the rest of the attrs
           // are asserted in other tests
-          t.match(tx.exceptions[0], {
+          test.match(tx.exceptions[0], {
             customAttributes: {
               'error.message': 'Premature close',
               'completion_id': /\w{32}/
@@ -248,9 +248,9 @@ tap.test('OpenAI instrumentation - chat completions', (t) => {
           res += chunk.choices[0]?.delta?.content
         }
 
-        t.ok(res)
+        test.ok(res)
         const events = agent.customEventAggregator.events.toArray()
-        t.equal(events.length, 0)
+        test.equal(events.length, 0)
         // we will still record the external segment but not the chat completion
         test.assertSegments(tx.trace.root, [
           'timers.setTimeout',
@@ -281,7 +281,7 @@ tap.test('OpenAI instrumentation - chat completions', (t) => {
         })
       } catch {}
 
-      t.equal(tx.exceptions.length, 1)
+      test.equal(tx.exceptions.length, 1)
       t.match(tx.exceptions[0], {
         error: {
           status: 401,
@@ -303,8 +303,8 @@ tap.test('OpenAI instrumentation - chat completions', (t) => {
       const summary = agent.customEventAggregator.events.toArray().find((e) => {
         return e[0].type === 'LlmChatCompletionSummary'
       })
-      t.ok(summary)
-      t.equal(summary[1].error, true)
+      test.ok(summary)
+      test.equal(summary[1].error, true)
 
       tx.end()
       test.end()
@@ -320,8 +320,8 @@ tap.test('OpenAI instrumentation - chat completions', (t) => {
         })
       } catch {}
 
-      t.equal(tx.exceptions.length, 1)
-      t.match(tx.exceptions[0], {
+      test.equal(tx.exceptions.length, 1)
+      test.match(tx.exceptions[0], {
         error: {
           status: 400,
           code: null,

--- a/test/versioned/openai/chat-completions.tap.js
+++ b/test/versioned/openai/chat-completions.tap.js
@@ -46,13 +46,11 @@ tap.test('OpenAI instrumentation - chat completions', (t) => {
       test.notOk(results.api_key, 'should remove api_key from user result')
       test.equal(results.choices[0].message.content, '1 plus 2 is 3.')
 
-      test.doesNotThrow(() => {
-        test.assertSegments(
-          tx.trace.root,
-          [OPENAI.COMPLETION, [`External/${host}:${port}/chat/completions`]],
-          { exact: false }
-        )
-      }, 'should have expected segments')
+      test.assertSegments(
+        tx.trace.root,
+        [OPENAI.COMPLETION, [`External/${host}:${port}/chat/completions`]],
+        { exact: false }
+      )
       tx.end()
       test.end()
     })
@@ -129,13 +127,11 @@ tap.test('OpenAI instrumentation - chat completions', (t) => {
         test.equal(chunk.choices[0].message.content, expectedRes.streamData)
         test.equal(chunk.choices[0].message.content, res)
 
-        test.doesNotThrow(() => {
-          test.assertSegments(
-            tx.trace.root,
-            [OPENAI.COMPLETION, [`External/${host}:${port}/chat/completions`]],
-            { exact: false }
-          )
-        }, 'should have expected segments')
+        test.assertSegments(
+          tx.trace.root,
+          [OPENAI.COMPLETION, [`External/${host}:${port}/chat/completions`]],
+          { exact: false }
+        )
         tx.end()
         test.end()
       })
@@ -256,12 +252,10 @@ tap.test('OpenAI instrumentation - chat completions', (t) => {
         const events = agent.customEventAggregator.events.toArray()
         t.equal(events.length, 0)
         // we will still record the external segment but not the chat completion
-        test.doesNotThrow(() => {
-          test.assertSegments(tx.trace.root, [
-            'timers.setTimeout',
-            `External/${host}:${port}/chat/completions`
-          ])
-        }, 'should have expected segments')
+        test.assertSegments(tx.trace.root, [
+          'timers.setTimeout',
+          `External/${host}:${port}/chat/completions`
+        ])
         tx.end()
         test.end()
       })

--- a/test/versioned/openai/embeddings.tap.js
+++ b/test/versioned/openai/embeddings.tap.js
@@ -45,9 +45,13 @@ tap.test('OpenAI instrumentation - embedding', (t) => {
       test.notOk(results.api_key, 'should remove api_key from user result')
       test.equal(results.model, 'text-embedding-ada-002-v2')
 
-      t.assertSegments(tx.trace.root, [OPENAI.EMBEDDING, [`External/${host}:${port}/embeddings`]], {
-        exact: false
-      })
+      test.assertSegments(
+        tx.trace.root,
+        [OPENAI.EMBEDDING, [`External/${host}:${port}/embeddings`]],
+        {
+          exact: false
+        }
+      )
       tx.end()
       test.end()
     })
@@ -62,7 +66,7 @@ tap.test('OpenAI instrumentation - embedding', (t) => {
       })
 
       const metrics = agent.metrics.getOrCreateMetric(`${OPENAI.TRACKING_PREFIX}/${pkgVersion}`)
-      t.equal(metrics.callCount > 0, true)
+      test.equal(metrics.callCount > 0, true)
 
       tx.end()
       test.end()
@@ -122,8 +126,8 @@ tap.test('OpenAI instrumentation - embedding', (t) => {
         })
       } catch {}
 
-      t.equal(tx.exceptions.length, 1)
-      t.match(tx.exceptions[0], {
+      test.equal(tx.exceptions.length, 1)
+      test.match(tx.exceptions[0], {
         error: {
           status: 403,
           code: null,
@@ -143,7 +147,7 @@ tap.test('OpenAI instrumentation - embedding', (t) => {
       })
 
       const embedding = agent.customEventAggregator.events.toArray().slice(0, 1)[0][1]
-      t.equal(embedding.error, true)
+      test.equal(embedding.error, true)
 
       tx.end()
       test.end()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
In #1919 mocha was removed as well as some common assertions were updated to properly use tap.  I missed a few places that were wrapping the tap assertion in a `t.doesNotThrow`.  This is no longer needed as the helper properly uses tap to do assertions. I also noticed some assertions were not using the proper instance of tap.
