### PR TITLE
test: updated abort controller test expected error message based on undici version

### DIFF
--- a/test/versioned/undici/requests.tap.js
+++ b/test/versioned/undici/requests.tap.js
@@ -11,6 +11,8 @@ const helper = require('../../lib/agent_helper')
 const metrics = require('../../lib/metrics_helper')
 const http = require('http')
 const https = require('https')
+const { version: pkgVersion } = require('undici/package')
+const semver = require('semver')
 
 tap.test('Undici request tests', (t) => {
   t.autoend()
@@ -241,7 +243,10 @@ tap.test('Undici request tests', (t) => {
       } catch (err) {
         t.assertSegments(tx.trace.root, [`External/${HOST}/delay/1000`], { exact: false })
         t.equal(tx.exceptions.length, 1)
-        t.equal(tx.exceptions[0].error.message, 'Request aborted')
+        const expectedErrMsg = semver.gte(pkgVersion, '6.3.0')
+          ? 'This operation was aborted'
+          : 'Request aborted'
+        t.equal(tx.exceptions[0].error.message, expectedErrMsg)
         tx.end()
         t.end()
       }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

CI was failing after the [6.3.0](https://github.com/nodejs/undici/releases/tag/v6.3.0) release of undici.

```sh
# Subtest: should add errors to transaction when external segment exists
        ok 1 - segment "ROOT" should have child "External/localhost:33941/delay/1000"
        ok 2 - should be equal
        not ok 3 - should be equal
          ---
          compare: ===
          at:
            line: 244
            column: 11
            file: requests.tap.js
          stack: |
            requests.tap.js:244:11
          source: |2
                    t.equal(tx.exceptions.length, 1)
                    t.equal(tx.exceptions[0].error.message, 'Request aborted')
            ----------^
                    tx.end()
                    t.end()
          diff: |
            --- expected
            +++ actual
            @@ -1,1 +1,1 @@
            -Request aborted
            +This operation was aborted
          ...
        
        1..3
        # failed 1 of 3 tests
```

Looks like generic error on aborted request changes. This PR updates that to handle it accordingly.
