### PR TITLE
docs: Fixed jsdoc generation by marking private methods as @private

### DIFF
--- a/api.js
+++ b/api.js
@@ -614,6 +614,7 @@ API.prototype.addIgnoringRule = function addIgnoringRule(pattern) {
  * Output an HTML comment and log a warning the comment is meant to be
  * innocuous to the end user.
  *
+ * @private
  * @see RUM_ISSUES
  * @param {number} errorCode Error code from `RUM_ISSUES`.
  * @param {boolean} [quiet=false] Be quiet about this failure.
@@ -631,6 +632,7 @@ function _gracefail(errorCode, quiet) {
 /**
  * Function for generating a fully formed RUM header based on configuration options
  *
+ * @private
  * @param {object} options Configuration options for RUM
  * @param {string} [options.nonce] Nonce to inject into `<script>` header.
  * @param {boolean} [options.hasToRemoveScriptWrapper] Used to import agent script without `<script>` tag wrapper.
@@ -658,6 +660,7 @@ function _generateRUMHeader(options = {}, metadata, loader) {
  * Helper method for determining if we have the minimum required
  * information to generate our Browser Agent script tag
  *
+ * @private
  * @param {object} config agent configuration settings
  * @param {Transaction} transaction the active transaction or null
  * @param {boolean} allowTransactionlessInjection whether or not to allow the Browser Agent to be injected when there is no active transaction
@@ -1655,6 +1658,7 @@ API.prototype.shutdown = function shutdown(options, cb) {
 /**
  * Helper function for logging if an error occurs, and where
  *
+ * @private
  * @param {Error} error If defined, the error that occurred
  * @param {string} phase Where in the process the error happened
  * @returns {void}
@@ -1668,6 +1672,7 @@ function _logErrorCallback(error, phase) {
 /**
  * Function for handling the graceful shutdown process, including processing of data and handling errors
  *
+ * @private
  * @param {object} api instantiation of this file
  * @param {object} options shutdown options object
  * @param {boolean} [options.collectPendingData=false]
@@ -1732,6 +1737,7 @@ function _doShutdown(api, options, callback) {
  * Validates that all keys in a given object have values that are less than or equal to a given length
  * Assumes all values have .length property (string/array)
  *
+ * @private
  * @param {object} object The object to validate
  * @param {number} maxLength The max allowed length
  * @returns {boolean} Whether or not the object passes validation
@@ -1803,6 +1809,7 @@ API.prototype.setUserID = function setUserID(id) {
 /**
  * Function for removing invalid attribute key/value pairs from an object
  *
+ * @private
  * @param {object} attributes The attribute object
  * @param {string} name Caller name, used for debugging/logging purposes only
  * @returns {object} Attribute object containing only valid key/value pairs

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -578,6 +578,7 @@ function captureInstanceAttributes(host, port, database) {
 /**
  * Parses the database name from a `USE` SQL query.
  *
+ * @memberof DatastoreShim.prototype
  * @param {string} query - The SQL query to parse the database name from.
  * @returns {?string} The name of the database if it could be parsed, otherwise
  *  `null`.

--- a/lib/shim/message-shim/subscribe-consume.js
+++ b/lib/shim/message-shim/subscribe-consume.js
@@ -33,6 +33,7 @@ function _nameMessageTransaction(shim, msgDesc) {
 /**
  * Wrapper for subscribing to a queue.
  *
+ * @private
  * @param {object} params to function
  * @param {MessageShim} params.shim instance of shim
  * @param {Function} params.fn subscriber function

--- a/lib/shim/promise-shim.js
+++ b/lib/shim/promise-shim.js
@@ -13,6 +13,7 @@ const symbols = require('../symbols')
  * Checks if function is actually not a function
  * or it is wrapped
  *
+ * @private
  * @param {Shim} shim instance of shim
  * @param {Function} fn function to wrap
  * @returns {boolean} is already wrapped or not
@@ -359,6 +360,7 @@ function _wrapExecutorContext(shim, args) {
 }
 
 /**
+ * @private
  * @param {object} context context object
  * @param {Function} fn function that is wrapped
  * @returns {Function} wrapped function
@@ -376,6 +378,7 @@ function _wrapResolver(context, fn) {
 
 /**
  *
+ * @private
  * @param {object} params object passed to wrapHandler
  * @param {Function} params.handler to wrap
  * @param {number} params.index index of argument

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -871,6 +871,7 @@ function record(nodule, properties, recordNamer) {
  * Wrapped function for Shim.prototype.record
  * This creates a segment for the method being recorded
  *
+ * @private
  * @param {object} params to function
  * @param {Shim} params.shim instance of shim
  * @param {Function} params.fn function being wrapped/recorded

--- a/lib/shim/webframework-shim/middleware-mounter.js
+++ b/lib/shim/webframework-shim/middleware-mounter.js
@@ -9,6 +9,7 @@ const { copyExpectedSpecParameters } = require('./common')
 /**
  * Wraps route mounter and all middleware defined within mounter(arguments to mounter)
  *
+ * @private
  * @param {object} spec for the middleware mounter
  * @param {Shim} shim instance of shim
  * @param {Function} fn middleware mounter function
@@ -53,6 +54,7 @@ function wrapMounter(spec, shim, fn, fnName) {
 /**
  * Wraps every middleware defined within middleware route mounter
  *
+ * @private
  * @param {object} params object passed to function
  * @param {number} params.routeIdx index of the router arg
  * @param {Array} params.middlewares remaining args(middleware) on route mounter

--- a/lib/shim/webframework-shim/middleware.js
+++ b/lib/shim/webframework-shim/middleware.js
@@ -25,6 +25,7 @@ const MIDDLEWARE_TYPE_DETAILS = {
 /**
  * Retrieves the route from the spec
  *
+ * @private
  * @param {object} spec middleware spec
  * @param {Shim} shim instance of shim
  * @returns {string} route route path
@@ -51,6 +52,7 @@ function getRoute(spec, shim) {
  * Retrieves the parameters from the spec.params
  * and prefixes them all with `request.parameters.route`
  *
+ * @private
  * @param {object} params object passed to fn
  * @param {object} params.spec middleware spec
  * @param {Shim} params.shim instance of shim
@@ -73,6 +75,7 @@ function copyParams({ spec, shim, fn, fnName, args, req }) {
 /**
  * Creates the middleware recorder if the type specifies this flag
  *
+ * @private
  * @param {object} params object passed to fn
  * @param {object} params.txInfo transaction
  * @param {object} params.typeDetails metadata about the middleware type
@@ -92,6 +95,7 @@ function constructRecorder({ txInfo, typeDetails, shim, metricName }) {
 /**
  * Updates nameState and errorHandled property of transaction info
  *
+ * @private
  * @param {object} params object passed to fn
  * @param {Shim} params.shim instance of shim
  * @param {string} params.fnName function name
@@ -123,6 +127,7 @@ function assignTxInfo({ shim, req, route, fnName, isErrorWare }) {
  * When called it will update transaction names, create a recorder for the middleware functions,
  * assign parameters from request, and name the segment
  *
+ * @private
  * @param {object} params fn params
  * @param {object} params.spec middleware spec
  * @param {object} params.typeDetails metadata about the middleware type
@@ -191,6 +196,7 @@ function middlewareWithCallbackRecorder({ spec, typeDetails, metricName, isError
  * When called it will update transaction names, create a recorder for the middleware functions,
  * assign parameters from request, and name the segment
  *
+ * @private
  * @param {object} params fn params
  * @param {object} params.spec middleware spec
  * @param {object} params.typeDetails metadata about the middleware type
@@ -258,6 +264,7 @@ function middlewareWithPromiseRecorder({ spec, typeDetails, metricName, isErrorW
 /**
  * Constructs segment name passed on path/route information
  *
+ * @private
  * @param {string} metricName metric name for middleware function
  * @param {object} typeDetails metadata about the middleware type
  * @param {string} route route path
@@ -277,6 +284,7 @@ function getSegmentName(metricName, typeDetails, route) {
 /**
  * Retrieves the req function that is called to retrieve the request
  *
+ * @private
  * @param {object} spec middleware spec
  * @param {Shim} shim instance of shim
  * @returns {Function} function to call to obtain request object
@@ -319,6 +327,7 @@ module.exports._recordMiddleware = function _recordMiddleware(shim, middleware, 
 /**
  * Creates a recorder for middleware metrics.
  *
+ * @private
  * @param {object} _shim instance of shim
  * @param {string} metricName name of metric
  * @returns {Function} recorder for middleware
@@ -336,11 +345,20 @@ function _makeMiddlewareRecorder(_shim, metricName) {
   }
 }
 
-/*
+/**
  * Wrap the `next` middleware function and push on our name state if we find it. We only want to
  * push the name state if there is a next so that we can safely remove it
  * if context leaves this middleware.
  *
+ * @param root0
+ * @param root0.shim
+ * @param root0.spec
+ * @param root0.route
+ * @param root0.args
+ * @param root0.isErrorWare
+ * @param root0.isPromise
+ * @param root0.txInfo
+ * @private
  */
 function wrapNextHandler({ shim, spec, route, args, isErrorWare, isPromise, txInfo }) {
   let nextWrapper = null
@@ -384,6 +402,7 @@ function wrapNextHandler({ shim, spec, route, args, isErrorWare, isPromise, txIn
 /**
  * Assigns the active segment to stack and wraps the next function
  *
+ * @private
  * @param {object} nextDetails details about the function
  * @param {object} txInfo transaction
  * @returns {Function} wrapped function
@@ -409,6 +428,7 @@ function _makeNextBinder(nextDetails, txInfo) {
  *
  * Called from outside to wrap functions that could be called to continue to the next middleware
  *
+ * @private
  * @param {object} params params as 1st arg
  * @param {object} params.shim instance of shim
  * @param {object} params.txInfo transaction

--- a/lib/transaction/handle.js
+++ b/lib/transaction/handle.js
@@ -81,6 +81,7 @@ module.exports = TransactionHandle
 
 /**
  *
+ * @private
  * @param metrics
  * @param functionName
  */

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "lint": "eslint ./*.{js,mjs} lib test bin examples",
     "lint:fix": "eslint --fix, ./*.{js,mjs} lib test bin examples",
     "lint:lockfile": "lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --validate-https --validate-integrity",
-    "public-docs": "jsdoc -c ./jsdoc-conf.json --tutorials examples/shim api.js lib/shim/ lib/transaction/handle.js && cp examples/shim/*.png out/",
+    "public-docs": "jsdoc -c ./jsdoc-conf.json --tutorials examples/shim api.js lib/shim/** lib/transaction/handle.js && cp examples/shim/*.png out/",
     "publish-docs": "./bin/publish-docs.sh",
     "services": "docker compose up -d --wait",
     "smoke": "npm run ssl && time tap test/smoke/**/**/*.tap.js --timeout=180 --no-coverage",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Thu Jan 18 2024 15:41:06 GMT-0500 (Eastern Standard Time)",
+  "lastUpdated": "Fri Jan 26 2024 08:32:03 GMT-0500 (Eastern Standard Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
I noticed after refactoring message-shim and webframework-shim the [API docs](https://newrelic.github.io/node-newrelic/) were not being properly generated.

One issue was the WebFrameworkShim and MessageShim docs are gone, this was because they are now subdirectories.  But there was also a lot of global functions. This PR marks all private methods as such in jsdoc with `@private`, but also fixes the `public-docs` script to include the new subdirectories of the shim files.

## How to Test

```
npm run public-docs
open out/index.html
```

It should have MessageShim and WebFrameworkShim in the Classes section.  Also the global section should remove a lot of private functions.

