### PR TITLE
fix: Updated Shim to properly calculate the _moduleRoot on windows environments

### DIFF
--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -14,6 +14,7 @@ const util = require('util')
 const symbols = require('../symbols')
 const { addCLMAttributes: maybeAddCLMAttributes } = require('../util/code-level-metrics')
 const { makeId } = require('../util/hashes')
+const { isBuiltin } = require('module')
 
 // Some modules do terrible things, like change the prototype of functions. To
 // avoid crashing things we'll use a cached copy of apply everywhere.
@@ -45,14 +46,9 @@ function Shim(agent, moduleName, resolvedName, shimName, pkgVersion) {
   this.assignId(shimName)
   this.pkgVersion = pkgVersion
 
-  // Determine the root directory of the module.
-  let moduleRoot = null
-  let next = resolvedName || '/'
-  do {
-    moduleRoot = next
-    next = path.dirname(moduleRoot)
-  } while (moduleRoot.length > 1 && !/node_modules(?:\/@[^/]+)?$/.test(next))
-  this._moduleRoot = moduleRoot
+  // Used in `shim.require`
+  // If this is a built-in the root is set as `.`
+  this._moduleRoot = isBuiltin(resolvedName || moduleName) ? '.' : resolvedName
 }
 module.exports = Shim
 

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -324,7 +324,7 @@ const shimmer = (module.exports = {
    */
   registerCoreInstrumentation(agent) {
     // Instrument global.
-    const globalShim = new shims.Shim(agent, 'globals', 'globals')
+    const globalShim = new shims.Shim(agent, 'globals', '.')
     applyDebugState(globalShim, global, false)
     const globalsFilepath = path.join(__dirname, 'instrumentation', 'core', 'globals.js')
     _firstPartyInstrumentation(agent, globalsFilepath, globalShim, global, 'globals')
@@ -336,7 +336,7 @@ const shimmer = (module.exports = {
       type: MODULE_TYPE.TRANSACTION,
       agent,
       moduleName: 'undici',
-      resolvedName: 'undici'
+      resolvedName: '.'
     })
     _firstPartyInstrumentation(agent, undiciPath, undiciShim)
 
@@ -778,8 +778,9 @@ function trackInstrumentationUsage(agent, shim, moduleName, metricPrefix) {
 }
 
 function tryGetVersion(shim) {
-  // Global module (i.e. domain) or finding root failed
-  if (shim._moduleRoot === '/') {
+  // Indicates it is a built-in where the version is not useful as
+  // it is `process.version`
+  if (shim._moduleRoot === '.') {
     return
   }
 

--- a/test/integration/module-loading/module-loading.tap.js
+++ b/test/integration/module-loading/module-loading.tap.js
@@ -179,6 +179,28 @@ tap.test('Should create usage version metric onRequire', (t) => {
   }
 })
 
+tap.test('Should create usage metric onRequire for built-in', (t) => {
+  const domainMetric = `${FEATURES.INSTRUMENTATION.ON_REQUIRE}/domain`
+  let agent = helper.instrumentMockedAgent()
+
+  t.teardown(() => {
+    helper.unloadAgent(agent)
+    agent = null
+  })
+
+  // eslint-disable-next-line node/no-deprecated-api
+  require('domain')
+
+  const onRequireMetric = agent.metrics._metrics.unscoped[domainMetric]
+
+  t.ok(onRequireMetric)
+  t.equal(onRequireMetric.callCount, 1)
+  const domainMetrics = Object.keys(agent.metrics._metrics.unscoped)
+  t.equal(domainMetrics.length, 1, 'should not log a version metric for a built-in')
+
+  t.end()
+})
+
 tap.test('should instrument a local package', (t) => {
   let agent = helper.instrumentMockedAgent()
 

--- a/test/unit/shim/shim.test.js
+++ b/test/unit/shim/shim.test.js
@@ -3061,4 +3061,48 @@ tap.test('Shim', function (t) {
       t.end()
     })
   })
+
+  t.test('_moduleRoot', (t) => {
+    t.beforeEach((t) => {
+      t.context.agent = helper.loadMockedAgent()
+    })
+
+    t.afterEach((t) => {
+      helper.unloadAgent(t.context.agent)
+    })
+
+    t.test('should set _moduleRoot to `.` if resolvedName is a built-in', (t) => {
+      const { agent } = t.context
+      const shim = new Shim(agent, 'http', 'http')
+      t.equal(shim._moduleRoot, '.')
+      t.end()
+    })
+
+    t.test(
+      'should set _moduleRoot to `.` if resolvedName is undefined but moduleName  is a built-in',
+      (t) => {
+        const { agent } = t.context
+        const shim = new Shim(agent, 'http')
+        t.equal(shim._moduleRoot, '.')
+        t.end()
+      }
+    )
+
+    t.test('should set _moduleRoot to resolvedName not a built-in', (t) => {
+      const { agent } = t.context
+      const root = '/path/to/app/node_modules/rando-mod'
+      const shim = new Shim(agent, 'rando-mod', root)
+      t.equal(shim._moduleRoot, root)
+      t.end()
+    })
+
+    t.test('should properly resolve _moduleRoot as windows path', (t) => {
+      const { agent } = t.context
+      const root = `c:\\path\\to\\app\\node_modules\\@scope\\test`
+      const shim = new Shim(agent, '@scope/test', root)
+      t.equal(shim._moduleRoot, root)
+      t.end()
+    })
+    t.end()
+  })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
This PR simplifies the calculation of `this._moduleRoot` on shim.  Since require-in-the-middle has been introduced it passes us the module root as basedir which gets passed in as `resolvedName`.  The previous logic traversed up directories to find the appropriate root.  This logic did not account for windows paths in the regular expression.  Instead of fixing that I found this code confusing and unnecessary. For built in packages, the `this._moduleRoot` will be set as `.`.  `this._moduleRoot` is only used when calling `shim.require` which is only done in 3rd party instrumentation so setting builtins to `.` is really just defensive code.

The only issue I have with this PR is I cannot figure out how to create a failing test for the issue as it only exists on windows and I can't seem to affect `path.dirname` without using `path.win32.dirname` but that is not called in shim code.


## How to Test
I have a vm that I can standup that shows my PR addresses the issue.

## Related Issues
Closes #2012
