### PR TITLE
fix: Updated grpc-js instrumentation to properly track errors and end transactions

### DIFF
--- a/lib/instrumentation/grpc-js/grpc.js
+++ b/lib/instrumentation/grpc-js/grpc.js
@@ -153,7 +153,11 @@ function wrapRegister(shim, original) {
     function instrumentedHandler(stream) {
       const { transaction, segment } = createTransaction()
       acceptDTHeaders(stream, transaction)
-      instrumentEventListeners(stream, transaction)
+      if (semver.gte(shim.pkgVersion, '1.10.0')) {
+        instrumentInterceptors(stream, transaction)
+      } else {
+        instrumentEventListeners(stream, transaction)
+      }
       return shim.applySegment(handler, segment, true, this, arguments)
     }
 
@@ -194,9 +198,48 @@ function wrapRegister(shim, original) {
       transaction.acceptDistributedTraceHeaders('HTTP', headers)
     }
 
+    /**
+     * Wraps the onCallEnd to add the response.status to trace, log an error,
+     * and end transaction.
+     *
+     * @param {object} stream the http2 server stream
+     * @param {object} transaction active transaction
+     */
+    function instrumentInterceptors(stream, transaction) {
+      const agent = shim.agent
+      const config = agent.config
+      if (!shim.isWrapped(stream.call.callEventTracker, 'onCallEnd')) {
+        shim.wrap(stream.call.callEventTracker, 'onCallEnd', function onCallEnd(shim, orig) {
+          return function wrappedOnCallEnd() {
+            const args = shim.argsToArray.apply(shim, arguments)
+            const [{ code: statusCode }] = args
+            transaction.trace.attributes.addAttribute(DESTINATION, 'response.status', statusCode)
+            if (shouldTrackError(statusCode, config)) {
+              const status = constants.Status[statusCode]
+              const error = new Error(`gRPC status code ${statusCode}: ${status}`)
+              agent.errors.add(transaction, error)
+            }
+            transaction.end()
+            return orig.apply(this, arguments)
+          }
+        })
+      }
+    }
+
+    /**
+     * Registers event listeners for callEnd and streamEnd to add the response.status to trace, log an error,
+     * and end transaction.
+     *
+     * Note: two listeners are registered as callEnd is emitted before streamEnd. Unlike the instrumentInterceptors
+     * case above where onCallEnd is called last.
+     *
+     * @param {object} stream the http2 server stream
+     * @param {object} transaction active transaction
+     */
     function instrumentEventListeners(stream, transaction) {
       const agent = shim.agent
       const config = agent.config
+
       stream.call.once('callEnd', (statusCode) => {
         transaction.trace.attributes.addAttribute(DESTINATION, 'response.status', statusCode)
         if (shouldTrackError(statusCode, config)) {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
In 1.10.0 of `@grpc/grpc-js` they refactored how they end calls/streams by introducing a server interceptor.  Weirdly the methods to end a call and stream are not exposed to the public API.  Either way this PR wraps the calls to work in 1.10.0.

## How to Test

`npm run versioned:internal grpc`

## Related Issues
Closes #2000
