### PR TITLE
fix: Updated instrumentation registration to allow for instrumenting of a local file that does not exist within node_modules. You must pass in `absolutePath` with the absolute path to the file that is being instrumented along with the moduleName which in this case is just the file name without the extension

### DIFF
--- a/api.js
+++ b/api.js
@@ -1312,7 +1312,7 @@ API.prototype.recordCustomEvent = function recordCustomEvent(eventType, attribut
  *
  * @param {string|object} moduleName The module name given to require to load the module, or the instrumentation specification
  * @param {string} moduleName.moduleName The module name given to require to load the module
- * @param {Function}  moduleName.onResolved The function to call prior to module load after the filepath has been resolved
+ * @param {string} [moduleName.absolutePath] Must provide absolute path to module if it does not exist within node_modules. This is used to instrument a file within the same application.
  * @param {Function}  moduleName.onRequire The function to call when the module has been loaded
  * @param {Function} [moduleName.onError] If provided, should `onRequire` throw an error, the error will be passed to
  * @param {Function} onRequire The function to call when the module has been loaded
@@ -1343,7 +1343,7 @@ API.prototype.instrument = function instrument(moduleName, onRequire, onError) {
  *
  * @param {string|object} moduleName The module name given to require to load the module, or the instrumentation specification
  * @param {string} moduleName.moduleName The module name given to require to load the module
- * @param {Function}  moduleName.onResolved The function to call prior to module load after the filepath has been resolved
+ * @param {string} [moduleName.absolutePath] Must provide absolute path to module if it does not exist within node_modules. This is used to instrument a file within the same application.
  * @param {Function}  moduleName.onRequire The function to call when the module has been loaded
  * @param {Function} [moduleName.onError] If provided, should `onRequire` throw an error, the error will be passed to
  * @param {Function} onRequire The function to call when the module has been loaded
@@ -1375,7 +1375,7 @@ API.prototype.instrumentConglomerate = function instrumentConglomerate(
  *
  * @param {string|object} moduleName The module name given to require to load the module, or the instrumentation specification
  * @param {string} moduleName.moduleName The module name given to require to load the module
- * @param {Function}  moduleName.onResolved The function to call prior to module load after the filepath has been resolved
+ * @param {string} [moduleName.absolutePath] Must provide absolute path to module if it does not exist within node_modules. This is used to instrument a file within the same application.
  * @param {Function}  moduleName.onRequire The function to call when the module has been loaded
  * @param {Function} [moduleName.onError] If provided, should `onRequire` throw an error, the error will be passed to
  * @param {Function} onRequire The function to call when the module has been loaded
@@ -1408,7 +1408,7 @@ API.prototype.instrumentDatastore = function instrumentDatastore(moduleName, onR
  *
  * @param {string|object} moduleName The module name given to require to load the module, or the instrumentation specification
  * @param {string} moduleName.moduleName The module name given to require to load the module
- * @param {Function}  moduleName.onResolved The function to call prior to module load after the filepath has been resolved
+ * @param {string} [moduleName.absolutePath] Must provide absolute path to module if it does not exist within node_modules. This is used to instrument a file within the same application.
  * @param {Function}  moduleName.onRequire The function to call when the module has been loaded
  * @param {Function} [moduleName.onError] If provided, should `onRequire` throw an error, the error will be passed to
  * @param {Function} onRequire The function to call when the module has been loaded
@@ -1445,7 +1445,7 @@ API.prototype.instrumentWebframework = function instrumentWebframework(
  *
  * @param {string|object} moduleName The module name given to require to load the module, or the instrumentation specification
  * @param {string} moduleName.moduleName The module name given to require to load the module
- * @param {Function}  moduleName.onResolved The function to call prior to module load after the filepath has been resolved
+ * @param {string} [moduleName.absolutePath] Must provide absolute path to module if it does not exist within node_modules. This is used to instrument a file within the same application.
  * @param {Function}  moduleName.onRequire The function to call when the module has been loaded
  * @param {Function} [moduleName.onError] If provided, should `onRequire` throw an error, the error will be passed to
  * @param {Function} onRequire The function to call when the module has been loaded

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -398,11 +398,17 @@ const shimmer = (module.exports = {
 
     if (!registeredInstrumentation) {
       shimmer.registeredInstrumentations[opts.moduleName] = []
+      // In cases where a customer is trying to instrument a file
+      // that is not within node_modules, they must provide the absolutePath
+      // so require-in-the-middle can call our callback. the moduleName
+      // still needs to be the resolved name so we can look up our instrumentation correctly
+      const pkgHook = opts.absolutePath || opts.moduleName
+
       // not using a set because this is shared by reference
       // to allow custom instrumentation to be loaded after the
       // agent is bootstrapped
-      if (!pkgsToHook.includes(opts.moduleName)) {
-        pkgsToHook.push(opts.moduleName)
+      if (!pkgsToHook.includes(pkgHook)) {
+        pkgsToHook.push(pkgHook)
       }
     }
 

--- a/test/integration/module-loading/local-package.js
+++ b/test/integration/module-loading/local-package.js
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+module.exports = () => ({ hello: 'world' })

--- a/test/unit/api/api-instrument-messages.test.js
+++ b/test/unit/api/api-instrument-messages.test.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const API = require('../../../api')
+const helper = require('../../lib/agent_helper')
+const sinon = require('sinon')
+const shimmer = require('../../../lib/shimmer')
+
+tap.test('Agent API - instrumentMessages', (t) => {
+  t.autoend()
+
+  let agent = null
+  let api = null
+
+  t.beforeEach(() => {
+    agent = helper.loadMockedAgent()
+    api = new API(agent)
+
+    sinon.spy(shimmer, 'registerInstrumentation')
+  })
+
+  t.afterEach(() => {
+    helper.unloadAgent(agent)
+    agent = null
+
+    shimmer.registerInstrumentation.restore()
+  })
+
+  t.test('should register the instrumentation with shimmer', (t) => {
+    const opts = {
+      moduleName: 'foobar',
+      absolutePath: `${__dirname}/foobar`,
+      onRequire: function () {}
+    }
+    api.instrumentMessages(opts)
+
+    t.ok(shimmer.registerInstrumentation.calledOnce)
+    const args = shimmer.registerInstrumentation.getCall(0).args
+    const [actualOpts] = args
+
+    t.same(actualOpts, opts)
+    t.equal(actualOpts.type, 'message')
+
+    t.end()
+  })
+
+  t.test('should convert separate args into an options object', (t) => {
+    function onRequire() {}
+    function onError() {}
+    api.instrumentMessages('foobar', onRequire, onError)
+
+    const opts = shimmer.registerInstrumentation.getCall(0).args[0]
+    t.equal(opts.moduleName, 'foobar')
+    t.equal(opts.onRequire, onRequire)
+    t.equal(opts.onError, onError)
+
+    t.end()
+  })
+})


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We tried to add instrumentation for local files. This was done in [messaging-app] but was using v9.x of the agent.  In v11.0.0 we now use `require-in-the-middle` for instrumenting CJS, which requires additional work to instrument files that are not within a 3rd party module.  This PR fixes that by providing a new `absolutePath` key:

```js
'use strict'

const newrelic = require('newrelic')
const niftyPath = require.resolve('./nifty-messages')

newrelic.instrumentMessages({ absolutePath: niftyPath, moduleName: 'nifty-messages', onRequireHandler)
```

## How to Test

`node test/integration/module-loading/module-loading.tap.js` adds a new test for this.

## Related Issues
Closes #1973
