### PR TITLE
chore: removed assigning unused metadata to LLM events

### DIFF
--- a/lib/instrumentation/openai.js
+++ b/lib/instrumentation/openai.js
@@ -76,7 +76,6 @@ function decorateSegment({ shim, result, apiKey }) {
  */
 function recordEvent({ agent, type, msg }) {
   agent.metrics.getOrCreateMetric(TRACKING_METRIC).incrementCallCount()
-  msg = agent?.llm?.metadata ? { ...agent.llm.metadata, ...msg } : msg
   agent.customEventAggregator.add([{ type, timestamp: Date.now() }, msg])
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

In #1918 we removed the ability to assign metadata to LLM events. This was because the implementation wasn't fully thought out at the org level.  I missed a spot where it was actually reading if `agent.llm.metadata` was present and spreading it on the LLM message.  
