### PR TITLE
chore: Do not re-create RecordeSpec if already an instance

### DIFF
--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -676,7 +676,8 @@ function recordWrapper({ shim, fn, name, recordNamer }) {
       shim.logger.trace('No segment descriptor for "%s", not recording.', name)
       return fnApply.call(fn, this, args)
     }
-    segDesc = new specs.RecorderSpec(segDesc)
+    segDesc =
+      segDesc instanceof specs.RecorderSpec === false ? new specs.RecorderSpec(segDesc) : segDesc
 
     // See if we're in an active transaction.
     let parent


### PR DESCRIPTION
From the conversation at https://github.com/newrelic/node-newrelic/pull/2009#discussion_r1488376828, this PR reduces the creation of `RecorderSpec` objects until we are able to solve #2022.