### PR TITLE
refactor: Updated message-shim to remove cognitive complexity violations.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
           'Logger',
           'Agent',
           'Shim',
+          'MessageShim',
           'TraceSegment',
           'Transaction',
           'Tracer',

--- a/lib/shim/message-shim/common.js
+++ b/lib/shim/message-shim/common.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const common = module.exports
+
+/**
+ * Constructs a message segment name from the given message descriptor.
+ *
+ * @private
+ * @param {MessageShim} shim The shim the segment will be constructed by.
+ * @param {object} msgDesc The message descriptor.
+ * @param {string} action Produce or consume?
+ * @returns {string} The generated name of the message segment.
+ */
+common._nameMessageSegment = function _nameMessageSegment(shim, msgDesc, action) {
+  let name =
+    shim._metrics.PREFIX +
+    shim._metrics.LIBRARY +
+    '/' +
+    (msgDesc.destinationType || shim.EXCHANGE) +
+    '/' +
+    action
+
+  if (msgDesc.destinationName) {
+    name += shim._metrics.NAMED + msgDesc.destinationName
+  } else {
+    name += shim._metrics.TEMP
+  }
+
+  return name
+}

--- a/lib/shim/message-shim/consume.js
+++ b/lib/shim/message-shim/consume.js
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const TraceSegment = require('../../transaction/trace/segment')
+const genericRecorder = require('../../metrics/recorders/generic')
+const { _nameMessageSegment } = require('./common')
+const specs = require('../specs')
+
+/**
+ * Generates the spec for the consumer
+ *
+ * @private
+ * @param {object} params to function
+ * @param {MessageShim} params.shim instance of shim
+ * @param {Function} params.fn consumer function
+ * @param {string} params.fnName name of function
+ * @param {Array} params.args arguments passed to original consume function
+ * @param {specs.MessageSpec} params.spec spec for the wrapped consume function
+ * @returns {specs.MessageSpec} new spec
+ */
+function updateSpecFromArgs({ shim, fn, fnName, args, spec }) {
+  let msgDesc = null
+  if (shim.isFunction(spec)) {
+    msgDesc = spec.call(this, shim, fn, fnName, args)
+    msgDesc = new specs.MessageSpec(msgDesc)
+  } else {
+    msgDesc = new specs.MessageSpec(spec)
+    const destIdx = shim.normalizeIndex(args.length, spec.destinationName)
+    if (destIdx !== null) {
+      msgDesc.destinationName = args[destIdx]
+    }
+  }
+
+  return msgDesc
+}
+
+/**
+ * Binds the consumer callback to the active segment.
+ *
+ * @private
+ * @param {object} params to function
+ * @param {MessageShim} params.shim instance of shim
+ * @param {Array} params.args arguments passed to original consume function
+ * @param {specs.MessageSpec} params.msgDesc spec for the wrapped consume function
+ * @param {TraceSegment} params.segment active segment to bind callback
+ * @param {boolean} params.getParams flag to copy message parameters to segment
+ * @param {Function} params.resHandler function to handle response from callback to obtain the message parameters
+ */
+function bindCallback({ shim, args, msgDesc, segment, getParams, resHandler }) {
+  const cbIdx = shim.normalizeIndex(args.length, msgDesc.callback)
+  if (cbIdx !== null) {
+    shim.bindCallbackSegment(args, cbIdx, segment)
+
+    // If we have a callback and a results handler, then wrap the callback so
+    // we can call the results handler and get the message properties.
+    if (resHandler) {
+      shim.wrap(args, cbIdx, function wrapCb(shim, cb, cbName) {
+        if (shim.isFunction(cb)) {
+          return function cbWrapper() {
+            const cbArgs = shim.argsToArray.apply(shim, arguments)
+            const msgProps = resHandler.call(this, shim, cb, cbName, cbArgs)
+            if (getParams && msgProps && msgProps.parameters) {
+              shim.copySegmentParameters(segment, msgProps.parameters)
+            }
+
+            return cb.apply(this, arguments)
+          }
+        }
+      })
+    }
+  }
+}
+
+/**
+ * Binds the consumer function to the async context and checks return to possibly
+ * bind the promise
+ *
+ * @private
+ * @param {object} params to function
+ * @param {MessageShim} params.shim instance of shim
+ * @param {Function} params.fn consumer function
+ * @param {string} params.fnName name of function
+ * @param {Array} params.args arguments passed to original consume function
+ * @param {specs.MessageSpec} params.msgDesc spec for the wrapped consume function
+ * @param {TraceSegment} params.segment active segment to bind callback
+ * @param {boolean} params.getParams flag to copy message parameters to segment
+ * @param {Function} params.resHandler function to handle response from callback to obtain the message parameters
+ * @returns {Promise|*} response from consume function
+ */
+function bindConsumer({ shim, fn, fnName, args, msgDesc, segment, getParams, resHandler }) {
+  // Call the method in the context of our segment.
+  let ret = shim.applySegment(fn, segment, true, this, args)
+
+  if (ret && msgDesc.promise && shim.isPromise(ret)) {
+    ret = shim.bindPromise(ret, segment)
+
+    // Intercept the promise to handle the result.
+    if (resHandler) {
+      ret = ret.then(function interceptValue(res) {
+        const msgProps = resHandler.call(this, shim, fn, fnName, res)
+        if (getParams && msgProps && msgProps.parameters) {
+          shim.copySegmentParameters(segment, msgProps.parameters)
+        }
+        return res
+      })
+    }
+  }
+
+  return ret
+}
+
+/**
+ *
+ * @private
+ * @param {object} params to function
+ * @param {MessageShim} params.shim instance of shim
+ * @param {Function} params.fn function that is being wrapped
+ * @param {string} params.fnName name of function
+ * @param {specs.MessageSpec} params.spec spec for the wrapped consume function
+ * @returns {Function} recorder for consume function
+ */
+module.exports = function createRecorder({ shim, fn, fnName, spec }) {
+  return function consumeRecorder() {
+    const parent = shim.getSegment()
+    if (!parent || !parent.transaction.isActive()) {
+      shim.logger.trace('Not recording consume, no active transaction.')
+      return fn.apply(this, arguments)
+    }
+
+    // Process the message args.
+    const args = shim.argsToArray.apply(shim, arguments)
+    const msgDesc = updateSpecFromArgs.call(this, { shim, fn, fnName, args, spec })
+
+    // Make the segment if we can.
+    if (!msgDesc) {
+      shim.logger.trace('Not recording consume, no message descriptor.')
+      return fn.apply(this, args)
+    }
+
+    const name = _nameMessageSegment(shim, msgDesc, shim._metrics.CONSUME)
+
+    // Adds details needed by createSegment when used with a spec
+    msgDesc.name = name
+    msgDesc.recorder = genericRecorder
+    msgDesc.parent = parent
+
+    const segment = shim.createSegment(msgDesc)
+    const getParams = shim.agent.config.message_tracer.segment_parameters.enabled
+    const resHandler = shim.isFunction(msgDesc.messageHandler) ? msgDesc.messageHandler : null
+
+    bindCallback({ shim, args, msgDesc, segment, getParams, resHandler })
+    return bindConsumer.call(this, {
+      shim,
+      fn,
+      fnName,
+      args,
+      msgDesc,
+      segment,
+      getParams,
+      resHandler
+    })
+  }
+}

