### PR TITLE
test: Fix DNS lookup in remote-method test

### DIFF
--- a/test/unit/collector/remote-method.test.js
+++ b/test/unit/collector/remote-method.test.js
@@ -7,6 +7,8 @@
 
 const tap = require('tap')
 const dns = require('dns')
+const events = require('events')
+const https = require('https')
 
 const url = require('url')
 const Config = require('../../../lib/config')
@@ -242,6 +244,20 @@ tap.test('when the connection fails', (t) => {
   t.autoend()
 
   t.test('should return the connection failure', (t) => {
+    const req = https.request
+    https.request = () => {
+      const error = Error('no server')
+      error.code = 'ECONNREFUSED'
+      const r = new events.EventEmitter()
+      r.end = function () {
+        this.emit('error', error)
+      }
+      return r
+    }
+    t.teardown(() => {
+      https.request = req
+    })
+
     const config = {
       max_payload_size_in_bytes: 100000
     }


### PR DESCRIPTION
The current test relies on whatever DNS server the system uses to return a "not found" answer for `failed.domain.clxrg`. There are two problems with this:

1. A unit test, in my opinion, should not rely on any external resources (servers) in order to work.
2. AT&T seems to ship gateways that will resolve whatever random domain you give them to arbitrary IP addresses.

This PR solves both problems.