### PR TITLE
feat: Assign pkgVersion and id of all child shim instances when using shim.makeSpecializedShim with a ConglomerateShim instance

### DIFF
--- a/lib/shim/conglomerate-shim.js
+++ b/lib/shim/conglomerate-shim.js
@@ -65,7 +65,15 @@ class ConglomerateShim extends Shim {
    */
   makeSpecializedShim(type, submodule) {
     const ShimClass = SHIM_CLASSES[type]
-    const shim = new ShimClass(this.agent, this.moduleName, this._resolvedName)
+    const shim = new ShimClass(
+      this.agent,
+      this.moduleName,
+      this._resolvedName,
+      null,
+      this.pkgVersion
+    )
+    // associate the parent shim.id with the new submodule
+    shim.id = this.id
     shim._logger = shim._logger.child({ submodule })
     return shim
   }

--- a/test/unit/shim/conglomerate-shim.test.js
+++ b/test/unit/shim/conglomerate-shim.test.js
@@ -75,6 +75,12 @@ test('ConglomerateShim', (t) => {
     t.equal(shim.moduleName, mod)
     t.equal(agent, shim._agent)
     t.equal(shim.pkgVersion, version)
+    function childFn() {}
+    const childShim = shim.makeSpecializedShim(shim.DATASTORE, childFn)
+    t.same(shim._agent, childShim._agent)
+    t.equal(shim.moduleName, childShim.moduleName)
+    t.equal(shim.pkgVersion, childShim.pkgVersion)
+    t.equal(shim.id, childShim.id)
     t.end()
   })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
In #1883 we added the ability to grab the version of the package via `shim.pkgVersion`.  There was an oversight when you create a child shim via `shim.makeSpecializedShim`. It was not using the pkgVersion and id from the parent shim.  This PR resolves that so if you are using a shim instance from `shim.makeSpecializedShim`, `shim.pkgVersion` will be present.