--- a/lib/shim/message-shim/consume.js
+++ b/lib/shim/message-shim/consume.js
@@ -8,6 +8,7 @@ const TraceSegment = require('../../transaction/trace/segment')
 const genericRecorder = require('../../metrics/recorders/generic')
 const { _nameMessageSegment } = require('./common')
 const specs = require('../specs')
+module.exports = createRecorder
 
 /**
  * Generates the spec for the consumer
@@ -122,7 +123,7 @@ function bindConsumer({ shim, fn, fnName, args, msgDesc, segment, getParams, res
  * @param {specs.MessageSpec} params.spec spec for the wrapped consume function
  * @returns {Function} recorder for consume function
  */
-module.exports = function createRecorder({ shim, fn, fnName, spec }) {
+function createRecorder({ shim, fn, fnName, spec }) {
   return function consumeRecorder() {
     const parent = shim.getSegment()
     if (!parent || !parent.transaction.isActive()) {

--- a/lib/shim/message-shim/index.js
+++ b/lib/shim/message-shim/index.js
@@ -5,18 +5,15 @@
 
 'use strict'
 
-/* eslint sonarjs/cognitive-complexity: ["error", 72] -- TODO: https://issues.newrelic.com/browse/NEWRELIC-5252*/
-
-const copy = require('../util/copy')
-const genericRecorder = require('../metrics/recorders/generic')
-const logger = require('../logger').child({ component: 'MessageShim' })
-const messageTransactionRecorder = require('../metrics/recorders/message-transaction')
-const props = require('../util/properties')
-const TransactionShim = require('./transaction-shim')
-const Shim = require('./shim') // For Shim.defineProperty
+const genericRecorder = require('../../metrics/recorders/generic')
+const logger = require('../../logger').child({ component: 'MessageShim' })
+const TransactionShim = require('../transaction-shim')
+const Shim = require('../shim') // For Shim.defineProperty
 const util = require('util')
-
-const ATTR_DESTS = require('../config/attribute-filter').DESTINATIONS
+const { _nameMessageSegment } = require('./common')
+const createRecorder = require('./consume')
+const createSubscriberWrapper = require('./subscribe-consume')
+const specs = require('../specs')
 
 /**
  * Enumeration of well-known message brokers.
@@ -119,7 +116,7 @@ MessageShim.prototype.recordSubscribedConsume = recordSubscribedConsume
  *  The name of the producer or consumer.
  * @param {Array.<*>} args
  *  The arguments being passed into the produce method or consumer.
- * @returns {MessageSpec} The specification for the message being produced or
+ * @returns {specs.MessageSpec} The specification for the message being produced or
  *  consumed.
  * @see MessageShim#recordProduce
  * @see MessageShim#recordConsume
@@ -143,7 +140,7 @@ MessageShim.prototype.recordSubscribedConsume = recordSubscribedConsume
  *  Either the arguments for the consumer callback function or the result of
  *  the resolved consume promise, depending on the mode of the instrumented
  *  method.
- * @returns {MessageSpec} The extracted properties of the consumed message.
+ * @returns {specs.MessageSpec} The extracted properties of the consumed message.
  * @see MessageShim#recordConsume
  */
 
@@ -163,62 +160,6 @@ MessageShim.prototype.recordSubscribedConsume = recordSubscribedConsume
  * @returns {Function} The consumer method, possibly wrapped.
  * @see MessageShim#recordSubscribedConsume
  * @see MessageShim#recordConsume
- */
-
-/**
- * @interface MessageSpec
- * @augments RecorderSpec
- * @description
- *  The specification for a message being produced or consumed.
- * @property {string} destinationName
- *  The name of the exchange or queue the message is being produced to or
- *  consumed from.
- * @property {MessageShim.DESTINATION_TYPES} [destinationType=null]
- *  The type of the destination. Defaults to `shim.EXCHANGE`.
- * @property {object} [headers=null]
- *  A reference to the message headers. On produce, more headers will be added
- *  to this object which should be sent along with the message. On consume,
- *  cross-application headers will be read from this object.
- * @property {string} [routingKey=null]
- *  The routing key for the message. If provided on consume, the routing key
- *  will be added to the transaction attributes as `message.routingKey`.
- * @property {string} [queue=null]
- *  The name of the queue the message was consumed from. If provided on
- *  consume, the queue name will be added to the transaction attributes as
- *  `message.queueName`.
- * @property {string} [parameters.correlation_id]
- *  In AMQP, this should be the correlation Id of the message, if it has one.
- * @property {string} [parameters.reply_to]
- *  In AMQP, this should be the name of the queue to reply to, if the message
- *  has one.
- * @property {MessageHandlerFunction} [messageHandler]
- *  An optional function to extract message properties from a consumed message.
- *  This method is only used in the consume case to pull data from the
- *  retrieved message.
- * @see RecorderSpec
- * @see MessageShim#recordProduce
- * @see MessageShim#recordConsume
- * @see MessageShim.DESTINATION_TYPES
- */
-
-/**
- * @interface MessageSubscribeSpec
- * @augments MessageSpec
- * @description
- *  Specification for message subscriber methods. That is, methods which
- *  register a consumer to start receiving messages.
- * @property {number} consumer
- *  The index of the consumer in the method's arguments. Note that if the
- *  consumer and callback indexes point to the same argument, the argument will
- *  be wrapped as a consumer.
- * @property {MessageHandlerFunction} messageHandler
- *  A function to extract message properties from a consumed message.
- *  This method is only used in the consume case to pull data from the
- *  retrieved message. Its return value is combined with the `MessageSubscribeSpec`
- *  to fully describe the consumed message.
- * @see MessageSpec
- * @see MessageConsumerWrapperFunction
- * @see MessageShim#recordSubscribedConsume
  */
 
 // -------------------------------------------------------------------------- //
@@ -275,7 +216,7 @@ function setLibrary(library) {
  *  wrapping it or its properties.
  * @see Shim#wrap
  * @see Shim#record
- * @see MessageSpec
+ * @see specs.MessageSpec
  * @see MessageFunction
  */
 function recordProduce(nodule, properties, recordNamer) {
@@ -315,8 +256,8 @@ function recordProduce(nodule, properties, recordNamer) {
     }
   })
 }
-
 /**
+ *
  * Wraps the given properties as message consumers to be recorded.
  *
  * - `recordConsume(nodule, properties, spec)`
@@ -333,7 +274,7 @@ function recordProduce(nodule, properties, recordNamer) {
  * @param {string|Array.<string>} [properties]
  *  One or more properties to wrap. If omitted, the `nodule` parameter is
  *  assumed to be the function to wrap.
- * @param {MessageSpec|MessageFunction} spec
+ * @param {specs.MessageSpec|MessageFunction} spec
  *  The spec for the method or a function which returns the details of the
  *  method.
  * @returns {object | Function} The first parameter to this function, after
@@ -341,7 +282,7 @@ function recordProduce(nodule, properties, recordNamer) {
  * @see Shim#wrap
  * @see Shim#record
  * @see MessageShim#recordSubscribedConsume
- * @see MessageSpec
+ * @see specs.MessageSpec
  * @see MessageFunction
  */
 function recordConsume(nodule, properties, spec) {
@@ -350,14 +291,8 @@ function recordConsume(nodule, properties, spec) {
     spec = properties
     properties = null
   }
-  const DEFAULT_SPEC = {
-    destinationName: null,
-    promise: false,
-    callback: null,
-    messageHandler: null
-  }
   if (!this.isFunction(spec)) {
-    spec = this.setDefaults(spec, DEFAULT_SPEC)
+    spec = new specs.MessageSpec(spec)
   }
 
   // This is using wrap instead of record because the spec allows for a messageHandler
@@ -370,93 +305,7 @@ function recordConsume(nodule, properties, spec) {
       return fn
     }
 
-    return function consumeRecorder() {
-      const parent = shim.getSegment()
-      if (!parent || !parent.transaction.isActive()) {
-        shim.logger.trace('Not recording consume, no active transaction.')
-        return fn.apply(this, arguments)
-      }
-
-      // Process the message args.
-      const args = shim.argsToArray.apply(shim, arguments)
-      let msgDesc = null
-      if (shim.isFunction(spec)) {
-        msgDesc = spec.call(this, shim, fn, fnName, args)
-        shim.setDefaults(msgDesc, DEFAULT_SPEC)
-      } else {
-        msgDesc = {
-          destinationName: null,
-          callback: spec.callback,
-          promise: spec.promise,
-          messageHandler: spec.messageHandler
-        }
-
-        const destIdx = shim.normalizeIndex(args.length, spec.destinationName)
-        if (destIdx !== null) {
-          msgDesc.destinationName = args[destIdx]
-        }
-      }
-
-      // Make the segment if we can.
-      if (!msgDesc) {
-        shim.logger.trace('Not recording consume, no message descriptor.')
-        return fn.apply(this, args)
-      }
-
-      const name = _nameMessageSegment(shim, msgDesc, shim._metrics.CONSUME)
-
-      // Adds details needed by createSegment when used with a spec
-      msgDesc.name = name
-      msgDesc.recorder = genericRecorder
-      msgDesc.parent = parent
-
-      const segment = shim.createSegment(msgDesc)
-      const getParams = shim.agent.config.message_tracer.segment_parameters.enabled
-      const resHandler = shim.isFunction(msgDesc.messageHandler) ? msgDesc.messageHandler : null
-
-      const cbIdx = shim.normalizeIndex(args.length, msgDesc.callback)
-      if (cbIdx !== null) {
-        shim.bindCallbackSegment(args, cbIdx, segment)
-
-        // If we have a callback and a results handler, then wrap the callback so
-        // we can call the results handler and get the message properties.
-        if (resHandler) {
-          shim.wrap(args, cbIdx, function wrapCb(shim, cb, cbName) {
-            if (shim.isFunction(cb)) {
-              return function cbWrapper() {
-                const cbArgs = shim.argsToArray.apply(shim, arguments)
-                const msgProps = resHandler.call(this, shim, cb, cbName, cbArgs)
-                if (getParams && msgProps && msgProps.parameters) {
-                  shim.copySegmentParameters(segment, msgProps.parameters)
-                }
-
-                return cb.apply(this, arguments)
-              }
-            }
-          })
-        }
-      }
-
-      // Call the method in the context of our segment.
-      let ret = shim.applySegment(fn, segment, true, this, args)
-
-      if (ret && msgDesc.promise && shim.isPromise(ret)) {
-        ret = shim.bindPromise(ret, segment)
-
-        // Intercept the promise to handle the result.
-        if (resHandler) {
-          ret = ret.then(function interceptValue(res) {
-            const msgProps = resHandler.call(this, shim, fn, fnName, res)
-            if (getParams && msgProps && msgProps.parameters) {
-              shim.copySegmentParameters(segment, msgProps.parameters)
-            }
-            return res
-          })
-        }
-      }
-
-      return ret
-    }
+    return createRecorder({ shim, fn, fnName, spec })
   })
 }
 
@@ -472,7 +321,7 @@ function recordConsume(nodule, properties, spec) {
  * @param {string|Array.<string>} [properties]
  *  One or more properties to wrap. If omitted, the `nodule` parameter is
  *  assumed to be the function to wrap.
- * @param {RecorderSpec} spec
+ * @param {specs.MessageSpec} spec
  *  The specification for this queue purge method's interface.
  * @param {string} spec.queue
  *  The name of the queue being purged.
@@ -498,12 +347,7 @@ function recordPurgeQueue(nodule, properties, spec) {
   // Fill the spec with defaults.
   const specIsFunction = this.isFunction(spec)
   if (!specIsFunction) {
-    spec = this.setDefaults(spec, {
-      queue: null,
-      callback: null,
-      promise: false,
-      internal: false
-    })
+    spec = new specs.MessageSpec(spec || {})
   }
 
   return this.record(nodule, properties, function purgeRecorder(shim, fn, name, args) {
@@ -554,14 +398,14 @@ function recordPurgeQueue(nodule, properties, spec) {
  * @param {string|Array.<string>} [properties]
  *  One or more properties to wrap. If omitted, the `nodule` parameter is
  *  assumed to be the function to wrap.
- * @param {MessageSubscribeSpec} spec
+ * @param {specs.MessageSubscribeSpec} spec
  *  The specification for this subscription method's interface.
  * @returns {object | Function} The first parameter to this function, after
  *  wrapping it or its properties.
  * @see Shim#wrap
  * @see Shim#record
  * @see MessageShim#recordConsume
- * @see MessageSubscribeSpec
+ * @see specs.MessageSubscribeSpec
  */
 function recordSubscribedConsume(nodule, properties, spec) {
   if (!nodule) {
@@ -576,16 +420,7 @@ function recordSubscribedConsume(nodule, properties, spec) {
     properties = null
   }
 
-  // Fill the spec with defaults.
-  spec = this.setDefaults(spec, {
-    name: null,
-    destinationName: null,
-    destinationType: null,
-    consumer: null,
-    callback: null,
-    messageHandler: null,
-    promise: false
-  })
+  spec = new specs.MessageSubscribeSpec(spec)
 
   // Make sure our spec has what we need.
   if (!this.isFunction(spec.messageHandler)) {
@@ -604,26 +439,8 @@ function recordSubscribedConsume(nodule, properties, spec) {
     if (!shim.isFunction(fn)) {
       return fn
     }
-    return function wrappedSubscribe() {
-      const args = shim.argsToArray.apply(shim, arguments)
-      const queueIdx = shim.normalizeIndex(args.length, spec.queue)
-      const consumerIdx = shim.normalizeIndex(args.length, spec.consumer)
-      const queue = queueIdx === null ? null : args[queueIdx]
-      let destName = null
 
-      if (destNameIsArg) {
-        const destNameIdx = shim.normalizeIndex(args.length, spec.destinationName)
-        if (destNameIdx !== null) {
-          destName = args[destNameIdx]
-        }
-      }
-
-      if (consumerIdx !== null) {
-        args[consumerIdx] = shim.wrap(args[consumerIdx], makeWrapConsumer(queue, destName))
-      }
-
-      return fn.apply(this, args)
-    }
+    return createSubscriberWrapper({ shim, fn, spec, destNameIsArg })
   })
 
   // Wrap the subscriber with segment creation.
@@ -647,177 +464,4 @@ function recordSubscribedConsume(nodule, properties, spec) {
       internal: false
     }
   })
-
-  /**
-   * @param queue
-   * @param destinationName
-   */
-  function makeWrapConsumer(queue, destinationName) {
-    const msgDescDefaults = copy.shallow(spec)
-    if (destNameIsArg && destinationName != null) {
-      msgDescDefaults.destinationName = destinationName
-    }
-    if (queue != null) {
-      msgDescDefaults.queue = queue
-    }
-
-    return function wrapConsumer(shim, consumer, cName) {
-      if (!shim.isFunction(consumer)) {
-        return consumer
-      }
-
-      return shim.bindCreateTransaction(
-        function createConsumeTrans() {
-          // If there is no transaction or we're in a pre-existing transaction,
-          // then don't do anything. Note that the latter should never happen.
-          const args = shim.argsToArray.apply(shim, arguments)
-          const tx = shim.tracer.getTransaction()
-
-          if (!tx || tx.baseSegment) {
-            shim.logger.debug({ transaction: !!tx }, 'Failed to start message transaction.')
-            return consumer.apply(this, args)
-          }
-
-          const msgDesc = spec.messageHandler.call(this, shim, consumer, cName, args)
-
-          // If message could not be handled, immediately kill this transaction.
-          if (!msgDesc) {
-            shim.logger.debug('No description for message, cancelling transaction.')
-            tx.setForceIgnore(true)
-            tx.end()
-            return consumer.apply(this, args)
-          }
-
-          // Derive the transaction name.
-          shim.setDefaults(msgDesc, msgDescDefaults)
-          const txName = _nameMessageTransaction(shim, msgDesc)
-          tx.setPartialName(txName)
-          tx.baseSegment = shim.createSegment({
-            name: tx.getFullName(),
-            recorder: messageTransactionRecorder
-          })
-
-          // Add would-be baseSegment attributes to transaction trace
-          for (const key in msgDesc.parameters) {
-            if (props.hasOwn(msgDesc.parameters, key)) {
-              tx.trace.attributes.addAttribute(
-                ATTR_DESTS.NONE,
-                'message.parameters.' + key,
-                msgDesc.parameters[key]
-              )
-
-              tx.baseSegment.attributes.addAttribute(
-                ATTR_DESTS.NONE,
-                'message.parameters.' + key,
-                msgDesc.parameters[key]
-              )
-            }
-          }
-
-          // If we have a routing key, add it to the transaction. Note that it is
-          // camel cased here, but snake cased in the segment parameters.
-          if (!shim.agent.config.high_security) {
-            if (msgDesc.routingKey) {
-              tx.trace.attributes.addAttribute(
-                ATTR_DESTS.TRANS_COMMON,
-                'message.routingKey',
-                msgDesc.routingKey
-              )
-
-              tx.baseSegment.addSpanAttribute('message.routingKey', msgDesc.routingKey)
-            }
-            if (shim.isString(msgDesc.queue)) {
-              tx.trace.attributes.addAttribute(
-                ATTR_DESTS.TRANS_COMMON,
-                'message.queueName',
-                msgDesc.queue
-              )
-
-              tx.baseSegment.addSpanAttribute('message.queueName', msgDesc.queue)
-            }
-          }
-          if (msgDesc.headers) {
-            shim.handleMqTracingHeaders(msgDesc.headers, tx.baseSegment, shim._transportType)
-          }
-
-          shim.logger.trace('Started message transaction %s named %s', tx.id, txName)
-
-          // Execute the original function and attempt to hook in the transaction
-          // finish.
-          let ret = null
-          try {
-            ret = shim.applySegment(consumer, tx.baseSegment, true, this, args)
-          } finally {
-            if (shim.isPromise(ret)) {
-              shim.logger.trace('Got a promise, attaching tx %s ending to promise', tx.id)
-              ret = shim.interceptPromise(ret, endTransaction)
-            } else if (!tx.handledExternally) {
-              // We have no way of knowing when this transaction ended! ABORT!
-              shim.logger.trace('Immediately ending message tx %s', tx.id)
-              setImmediate(endTransaction)
-            }
-          }
-
-          return ret
-
-          /**
-           *
-           */
-          function endTransaction() {
-            tx.finalizeName(null) // Use existing partial name.
-            tx.end()
-          }
-        },
-        {
-          type: shim.MESSAGE,
-          nest: true
-        }
-      )
-    }
-  }
-}
-
-// -------------------------------------------------------------------------- //
-
-/**
- * Constructs a message segment name from the given message descriptor.
- *
- * @private
- * @param {MessageShim} shim    - The shim the segment will be constructed by.
- * @param {MessageSpec} msgDesc - The message descriptor.
- * @param {string}      action  - Produce or consume?
- * @returns {string} The generated name of the message segment.
- */
-function _nameMessageSegment(shim, msgDesc, action) {
-  let name =
-    shim._metrics.PREFIX +
-    shim._metrics.LIBRARY +
-    '/' +
-    (msgDesc.destinationType || shim.EXCHANGE) +
-    '/' +
-    action
-
-  if (msgDesc.destinationName) {
-    name += shim._metrics.NAMED + msgDesc.destinationName
-  } else {
-    name += shim._metrics.TEMP
-  }
-
-  return name
-}
-
-/**
- * @param shim
- * @param msgDesc
- */
-function _nameMessageTransaction(shim, msgDesc) {
-  let name = shim._metrics.LIBRARY + '/' + (msgDesc.destinationType || shim.EXCHANGE) + '/'
-
-  if (msgDesc.destinationName) {
-    name += shim._metrics.NAMED + msgDesc.destinationName
-  } else {
-    name += shim._metrics.TEMP
-  }
-
-  return name
 }

--- a/lib/shim/message-shim/subscribe-consume.js
+++ b/lib/shim/message-shim/subscribe-consume.js
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const ATTR_DESTS = require('../../config/attribute-filter').DESTINATIONS
+const messageTransactionRecorder = require('../../metrics/recorders/message-transaction')
+const props = require('../../util/properties')
+const specs = require('../specs')
+
+/**
+ * Derives the transaction name based on the spec passed in
+ *
+ * @private
+ * @param {MessageShim} shim instance of shim
+ * @param {specs.MessageSubscribeSpec} msgDesc spec for function
+ * @returns {string} constructed name for transaction
+ */
+function _nameMessageTransaction(shim, msgDesc) {
+  let name = shim._metrics.LIBRARY + '/' + (msgDesc.destinationType || shim.EXCHANGE) + '/'
+
+  if (msgDesc.destinationName) {
+    name += shim._metrics.NAMED + msgDesc.destinationName
+  } else {
+    name += shim._metrics.TEMP
+  }
+
+  return name
+}
+
+/**
+ * Wrapper for subscribing to a queue.
+ *
+ * @param {object} params to function
+ * @param {MessageShim} params.shim instance of shim
+ * @param {Function} params.fn subscriber function
+ * @param {specs.MessageSubscribeSpec} params.spec spec for subscriber
+ * @param {boolean} params.destNameIsArg flag to state if destination is an argument
+ * @returns {Function} wrapped subscribe function
+ */
+module.exports = function createSubscriberWrapper({ shim, fn, spec, destNameIsArg }) {
+  return function wrappedSubscribe() {
+    const args = shim.argsToArray.apply(shim, arguments)
+    const queueIdx = shim.normalizeIndex(args.length, spec.queue)
+    const consumerIdx = shim.normalizeIndex(args.length, spec.consumer)
+    const queue = queueIdx === null ? null : args[queueIdx]
+    let destinationName = null
+
+    if (destNameIsArg) {
+      const destNameIdx = shim.normalizeIndex(args.length, spec.destinationName)
+      if (destNameIdx !== null) {
+        destinationName = args[destNameIdx]
+      }
+    }
+
+    if (consumerIdx !== null) {
+      args[consumerIdx] = shim.wrap(
+        args[consumerIdx],
+        makeWrapConsumer({ spec, queue, destinationName, destNameIsArg })
+      )
+    }
+
+    return fn.apply(this, args)
+  }
+}
+
+/**
+ * @private
+ * @param {object} params to function
+ * @param {specs.MessageSubscribeSpec} params.spec The message descriptor.
+ * @param {string} params.queue name of queue
+ * @param {string} params.destinationName destination of message in consume function
+ * @param {boolean} params.destNameIsArg flag to state if destination is an argument
+ * @returns {Function} wrapped consumer function
+ */
+function makeWrapConsumer({ spec, queue, destinationName, destNameIsArg }) {
+  const msgDescDefaults = new specs.MessageSubscribeSpec(spec)
+  if (destNameIsArg && destinationName != null) {
+    msgDescDefaults.destinationName = destinationName
+  }
+  if (queue != null) {
+    msgDescDefaults.queue = queue
+  }
+
+  return function wrapConsumer(shim, consumer, cName) {
+    if (!shim.isFunction(consumer)) {
+      return consumer
+    }
+
+    const consumerWrapper = createConsumerWrapper({ shim, consumer, cName, spec: msgDescDefaults })
+    return shim.bindCreateTransaction(consumerWrapper, {
+      type: shim.MESSAGE,
+      nest: true
+    })
+  }
+}
+
+/**
+ * Handler for the transaction that is being created when consuming messages
+ *
+ * @private
+ * @param {object} params to function
+ * @param {MessageShim} params.shim instance of shim
+ * @param {specs.MessageSubscribeSpec} params.spec spec for function
+ * @param {Function} params.consumer function for consuming message
+ * @param {string} params.cName name of consumer function
+ * @returns {Function} handler for the transaction being created
+ */
+function createConsumerWrapper({ shim, spec, consumer, cName }) {
+  return function createConsumeTrans() {
+    // If there is no transaction or we're in a pre-existing transaction,
+    // then don't do anything. Note that the latter should never happen.
+    const args = shim.argsToArray.apply(shim, arguments)
+    const tx = shim.tracer.getTransaction()
+
+    if (!tx || tx.baseSegment) {
+      shim.logger.debug({ transaction: !!tx }, 'Failed to start message transaction.')
+      return consumer.apply(this, args)
+    }
+
+    const msgDesc = spec.messageHandler.call(this, shim, consumer, cName, args)
+
+    // If message could not be handled, immediately kill this transaction.
+    if (!msgDesc) {
+      shim.logger.debug('No description for message, cancelling transaction.')
+      tx.setForceIgnore(true)
+      tx.end()
+      return consumer.apply(this, args)
+    }
+
+    // Derive the transaction name.
+    shim.setDefaults(msgDesc, spec)
+    const txName = _nameMessageTransaction(shim, msgDesc)
+    tx.setPartialName(txName)
+    tx.baseSegment = shim.createSegment({
+      name: tx.getFullName(),
+      recorder: messageTransactionRecorder
+    })
+
+    // Add would-be baseSegment attributes to transaction trace
+    for (const key in msgDesc.parameters) {
+      if (props.hasOwn(msgDesc.parameters, key)) {
+        tx.trace.attributes.addAttribute(
+          ATTR_DESTS.NONE,
+          'message.parameters.' + key,
+          msgDesc.parameters[key]
+        )
+
+        tx.baseSegment.attributes.addAttribute(
+          ATTR_DESTS.NONE,
+          'message.parameters.' + key,
+          msgDesc.parameters[key]
+        )
+      }
+    }
+
+    // If we have a routing key, add it to the transaction. Note that it is
+    // camel cased here, but snake cased in the segment parameters.
+    if (!shim.agent.config.high_security) {
+      if (msgDesc.routingKey) {
+        tx.trace.attributes.addAttribute(
+          ATTR_DESTS.TRANS_COMMON,
+          'message.routingKey',
+          msgDesc.routingKey
+        )
+
+        tx.baseSegment.addSpanAttribute('message.routingKey', msgDesc.routingKey)
+      }
+      if (shim.isString(msgDesc.queue)) {
+        tx.trace.attributes.addAttribute(
+          ATTR_DESTS.TRANS_COMMON,
+          'message.queueName',
+          msgDesc.queue
+        )
+
+        tx.baseSegment.addSpanAttribute('message.queueName', msgDesc.queue)
+      }
+    }
+    if (msgDesc.headers) {
+      shim.handleMqTracingHeaders(msgDesc.headers, tx.baseSegment, shim._transportType)
+    }
+
+    shim.logger.trace('Started message transaction %s named %s', tx.id, txName)
+
+    // Execute the original function and attempt to hook in the transaction
+    // finish.
+    let ret = null
+    try {
+      ret = shim.applySegment(consumer, tx.baseSegment, true, this, args)
+    } finally {
+      if (shim.isPromise(ret)) {
+        shim.logger.trace('Got a promise, attaching tx %s ending to promise', tx.id)
+        ret = shim.interceptPromise(ret, endTransaction)
+      } else if (!tx.handledExternally) {
+        // We have no way of knowing when this transaction ended! ABORT!
+        shim.logger.trace('Immediately ending message tx %s', tx.id)
+        setImmediate(endTransaction)
+      }
+    }
+
+    return ret
+
+    /**
+     * finalizes transaction name and ends transaction
+     */
+    function endTransaction() {
+      tx.finalizeName(null) // Use existing partial name.
+      tx.end()
+    }
+  }
+}

--- a/lib/shim/message-shim/subscribe-consume.js
+++ b/lib/shim/message-shim/subscribe-consume.js
@@ -8,6 +8,7 @@ const ATTR_DESTS = require('../../config/attribute-filter').DESTINATIONS
 const messageTransactionRecorder = require('../../metrics/recorders/message-transaction')
 const props = require('../../util/properties')
 const specs = require('../specs')
+module.exports = createSubscriberWrapper
 
 /**
  * Derives the transaction name based on the spec passed in
@@ -39,7 +40,7 @@ function _nameMessageTransaction(shim, msgDesc) {
  * @param {boolean} params.destNameIsArg flag to state if destination is an argument
  * @returns {Function} wrapped subscribe function
  */
-module.exports = function createSubscriberWrapper({ shim, fn, spec, destNameIsArg }) {
+function createSubscriberWrapper({ shim, fn, spec, destNameIsArg }) {
   return function wrappedSubscribe() {
     const args = shim.argsToArray.apply(shim, arguments)
     const queueIdx = shim.normalizeIndex(args.length, spec.queue)

--- a/lib/shim/specs/index.js
+++ b/lib/shim/specs/index.js
@@ -37,6 +37,8 @@ exports.MiddlewareSpec = MiddlewareSpec
 exports.RecorderSpec = RecorderSpec
 exports.SegmentSpec = SegmentSpec
 exports.WrapSpec = WrapSpec
+exports.MessageSpec = MessageSpec
+exports.MessageSubscribeSpec = MessageSubscribeSpec
 
 function cast(Class, spec) {
   return spec instanceof Class ? spec : new Class(spec)
@@ -79,6 +81,24 @@ function MiddlewareSpec(spec) {
   this.appendPath = hasOwnProperty(spec, 'appendPath') ? spec.appendPath : true
 }
 util.inherits(MiddlewareSpec, RecorderSpec)
+
+function MessageSpec(spec) {
+  RecorderSpec.call(this, spec)
+  this.destinationName = hasOwnProperty(spec, 'destinationName') ? spec.destinationName : null
+  this.destinationType = hasOwnProperty(spec, 'destinationType') ? spec.destinationType : null
+  this.headers = hasOwnProperty(spec, 'headers') ? spec.headers : null
+  this.routingKey = hasOwnProperty(spec, 'routingKey') ? spec.routingKey : null
+  this.queue = hasOwnProperty(spec, 'queue') ? spec.queue : null
+  this.messageHandler = hasOwnProperty(spec, 'messageHandler') ? spec.messageHandler : null
+}
+
+util.inherits(MessageSpec, RecorderSpec)
+
+function MessageSubscribeSpec(spec) {
+  MessageSpec.call(this, spec)
+  this.consumer = hasOwnProperty(spec, 'consumer') ? spec.consumer : null
+}
+util.inherits(MessageSubscribeSpec, MessageSpec)
 
 function _defaultGetParams(shim, fn, name, args, req) {
   return req && req.params


### PR DESCRIPTION
 Fixed jsdoc warnings as well.

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

I refactored message-shim by extracting inline functions into top level scope. I also moved some of the helper functions into their own files.  I fixed all the jsdoc violations and lastly added the MessageSpec and MessageSubscribeSpec into specs instead of inline within file.

## How to Test

`npm test`

## Related Issues

Closes NR-134575
