### PR TITLE
feat: Added transaction ID to ErrorTrace event

### DIFF
--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -67,7 +67,8 @@ class Exception {
  *                                                 [1] -> name extracted from error info,
  *                                                 [2] -> extracted error message,
  *                                                 [3] -> extracted error type,
- *                                                 [4] -> attributes
+ *                                                 [4] -> attributes,
+ *                                                 [5] -> transaction id
  */
 function createError(transaction, exception, config) {
   const error = exception.error
@@ -111,7 +112,7 @@ function createError(transaction, exception, config) {
 
   maybeAddAgentAttributes(params, exception)
 
-  return [0, name, message, type, params]
+  return [0, name, message, type, params, transaction?.id]
 }
 
 function isValidErrorGroupOutput(output) {

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -112,7 +112,10 @@ function createError(transaction, exception, config) {
 
   maybeAddAgentAttributes(params, exception)
 
-  return [0, name, message, type, params, transaction?.id]
+  if (transaction?.id) {
+    return [0, name, message, type, params, transaction.id]
+  }
+  return [0, name, message, type, params]
 }
 
 function isValidErrorGroupOutput(output) {

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -112,10 +112,7 @@ function createError(transaction, exception, config) {
 
   maybeAddAgentAttributes(params, exception)
 
-  if (transaction?.id) {
-    return [0, name, message, type, params, transaction.id]
-  }
-  return [0, name, message, type, params]
+  return [0, name, message, type, params, transaction?.id]
 }
 
 function isValidErrorGroupOutput(output) {

--- a/test/unit/api/api-set-user-id.test.js
+++ b/test/unit/api/api-set-user-id.test.js
@@ -63,7 +63,7 @@ tap.test('Agent API = set user id', (t) => {
       api.setUserID(id)
       const exception = new Exception(new Error('Test error.'))
       const [...data] = createError(tx, exception, agent.config)
-      const params = data.pop()
+      const params = data[data.length - 2]
       t.equal(params.agentAttributes['enduser.id'], id, 'should set enduser.id attribute on error')
       t.end()
     })

--- a/test/unit/api/api-set-user-id.test.js
+++ b/test/unit/api/api-set-user-id.test.js
@@ -63,7 +63,7 @@ tap.test('Agent API = set user id', (t) => {
       api.setUserID(id)
       const exception = new Exception(new Error('Test error.'))
       const [...data] = createError(tx, exception, agent.config)
-      const params = data[data.length - 2]
+      const params = data.at(-2)
       t.equal(params.agentAttributes['enduser.id'], id, 'should set enduser.id attribute on error')
       t.end()
     })

--- a/test/unit/errors/error-collector.test.js
+++ b/test/unit/errors/error-collector.test.js
@@ -220,7 +220,7 @@ tap.test('Errors', (t) => {
       errorJSON = errorTraces[0]
 
       const transactionId = errorJSON[5]
-      t.not(transactionId, undefined)
+      t.equal(transactionId, transaction.id)
       transaction.end()
       t.end()
     })
@@ -258,7 +258,7 @@ tap.test('Errors', (t) => {
       errorJSON = errorTraces[0]
 
       const transactionId = errorJSON[5]
-      t.not(transactionId, undefined)
+      t.equal(transactionId, transaction.id)
       transaction.end()
       t.end()
     })
@@ -361,7 +361,7 @@ tap.test('Errors', (t) => {
 
       const errorTraces = getErrorTraces(agent.errors)
       const error = errorTraces[0]
-      t.equal(error[error.length - 2], testError.name)
+      t.equal(error[error.length - 3], testError.name)
       t.end()
     })
 
@@ -698,11 +698,12 @@ tap.test('Errors', (t) => {
       t.autoend()
       let noErrorStatusTracer
       let errorJSON
+      let transaction
 
       t.beforeEach(() => {
         noErrorStatusTracer = agent.errors
 
-        const transaction = new Transaction(agent)
+        transaction = new Transaction(agent)
         transaction.statusCode = 503 // PDX wut wut
 
         noErrorStatusTracer.add(transaction, null)
@@ -746,7 +747,7 @@ tap.test('Errors', (t) => {
 
       t.test('should have a transaction id', (t) => {
         const transactionId = errorJSON[5]
-        t.not(transactionId, undefined)
+        t.equal(transactionId, transaction.id)
         t.end()
       })
 
@@ -759,9 +760,10 @@ tap.test('Errors', (t) => {
     t.test('with transaction agent attrs, status code, and no error', (t) => {
       let errorJSON = null
       let params = null
+      let transaction
 
       t.beforeEach(() => {
-        const transaction = new Transaction(agent)
+        transaction = new Transaction(agent)
         transaction.statusCode = 501
         transaction.url = '/'
         transaction.trace.attributes.addAttributes(DESTS.TRANS_SCOPE, {
@@ -810,7 +812,7 @@ tap.test('Errors', (t) => {
 
       t.test('should have a transaction id', (t) => {
         const transactionId = errorJSON[5]
-        t.not(transactionId, undefined)
+        t.equal(transactionId, transaction.id)
         t.end()
       })
 
@@ -931,11 +933,12 @@ tap.test('Errors', (t) => {
       t.autoend()
       let typeErrorTracer
       let errorJSON
+      let transaction
 
       t.beforeEach(() => {
         typeErrorTracer = agent.errors
 
-        const transaction = new Transaction(agent)
+        transaction = new Transaction(agent)
         const exception = new TypeError('Dare to be different!')
 
         typeErrorTracer.add(transaction, exception)
@@ -980,7 +983,7 @@ tap.test('Errors', (t) => {
 
       t.test('should have a transaction id', (t) => {
         const transactionId = errorJSON[5]
-        t.not(transactionId, undefined)
+        t.equal(transactionId, transaction.id)
         t.end()
       })
     })
@@ -989,9 +992,10 @@ tap.test('Errors', (t) => {
       t.autoend()
       let errorJSON = null
       let params = null
+      let transaction
 
       t.beforeEach(() => {
-        const transaction = new Transaction(agent)
+        transaction = new Transaction(agent)
         const exception = new TypeError('wanted JSON, got XML')
 
         transaction.trace.attributes.addAttributes(DESTS.TRANS_SCOPE, {
@@ -1042,7 +1046,7 @@ tap.test('Errors', (t) => {
 
       t.test('should have a transaction id', (t) => {
         const transactionId = errorJSON[5]
-        t.not(transactionId, undefined)
+        t.equal(transactionId, transaction.id)
         t.end()
       })
 
@@ -1066,11 +1070,12 @@ tap.test('Errors', (t) => {
       t.autoend()
       let thrownTracer
       let errorJSON
+      let transaction
 
       t.beforeEach(() => {
         thrownTracer = agent.errors
 
-        const transaction = new Transaction(agent)
+        transaction = new Transaction(agent)
         const exception = 'Dare to be different!'
 
         thrownTracer.add(transaction, exception)
@@ -1113,7 +1118,7 @@ tap.test('Errors', (t) => {
 
       t.test('should have a transaction id', (t) => {
         const transactionId = errorJSON[5]
-        t.not(transactionId, undefined)
+        t.equal(transactionId, transaction.id)
         t.end()
       })
     })
@@ -1122,9 +1127,10 @@ tap.test('Errors', (t) => {
       t.autoend()
       let errorJSON = null
       let params = null
+      let transaction
 
       t.beforeEach(() => {
-        const transaction = new Transaction(agent)
+        transaction = new Transaction(agent)
         const exception = 'wanted JSON, got XML'
 
         transaction.trace.attributes.addAttributes(DESTS.TRANS_SCOPE, {
@@ -1175,7 +1181,7 @@ tap.test('Errors', (t) => {
 
       t.test('should have a transaction id', (t) => {
         const transactionId = errorJSON[5]
-        t.not(transactionId, undefined)
+        t.equal(transactionId, transaction.id)
         t.end()
       })
 
@@ -2181,9 +2187,9 @@ test('When using the async listener', (t) => {
     })
   })
 
-  t.test('should have 5 elements in the trace', (t) => {
+  t.test('should have 6 elements in the trace', (t) => {
     executeThrowingTransaction(() => {
-      t.equal(json.length, 5)
+      t.equal(json.length, 6)
       t.end()
     })
   })

--- a/test/unit/errors/error-collector.test.js
+++ b/test/unit/errors/error-collector.test.js
@@ -285,7 +285,7 @@ tap.test('Errors', (t) => {
 
       const errorTraces = getErrorTraces(agent.errors)
       const error = errorTraces[0]
-      t.equal(error[error.length - 3], testError.name)
+      t.equal(error[error.length - 2], testError.name)
       t.end()
     })
 
@@ -844,9 +844,9 @@ tap.test('Errors', (t) => {
         t.end()
       })
 
-      t.test('should have undefined for transaction id', (t) => {
+      t.test('should not have a transaction id', (t) => {
         const transactionId = errorJSON[5]
-        t.equal(transactionId, undefined)
+        t.notOk(transactionId)
         t.end()
       })
     })
@@ -2105,9 +2105,9 @@ test('When using the async listener', (t) => {
     })
   })
 
-  t.test('should have 6 elements in the trace', (t) => {
+  t.test('should have 5 elements in the trace', (t) => {
     executeThrowingTransaction(() => {
-      t.equal(json.length, 6)
+      t.equal(json.length, 5)
       t.end()
     })
   })

--- a/test/unit/errors/error-collector.test.js
+++ b/test/unit/errors/error-collector.test.js
@@ -199,6 +199,82 @@ tap.test('Errors', (t) => {
     })
   })
 
+  t.test('transaction id with distributed tracing enabled', (t) => {
+    t.autoend()
+    let errorJSON
+    let transaction
+    let error
+
+    t.beforeEach(() => {
+      agent.config.distributed_tracing.enabled = true
+      error = new Error('this is an error')
+    })
+
+    t.test('should have a transaction id when there is a transaction', (t) => {
+      transaction = new Transaction(agent)
+
+      agent.errors.add(transaction, error)
+      agent.errors.onTransactionFinished(transaction)
+
+      const errorTraces = getErrorTraces(agent.errors)
+      errorJSON = errorTraces[0]
+
+      const transactionId = errorJSON[5]
+      t.not(transactionId, undefined)
+      transaction.end()
+      t.end()
+    })
+
+    t.test('should not have a transaction id when there is no transaction', (t) => {
+      agent.errors.add(null, error)
+
+      const errorTraces = getErrorTraces(agent.errors)
+      errorJSON = errorTraces[0]
+
+      const transactionId = errorJSON[5]
+      t.notOk(transactionId)
+      t.end()
+    })
+  })
+
+  t.test('transaction id with distributed tracing disabled', (t) => {
+    t.autoend()
+    let errorJSON
+    let transaction
+    let error
+
+    t.beforeEach(() => {
+      agent.config.distributed_tracing.enabled = false
+      error = new Error('this is an error')
+    })
+
+    t.test('should have a transaction id when there is a transaction', (t) => {
+      transaction = new Transaction(agent)
+
+      agent.errors.add(transaction, error)
+      agent.errors.onTransactionFinished(transaction)
+
+      const errorTraces = getErrorTraces(agent.errors)
+      errorJSON = errorTraces[0]
+
+      const transactionId = errorJSON[5]
+      t.not(transactionId, undefined)
+      transaction.end()
+      t.end()
+    })
+
+    t.test('should not have a transaction id when there is no transaction', (t) => {
+      agent.errors.add(null, error)
+
+      const errorTraces = getErrorTraces(agent.errors)
+      errorJSON = errorTraces[0]
+
+      const transactionId = errorJSON[5]
+      t.notOk(transactionId)
+      t.end()
+    })
+  })
+
   t.test('display name', (t) => {
     t.autoend()
     const PARAMS = 4

--- a/test/unit/errors/error-collector.test.js
+++ b/test/unit/errors/error-collector.test.js
@@ -285,7 +285,7 @@ tap.test('Errors', (t) => {
 
       const errorTraces = getErrorTraces(agent.errors)
       const error = errorTraces[0]
-      t.equal(error[error.length - 2], testError.name)
+      t.equal(error[error.length - 3], testError.name)
       t.end()
     })
 
@@ -667,6 +667,17 @@ tap.test('Errors', (t) => {
         t.notHas(params, 'stack_trace')
         t.end()
       })
+
+      t.test('should have a transaction id', (t) => {
+        const transactionId = errorJSON[5]
+        t.not(transactionId, undefined)
+        t.end()
+      })
+
+      t.test('should have 6 elements in errorJson', (t) => {
+        t.equal(errorJSON.length, 6)
+        t.end()
+      })
     })
 
     t.test('with transaction agent attrs, status code, and no error', (t) => {
@@ -718,6 +729,12 @@ tap.test('Errors', (t) => {
 
       t.test('should not have a stack trace in the params', (t) => {
         t.notHas(params, 'stack_trace')
+        t.end()
+      })
+
+      t.test('should have a transaction id', (t) => {
+        const transactionId = errorJSON[5]
+        t.not(transactionId, undefined)
         t.end()
       })
 
@@ -826,6 +843,12 @@ tap.test('Errors', (t) => {
         t.equal(params.stack_trace[0], 'Error: Dare to be the same!')
         t.end()
       })
+
+      t.test('should have undefined for transaction id', (t) => {
+        const transactionId = errorJSON[5]
+        t.equal(transactionId, undefined)
+        t.end()
+      })
     })
 
     t.test('with a thrown TypeError and a transaction with no params', (t) => {
@@ -876,6 +899,12 @@ tap.test('Errors', (t) => {
         const params = errorJSON[4]
         t.hasProp(params, 'stack_trace')
         t.equal(params.stack_trace[0], 'TypeError: Dare to be different!')
+        t.end()
+      })
+
+      t.test('should have a transaction id', (t) => {
+        const transactionId = errorJSON[5]
+        t.not(transactionId, undefined)
         t.end()
       })
     })
@@ -932,6 +961,12 @@ tap.test('Errors', (t) => {
       t.test('should have a stack trace in the params', (t) => {
         t.hasProp(params, 'stack_trace')
         t.equal(params.stack_trace[0], 'TypeError: wanted JSON, got XML')
+        t.end()
+      })
+
+      t.test('should have a transaction id', (t) => {
+        const transactionId = errorJSON[5]
+        t.not(transactionId, undefined)
         t.end()
       })
 
@@ -999,6 +1034,12 @@ tap.test('Errors', (t) => {
         t.notHas(errorJSON[4], 'stack_trace')
         t.end()
       })
+
+      t.test('should have a transaction id', (t) => {
+        const transactionId = errorJSON[5]
+        t.not(transactionId, undefined)
+        t.end()
+      })
     })
 
     t.test('with a thrown string and a transaction with agent parameters', (t) => {
@@ -1053,6 +1094,12 @@ tap.test('Errors', (t) => {
 
       t.test('should not have a stack trace in the params', (t) => {
         t.notHas(params, 'stack_trace')
+        t.end()
+      })
+
+      t.test('should have a transaction id', (t) => {
+        const transactionId = errorJSON[5]
+        t.not(transactionId, undefined)
         t.end()
       })
 
@@ -2058,9 +2105,9 @@ test('When using the async listener', (t) => {
     })
   })
 
-  t.test('should have 5 elements in the trace', (t) => {
+  t.test('should have 6 elements in the trace', (t) => {
     executeThrowingTransaction(() => {
-      t.equal(json.length, 5)
+      t.equal(json.length, 6)
       t.end()
     })
   })

--- a/test/unit/protocols.test.js
+++ b/test/unit/protocols.test.js
@@ -36,7 +36,7 @@ tap.test('errors', (t) => {
       t.same(
         errors,
         '[1,[[0,"Unknown","test","Error",{"userAttributes":{},"agentAttributes":{},' +
-          '"intrinsics":{"error.expected":false},"stack_trace":["test stack"]}]]]'
+          '"intrinsics":{"error.expected":false},"stack_trace":["test stack"]},null]]]'
       )
       t.end()
     })

--- a/test/unit/protocols.test.js
+++ b/test/unit/protocols.test.js
@@ -36,7 +36,7 @@ tap.test('errors', (t) => {
       t.same(
         errors,
         '[1,[[0,"Unknown","test","Error",{"userAttributes":{},"agentAttributes":{},' +
-          '"intrinsics":{"error.expected":false},"stack_trace":["test stack"]},null]]]'
+          '"intrinsics":{"error.expected":false},"stack_trace":["test stack"]}]]]'
       )
       t.end()
     })

--- a/test/versioned/connect/error-intercept.tap.js
+++ b/test/versioned/connect/error-intercept.tap.js
@@ -74,7 +74,7 @@ test('intercepting errors with connect 2', function (t) {
       t.equal(errors.length, 1, 'the error got traced')
 
       const error = errors[0]
-      t.equal(error.length, 5, 'format for traced error is correct')
+      t.equal(error.length, 6, 'format for traced error is correct')
       t.equal(error[3], 'TypeError', 'got the correct class for the error')
 
       server.close()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
We need to add the transaction id to ErrorTrace event to [link Transactions to Traces](https://newrelic.atlassian.net/wiki/spaces/CPE1/pages/2885255250/CDD+Put+Transaction+IDs+into+ErrorTrace+Events). 

Added transaction.id as the last field of the Error Trace JSON payload if the error occurs within a transaction. 

Example error trace payload:

```
[
  "BSr1H3OtQKJhADnLvCAdVaVlqrHUAAgBAAAnIQEAAMwQAgQgHVy5AwAGMTEuOYWZ0ZXItMw",
  [
    0,
    "WebTransaction/Expressjs/GET//error-stack",
    "Expected ',' or '}' after property value in JSON at position 47",
    "SyntaxError",
    {
      "userAttributes": {},
      "agentAttributes": {
        "spanId": "4c6c496ad0492950",
        "request.headers.host": "localhost:3000",
        "request.headers.userAgent": "curl/8.4.0",
        "request.headers.accept": "*/*",
        "request.method": "GET",
        "request.uri": "/error-stack",
        "http.statusCode": "500",
        "http.statusText": "Internal Server Error",
        "response.headers.contentSecurityPolicy": "default-src 'none'",
        "response.headers.contentType": "text/html; charset=utf-8",
        "response.headers.contentLength": 1228
      },
      "intrinsics": {
        "totalTime": 0.009906432625,
        "error.expected": false
      },
      "stack_trace": [ // snipped ]
    },
    "80e1fa9afe5439fb" // Transaction ID
  ]
]
```

## How to Test

Updated some unit tests. Added unit tests that confirm transaction id is added to error trace json when distributed tracking is both turned off and turned on.

## Related Issues

Closes #1951 