### PR TITLE
test: Cleaned up pending mocks in the log dropping test to avoid a console warning around pending mocks in after each

### DIFF
--- a/test/unit/collector/api.test.js
+++ b/test/unit/collector/api.test.js
@@ -77,6 +77,8 @@ tap.test('reportSettings', (t) => {
   })
 
   t.test('handles excessive payload sizes without blocking subsequent sends', (t) => {
+    // remove the nock to agent_settings from beforeEach to avoid a console.error on afterEach
+    nock.cleanAll()
     const tstamp = 1_707_756_300_000 // 2024-02-12T11:45:00.000-05:00
     function log(data) {
       return JSON.stringify({


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
I was running unit tests and noticed:

```sh
  # Subtest: handles excessive payload sizes without blocking subsequent sends
        ok 1 - should be equal
Cleaning pending mocks: ["POST https://collector.newrelic.com:443/agent_listener/invoke_raw_method"]
        1..1
```

I thought it was an issue with a recent fix #2013 but it turned about to be an issue with cleaning up pending mocks as the log test doesn't hit `agent_settings`. This PR fixes the warning to avoid confusion in the future.

## How to test
`node test/unit/collector/api.test.js`

You should no longer see the 

```sh
Cleaning pending mocks: ["POST https://collector.newrelic.com:443/agent_listener/invoke_raw_method"]
```

when running the tests