### PR TITLE
chore: Migrated non-sensitive CI values to vars

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -20,8 +20,8 @@ jobs:
       run: node ./bin/pending-prs.js --repos $NR_REPOS --ignore-labels $IGNORE_LABELS
       env:
         GITHUB_TOKEN: ${{ secrets.NODE_AGENT_GH_TOKEN }}
-        SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+        SLACK_CHANNEL: ${{ vars.SLACK_CHANNEL }}
         SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
         SLACK_SECRET: ${{ secrets.SLACK_SECRET }}
-        NR_REPOS: ${{ secrets.NR_REPOS }}
-        IGNORE_LABELS: ${{ secrets.IGNORE_LABELS }}
+        NR_REPOS: ${{ vars.NR_REPOS }}
+        IGNORE_LABELS: ${{ vars.IGNORE_LABELS }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -42,5 +42,5 @@ jobs:
       run: node ./bin/create-docs-pr.js --tag v${{ steps.get_tag.outputs.latest_tag }}
       env:
         GITHUB_TOKEN: ${{ secrets.NODE_AGENT_GH_TOKEN }}
-        GITHUB_USER: ${{ secrets.NODE_AGENT_CI_USER_NAME }}
-        GITHUB_EMAIL: ${{ secrets.NODE_AGENT_CI_USER_EMAIL }}
+        GITHUB_USER: ${{ vars.NODE_AGENT_CI_USER_NAME }}
+        GITHUB_EMAIL: ${{ vars.NODE_AGENT_CI_USER_EMAIL }}


### PR DESCRIPTION
## Description

Some non-sensitive repository values used for CI were set as secrets, but that's an unnecessary overloading of secrets: 

- NR_REPOS
- IGNORE_LABELS
- SLACK_CHANNEL
- NODE_AGENT_CI_USER_NAME
- NODE_AGENT_CI_USER_EMAIL

This PR migrates them to repo vars. 

## Related Issues

Closes #1637 
Closes NR-137604