### PR TITLE
test: updated prisma versioned test range to skip 5.9.0 as it was broken

### DIFF
--- a/test/versioned/prisma/package.json
+++ b/test/versioned/prisma/package.json
@@ -11,7 +11,7 @@
         "node": ">=16"
       },
       "dependencies": {
-        "@prisma/client": ">=5.0.0 <5.9.0",
+        "@prisma/client": ">=5.0.0 <5.9.0 || >=5.9.1",
         "prisma": "latest"
       },
       "files": [


### PR DESCRIPTION
Prisma fixed their exports issues in 5.9.1 this PR updates the versioned test range to skip 5.9.0 but continue testing on newer versions

## Links
Closes #1984 