### PR TITLE
test: Updated smoke tests to send data to the appropriate collector method

### DIFF
--- a/test/smoke/api/error-data.tap.js
+++ b/test/smoke/api/error-data.tap.js
@@ -45,7 +45,7 @@ test('Collector API should send errors to staging-collector.newrelic.com', (t) =
 
     const payload = [agent.config.run_id, agent.errors.traceAggregator.errors]
 
-    api.error_data(payload, function (error, command) {
+    api.send('error_data', payload, function (error, command) {
       t.error(error, 'sent errors without error')
       t.notOk(command.returned, 'return value is null')
 

--- a/test/smoke/api/metric-data.tap.js
+++ b/test/smoke/api/metric-data.tap.js
@@ -45,7 +45,7 @@ test('Collector API should send metrics to staging-collector.newrelic.com', (t) 
 
     const payload = [agent.config.run_id, metrics.started / 1000, Date.now() / 1000, metrics]
 
-    api.metric_data(payload, function (error, command) {
+    api.send('metric_data', payload, function (error, command) {
       t.notOk(error, 'sent metrics without error')
       t.ok(command, 'got a response')
 

--- a/test/smoke/api/transaction-sample-data.tap.js
+++ b/test/smoke/api/transaction-sample-data.tap.js
@@ -52,7 +52,7 @@ tap.test('Collector API should send transaction traces to staging-collector.newr
 
       const payload = [agent.config.run_id, [encoded]]
 
-      api.transaction_sample_data(payload, function (error, command) {
+      api.send('transaction_sample_data', payload, function (error, command) {
         t.error(error, 'sent transaction trace without error')
         t.notOk(command.returned, 'return value is null')
 


### PR DESCRIPTION
#1981 refactored the collector to have a common send function and the first argument is now the method on collector API. Smoke tests apparently used this directly and needed to be updated to use the send function instead of the specific collector method as function name. I also pushed my branch to the origin so the smoke tests should run and pass now