### PR TITLE
refactor: Updated capturing conversation_id on Llm Events as `llm.conversation_id`

### DIFF
--- a/lib/instrumentation/openai.js
+++ b/lib/instrumentation/openai.js
@@ -97,7 +97,7 @@ function assignIdsToTx({ tx, completionMsg, responseId }) {
     tracker.get(responseId) ??
     new LlmTrackedIds({
       requestId: completionMsg.request_id,
-      conversationId: completionMsg.conversation_id
+      conversationId: completionMsg['llm.conversation_id']
     })
   trackedIds.message_ids.push(completionMsg.id)
   tracker.set(responseId, trackedIds)

--- a/lib/llm-events/event.js
+++ b/lib/llm-events/event.js
@@ -6,22 +6,13 @@
 'use strict'
 
 const { DESTINATIONS } = require('../config/attribute-filter')
-const CONVERSATION_ID = 'llm.conversation_id'
 
 class BaseLlmEvent {
-  getCustomAttributes(agent) {
-    const transaction = agent.tracer.getTransaction()
-    return transaction?.trace?.custom.get(DESTINATIONS.TRANS_SCOPE) || {}
-  }
-
-  conversationId(agent) {
-    return this.getCustomAttributes(agent)?.[CONVERSATION_ID]
-  }
-
   set metadata(agent) {
-    const attrs = this.getCustomAttributes(agent)
+    const transaction = agent.tracer.getTransaction()
+    const attrs = transaction?.trace?.custom.get(DESTINATIONS.TRANS_SCOPE) || {}
     for (const [key, value] of Object.entries(attrs)) {
-      if (key.startsWith('llm.') && key !== CONVERSATION_ID) {
+      if (key.startsWith('llm.')) {
         this[key] = value
       }
     }

--- a/lib/llm-events/langchain/event.js
+++ b/lib/llm-events/langchain/event.js
@@ -40,7 +40,6 @@ const defaultParams = {
 class LangChainEvent extends BaseEvent {
   id = makeId(36)
   appName
-  conversation_id
   span_id
   request_id
   transaction_id
@@ -55,7 +54,6 @@ class LangChainEvent extends BaseEvent {
     const { agent, segment } = params
 
     this.appName = agent.config.applications()[0]
-    this.conversation_id = this.conversationId(agent)
     this.span_id = segment?.id
     this.request_id = params.runId
     this.transaction_id = segment?.transaction?.id

--- a/lib/llm-events/openai/chat-completion-message.js
+++ b/lib/llm-events/openai/chat-completion-message.js
@@ -10,7 +10,6 @@ module.exports = class LlmChatCompletionMessage extends LlmEvent {
   constructor({ agent, segment, request = {}, response = {}, index = 0, message, completionId }) {
     super({ agent, segment, request, response })
     this.id = `${response.id}-${index}`
-    this.conversation_id = this.conversationId(agent)
     this.content = message?.content
     this.role = message?.role
     this.sequence = index

--- a/lib/llm-events/openai/chat-completion-summary.js
+++ b/lib/llm-events/openai/chat-completion-summary.js
@@ -10,7 +10,6 @@ module.exports = class LlmChatCompletionSummary extends LlmEvent {
   constructor({ agent, segment, request = {}, response = {}, withError = false }) {
     super({ agent, segment, request, response, responseAttrs: true })
     this.error = withError
-    this.conversation_id = this.conversationId(agent)
     this['request.max_tokens'] = request.max_tokens
     this['request.temperature'] = request.temperature
     this['response.number_of_messages'] = request?.messages?.length + response?.choices?.length

--- a/test/unit/llm-events/langchain/chat-completion-message.test.js
+++ b/test/unit/llm-events/langchain/chat-completion-message.test.js
@@ -56,7 +56,7 @@ tap.test('creates entity', async (t) => {
   t.match(msg, {
     id: 'run-1-1',
     appName: 'test-app',
-    conversation_id: 'test-conversation',
+    ['llm.conversation_id']: 'test-conversation',
     span_id: 'segment-1',
     request_id: 'run-1',
     transaction_id: 'tx-1',

--- a/test/unit/llm-events/langchain/chat-completion-summary.test.js
+++ b/test/unit/llm-events/langchain/chat-completion-summary.test.js
@@ -54,7 +54,7 @@ tap.test('creates entity', async (t) => {
   t.match(msg, {
     id: /[a-z0-9-]{36}/,
     appName: 'test-app',
-    conversation_id: 'test-conversation',
+    ['llm.conversation_id']: 'test-conversation',
     span_id: 'segment-1',
     request_id: 'run-1',
     transaction_id: 'tx-1',
@@ -74,7 +74,7 @@ tap.test('sets tags', async (t) => {
   t.match(msg, {
     id: /[a-z0-9-]{36}/,
     appName: 'test-app',
-    conversation_id: 'test-conversation',
+    ['llm.conversation_id']: 'test-conversation',
     span_id: 'segment-1',
     request_id: 'run-1',
     transaction_id: 'tx-1',

--- a/test/unit/llm-events/langchain/event.test.js
+++ b/test/unit/llm-events/langchain/event.test.js
@@ -54,7 +54,7 @@ tap.test('constructs default instance', async (t) => {
   t.match(event, {
     id: /[a-z0-9-]{36}/,
     appName: 'test-app',
-    conversation_id: 'test-conversation',
+    ['llm.conversation_id']: 'test-conversation',
     span_id: 'segment-1',
     request_id: 'run-1',
     transaction_id: 'tx-1',

--- a/test/unit/llm-events/langchain/vector-search-result.test.js
+++ b/test/unit/llm-events/langchain/vector-search-result.test.js
@@ -55,7 +55,7 @@ tap.test('create entity', async (t) => {
   t.match(search, {
     id: /[a-z0-9-]{36}/,
     appName: 'test-app',
-    conversation_id: 'test-conversation',
+    ['llm.conversation_id']: 'test-conversation',
     request_id: 'run-1',
     span_id: 'segment-1',
     transaction_id: 'tx-1',

--- a/test/unit/llm-events/langchain/vector-search.test.js
+++ b/test/unit/llm-events/langchain/vector-search.test.js
@@ -56,7 +56,7 @@ tap.test('create entity', async (t) => {
   t.match(search, {
     'id': /[a-z0-9-]{36}/,
     'appName': 'test-app',
-    'conversation_id': 'test-conversation',
+    ['llm.conversation_id']: 'test-conversation',
     'request_id': 'run-1',
     'span_id': 'segment-1',
     'transaction_id': 'tx-1',

--- a/test/unit/llm-events/openai/chat-completion-message.test.js
+++ b/test/unit/llm-events/openai/chat-completion-message.test.js
@@ -81,7 +81,7 @@ tap.test('LlmChatCompletionMessage', (t) => {
         request: {},
         response: {}
       })
-      t.equal(chatMessageEvent.conversation_id, conversationId)
+      t.equal(chatMessageEvent['llm.conversation_id'], conversationId)
       t.end()
     })
   })

--- a/test/unit/llm-events/openai/chat-completion-summary.test.js
+++ b/test/unit/llm-events/openai/chat-completion-summary.test.js
@@ -41,22 +41,6 @@ tap.test('LlmChatCompletionSummary', (t) => {
     })
   })
 
-  t.test('should set conversation_id from custom attributes', (t) => {
-    const api = helper.getAgentApi()
-    const conversationId = 'convo-id'
-    helper.runInTransaction(agent, () => {
-      api.addCustomAttribute('llm.conversation_id', conversationId)
-      const chatSummaryEvent = new LlmChatCompletionSummary({
-        agent,
-        segment: null,
-        request: {},
-        response: {}
-      })
-      t.equal(chatSummaryEvent.conversation_id, conversationId)
-      t.end()
-    })
-  })
-
   t.test('should set error to true', (t) => {
     helper.runInTransaction(agent, () => {
       const chatSummaryEvent = new LlmChatCompletionSummary({
@@ -71,28 +55,25 @@ tap.test('LlmChatCompletionSummary', (t) => {
     })
   })
 
-  t.test(
-    'should set `llm.` attributes from custom attributes except `llm.conversation_id`',
-    (t) => {
-      const api = helper.getAgentApi()
-      const conversationId = 'convo-id'
-      helper.runInTransaction(agent, () => {
-        api.addCustomAttribute('llm.conversation_id', conversationId)
-        api.addCustomAttribute('llm.foo', 'bar')
-        api.addCustomAttribute('llm.bar', 'baz')
-        api.addCustomAttribute('rando-key', 'rando-value')
-        const chatSummaryEvent = new LlmChatCompletionSummary({
-          agent,
-          segment: null,
-          request: {},
-          response: {}
-        })
-        t.equal(chatSummaryEvent.conversation_id, conversationId)
-        t.equal(chatSummaryEvent['llm.foo'], 'bar')
-        t.equal(chatSummaryEvent['llm.bar'], 'baz')
-        t.notOk(chatSummaryEvent['rando-key'])
-        t.end()
+  t.test('should set `llm.` attributes from custom attributes', (t) => {
+    const api = helper.getAgentApi()
+    const conversationId = 'convo-id'
+    helper.runInTransaction(agent, () => {
+      api.addCustomAttribute('llm.conversation_id', conversationId)
+      api.addCustomAttribute('llm.foo', 'bar')
+      api.addCustomAttribute('llm.bar', 'baz')
+      api.addCustomAttribute('rando-key', 'rando-value')
+      const chatSummaryEvent = new LlmChatCompletionSummary({
+        agent,
+        segment: null,
+        request: {},
+        response: {}
       })
-    }
-  )
+      t.equal(chatSummaryEvent['llm.conversation_id'], conversationId)
+      t.equal(chatSummaryEvent['llm.foo'], 'bar')
+      t.equal(chatSummaryEvent['llm.bar'], 'baz')
+      t.notOk(chatSummaryEvent['rando-key'])
+      t.end()
+    })
+  })
 })

--- a/test/unit/llm-events/openai/common.js
+++ b/test/unit/llm-events/openai/common.js
@@ -80,7 +80,6 @@ function getExpectedResult(tx, event, type, completionId) {
       expected = {
         ...expected,
         ...resKeys,
-        conversation_id: undefined,
         ['request.max_tokens']: '1000000',
         ['request.temperature']: 'medium-rare',
         ['response.number_of_messages']: 3,
@@ -92,7 +91,6 @@ function getExpectedResult(tx, event, type, completionId) {
     case 'message':
       expected = {
         ...expected,
-        conversation_id: undefined,
         content: 'What is a woodchuck?',
         role: 'inquisitive-kid',
         sequence: 0,

--- a/test/versioned/openai/feedback-messages.tap.js
+++ b/test/versioned/openai/feedback-messages.tap.js
@@ -26,8 +26,11 @@ tap.test('OpenAI instrumentation - feedback messages', (t) => {
   t.test(
     'should store conversation_id, request_id and message_ids on transaction by response_id',
     (test) => {
+      const conversationId = 'convo-id'
       const { client, agent } = t.context
+      const api = helper.getAgentApi()
       helper.runInTransaction(agent, async (tx) => {
+        api.addCustomAttribute('llm.conversation_id', conversationId)
         const results = await client.chat.completions.create({
           messages: [
             { role: 'user', content: 'You are a mathematician.' },
@@ -35,10 +38,9 @@ tap.test('OpenAI instrumentation - feedback messages', (t) => {
           ]
         })
 
-        const api = helper.getAgentApi()
         const trackedIds = api.getLlmMessageIds({ responseId: results.id })
         test.same(trackedIds, {
-          conversation_id: '',
+          conversation_id: conversationId,
           request_id: '49dbbffbd3c3f4612aa48def69059aad',
           message_ids: [
             'chatcmpl-87sb95K4EF2nuJRcTs43Tm9ntTeat-0',


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
Moves `conversation_id` to `llm.conversation_id` and have it apply to all Llm Events.

## Related Issues
Closes #2019
