### PR TITLE
feat: Added instrumentation for langchain tools.

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -295,7 +295,7 @@ This product includes source derived from [@grpc/grpc-js](https://github.com/grp
 
 ### @grpc/proto-loader
 
-This product includes source derived from [@grpc/proto-loader](https://github.com/grpc/grpc-node) ([v0.7.10](https://github.com/grpc/grpc-node/tree/v0.7.10)), distributed under the [Apache-2.0 License](https://github.com/grpc/grpc-node/blob/v0.7.10/LICENSE):
+This product includes source derived from [@grpc/proto-loader](https://github.com/grpc/grpc-node) ([v0.7.9](https://github.com/grpc/grpc-node/tree/v0.7.9)), distributed under the [Apache-2.0 License](https://github.com/grpc/grpc-node/blob/v0.7.9/LICENSE):
 
 ```
                                  Apache License
@@ -1282,7 +1282,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ### import-in-the-middle
 
-This product includes source derived from [import-in-the-middle](https://github.com/DataDog/import-in-the-middle) ([v1.7.3](https://github.com/DataDog/import-in-the-middle/tree/v1.7.3)), distributed under the [Apache-2.0 License](https://github.com/DataDog/import-in-the-middle/blob/v1.7.3/LICENSE):
+This product includes source derived from [import-in-the-middle](https://github.com/DataDog/import-in-the-middle) ([v1.6.0](https://github.com/DataDog/import-in-the-middle/tree/v1.6.0)), distributed under the [Apache-2.0 License](https://github.com/DataDog/import-in-the-middle/blob/v1.6.0/LICENSE):
 
 ```
 Copyright 2021 Datadog, Inc.
@@ -2150,7 +2150,7 @@ THE SOFTWARE.
 
 ### @slack/bolt
 
-This product includes source derived from [@slack/bolt](https://github.com/slackapi/bolt) ([v3.17.1](https://github.com/slackapi/bolt/tree/v3.17.1)), distributed under the [MIT License](https://github.com/slackapi/bolt/blob/v3.17.1/LICENSE):
+This product includes source derived from [@slack/bolt](https://github.com/slackapi/bolt) ([v3.15.0](https://github.com/slackapi/bolt/tree/v3.15.0)), distributed under the [MIT License](https://github.com/slackapi/bolt/blob/v3.15.0/LICENSE):
 
 ```
 The MIT License (MIT)
@@ -2210,7 +2210,7 @@ SOFTWARE.
 
 ### async
 
-This product includes source derived from [async](https://github.com/caolan/async) ([v3.2.5](https://github.com/caolan/async/tree/v3.2.5)), distributed under the [MIT License](https://github.com/caolan/async/blob/v3.2.5/LICENSE):
+This product includes source derived from [async](https://github.com/caolan/async) ([v3.2.4](https://github.com/caolan/async/tree/v3.2.4)), distributed under the [MIT License](https://github.com/caolan/async/blob/v3.2.4/LICENSE):
 
 ```
 Copyright (c) 2010-2018 Caolan McMahon
@@ -2259,7 +2259,7 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ### clean-jsdoc-theme
 
-This product includes source derived from [clean-jsdoc-theme](https://github.com/ankitskvmdam/clean-jsdoc-theme) ([v4.2.17](https://github.com/ankitskvmdam/clean-jsdoc-theme/tree/v4.2.17)), distributed under the [MIT License](https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/v4.2.17/LICENSE):
+This product includes source derived from [clean-jsdoc-theme](https://github.com/ankitskvmdam/clean-jsdoc-theme) ([v4.2.10](https://github.com/ankitskvmdam/clean-jsdoc-theme/tree/v4.2.10)), distributed under the [MIT License](https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/v4.2.10/LICENSE):
 
 ```
 MIT License
@@ -2631,7 +2631,7 @@ Library.
 
 ### eslint
 
-This product includes source derived from [eslint](https://github.com/eslint/eslint) ([v8.56.0](https://github.com/eslint/eslint/tree/v8.56.0)), distributed under the [MIT License](https://github.com/eslint/eslint/blob/v8.56.0/LICENSE):
+This product includes source derived from [eslint](https://github.com/eslint/eslint) ([v8.48.0](https://github.com/eslint/eslint/tree/v8.48.0)), distributed under the [MIT License](https://github.com/eslint/eslint/blob/v8.48.0/LICENSE):
 
 ```
 Copyright OpenJS Foundation and other contributors, <www.openjsf.org>
@@ -3345,7 +3345,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ### tap
 
-This product includes source derived from [tap](https://github.com/tapjs/node-tap) ([v16.3.10](https://github.com/tapjs/node-tap/tree/v16.3.10)), distributed under the [ISC License](https://github.com/tapjs/node-tap/blob/v16.3.10/LICENSE):
+This product includes source derived from [tap](https://github.com/tapjs/node-tap) ([v16.3.8](https://github.com/tapjs/node-tap/tree/v16.3.8)), distributed under the [ISC License](https://github.com/tapjs/node-tap/blob/v16.3.8/LICENSE):
 
 ```
 The ISC License
@@ -3456,7 +3456,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ### @newrelic/native-metrics
 
-This product includes source derived from [@newrelic/native-metrics](https://github.com/newrelic/node-native-metrics) ([v10.0.1](https://github.com/newrelic/node-native-metrics/tree/v10.0.1)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-native-metrics/blob/v10.0.1/LICENSE):
+This product includes source derived from [@newrelic/native-metrics](https://github.com/newrelic/node-native-metrics) ([v10.0.0](https://github.com/newrelic/node-native-metrics/tree/v10.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-native-metrics/blob/v10.0.0/LICENSE):
 
 ```
                                  Apache License

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -295,7 +295,7 @@ This product includes source derived from [@grpc/grpc-js](https://github.com/grp
 
 ### @grpc/proto-loader
 
-This product includes source derived from [@grpc/proto-loader](https://github.com/grpc/grpc-node) ([v0.7.9](https://github.com/grpc/grpc-node/tree/v0.7.9)), distributed under the [Apache-2.0 License](https://github.com/grpc/grpc-node/blob/v0.7.9/LICENSE):
+This product includes source derived from [@grpc/proto-loader](https://github.com/grpc/grpc-node) ([v0.7.10](https://github.com/grpc/grpc-node/tree/v0.7.10)), distributed under the [Apache-2.0 License](https://github.com/grpc/grpc-node/blob/v0.7.10/LICENSE):
 
 ```
                                  Apache License
@@ -1282,7 +1282,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ### import-in-the-middle
 
-This product includes source derived from [import-in-the-middle](https://github.com/DataDog/import-in-the-middle) ([v1.6.0](https://github.com/DataDog/import-in-the-middle/tree/v1.6.0)), distributed under the [Apache-2.0 License](https://github.com/DataDog/import-in-the-middle/blob/v1.6.0/LICENSE):
+This product includes source derived from [import-in-the-middle](https://github.com/DataDog/import-in-the-middle) ([v1.7.3](https://github.com/DataDog/import-in-the-middle/tree/v1.7.3)), distributed under the [Apache-2.0 License](https://github.com/DataDog/import-in-the-middle/blob/v1.7.3/LICENSE):
 
 ```
 Copyright 2021 Datadog, Inc.
@@ -2150,7 +2150,7 @@ THE SOFTWARE.
 
 ### @slack/bolt
 
-This product includes source derived from [@slack/bolt](https://github.com/slackapi/bolt) ([v3.15.0](https://github.com/slackapi/bolt/tree/v3.15.0)), distributed under the [MIT License](https://github.com/slackapi/bolt/blob/v3.15.0/LICENSE):
+This product includes source derived from [@slack/bolt](https://github.com/slackapi/bolt) ([v3.17.1](https://github.com/slackapi/bolt/tree/v3.17.1)), distributed under the [MIT License](https://github.com/slackapi/bolt/blob/v3.17.1/LICENSE):
 
 ```
 The MIT License (MIT)
@@ -2210,7 +2210,7 @@ SOFTWARE.
 
 ### async
 
-This product includes source derived from [async](https://github.com/caolan/async) ([v3.2.4](https://github.com/caolan/async/tree/v3.2.4)), distributed under the [MIT License](https://github.com/caolan/async/blob/v3.2.4/LICENSE):
+This product includes source derived from [async](https://github.com/caolan/async) ([v3.2.5](https://github.com/caolan/async/tree/v3.2.5)), distributed under the [MIT License](https://github.com/caolan/async/blob/v3.2.5/LICENSE):
 
 ```
 Copyright (c) 2010-2018 Caolan McMahon
@@ -2259,7 +2259,7 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ### clean-jsdoc-theme
 
-This product includes source derived from [clean-jsdoc-theme](https://github.com/ankitskvmdam/clean-jsdoc-theme) ([v4.2.10](https://github.com/ankitskvmdam/clean-jsdoc-theme/tree/v4.2.10)), distributed under the [MIT License](https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/v4.2.10/LICENSE):
+This product includes source derived from [clean-jsdoc-theme](https://github.com/ankitskvmdam/clean-jsdoc-theme) ([v4.2.17](https://github.com/ankitskvmdam/clean-jsdoc-theme/tree/v4.2.17)), distributed under the [MIT License](https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/v4.2.17/LICENSE):
 
 ```
 MIT License
@@ -2631,7 +2631,7 @@ Library.
 
 ### eslint
 
-This product includes source derived from [eslint](https://github.com/eslint/eslint) ([v8.48.0](https://github.com/eslint/eslint/tree/v8.48.0)), distributed under the [MIT License](https://github.com/eslint/eslint/blob/v8.48.0/LICENSE):
+This product includes source derived from [eslint](https://github.com/eslint/eslint) ([v8.56.0](https://github.com/eslint/eslint/tree/v8.56.0)), distributed under the [MIT License](https://github.com/eslint/eslint/blob/v8.56.0/LICENSE):
 
 ```
 Copyright OpenJS Foundation and other contributors, <www.openjsf.org>
@@ -3345,7 +3345,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ### tap
 
-This product includes source derived from [tap](https://github.com/tapjs/node-tap) ([v16.3.8](https://github.com/tapjs/node-tap/tree/v16.3.8)), distributed under the [ISC License](https://github.com/tapjs/node-tap/blob/v16.3.8/LICENSE):
+This product includes source derived from [tap](https://github.com/tapjs/node-tap) ([v16.3.10](https://github.com/tapjs/node-tap/tree/v16.3.10)), distributed under the [ISC License](https://github.com/tapjs/node-tap/blob/v16.3.10/LICENSE):
 
 ```
 The ISC License
@@ -3456,7 +3456,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ### @newrelic/native-metrics
 
-This product includes source derived from [@newrelic/native-metrics](https://github.com/newrelic/node-native-metrics) ([v10.0.0](https://github.com/newrelic/node-native-metrics/tree/v10.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-native-metrics/blob/v10.0.0/LICENSE):
+This product includes source derived from [@newrelic/native-metrics](https://github.com/newrelic/node-native-metrics) ([v10.0.1](https://github.com/newrelic/node-native-metrics/tree/v10.0.1)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-native-metrics/blob/v10.0.1/LICENSE):
 
 ```
                                  Apache License

--- a/lib/instrumentation/langchain/callback-manager.js
+++ b/lib/instrumentation/langchain/callback-manager.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const { langchainRunId } = require('../../symbols')
+
+module.exports = function initialize(shim, callbacks) {
+  shim.wrap(
+    callbacks.CallbackManager.prototype,
+    ['handleChainStart', 'handleToolStart'],
+    function wrapStart(shim, orig) {
+      return async function wrappedStart() {
+        const result = await orig.apply(this, arguments)
+        const segment = shim.getActiveSegment()
+        if (segment) {
+          segment[langchainRunId] = result?.runId
+        }
+
+        return result
+      }
+    }
+  )
+}

--- a/lib/instrumentation/langchain/common.js
+++ b/lib/instrumentation/langchain/common.js
@@ -18,7 +18,7 @@ const common = module.exports
  * @param {Array} paramsTags tags defined on the method
  * @returns {Array} a merged array of unique tags
  */
-common.getTags = function getTags(localTags = [], paramsTags = []) {
+common.mergeTags = function mergeTags(localTags = [], paramsTags = []) {
   const tags = localTags.filter((tag) => !paramsTags.includes(tag))
   tags.push(...paramsTags)
   return tags
@@ -33,7 +33,7 @@ common.getTags = function getTags(localTags = [], paramsTags = []) {
  * @param {object} paramsMeta metadata defined on the method
  * @returns {object} a merged object of metadata
  */
-common.getMetadata = function getMetadata(localMeta = {}, paramsMeta = {}) {
+common.mergeMetadata = function mergeMetadata(localMeta = {}, paramsMeta = {}) {
   return { ...localMeta, ...paramsMeta }
 }
 

--- a/lib/instrumentation/langchain/common.js
+++ b/lib/instrumentation/langchain/common.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const {
+  AI: { LANGCHAIN }
+} = require('../../metrics/names')
+
+const common = module.exports
+
+/**
+ * Langchain allows you to define tags at the instance and call level
+ * This helper merges the two into 1 array ensuring there are not duplicates
+ *
+ * @param {Array} localTags tags defined on instance of a langchain object
+ * @param {Array} paramsTags tags defined on the method
+ * @returns {Array} a merged array of unique tags
+ */
+common.getTags = function getTags(localTags = [], paramsTags = []) {
+  const tags = localTags.filter((tag) => !paramsTags.includes(tag))
+  tags.push(...paramsTags)
+  return tags
+}
+
+/**
+ * Langchain allows you to define metadata at the instance and call level
+ * This helper merges the two into object favoring the call level metadata
+ * values when duplicate keys exist.
+ *
+ * @param {object} localMeta metadata defined on instance of a langchain object
+ * @param {object} paramsMeta metadata defined on the method
+ * @returns {object} a merged object of metadata
+ */
+common.getMetadata = function getMetadata(localMeta = {}, paramsMeta = {}) {
+  return { ...localMeta, ...paramsMeta }
+}
+
+/**
+ * Helper to enqueue a LLM event into the custom event aggregator.  This will also
+ * increment the Supportability metric that's used to derive a tag on the APM entity.
+ *
+ * @param {object} params function params
+ * @param {Agent} params.agent NR agent
+ * @param {string} params.type type of llm event(i.e.- LlmChatCompletionMessage, LlmTool, etc)
+ * @param {object} params.msg the llm event getting enqueued
+ * @param {string} params.pkgVersion version of langchain library instrumented
+ */
+common.recordEvent = function recordEvent({ agent, type, msg, pkgVersion }) {
+  agent.metrics.getOrCreateMetric(`${LANGCHAIN.TRACKING_PREFIX}/${pkgVersion}`).incrementCallCount()
+  agent.customEventAggregator.add([{ type, timestamp: Date.now() }, msg])
+}
+
+/**
+ * Helper to decide if instrumentation should be registered.
+ *
+ * @param {object} config agent config
+ * @returns {boolean} flag if we should skip instrumentation
+ */
+common.shouldSkipInstrumentation = function shouldSkipInstrumentation(config) {
+  return !(
+    config.ai_monitoring.enabled === true && config.feature_flag.langchain_instrumentation === true
+  )
+}

--- a/lib/instrumentation/langchain/nr-hooks.js
+++ b/lib/instrumentation/langchain/nr-hooks.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const toolsInstrumentation = require('./tools')
+
+module.exports = [
+  {
+    type: 'generic',
+    moduleName: '@langchain/core/tools',
+    onRequire: toolsInstrumentation
+  }
+]

--- a/lib/instrumentation/langchain/nr-hooks.js
+++ b/lib/instrumentation/langchain/nr-hooks.js
@@ -5,11 +5,17 @@
 
 'use strict'
 const toolsInstrumentation = require('./tools')
+const cbManagerInstrumentation = require('./callback-manager')
 
 module.exports = [
   {
     type: 'generic',
     moduleName: '@langchain/core/tools',
     onRequire: toolsInstrumentation
+  },
+  {
+    type: 'generic',
+    moduleName: '@langchain/core/dist/callbacks/manager',
+    onRequire: cbManagerInstrumentation
   }
 ]

--- a/lib/instrumentation/langchain/tools.js
+++ b/lib/instrumentation/langchain/tools.js
@@ -11,6 +11,7 @@ const {
 } = require('../../metrics/names')
 const { langchainRunId } = require('../../symbols')
 const { DESTINATIONS } = require('../../config/attribute-filter')
+const { RecorderSpec } = require('../../shim/specs')
 
 module.exports = function initialize(shim, tools) {
   const { agent, pkgVersion } = shim
@@ -26,7 +27,7 @@ module.exports = function initialize(shim, tools) {
     const { name, metadata: instanceMeta, description, tags: instanceTags } = this
     const [request, params] = args
     const { metadata: paramsMeta, tags: paramsTags } = params || {}
-    return {
+    return new RecorderSpec({
       name: `${LANGCHAIN.TOOL}/${name}`,
       promise: true,
       // eslint-disable-next-line max-params
@@ -48,6 +49,6 @@ module.exports = function initialize(shim, tools) {
         recordEvent({ agent, type: 'LlmTool', pkgVersion, msg: toolEvent })
         segment.transaction.trace.attributes.addAttribute(DESTINATIONS.TRANS_EVENT, 'llm', true)
       }
-    }
+    })
   })
 }

--- a/lib/instrumentation/langchain/tools.js
+++ b/lib/instrumentation/langchain/tools.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const { LangChainTool } = require('../../llm-events/langchain')
+const common = require('./common')
+const {
+  AI: { LANGCHAIN }
+} = require('../../metrics/names')
+const runId = Symbol('runId')
+const { DESTINATIONS } = require('../../config/attribute-filter')
+
+module.exports = function initialize(shim, tools) {
+  const { agent, pkgVersion } = shim
+
+  if (common.shouldSkipInstrumentation(agent.config)) {
+    shim.logger.debug(
+      'langchain instrumentation is disabled.  To enable set `config.ai_monitoring.enabled` to true'
+    )
+    return
+  }
+
+  shim.record(tools.StructuredTool.prototype, 'call', function wrapCall(shim, call, fnName, args) {
+    const { name, metadata: instanceMeta, description, tags: instanceTags } = this
+    if (!shim.isWrapped(this, '_call')) {
+      shim.wrap(this, '_call', wrapUnderCall)
+    }
+
+    const [request, params] = args
+    const { metadata: paramsMeta, tags: paramsTags } = params || {}
+    return {
+      name: `${LANGCHAIN.TOOL}/${name}`,
+      promise: true,
+      // eslint-disable-next-line max-params
+      after(_shim, _fn, _name, _err, output, segment) {
+        const metadata = common.getMetadata(instanceMeta, paramsMeta)
+        const tags = common.getTags(instanceTags, paramsTags)
+        segment.end()
+        const toolEvent = new LangChainTool({
+          agent,
+          description,
+          name,
+          runId: segment[runId],
+          metadata,
+          tags,
+          input: request?.input,
+          output,
+          segment
+        })
+        common.recordEvent({ agent, type: 'LlmTool', pkgVersion, msg: toolEvent })
+        segment.transaction.trace.attributes.addAttribute(DESTINATIONS.TRANS_EVENT, 'llm', true)
+      }
+    }
+  })
+}
+
+/**
+ * Wraps the _call method on a Tool instance.
+ * This has to be done on the instance because it's an abstract method that only
+ * gets defined at construction. This function will only get called if `_call` isn't
+ * wrapped.
+ *
+ * @param {object} shim langchain shim instance
+ * @param {Function} orig the original _call function
+ * @returns {Function} wrapped _call function
+ */
+function wrapUnderCall(shim, orig) {
+  return function wrappedCall() {
+    const callArgs = shim.argsToArray.apply(shim, arguments)
+    const segment = shim.getActiveSegment()
+    if (segment) {
+      segment[runId] = callArgs?.[1]?.runId
+    }
+    return orig.apply(this, arguments)
+  }
+}

--- a/lib/instrumentation/langchain/tools.js
+++ b/lib/instrumentation/langchain/tools.js
@@ -5,17 +5,17 @@
 
 'use strict'
 const { LangChainTool } = require('../../llm-events/langchain')
-const common = require('./common')
+const { mergeMetadata, mergeTags, recordEvent, shouldSkipInstrumentation } = require('./common')
 const {
   AI: { LANGCHAIN }
 } = require('../../metrics/names')
-const runId = Symbol('runId')
+const { langchainRunId } = require('../../symbols')
 const { DESTINATIONS } = require('../../config/attribute-filter')
 
 module.exports = function initialize(shim, tools) {
   const { agent, pkgVersion } = shim
 
-  if (common.shouldSkipInstrumentation(agent.config)) {
+  if (shouldSkipInstrumentation(agent.config)) {
     shim.logger.debug(
       'langchain instrumentation is disabled.  To enable set `config.ai_monitoring.enabled` to true'
     )
@@ -35,21 +35,21 @@ module.exports = function initialize(shim, tools) {
       promise: true,
       // eslint-disable-next-line max-params
       after(_shim, _fn, _name, _err, output, segment) {
-        const metadata = common.getMetadata(instanceMeta, paramsMeta)
-        const tags = common.getTags(instanceTags, paramsTags)
+        const metadata = mergeMetadata(instanceMeta, paramsMeta)
+        const tags = mergeTags(instanceTags, paramsTags)
         segment.end()
         const toolEvent = new LangChainTool({
           agent,
           description,
           name,
-          runId: segment[runId],
+          runId: segment[langchainRunId],
           metadata,
           tags,
           input: request?.input,
           output,
           segment
         })
-        common.recordEvent({ agent, type: 'LlmTool', pkgVersion, msg: toolEvent })
+        recordEvent({ agent, type: 'LlmTool', pkgVersion, msg: toolEvent })
         segment.transaction.trace.attributes.addAttribute(DESTINATIONS.TRANS_EVENT, 'llm', true)
       }
     }
@@ -71,7 +71,7 @@ function wrapUnderCall(shim, orig) {
     const callArgs = shim.argsToArray.apply(shim, arguments)
     const segment = shim.getActiveSegment()
     if (segment) {
-      segment[runId] = callArgs?.[1]?.runId
+      segment[langchainRunId] = callArgs?.[1]?.runId
     }
     return orig.apply(this, arguments)
   }

--- a/lib/instrumentation/langchain/tools.js
+++ b/lib/instrumentation/langchain/tools.js
@@ -24,10 +24,6 @@ module.exports = function initialize(shim, tools) {
 
   shim.record(tools.StructuredTool.prototype, 'call', function wrapCall(shim, call, fnName, args) {
     const { name, metadata: instanceMeta, description, tags: instanceTags } = this
-    if (!shim.isWrapped(this, '_call')) {
-      shim.wrap(this, '_call', wrapUnderCall)
-    }
-
     const [request, params] = args
     const { metadata: paramsMeta, tags: paramsTags } = params || {}
     return {
@@ -54,25 +50,4 @@ module.exports = function initialize(shim, tools) {
       }
     }
   })
-}
-
-/**
- * Wraps the _call method on a Tool instance.
- * This has to be done on the instance because it's an abstract method that only
- * gets defined at construction. This function will only get called if `_call` isn't
- * wrapped.
- *
- * @param {object} shim langchain shim instance
- * @param {Function} orig the original _call function
- * @returns {Function} wrapped _call function
- */
-function wrapUnderCall(shim, orig) {
-  return function wrappedCall() {
-    const callArgs = shim.argsToArray.apply(shim, arguments)
-    const segment = shim.getActiveSegment()
-    if (segment) {
-      segment[langchainRunId] = callArgs?.[1]?.runId
-    }
-    return orig.apply(this, arguments)
-  }
 }

--- a/lib/instrumentations.js
+++ b/lib/instrumentations.js
@@ -25,11 +25,13 @@ module.exports = function instrumentations() {
     '@hapi/hapi': { type: MODULE_TYPE.WEB_FRAMEWORK },
     'ioredis': { type: MODULE_TYPE.DATASTORE },
     'koa': { module: '@newrelic/koa' },
+    'langchain': { module: './instrumentation/langchain' },
     'memcached': { type: MODULE_TYPE.DATASTORE },
     'mongodb': { type: MODULE_TYPE.DATASTORE },
     'mysql': { module: './instrumentation/mysql' },
     'openai': { type: MODULE_TYPE.GENERIC },
     '@nestjs/core': { type: MODULE_TYPE.WEB_FRAMEWORK },
+    '@prisma/client': { type: MODULE_TYPE.DATASTORE },
     'pino': { module: './instrumentation/pino' },
     'pg': { type: MODULE_TYPE.DATASTORE },
     'q': { type: null },
@@ -53,7 +55,6 @@ module.exports = function instrumentations() {
     'loglevel': { type: MODULE_TYPE.TRACKING },
     'npmlog': { type: MODULE_TYPE.TRACKING },
     'fancy-log': { type: MODULE_TYPE.TRACKING },
-    '@prisma/client': { type: MODULE_TYPE.DATASTORE },
     'knex': { type: MODULE_TYPE.TRACKING }
   }
 }

--- a/lib/llm-events/langchain/chat-completion-message.js
+++ b/lib/llm-events/langchain/chat-completion-message.js
@@ -26,7 +26,7 @@ const defaultParams = {
   completionId: makeId(36)
 }
 
-class LangChainCompletionMesssage extends LangChainEvent {
+class LangChainCompletionMessage extends LangChainEvent {
   content
   role
   sequence
@@ -49,4 +49,4 @@ class LangChainCompletionMesssage extends LangChainEvent {
   }
 }
 
-module.exports = LangChainCompletionMesssage
+module.exports = LangChainCompletionMessage

--- a/lib/llm-events/langchain/chat-completion-summary.js
+++ b/lib/llm-events/langchain/chat-completion-summary.js
@@ -28,28 +28,13 @@ class LangChainCompletionSummary extends LangChainEvent {
   duration;
   ['response.number_of_messages'] = 0
 
-  #tags
-
   constructor(params = defaultParams) {
     params = Object.assign({}, defaultParams, params)
     super(params)
     const { segment } = params
 
-    this.tags = params.tags
     this.duration = segment?.getDurationInMillis()
     this['response.number_of_messages'] = params.messages?.length
-  }
-
-  get tags() {
-    return this.#tags
-  }
-
-  set tags(value) {
-    if (Array.isArray(value)) {
-      this.#tags = value.join(',')
-    } else if (typeof value === 'string') {
-      this.#tags = value
-    }
   }
 }
 

--- a/lib/llm-events/langchain/event.js
+++ b/lib/llm-events/langchain/event.js
@@ -29,6 +29,7 @@ const defaultParams = {
   segment: {
     transaction: {}
   },
+  tags: [],
   runId: '',
   metadata: {},
   virtual: undefined
@@ -60,6 +61,7 @@ class LangChainEvent extends BaseEvent {
     this.trace_id = segment?.transaction?.traceId
     this.langchainMeta = params.metadata
     this.metadata = agent
+    this.tags = Array.isArray(params.tags) ? params.tags.join(',') : params.tags
 
     if (params.virtual !== undefined) {
       if (params.virtual !== true && params.virtual !== false) {

--- a/lib/llm-events/langchain/index.js
+++ b/lib/llm-events/langchain/index.js
@@ -10,5 +10,6 @@ module.exports = {
   LangChainCompletionMessage: require('./chat-completion-message'),
   LangChainCompletionSummary: require('./chat-completion-summary'),
   LangChainVectorSearch: require('./vector-search'),
-  LangChainVectorSearchResult: require('./vector-search-result')
+  LangChainVectorSearchResult: require('./vector-search-result'),
+  LangChainTool: require('./tool')
 }

--- a/lib/llm-events/langchain/tool.js
+++ b/lib/llm-events/langchain/tool.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const LangChainEvent = require('./event')
+
+class LangChainTool extends LangChainEvent {
+  constructor(params) {
+    super(params)
+    this.input = params.input
+    this.output = params.output
+    this.name = params.name
+    this.description = params.description
+    this.duration = params?.segment?.getDurationInMillis()
+    this.run_id = this.request_id
+    delete this.request_id
+    delete this.virtual_llm
+    delete this.conversation_id
+  }
+}
+
+module.exports = LangChainTool

--- a/lib/metrics/names.js
+++ b/lib/metrics/names.js
@@ -168,13 +168,21 @@ const AI = {
   TRACKING_PREFIX: `${SUPPORTABILITY.NODEJS}/ML`,
   STREAMING_DISABLED: `${SUPPORTABILITY.NODEJS}/ML/Streaming/Disabled`,
   EMBEDDING: 'Llm/embedding',
-  COMPLETION: 'Llm/completion'
+  COMPLETION: 'Llm/completion',
+  TOOL: 'Llm/tool'
 }
 
 AI.OPENAI = {
   TRACKING_PREFIX: `${AI.TRACKING_PREFIX}/OpenAI`,
   EMBEDDING: `${AI.EMBEDDING}/OpenAI/create`,
   COMPLETION: `${AI.COMPLETION}/OpenAI/create`
+}
+
+AI.LANGCHAIN = {
+  TRACKING_PREFIX: `${AI.TRACKING_PREFIX}/Langchain`,
+  EMBEDDING: `${AI.EMBEDDING}/Langchain`,
+  COMPLETION: `${AI.COMPLETION}/Langchain`,
+  TOOL: `${AI.TOOL}/Langchain`
 }
 
 const RESTIFY = {

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -21,6 +21,7 @@ module.exports = {
   openAiHeaders: Symbol('openAiHeaders'),
   openAiApiKey: Symbol('openAiApiKey'),
   parentSegment: Symbol('parentSegment'),
+  langchainRunId: Symbol('runId'),
   prismaConnection: Symbol('prismaConnection'),
   prismaModelCall: Symbol('modelCall'),
   segment: Symbol('segment'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,10 +24,6 @@
         "json-stringify-safe": "^5.0.0",
         "module-details-from-path": "^1.0.3",
         "readable-stream": "^3.6.1",
-<<<<<<< HEAD
-=======
-        "require-in-the-middle": "jsumners-nr/require-in-the-middle#mapped-exports",
->>>>>>> 16ac039b5 (feat: Added instrumentation for langchain tools.)
         "semver": "^7.5.2",
         "winston-transport": "^4.5.0"
       },
@@ -11380,22 +11376,6 @@
         "node": ">=0.10.0"
       }
     },
-<<<<<<< HEAD
-=======
-    "node_modules/require-in-the-middle": {
-      "version": "7.2.0",
-      "resolved": "git+ssh://git@github.com/jsumners-nr/require-in-the-middle.git#3e1d176d3c7b24d5e48ec6944fdea93252143dea",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "module-details-from-path": "^1.0.3",
-        "resolve": "^1.22.1"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
->>>>>>> 16ac039b5 (feat: Added instrumentation for langchain tools.)
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,10 @@
         "json-stringify-safe": "^5.0.0",
         "module-details-from-path": "^1.0.3",
         "readable-stream": "^3.6.1",
+<<<<<<< HEAD
+=======
+        "require-in-the-middle": "jsumners-nr/require-in-the-middle#mapped-exports",
+>>>>>>> 16ac039b5 (feat: Added instrumentation for langchain tools.)
         "semver": "^7.5.2",
         "winston-transport": "^4.5.0"
       },
@@ -135,9 +139,9 @@
       "dev": true
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.502.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.502.0.tgz",
-      "integrity": "sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==",
+      "version": "3.511.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.511.0.tgz",
+      "integrity": "sha512-P03ufufxmkvd7nO46oOeEqYIMPJ8qMCKxAsfJk1JBVPQ1XctVntbail4/UFnrnzij8DTl4Mk/D62uGo7+RolXA==",
       "dev": true,
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -3822,9 +3826,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.16.tgz",
-      "integrity": "sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==",
+      "version": "20.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
+      "integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -5756,9 +5760,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.659",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.659.tgz",
-      "integrity": "sha512-sRJ3nV3HowrYpBtPF9bASQV7OW49IgZC01Xiq43WfSE3RTCkK0/JidoCmR73Hyc1mN+l/H4Yqx0eNiomvExFZg==",
+      "version": "1.4.665",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.665.tgz",
+      "integrity": "sha512-UpyCWObBoD+nSZgOC2ToaIdZB0r9GhqT2WahPKiSki6ckkSuKhQNso8V2PrFcHBMleI/eqbKgVQgVC4Wni4ilw==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -7076,13 +7080,14 @@
       }
     },
     "node_modules/get-symbol-description": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.1.tgz",
-      "integrity": "sha512-KmuibvwbWaM4BHcBRYwJfZ1JxyJeBwB8ct9YYu67SvYdbEIlcQ2e56dHxfbobqW38GXo8/zDFqJeGtHiVbWyQw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+      "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.5",
-        "es-errors": "^1.3.0"
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11375,6 +11380,22 @@
         "node": ">=0.10.0"
       }
     },
+<<<<<<< HEAD
+=======
+    "node_modules/require-in-the-middle": {
+      "version": "7.2.0",
+      "resolved": "git+ssh://git@github.com/jsumners-nr/require-in-the-middle.git#3e1d176d3c7b24d5e48ec6944fdea93252143dea",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+>>>>>>> 16ac039b5 (feat: Added instrumentation for langchain tools.)
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -12049,9 +12070,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
-      "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
+      "integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
       "dev": true
     },
     "node_modules/spdx-license-list": {

--- a/test/lib/agent_helper.js
+++ b/test/lib/agent_helper.js
@@ -20,6 +20,7 @@ const http = require('http')
 const https = require('https')
 const semver = require('semver')
 const crypto = require('crypto')
+const util = require('util')
 
 const KEYPATH = path.join(__dirname, 'test-key.key')
 const CERTPATH = path.join(__dirname, 'self-signed-test-certificate.crt')
@@ -422,9 +423,25 @@ helper.getRequestLib = function getRequestLib(ca) {
   return request[symbols.original] || request
 }
 
+/**
+ * Make http get request via callback
+ *
+ * @param {string} url path to request
+ * @param {object} options http options
+ * @param {Function} callback function to execute after request
+ */
 helper.makeGetRequest = (url, options, callback) => {
   helper.makeRequest(url, options, callback)
 }
+
+/**
+ * Make http get request via callback
+ *
+ * @param {string} url path to request
+ * @param {object} options http options
+ * @returns {Promise} promise with response on resolve/reject
+ */
+helper.makeGetRequestAsync = util.promisify(helper.makeGetRequest)
 
 helper.makeRequest = (url, options, callback) => {
   if (!options || typeof options === 'function') {

--- a/test/unit/instrumentation/langchain/tools.test.js
+++ b/test/unit/instrumentation/langchain/tools.test.js
@@ -11,8 +11,6 @@ const GenericShim = require('../../../../lib/shim/shim')
 const sinon = require('sinon')
 
 test('langchain/core/tools unit tests', (t) => {
-  t.autoend()
-
   t.beforeEach(function (t) {
     const sandbox = sinon.createSandbox()
     const agent = helper.loadMockedAgent()
@@ -82,4 +80,5 @@ test('langchain/core/tools unit tests', (t) => {
     const unwrapped = shim.unwrap(tool._call)
     t.equal(unwrapped.name, '_call', 'unwrapped _call should have a name of _call')
   })
+  t.end()
 })

--- a/test/unit/instrumentation/langchain/tools.test.js
+++ b/test/unit/instrumentation/langchain/tools.test.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { test } = require('tap')
+const helper = require('../../../lib/agent_helper')
+const GenericShim = require('../../../../lib/shim/shim')
+const sinon = require('sinon')
+
+test('langchain/core/tools unit tests', (t) => {
+  t.autoend()
+
+  t.beforeEach(function (t) {
+    const sandbox = sinon.createSandbox()
+    const agent = helper.loadMockedAgent()
+    agent.config.ai_monitoring = { enabled: true }
+    agent.config.feature_flag = { langchain_instrumentation: true }
+    const shim = new GenericShim(agent, 'langchain')
+    shim.pkgVersion = '0.1.26'
+    sandbox.stub(shim.logger, 'debug')
+    sandbox.stub(shim.logger, 'warn')
+
+    t.context.agent = agent
+    t.context.shim = shim
+    t.context.sandbox = sandbox
+    t.context.initialize = require('../../../../lib/instrumentation/langchain/tools')
+  })
+
+  t.afterEach(function (t) {
+    helper.unloadAgent(t.context.agent)
+    t.context.sandbox.restore()
+  })
+
+  function getMockModule() {
+    function StructuredTool() {}
+    StructuredTool.prototype.call = async function call() {}
+    StructuredTool.prototype._call = async function _call() {}
+    return { StructuredTool }
+  }
+
+  ;[
+    { aiMonitoring: false, langChain: true },
+    { aiMonitoring: true, langChain: false },
+    { aiMonitoring: false, langChain: false }
+  ].forEach(({ aiMonitoring, langChain }) => {
+    t.test(
+      `should not register instrumentation if ai_monitoring is ${aiMonitoring} and langchain_instrumentation is ${langChain}`,
+      (t) => {
+        const { shim, agent, initialize } = t.context
+        const MockTool = getMockModule()
+        agent.config.ai_monitoring.enabled = aiMonitoring
+        agent.config.feature_flag.langchain_instrumentation = langChain
+
+        initialize(shim, MockTool)
+        t.equal(shim.logger.debug.callCount, 1, 'should log 1 debug messages')
+        t.equal(
+          shim.logger.debug.args[0][0],
+          'langchain instrumentation is disabled.  To enable set `config.ai_monitoring.enabled` to true'
+        )
+        const isWrapped = shim.isWrapped(MockTool.StructuredTool.prototype.call)
+        t.equal(isWrapped, false, 'should not wrap tool create')
+        t.end()
+      }
+    )
+  })
+
+  t.test('should only wrap _call once', async (t) => {
+    const { shim, initialize } = t.context
+    const MockTool = getMockModule()
+    initialize(shim, MockTool)
+    const tool = new MockTool.StructuredTool()
+    let wrapped = shim.isWrapped(tool._call)
+    t.notOk(wrapped, 'should not wrap _call until call is invoked')
+    await tool.call()
+    wrapped = shim.isWrapped(tool._call)
+    t.ok(wrapped, '_call is wrapped since call was invoked')
+    await tool.call()
+    t.equal(tool._call.name, 'wrappedCall', '_call name should be named wrappedCall')
+    const unwrapped = shim.unwrap(tool._call)
+    t.equal(unwrapped.name, '_call', 'unwrapped _call should have a name of _call')
+  })
+})

--- a/test/unit/instrumentation/langchain/tools.test.js
+++ b/test/unit/instrumentation/langchain/tools.test.js
@@ -35,7 +35,6 @@ test('langchain/core/tools unit tests', (t) => {
   function getMockModule() {
     function StructuredTool() {}
     StructuredTool.prototype.call = async function call() {}
-    StructuredTool.prototype._call = async function _call() {}
     return { StructuredTool }
   }
 
@@ -65,20 +64,5 @@ test('langchain/core/tools unit tests', (t) => {
     )
   })
 
-  t.test('should only wrap _call once', async (t) => {
-    const { shim, initialize } = t.context
-    const MockTool = getMockModule()
-    initialize(shim, MockTool)
-    const tool = new MockTool.StructuredTool()
-    let wrapped = shim.isWrapped(tool._call)
-    t.notOk(wrapped, 'should not wrap _call until call is invoked')
-    await tool.call()
-    wrapped = shim.isWrapped(tool._call)
-    t.ok(wrapped, '_call is wrapped since call was invoked')
-    await tool.call()
-    t.equal(tool._call.name, 'wrappedCall', '_call name should be named wrappedCall')
-    const unwrapped = shim.unwrap(tool._call)
-    t.equal(unwrapped.name, '_call', 'unwrapped _call should have a name of _call')
-  })
   t.end()
 })

--- a/test/unit/llm-events/langchain/event.test.js
+++ b/test/unit/llm-events/langchain/event.test.js
@@ -91,3 +91,15 @@ tap.test('metadata is parsed correctly', async (t) => {
   t.equal(event['llm.bar'], 'baz')
   t.notOk(event.customKey)
 })
+
+tap.test('sets tags from array', async (t) => {
+  t.context.tags = ['foo', 'bar']
+  const msg = new LangChainEvent(t.context)
+  t.equal(msg.tags, 'foo,bar')
+})
+
+tap.test('sets tags from string', async (t) => {
+  t.context.tags = 'foo,bar'
+  const msg = new LangChainEvent(t.context)
+  t.equal(msg.tags, 'foo,bar')
+})

--- a/test/unit/llm-events/langchain/tool.test.js
+++ b/test/unit/llm-events/langchain/tool.test.js
@@ -6,7 +6,7 @@
 'use strict'
 
 const tap = require('tap')
-const LangChainCompletionSummary = require('../../../../lib/llm-events/langchain/chat-completion-summary')
+const LangChainTool = require('../../../../lib/llm-events/langchain/tool')
 
 tap.beforeEach((t) => {
   t.context._tx = {
@@ -35,36 +35,40 @@ tap.beforeEach((t) => {
   }
 
   t.context.segment = {
+    getDurationInMillis() {
+      return 1.01
+    },
     id: 'segment-1',
     transaction: {
       id: 'tx-1',
       traceId: 'trace-1'
-    },
-    getDurationInMillis() {
-      return 42
     }
   }
 
   t.context.runId = 'run-1'
   t.context.metadata = { foo: 'foo' }
+  t.context.name = 'test-tool'
+  t.context.description = 'test tool description'
+  t.context.input = 'input'
+  t.context.output = 'output'
 })
 
-tap.test('creates entity', async (t) => {
-  const msg = new LangChainCompletionSummary(t.context)
-  t.match(msg, {
+tap.test('constructs default instance', async (t) => {
+  const event = new LangChainTool(t.context)
+  t.match(event, {
+    input: 'input',
+    output: 'output',
+    name: 'test-tool',
+    description: 'test tool description',
+    run_id: 'run-1',
     id: /[a-z0-9-]{36}/,
     appName: 'test-app',
-    ['llm.conversation_id']: 'test-conversation',
     span_id: 'segment-1',
-    request_id: 'run-1',
     transaction_id: 'tx-1',
     trace_id: 'trace-1',
+    duration: 1.01,
     ['metadata.foo']: 'foo',
     ingest_source: 'Node',
-    vendor: 'langchain',
-    virtual_llm: true,
-    tags: '',
-    duration: 42,
-    ['response.number_of_messages']: 0
+    vendor: 'langchain'
   })
 })

--- a/test/versioned/fastify/common.js
+++ b/test/versioned/fastify/common.js
@@ -5,9 +5,7 @@
 
 'use strict'
 const common = module.exports
-const util = require('util')
 const helper = require('../../lib/agent_helper')
-const getAsync = util.promisify(helper.makeGetRequest)
 
 const ROUTES = {
   ASYNC_RETURN: '/async-return',
@@ -115,6 +113,6 @@ common.registerMiddlewares = ({ fastify, calls }) => {
  */
 common.makeRequest = async ({ address, port, family }, uri) => {
   const formattedAddress = family === 'IPv6' ? `[${address}]` : address
-  const { body } = await getAsync(`http://${formattedAddress}:${port}${uri}`)
+  const { body } = await helper.makeGetRequestAsync(`http://${formattedAddress}:${port}${uri}`)
   return body
 }

--- a/test/versioned/langchain/helpers/custom-tool.js
+++ b/test/versioned/langchain/helpers/custom-tool.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const { Tool } = require('@langchain/core/tools')
+const { makeGetRequestAsync } = require('../../../lib/agent_helper')
+
+module.exports = class TestTool extends Tool {
+  static lc_name() {
+    return 'TestTool'
+  }
+
+  name = 'node-agent-test-tool'
+  description = 'A test tool for versioned tests'
+  key
+
+  constructor(params) {
+    super()
+    this.baseUrl = params.baseUrl ?? this.baseUrl
+  }
+
+  async _call(uri) {
+    const url = `${this.baseUrl}/${uri}`
+    const res = await makeGetRequestAsync(url)
+    if (res.statusCode !== 200) {
+      throw new Error('Failed to make request')
+    }
+
+    return res.body[this.key] || res.body
+  }
+}

--- a/test/versioned/langchain/helpers/custom-tool.js
+++ b/test/versioned/langchain/helpers/custom-tool.js
@@ -5,7 +5,9 @@
 
 'use strict'
 const { Tool } = require('@langchain/core/tools')
-const { makeGetRequestAsync } = require('../../../lib/agent_helper')
+const data = {
+  langchain: 'Langchain is the best!'
+}
 
 module.exports = class TestTool extends Tool {
   static lc_name() {
@@ -19,15 +21,13 @@ module.exports = class TestTool extends Tool {
   constructor(params) {
     super()
     this.baseUrl = params.baseUrl ?? this.baseUrl
+    this.fakeData = data
   }
 
-  async _call(uri) {
-    const url = `${this.baseUrl}/${uri}`
-    const res = await makeGetRequestAsync(url)
-    if (res.statusCode !== 200) {
-      throw new Error('Failed to make request')
+  async _call(key) {
+    if (this.fakeData[key]) {
+      return this.fakeData[key]
     }
-
-    return res.body[this.key] || res.body
+    throw new Error('Failed to retrieve data')
   }
 }

--- a/test/versioned/langchain/package.json
+++ b/test/versioned/langchain/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "langchain-tests",
+  "version": "0.0.0",
+  "private": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "tests": [
+    {
+      "engines": {
+        "node": ">=18"
+      },
+      "dependencies": {
+        "@langchain/core": ">=0.1.17",
+        "@langchain/community": "latest"
+      },
+      "files": [
+        "tools.tap.js"
+      ]
+    }
+  ]
+}

--- a/test/versioned/langchain/package.json
+++ b/test/versioned/langchain/package.json
@@ -11,8 +11,7 @@
         "node": ">=18"
       },
       "dependencies": {
-        "@langchain/core": ">=0.1.17",
-        "@langchain/community": "latest"
+        "@langchain/core": ">=0.1.17"
       },
       "files": [
         "tools.tap.js"

--- a/test/versioned/langchain/tools.tap.js
+++ b/test/versioned/langchain/tools.tap.js
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const helper = require('../../lib/agent_helper')
+// load the assertSegments assertion
+require('../../lib/metrics_helper')
+const fs = require('fs')
+// have to read and not require because openai does not export the package.json
+const { version: pkgVersion } = JSON.parse(
+  fs.readFileSync(`${__dirname}/node_modules/@langchain/core/package.json`)
+)
+const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
+const config = {
+  ai_monitoring: {
+    enabled: true
+  },
+  feature_flag: {
+    langchain_instrumentation: true
+  }
+}
+
+tap.test('Langchain instrumentation - tools', (t) => {
+  t.autoend()
+
+  t.before(() => {
+    t.context.agent = helper.instrumentMockedAgent(config)
+    const { WikipediaQueryRun } = require('@langchain/community/tools/wikipedia_query_run')
+    t.context.tool = new WikipediaQueryRun({
+      topKResults: 3,
+      maxDocContentLength: 4000
+    })
+  })
+
+  t.afterEach(() => {
+    t.context.agent.customEventAggregator.clear()
+  })
+
+  t.teardown(() => {
+    helper.unloadAgent(t.context.agent)
+  })
+
+  t.test('should create span on successful tools create', (test) => {
+    const { agent, tool } = t.context
+    helper.runInTransaction(agent, async (tx) => {
+      const result = await tool.call('Langchain')
+      test.ok(result)
+      test.assertSegments(
+        tx.trace.root,
+        ['Llm/tool/Langchain/wikipedia-api', [`External/en.wikipedia.org/w/api.php`]],
+        { exact: false }
+      )
+      tx.end()
+      test.end()
+    })
+  })
+
+  t.test('should increment tracking metric for each tool event', (test) => {
+    const { tool, agent } = t.context
+    helper.runInTransaction(agent, async (tx) => {
+      await tool.call('Langchain')
+
+      const metrics = agent.metrics.getOrCreateMetric(
+        `Supportability/Nodejs/ML/Langchain/${pkgVersion}`
+      )
+      test.equal(metrics.callCount > 0, true)
+
+      tx.end()
+      test.end()
+    })
+  })
+
+  t.test('should create LlmTool event for every tool.call', (test) => {
+    const { agent, tool } = t.context
+    helper.runInTransaction(agent, async (tx) => {
+      const input = 'Langchain'
+      tool.metadata = { key: 'instance-value', hello: 'world' }
+      tool.tags = ['tag1', 'tag2']
+      await tool.call(input, { metadata: { key: 'value' }, tags: ['tag2', 'tag3'] })
+      const events = agent.customEventAggregator.events.toArray()
+      test.equal(events.length, 1, 'should create a LlmTool event')
+      const [[{ type }, toolEvent]] = events
+      test.equal(type, 'LlmTool')
+      test.match(toolEvent, {
+        'id': /[a-f0-9]{36}/,
+        'appName': 'New Relic for Node.js tests',
+        'span_id': tx.trace.root.children[0].id,
+        'trace_id': tx.traceId,
+        'transaction_id': tx.id,
+        'ingest_source': 'Node',
+        'vendor': 'langchain',
+        'metadata.key': 'value',
+        'metadata.hello': 'world',
+        'tags': 'tag1,tag2,tag3',
+        input,
+        'output': /Page: LangChain.*/,
+        'name': tool.name,
+        'description': tool.description,
+        'duration': tx.trace.root.children[0].getDurationInMillis(),
+        'run_id': undefined
+      })
+      tx.end()
+      test.end()
+    })
+  })
+
+  t.test('should add runId when a callback handler exists', (test) => {
+    const { BaseCallbackHandler } = require('@langchain/core/callbacks/base')
+    let runId
+    const cbHandler = BaseCallbackHandler.fromMethods({
+      handleToolStart(...args) {
+        runId = args?.[2]
+      }
+    })
+
+    const { agent, tool } = t.context
+    tool.callbacks = [cbHandler]
+    helper.runInTransaction(agent, async (tx) => {
+      const input = 'Langchain'
+      await tool.call(input)
+      const events = agent.customEventAggregator.events.toArray()
+      test.equal(events.length, 1, 'should create a LlmTool event')
+      const [[, toolEvent]] = events
+
+      test.equal(toolEvent.run_id, runId)
+      tx.end()
+      test.end()
+    })
+  })
+
+  t.test('should not create llm tool events when not in a transaction', async (test) => {
+    const { tool, agent } = t.context
+    await tool.call('Langchain')
+
+    const events = agent.customEventAggregator.events.toArray()
+    test.equal(events.length, 0, 'should not create llm events')
+  })
+
+  t.test('should add llm attribute to transaction', (test) => {
+    const { tool, agent } = t.context
+    helper.runInTransaction(agent, async (tx) => {
+      await tool.call('Langchain')
+
+      const attributes = tx.trace.attributes.get(DESTINATIONS.TRANS_EVENT)
+      t.equal(attributes.llm, true)
+
+      tx.end()
+      test.end()
+    })
+  })
+})

--- a/test/versioned/langchain/tools.tap.js
+++ b/test/versioned/langchain/tools.tap.js
@@ -45,7 +45,7 @@ tap.test('Langchain instrumentation - tools', (t) => {
     helper.unloadAgent(t.context.agent)
     // bust the require-cache so it can re-instrument
     Object.keys(require.cache).forEach((key) => {
-      if (key.endsWith('@langchain/core/tools.cjs') || key.endsWith('/helpers/custom-tool.js')) {
+      if (key.includes('@langchain/core') || key.endsWith('/helpers/custom-tool.js')) {
         delete require.cache[key]
       }
     })

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -16,15 +16,15 @@
       "licenseTextSource": "file",
       "publisher": "Contrast Security"
     },
-    "@newrelic/native-metrics@10.0.1": {
+    "@newrelic/native-metrics@10.0.0": {
       "name": "@newrelic/native-metrics",
-      "version": "10.0.1",
+      "version": "10.0.0",
       "range": "^10.0.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-native-metrics",
-      "versionedRepoUrl": "https://github.com/newrelic/node-native-metrics/tree/v10.0.1",
+      "versionedRepoUrl": "https://github.com/newrelic/node-native-metrics/tree/v10.0.0",
       "licenseFile": "node_modules/@newrelic/native-metrics/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-native-metrics/blob/v10.0.1/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-native-metrics/blob/v10.0.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"
@@ -56,15 +56,15 @@
       "licenseTextSource": "file",
       "publisher": "Google Inc."
     },
-    "@grpc/proto-loader@0.7.10": {
+    "@grpc/proto-loader@0.7.9": {
       "name": "@grpc/proto-loader",
-      "version": "0.7.10",
+      "version": "0.7.9",
       "range": "^0.7.5",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/grpc/grpc-node",
-      "versionedRepoUrl": "https://github.com/grpc/grpc-node/tree/v0.7.10",
+      "versionedRepoUrl": "https://github.com/grpc/grpc-node/tree/v0.7.9",
       "licenseFile": "node_modules/@grpc/proto-loader/LICENSE",
-      "licenseUrl": "https://github.com/grpc/grpc-node/blob/v0.7.10/LICENSE",
+      "licenseUrl": "https://github.com/grpc/grpc-node/blob/v0.7.9/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Google Inc."
     },
@@ -173,15 +173,15 @@
       "email": "nathan@tootallnate.net",
       "url": "http://n8.io/"
     },
-    "import-in-the-middle@1.7.3": {
+    "import-in-the-middle@1.6.0": {
       "name": "import-in-the-middle",
-      "version": "1.7.3",
+      "version": "1.6.0",
       "range": "^1.6.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/DataDog/import-in-the-middle",
-      "versionedRepoUrl": "https://github.com/DataDog/import-in-the-middle/tree/v1.7.3",
+      "versionedRepoUrl": "https://github.com/DataDog/import-in-the-middle/tree/v1.6.0",
       "licenseFile": "node_modules/import-in-the-middle/LICENSE",
-      "licenseUrl": "https://github.com/DataDog/import-in-the-middle/blob/v1.7.3/LICENSE",
+      "licenseUrl": "https://github.com/DataDog/import-in-the-middle/blob/v1.6.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Bryan English",
       "email": "bryan.english@datadoghq.com"
@@ -314,15 +314,15 @@
       "licenseUrl": "https://github.com/octokit/rest.js/blob/v18.12.0/LICENSE",
       "licenseTextSource": "file"
     },
-    "@slack/bolt@3.17.1": {
+    "@slack/bolt@3.15.0": {
       "name": "@slack/bolt",
-      "version": "3.17.1",
+      "version": "3.15.0",
       "range": "^3.7.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/slackapi/bolt",
-      "versionedRepoUrl": "https://github.com/slackapi/bolt/tree/v3.17.1",
+      "versionedRepoUrl": "https://github.com/slackapi/bolt/tree/v3.15.0",
       "licenseFile": "node_modules/@slack/bolt/LICENSE",
-      "licenseUrl": "https://github.com/slackapi/bolt/blob/v3.17.1/LICENSE",
+      "licenseUrl": "https://github.com/slackapi/bolt/blob/v3.15.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Slack Technologies, LLC"
     },
@@ -338,15 +338,15 @@
       "licenseTextSource": "file",
       "publisher": "Evgeny Poberezkin"
     },
-    "async@3.2.5": {
+    "async@3.2.4": {
       "name": "async",
-      "version": "3.2.5",
+      "version": "3.2.4",
       "range": "^3.2.4",
       "licenses": "MIT",
       "repoUrl": "https://github.com/caolan/async",
-      "versionedRepoUrl": "https://github.com/caolan/async/tree/v3.2.5",
+      "versionedRepoUrl": "https://github.com/caolan/async/tree/v3.2.4",
       "licenseFile": "node_modules/async/LICENSE",
-      "licenseUrl": "https://github.com/caolan/async/blob/v3.2.5/LICENSE",
+      "licenseUrl": "https://github.com/caolan/async/blob/v3.2.4/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Caolan McMahon"
     },
@@ -363,15 +363,15 @@
       "publisher": "Ben Coe",
       "email": "ben@npmjs.com"
     },
-    "clean-jsdoc-theme@4.2.17": {
+    "clean-jsdoc-theme@4.2.10": {
       "name": "clean-jsdoc-theme",
-      "version": "4.2.17",
+      "version": "4.2.10",
       "range": "^4.2.4",
       "licenses": "MIT",
       "repoUrl": "https://github.com/ankitskvmdam/clean-jsdoc-theme",
-      "versionedRepoUrl": "https://github.com/ankitskvmdam/clean-jsdoc-theme/tree/v4.2.17",
+      "versionedRepoUrl": "https://github.com/ankitskvmdam/clean-jsdoc-theme/tree/v4.2.10",
       "licenseFile": "node_modules/clean-jsdoc-theme/LICENSE",
-      "licenseUrl": "https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/v4.2.17/LICENSE",
+      "licenseUrl": "https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/v4.2.10/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Ank"
     },
@@ -466,15 +466,15 @@
       "licenseUrl": "https://github.com/SonarSource/eslint-plugin-sonarjs/blob/v0.18.0/LICENSE",
       "licenseTextSource": "file"
     },
-    "eslint@8.56.0": {
+    "eslint@8.48.0": {
       "name": "eslint",
-      "version": "8.56.0",
+      "version": "8.48.0",
       "range": "^8.24.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/eslint/eslint",
-      "versionedRepoUrl": "https://github.com/eslint/eslint/tree/v8.56.0",
+      "versionedRepoUrl": "https://github.com/eslint/eslint/tree/v8.48.0",
       "licenseFile": "node_modules/eslint/LICENSE",
-      "licenseUrl": "https://github.com/eslint/eslint/blob/v8.56.0/LICENSE",
+      "licenseUrl": "https://github.com/eslint/eslint/blob/v8.48.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Nicholas C. Zakas",
       "email": "nicholas+npm@nczconsulting.com"
@@ -688,15 +688,15 @@
       "licenseTextSource": "file",
       "publisher": "Christian Johansen"
     },
-    "tap@16.3.10": {
+    "tap@16.3.8": {
       "name": "tap",
-      "version": "16.3.10",
+      "version": "16.3.8",
       "range": "^16.3.4",
       "licenses": "ISC",
       "repoUrl": "https://github.com/tapjs/node-tap",
-      "versionedRepoUrl": "https://github.com/tapjs/node-tap/tree/v16.3.10",
+      "versionedRepoUrl": "https://github.com/tapjs/node-tap/tree/v16.3.8",
       "licenseFile": "node_modules/tap/LICENSE",
-      "licenseUrl": "https://github.com/tapjs/node-tap/blob/v16.3.10/LICENSE",
+      "licenseUrl": "https://github.com/tapjs/node-tap/blob/v16.3.8/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Isaac Z. Schlueter",
       "email": "i@izs.me",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Wed Feb 21 2024 15:11:52 GMT-0500 (Eastern Standard Time)",
+  "lastUpdated": "Wed Feb 21 2024 15:23:19 GMT-0500 (Eastern Standard Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -16,15 +16,15 @@
       "licenseTextSource": "file",
       "publisher": "Contrast Security"
     },
-    "@newrelic/native-metrics@10.0.0": {
+    "@newrelic/native-metrics@10.0.1": {
       "name": "@newrelic/native-metrics",
-      "version": "10.0.0",
+      "version": "10.0.1",
       "range": "^10.0.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-native-metrics",
-      "versionedRepoUrl": "https://github.com/newrelic/node-native-metrics/tree/v10.0.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-native-metrics/tree/v10.0.1",
       "licenseFile": "node_modules/@newrelic/native-metrics/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-native-metrics/blob/v10.0.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-native-metrics/blob/v10.0.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"
@@ -56,15 +56,15 @@
       "licenseTextSource": "file",
       "publisher": "Google Inc."
     },
-    "@grpc/proto-loader@0.7.9": {
+    "@grpc/proto-loader@0.7.10": {
       "name": "@grpc/proto-loader",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "range": "^0.7.5",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/grpc/grpc-node",
-      "versionedRepoUrl": "https://github.com/grpc/grpc-node/tree/v0.7.9",
+      "versionedRepoUrl": "https://github.com/grpc/grpc-node/tree/v0.7.10",
       "licenseFile": "node_modules/@grpc/proto-loader/LICENSE",
-      "licenseUrl": "https://github.com/grpc/grpc-node/blob/v0.7.9/LICENSE",
+      "licenseUrl": "https://github.com/grpc/grpc-node/blob/v0.7.10/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Google Inc."
     },
@@ -173,15 +173,15 @@
       "email": "nathan@tootallnate.net",
       "url": "http://n8.io/"
     },
-    "import-in-the-middle@1.6.0": {
+    "import-in-the-middle@1.7.3": {
       "name": "import-in-the-middle",
-      "version": "1.6.0",
+      "version": "1.7.3",
       "range": "^1.6.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/DataDog/import-in-the-middle",
-      "versionedRepoUrl": "https://github.com/DataDog/import-in-the-middle/tree/v1.6.0",
+      "versionedRepoUrl": "https://github.com/DataDog/import-in-the-middle/tree/v1.7.3",
       "licenseFile": "node_modules/import-in-the-middle/LICENSE",
-      "licenseUrl": "https://github.com/DataDog/import-in-the-middle/blob/v1.6.0/LICENSE",
+      "licenseUrl": "https://github.com/DataDog/import-in-the-middle/blob/v1.7.3/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Bryan English",
       "email": "bryan.english@datadoghq.com"
@@ -314,15 +314,15 @@
       "licenseUrl": "https://github.com/octokit/rest.js/blob/v18.12.0/LICENSE",
       "licenseTextSource": "file"
     },
-    "@slack/bolt@3.15.0": {
+    "@slack/bolt@3.17.1": {
       "name": "@slack/bolt",
-      "version": "3.15.0",
+      "version": "3.17.1",
       "range": "^3.7.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/slackapi/bolt",
-      "versionedRepoUrl": "https://github.com/slackapi/bolt/tree/v3.15.0",
+      "versionedRepoUrl": "https://github.com/slackapi/bolt/tree/v3.17.1",
       "licenseFile": "node_modules/@slack/bolt/LICENSE",
-      "licenseUrl": "https://github.com/slackapi/bolt/blob/v3.15.0/LICENSE",
+      "licenseUrl": "https://github.com/slackapi/bolt/blob/v3.17.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Slack Technologies, LLC"
     },
@@ -338,15 +338,15 @@
       "licenseTextSource": "file",
       "publisher": "Evgeny Poberezkin"
     },
-    "async@3.2.4": {
+    "async@3.2.5": {
       "name": "async",
-      "version": "3.2.4",
+      "version": "3.2.5",
       "range": "^3.2.4",
       "licenses": "MIT",
       "repoUrl": "https://github.com/caolan/async",
-      "versionedRepoUrl": "https://github.com/caolan/async/tree/v3.2.4",
+      "versionedRepoUrl": "https://github.com/caolan/async/tree/v3.2.5",
       "licenseFile": "node_modules/async/LICENSE",
-      "licenseUrl": "https://github.com/caolan/async/blob/v3.2.4/LICENSE",
+      "licenseUrl": "https://github.com/caolan/async/blob/v3.2.5/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Caolan McMahon"
     },
@@ -363,15 +363,15 @@
       "publisher": "Ben Coe",
       "email": "ben@npmjs.com"
     },
-    "clean-jsdoc-theme@4.2.10": {
+    "clean-jsdoc-theme@4.2.17": {
       "name": "clean-jsdoc-theme",
-      "version": "4.2.10",
+      "version": "4.2.17",
       "range": "^4.2.4",
       "licenses": "MIT",
       "repoUrl": "https://github.com/ankitskvmdam/clean-jsdoc-theme",
-      "versionedRepoUrl": "https://github.com/ankitskvmdam/clean-jsdoc-theme/tree/v4.2.10",
+      "versionedRepoUrl": "https://github.com/ankitskvmdam/clean-jsdoc-theme/tree/v4.2.17",
       "licenseFile": "node_modules/clean-jsdoc-theme/LICENSE",
-      "licenseUrl": "https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/v4.2.10/LICENSE",
+      "licenseUrl": "https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/v4.2.17/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Ank"
     },
@@ -466,15 +466,15 @@
       "licenseUrl": "https://github.com/SonarSource/eslint-plugin-sonarjs/blob/v0.18.0/LICENSE",
       "licenseTextSource": "file"
     },
-    "eslint@8.48.0": {
+    "eslint@8.56.0": {
       "name": "eslint",
-      "version": "8.48.0",
+      "version": "8.56.0",
       "range": "^8.24.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/eslint/eslint",
-      "versionedRepoUrl": "https://github.com/eslint/eslint/tree/v8.48.0",
+      "versionedRepoUrl": "https://github.com/eslint/eslint/tree/v8.56.0",
       "licenseFile": "node_modules/eslint/LICENSE",
-      "licenseUrl": "https://github.com/eslint/eslint/blob/v8.48.0/LICENSE",
+      "licenseUrl": "https://github.com/eslint/eslint/blob/v8.56.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Nicholas C. Zakas",
       "email": "nicholas+npm@nczconsulting.com"
@@ -688,15 +688,15 @@
       "licenseTextSource": "file",
       "publisher": "Christian Johansen"
     },
-    "tap@16.3.8": {
+    "tap@16.3.10": {
       "name": "tap",
-      "version": "16.3.8",
+      "version": "16.3.10",
       "range": "^16.3.4",
       "licenses": "ISC",
       "repoUrl": "https://github.com/tapjs/node-tap",
-      "versionedRepoUrl": "https://github.com/tapjs/node-tap/tree/v16.3.8",
+      "versionedRepoUrl": "https://github.com/tapjs/node-tap/tree/v16.3.10",
       "licenseFile": "node_modules/tap/LICENSE",
-      "licenseUrl": "https://github.com/tapjs/node-tap/blob/v16.3.8/LICENSE",
+      "licenseUrl": "https://github.com/tapjs/node-tap/blob/v16.3.10/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Isaac Z. Schlueter",
       "email": "i@izs.me",


### PR DESCRIPTION
## Description

**Note**: I'm using a community tool in wikipedia which is making real http requests. I could mock just not sure it matters yet.  We also cannot merge this because it depends on the https://github.com/elastic/require-in-the-middle/pull/82 PR which hasn't landed nor is released.  

This PR instruments langchain StructuredTool class to create LlmTool events and records spans when their call methods are invoked.  I also had to tweak some of the llm events to put attributes on the base class.  This also partially addresses #2007 but I can PR that separately as the openai tests will be failing

## Related Issues
Closes #1964 