### PR TITLE
chore: Synchronize docs fixes into spec-refactor branch

### DIFF
--- a/lib/instrumentation/mongodb/common.js
+++ b/lib/instrumentation/mongodb/common.js
@@ -95,7 +95,7 @@ common.makeQueryDescFunc = function makeQueryDescFunc(shim, methodName) {
     const parameters = getInstanceAttributeParameters(shim, this)
     // TODO: updating this to QuerySpec causes some tests to fail
     return { query: methodName, parameters, promise: true, callback: shim.LAST, opaque: true }
-    //return QuerySpec({ query: methodName, parameters, promise: true, callback: shim.LAST, opaque: true })
+    // return QuerySpec({ query: methodName, parameters, promise: true, callback: shim.LAST, opaque: true })
   }
 }
 

--- a/lib/instrumentation/mongodb/v3-mongo.js
+++ b/lib/instrumentation/mongodb/v3-mongo.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-const {RecorderSpec} = require('../../shim/specs')
+const { RecorderSpec } = require('../../shim/specs')
 const {
   captureAttributesOnStarted,
   instrumentBulkOperation,

--- a/lib/instrumentation/mongodb/v4-mongo.js
+++ b/lib/instrumentation/mongodb/v4-mongo.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-const {RecorderSpec} = require('../../shim/specs')
+const { RecorderSpec } = require('../../shim/specs')
 const { instrumentCollection, instrumentCursor, instrumentDb, parseAddress } = require('./common')
 
 /**

--- a/lib/instrumentation/restify.js
+++ b/lib/instrumentation/restify.js
@@ -49,20 +49,27 @@ module.exports = function initialize(_agent, restify, _moduleName, shim) {
   function wrapServer(serverProto) {
     // These are all the methods for mounting routed middleware.
     const routings = ['del', 'get', 'head', 'opts', 'post', 'put', 'patch']
-    shim.wrapMiddlewareMounter(serverProto, routings, new MiddlewareMounterSpec({
-      route: shim.FIRST,
-      endpoint: shim.LAST,
-      wrapper: wrapMiddleware
-    }))
+    shim.wrapMiddlewareMounter(
+      serverProto,
+      routings,
+      new MiddlewareMounterSpec({
+        route: shim.FIRST,
+        endpoint: shim.LAST,
+        wrapper: wrapMiddleware
+      })
+    )
 
     // These methods do not accept a route, just middleware functions.
     const mounters = ['pre', 'use']
-    shim.wrapMiddlewareMounter(serverProto, mounters, new MiddlewareMounterSpec({
-      wrapper: wrapMiddleware
-    }))
+    shim.wrapMiddlewareMounter(
+      serverProto,
+      mounters,
+      new MiddlewareMounterSpec({
+        wrapper: wrapMiddleware
+      })
+    )
   }
 }
-
 
 /**
  * Wraps the middleware handler. In case of `pre` and `use`

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -273,14 +273,14 @@ function recordOperation(nodule, properties, opSpec) {
     if (shim.isFunction(opSpec)) {
       segDesc = opSpec.call(this, shim, fn, fnName, args)
     } else {
-      //segDesc = opSpec
-      //segDesc.name = fnName
+      // segDesc = opSpec
+      // segDesc.name = fnName
       segDesc = new OperationSpec({
         ...opSpec,
         name: fnName || 'other',
         opaque: false,
         after: null,
-        promise: null,
+        promise: null
       })
     }
     if (hasOwnProperty(segDesc, 'parameters')) {
@@ -514,6 +514,7 @@ function getDatabaseNameFromUseQuery(query) {
 
 // -------------------------------------------------------------------------- //
 
+/* eslint-disable sonarjs/cognitive-complexity */
 /**
  * Wraps the given properties as datastore query that should be recorded.
  *
@@ -568,7 +569,7 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
 
     // TODO: well this is a mess, we should probably update this
     // instead of passing in a spec and changing it
-    
+    // //
     // If we're not actually recording this, then just return the segment
     // descriptor now.
     if (queryDesc?.record === false) {
@@ -606,6 +607,7 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
     }
   })
 }
+/* eslint-enable sonarjs/cognitive-complexity */
 
 /**
  * Records all the metrics required for database operations.

--- a/lib/shim/specs/class.js
+++ b/lib/shim/specs/class.js
@@ -7,6 +7,15 @@
 
 const WrapSpec = require('./wrap')
 
+/* eslint-disable jsdoc/require-property-description */
+/**
+ * @typedef {object} ClassWrapSpecParams
+ * @mixes WrapSpecParams
+ * @property {boolean} [es6]
+ * @property {function} [pre]
+ * @property {function} [post]
+ */
+
 /**
  * Pre/post constructor execution hook for wrapping classes.
  *
@@ -74,10 +83,7 @@ class ClassWrapSpec extends WrapSpec {
 
   /* eslint-disable jsdoc/require-param-description */
   /**
-   * @param {object} params
-   * @param {boolean} [params.es6]
-   * @param {function} [params.pre]
-   * @param {function} [params.post]
+   * @param {ClassWrapSpecParams} params
    */
   constructor(params) {
     super(params)

--- a/lib/shim/specs/message-subscribe.js
+++ b/lib/shim/specs/message-subscribe.js
@@ -10,7 +10,7 @@ const MessageSpec = require('./message')
 /* eslint-disable jsdoc/require-property-description */
 /**
  * @typedef {object} MessageSubscribeSpecParams
- * @augments MessageSpecParams
+ * @mixes MessageSpecParams
  * @property {number|null} [consumer]
  */
 

--- a/lib/shim/specs/message.js
+++ b/lib/shim/specs/message.js
@@ -10,7 +10,7 @@ const RecorderSpec = require('./recorder')
 /* eslint-disable jsdoc/require-property-description */
 /**
  * @typedef {object} MessageSpecParams
- * @augments RecorderSpecParams
+ * @mixes RecorderSpecParams
  * @property {number|string} [destinationName]
  * @property {string|null} [destinationType]
  * @property {Object<string, string>|null} [headers]

--- a/lib/shim/specs/middleware-mounter.js
+++ b/lib/shim/specs/middleware-mounter.js
@@ -40,6 +40,14 @@ const MiddlewareSpec = require('./middleware')
  * @see WebFrameworkShim#recordParamware
  */
 
+/* eslint-disable jsdoc/require-property-description */
+/**
+ * @typedef {object} MiddlewareMounterSpecParams
+ * @mixes MiddlewareSpecParams
+ * @property {RouteParserFunction|string|number|null} [route]
+ * @property {MiddlewareWrapperFunction} [wrapper]
+ */
+
 class MiddlewareMounterSpec extends MiddlewareSpec {
   /**
    * Indicates which argument specifies the mounting path for the other
@@ -62,9 +70,7 @@ class MiddlewareMounterSpec extends MiddlewareSpec {
 
   /* eslint-disable jsdoc/require-param-description */
   /**
-   * @param {object} params
-   * @param {RouteParserFunction|string|number|null} [params.route]
-   * @param {MiddlewareWrapperFunction} [params.wrapper]
+   * @param {MiddlewareMounterSpecParams} params
    */
   constructor(params) {
     super(params)

--- a/lib/shim/specs/middleware.js
+++ b/lib/shim/specs/middleware.js
@@ -45,7 +45,7 @@ const RecorderSpec = require('./recorder')
 /* eslint-disable jsdoc/require-property-description */
 /**
  * @typedef {object} MiddlewareSpecParams
- * @augments RecorderSpecParams
+ * @mixes RecorderSpecParams
  * @property {boolean} [appendPath]
  * @property {number|RouteNextFunction} [next]
  * @property {RouteParameterFunction|null} [params]
@@ -121,6 +121,7 @@ class MiddlewareSpec extends RecorderSpec {
    */
   type
 
+  /* eslint-disable jsdoc/require-param-description */
   /**
    * @param {MiddlewareSpecParams} constructorParams
    */

--- a/lib/shim/specs/operation.js
+++ b/lib/shim/specs/operation.js
@@ -23,6 +23,14 @@ const RecorderSpec = require('./recorder')
  *  The name of the database being queried or operated on.
  */
 
+/* eslint-disable jsdoc/require-property-description */
+/**
+ * @typedef {object} OperationSpecParams
+ * @mixes RecorderSpecParams
+ * @property {DatastoreParameters|null} [parameters]
+ * @property {boolean} [record]
+ */
+
 /**
  * Spec that describes an operation, e.g. connecting to a database.
  */
@@ -44,9 +52,7 @@ class OperationSpec extends RecorderSpec {
 
   /* eslint-disable jsdoc/require-param-description */
   /**
-   * @param {object} params
-   * @param {DatastoreParameters|null} [params.parameters]
-   * @param {boolean} [params.record]
+   * @param {OperationSpecParams} params
    */
   constructor(params) {
     super(params)

--- a/lib/shim/specs/query.js
+++ b/lib/shim/specs/query.js
@@ -18,6 +18,13 @@ const OperationSpec = require('./operation')
  * @returns {string} The query string from the arguments list.
  */
 
+/* eslint-disable jsdoc/require-property-description */
+/**
+ * @typedef {object} QuerySpecParams
+ * @mixes OperationSpecParams
+ * @property {number|string|QueryFunction} [query]
+ */
+
 /**
  * Spec that describes a database query operation.
  */
@@ -34,8 +41,7 @@ class QuerySpec extends OperationSpec {
 
   /* eslint-disable jsdoc/require-param-description */
   /**
-   * @param {object} params
-   * @param {number|string|QueryFunction} [params.query]
+   * @param {QuerySpecParams} params
    */
   constructor(params) {
     super(params)

--- a/lib/shim/specs/recorder.js
+++ b/lib/shim/specs/recorder.js
@@ -10,7 +10,7 @@ const WrapSpec = require('./wrap')
 /* eslint-disable jsdoc/require-property-description */
 /**
  * @typedef {object} RecorderSpecParams
- * @augments SegmentSpecParams
+ * @mixes SegmentSpecParams
  * @property {SpecAfterFunction} [after]
  * @property {number|CallbackBindFunction} [callback]
  * @property {boolean} [callbackRequired]
@@ -108,6 +108,10 @@ class RecorderSpec extends WrapSpec {
    */
   stream
 
+  /* eslint-disable jsdoc/require-param-description */
+  /**
+   * @param {RecorderSpecParams} params
+   */
   constructor(params) {
     super(params)
 

--- a/lib/shim/specs/render.js
+++ b/lib/shim/specs/render.js
@@ -10,8 +10,8 @@ const { ARG_INDEXES } = require('./constants')
 
 /* eslint-disable jsdoc/require-property-description */
 /**
- * @typedef {object} RecorderSpecParams
- * @augments RecorderSpecParams
+ * @typedef {object} RenderSpecParams
+ * @mixes RecorderSpecParams
  * @property {number} [view]
  */
 
@@ -29,8 +29,9 @@ class RenderSpec extends RecorderSpec {
    */
   view
 
+  /* eslint-disable jsdoc/require-param-description */
   /**
-   * @param {RecorderSpecParams} params
+   * @param {RenderSpecParams} params
    */
   constructor(params) {
     super(params)

--- a/lib/shim/specs/transaction.js
+++ b/lib/shim/specs/transaction.js
@@ -7,6 +7,14 @@
 
 const SegmentSpec = require('./segment')
 
+/* eslint-disable jsdoc/require-property-description */
+/**
+ * @typedef {object} TransactionSpecParams
+ * @mixes SegmentSpecParams
+ * @property {boolean} [nest]
+ * @property {string} [type]
+ */
+
 /**
  * Spec that describes the type of agent transaction to be created by the
  * function being wrapped by {@link TransactionShim.bindCreateTransaction}.
@@ -33,9 +41,7 @@ class TransactionSpec extends SegmentSpec {
 
   /* eslint-disable jsdoc/require-param-description */
   /**
-   * @param {object} params
-   * @param {boolean} [params.nest]
-   * @param {string} [params.type]
+   * @param {TransactionSpecParams} params
    */
   constructor(params) {
     super(params)

--- a/lib/shim/specs/wrap.js
+++ b/lib/shim/specs/wrap.js
@@ -7,6 +7,14 @@
 
 const SegmentSpec = require('./segment')
 
+/* eslint-disable jsdoc/require-property-description */
+/**
+ * @typedef {object} WrapSpecParams
+ * @mixes SegmentSpecParams
+ * @property {boolean} [matchArity]
+ * @property {function} [wrapper]
+ */
+
 /**
  * Provides configuration for wrapping functions.
  *
@@ -42,9 +50,7 @@ class WrapSpec extends SegmentSpec {
    * wrapper. Otherwise, the parameters must be an object with a `wrapper`
    * property set to the function that should be the wrapper.
    *
-   * @param {object|function} params
-   * @param {boolean} [params.matchArity]
-   * @param {function} [params.wrapper]
+   * @param {WrapSpecParams|function} params
    */
   constructor(params) {
     super(params)


### PR DESCRIPTION
I targeted `main` with #2024 when I meant to target `spec-refactor`. This PR synchronizes the two so that our work on #2022 will be accurate.