### PR TITLE
fix: remove extra / in openai framework metric name

### DIFF
--- a/lib/metrics/names.js
+++ b/lib/metrics/names.js
@@ -165,7 +165,7 @@ const EXPRESS = {
 }
 
 const AI = {
-  TRACKING_PREFIX: 'Nodejs/ML/',
+  TRACKING_PREFIX: 'Nodejs/ML',
   EMBEDDING: 'Llm/embedding',
   COMPLETION: 'Llm/completion'
 }

--- a/test/versioned/openai/chat-completions.tap.js
+++ b/test/versioned/openai/chat-completions.tap.js
@@ -63,7 +63,8 @@ tap.test('OpenAI instrumentation - chat completions', (t) => {
         messages: [{ role: 'user', content: 'You are a mathematician.' }]
       })
 
-      const metrics = agent.metrics.getOrCreateMetric(`${OPENAI.TRACKING_PREFIX}/${pkgVersion}`)
+      console.log(OPENAI.TRACKING_PREFIX)
+      const metrics = agent.metrics.getOrCreateMetric(`Nodejs/ML/OpenAI/${pkgVersion}`)
       t.equal(metrics.callCount > 0, true)
 
       tx.end()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

The Nodejs/ML/OpenAI/<version> metric is needed to apply a tag to the apm entity. A dev rel engineer wasn't seeing it. It was because it had `//` in one of the path segments.  Also our test was using the same constant to assert the broken behavior. Fixed it all.
