### PR TITLE
security(remote_method): redact ingest key in trace level logs

### DIFF
--- a/lib/collector/remote-method.js
+++ b/lib/collector/remote-method.js
@@ -266,7 +266,7 @@ RemoteMethod.prototype._safeRequest = function _safeRequest(options) {
     protocol,
     options.host,
     options.port,
-    options.path
+    this._path(true)
   )
 
   this._request(options)
@@ -336,13 +336,14 @@ RemoteMethod.prototype._userAgent = function _userAgent() {
 /**
  * Generate a URL the collector understands.
  *
+ * @param {boolean} redactLicenseKey flag to redact license key in path
  * @returns {string} The URL path to be POSTed to.
  */
-RemoteMethod.prototype._path = function _path() {
+RemoteMethod.prototype._path = function _path(redactLicenseKey) {
   const query = {
     marshal_format: 'json',
     protocol_version: this._protocolVersion,
-    license_key: this._config.license_key,
+    license_key: redactLicenseKey ? 'REDACTED' : this._config.license_key,
     method: this.name
   }
 

--- a/lib/collector/remote-method.js
+++ b/lib/collector/remote-method.js
@@ -259,15 +259,19 @@ RemoteMethod.prototype._safeRequest = function _safeRequest(options) {
     level = 'info'
   }
 
-  const logBody = Buffer.isBuffer(options.body) ? 'Buffer ' + options.body.length : options.body
-  logger[level](
-    { body: logBody },
-    'Posting to %s://%s:%s%s',
-    protocol,
-    options.host,
-    options.port,
-    this._path(true)
-  )
+  // check if trace is enabled or audit log(aka info in this case) before attemping
+  // to get the body length or parse the path with redacted key
+  if (logger.traceEnabled() || level === 'info') {
+    const logBody = Buffer.isBuffer(options.body) ? 'Buffer ' + options.body.length : options.body
+    logger[level](
+      { body: logBody },
+      'Posting to %s://%s:%s%s',
+      protocol,
+      options.host,
+      options.port,
+      this._path({ redactLicenseKey: true })
+    )
+  }
 
   this._request(options)
 }
@@ -339,7 +343,7 @@ RemoteMethod.prototype._userAgent = function _userAgent() {
  * @param {boolean} redactLicenseKey flag to redact license key in path
  * @returns {string} The URL path to be POSTed to.
  */
-RemoteMethod.prototype._path = function _path(redactLicenseKey) {
+RemoteMethod.prototype._path = function _path({ redactLicenseKey } = {}) {
   const query = {
     marshal_format: 'json',
     protocol_version: this._protocolVersion,

--- a/test/unit/collector/remote-method.test.js
+++ b/test/unit/collector/remote-method.test.js
@@ -17,7 +17,6 @@ const Config = require('../../../lib/config')
 const helper = require('../../lib/agent_helper')
 require('../../lib/metrics_helper')
 const NAMES = require('../../../lib/metrics/names')
-
 const BARE_AGENT = { config: {}, metrics: { measureBytes() {} } }
 
 function generate(method, runID, protocolVersion) {
@@ -940,44 +939,89 @@ tap.test('record data usage supportability metrics', (t) => {
   })
 })
 
-tap.test('should redact license key in logs', (t) => {
-  const sandbox = sinon.createSandbox()
-  t.teardown(() => {
+tap.test('_safeRequest logging', (t) => {
+  t.autoend()
+  t.beforeEach((t) => {
+    const sandbox = sinon.createSandbox()
+    const loggerMock = require('../mocks/logger')(sandbox)
+    const RemoteMethod = proxyquire('../../../lib/collector/remote-method', {
+      '../logger': {
+        child: sandbox.stub().callsFake(() => loggerMock)
+      }
+    })
+    sandbox.stub(RemoteMethod.prototype, '_request')
+    t.context.loggerMock = loggerMock
+    t.context.RemoteMethod = RemoteMethod
+    t.context.sandbox = sandbox
+    t.context.options = {
+      host: 'collector.newrelic.com',
+      port: 80,
+      onError: () => {},
+      onResponse: () => {},
+      body: 'test-body',
+      path: '/nonexistent'
+    }
+    t.context.config = { license_key: 'shhh-dont-tell', max_payload_size_in_bytes: 10000 }
+  })
+
+  t.afterEach((t) => {
+    const { sandbox } = t.context
     sandbox.restore()
   })
-  const loggerMock = require('../mocks/logger')(sandbox)
-  const RemoteMethod = proxyquire('../../../lib/collector/remote-method', {
-    '../logger': {
-      child: sandbox.stub().callsFake(() => loggerMock)
-    }
-  })
-  const method = new RemoteMethod('test', {
-    config: { license_key: 'shhh-dont-tell', max_payload_size_in_bytes: 10000 }
-  })
-  method
-  const options = {
-    host: 'collector.newrelic.com',
-    port: 80,
-    onError: () => {},
-    onResponse: () => {},
-    body: 'test-body',
-    path: '/nonexistent'
-  }
-  sandbox.stub(method, '_request')
-  method._safeRequest(options)
-  t.same(
-    loggerMock.trace.args,
-    [
+
+  t.test('should redact license key in logs', (t) => {
+    const { RemoteMethod, loggerMock, options, config } = t.context
+    loggerMock.traceEnabled.returns(true)
+    const method = new RemoteMethod('test', { config })
+    method._safeRequest(options)
+    t.same(
+      loggerMock.trace.args,
       [
-        { body: options.body },
-        'Posting to %s://%s:%s%s',
-        'https',
-        options.host,
-        options.port,
-        '/agent_listener/invoke_raw_method?marshal_format=json&protocol_version=17&license_key=REDACTED&method=test'
-      ]
-    ],
-    'should redact key in trace level log'
-  )
-  t.end()
+        [
+          { body: options.body },
+          'Posting to %s://%s:%s%s',
+          'https',
+          options.host,
+          options.port,
+          '/agent_listener/invoke_raw_method?marshal_format=json&protocol_version=17&license_key=REDACTED&method=test'
+        ]
+      ],
+      'should redact key in trace level log'
+    )
+    t.end()
+  })
+
+  t.test('should call logger if trace is not enabled but audit logging is enabled', (t) => {
+    const { RemoteMethod, loggerMock, options, config } = t.context
+    loggerMock.traceEnabled.returns(false)
+    config.logging = { level: 'info' }
+    config.audit_log = { enabled: true, endpoints: ['test'] }
+    const method = new RemoteMethod('test', { config })
+    method._safeRequest(options)
+    t.same(
+      loggerMock.info.args,
+      [
+        [
+          { body: options.body },
+          'Posting to %s://%s:%s%s',
+          'https',
+          options.host,
+          options.port,
+          '/agent_listener/invoke_raw_method?marshal_format=json&protocol_version=17&license_key=REDACTED&method=test'
+        ]
+      ],
+      'should redact key in trace level log'
+    )
+    t.end()
+  })
+
+  t.test('should not call logger if trace or audit logging is not enabled', (t) => {
+    const { RemoteMethod, loggerMock, options, config } = t.context
+    loggerMock.traceEnabled.returns(false)
+    const method = new RemoteMethod('test', { config })
+    method._safeRequest(options)
+    t.ok(loggerMock.trace.callCount === 0, 'should not log outgoing message to collector')
+    t.ok(loggerMock.info.callCount === 0, 'should not log outgoing message to collector')
+    t.end()
+  })
 })

--- a/test/unit/mocks/logger.js
+++ b/test/unit/mocks/logger.js
@@ -7,6 +7,7 @@
 const sinon = require('sinon')
 
 module.exports = (sandbox = sinon) => ({
+  traceEnabled: sandbox.stub().returns(true),
   trace: sandbox.stub(),
   info: sandbox.stub(),
   debug: sandbox.stub(),


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
Updated private `_path` method to pass in boolean to generate path for remote method.  If arg is true it'll redact the ingest key. This is only called when logging certain trace level logs. This does not remove ingest key from collector path or payload in connect and pre-connect as the downstream services lack support for this.

After this PR you see this in logs

```
{"v":0,"level":10,"name":"newrelic","hostname":"TK46XHNX04","pid":84136,"time":"2024-01-12T21:26:05.878Z","msg":"Posting to https://staging-collector.newrelic.com:443/agent_listener/invoke_raw_method?marshal_format=json&protocol_version=17&license_key=REDACTED&method=agent_settings&run_id=","component":"remote_method","body":"Buffer 26910"}
```


## Related Issues
Fixes NR-214994

