### PR TITLE
chore(deps): updated @newrelic/aws-sdk to latest and removed aws_bedrock_instrumentation feature flag

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -509,7 +509,7 @@ This product includes source derived from [@grpc/proto-loader](https://github.co
 
 ### @newrelic/aws-sdk
 
-This product includes source derived from [@newrelic/aws-sdk](https://github.com/newrelic/node-newrelic-aws-sdk) ([v7.0.3](https://github.com/newrelic/node-newrelic-aws-sdk/tree/v7.0.3)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-aws-sdk/blob/v7.0.3/LICENSE):
+This product includes source derived from [@newrelic/aws-sdk](https://github.com/newrelic/node-newrelic-aws-sdk) ([v7.1.0](https://github.com/newrelic/node-newrelic-aws-sdk/tree/v7.1.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic-aws-sdk/blob/v7.1.0/LICENSE):
 
 ```
                                  Apache License

--- a/lib/feature_flags.js
+++ b/lib/feature_flags.js
@@ -12,8 +12,7 @@ exports.prerelease = {
   reverse_naming_rules: false,
   undici_async_tracking: true,
   unresolved_promise_cleanup: true,
-  legacy_context_manager: false,
-  aws_bedrock_instrumentation: false
+  legacy_context_manager: false
 }
 
 // flags that are no longer used for released features
@@ -34,7 +33,8 @@ exports.released = [
   'await_support',
   'certificate_bundle',
   'async_local_context',
-  'undici_instrumentation'
+  'undici_instrumentation',
+  'aws_bedrock_instrumentation'
 ]
 
 // flags that are no longer used for unreleased features

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.9.4",
         "@grpc/proto-loader": "^0.7.5",
-        "@newrelic/aws-sdk": "^7.0.3",
+        "@newrelic/aws-sdk": "^7.1.0",
         "@newrelic/koa": "^8.0.1",
         "@newrelic/security-agent": "^0.6.0",
         "@newrelic/superagent": "^7.0.1",
@@ -1354,9 +1354,9 @@
       }
     },
     "node_modules/@newrelic/aws-sdk": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-7.0.3.tgz",
-      "integrity": "sha512-oafBFD+DEAqXTg0w15eEu2rfoedWMS7abyW5CuOJxSb+7OWiFUx9jZPpdFblsYPVNWBehxFdws6/JEio3GklyA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-7.1.0.tgz",
+      "integrity": "sha512-deP7UC0/rYLuGGeK5ZWB1a6fG6b8I21kaZl8+zpkG3nflsRw+DgDTC7y3iiIoX5DtLodjqWO6pAcroxnpHal8g==",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -17289,9 +17289,9 @@
       }
     },
     "@newrelic/aws-sdk": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-7.0.3.tgz",
-      "integrity": "sha512-oafBFD+DEAqXTg0w15eEu2rfoedWMS7abyW5CuOJxSb+7OWiFUx9jZPpdFblsYPVNWBehxFdws6/JEio3GklyA=="
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-7.1.0.tgz",
+      "integrity": "sha512-deP7UC0/rYLuGGeK5ZWB1a6fG6b8I21kaZl8+zpkG3nflsRw+DgDTC7y3iiIoX5DtLodjqWO6pAcroxnpHal8g=="
     },
     "@newrelic/eslint-config": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.9.4",
     "@grpc/proto-loader": "^0.7.5",
-    "@newrelic/aws-sdk": "^7.0.3",
+    "@newrelic/aws-sdk": "^7.1.0",
     "@newrelic/koa": "^8.0.1",
     "@newrelic/security-agent": "^0.6.0",
     "@newrelic/superagent": "^7.0.1",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Fri Jan 12 2024 14:52:55 GMT-0500 (Eastern Standard Time)",
+  "lastUpdated": "Thu Jan 18 2024 13:20:18 GMT-0500 (Eastern Standard Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -68,15 +68,15 @@
       "licenseTextSource": "file",
       "publisher": "Google Inc."
     },
-    "@newrelic/aws-sdk@7.0.3": {
+    "@newrelic/aws-sdk@7.1.0": {
       "name": "@newrelic/aws-sdk",
-      "version": "7.0.3",
-      "range": "^7.0.3",
+      "version": "7.1.0",
+      "range": "^7.1.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic-aws-sdk",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-aws-sdk/tree/v7.0.3",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic-aws-sdk/tree/v7.1.0",
       "licenseFile": "node_modules/@newrelic/aws-sdk/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic-aws-sdk/blob/v7.0.3/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic-aws-sdk/blob/v7.1.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We typically don't update deps that fall within semver ranges but this PR is mostly to remove the `aws_bedrock_instrumentation` feature flag now that the code is complete and released in 7.1.0 of `@newrelic/aws-sdk`.
