### PR TITLE
docs: Add note about using sudo for firewall script

### DIFF
--- a/bin/macos-firewall.sh
+++ b/bin/macos-firewall.sh
@@ -3,6 +3,10 @@
 # popups asking to accept incoming network connections when
 # running tests.
 #
+# This script must be run with elevated privileges, i.e.:
+#
+#   $ sudo ./macos-firewall.sh
+#
 # Originally from https://github.com/nodejs/node/blob/5398cb55ca10d34ed7ba5592f95b3b9f588e5754/tools/macos-firewall.sh
 
 SFW="/usr/libexec/ApplicationFirewall/socketfilterfw"

--- a/documentation/developer-setup.md
+++ b/documentation/developer-setup.md
@@ -62,4 +62,8 @@ Note: when running the versioned test suite on a macOS system, the application
 firewall is likely to issue multiple requests to authorize the `node` binary
 for incoming connections. This can be avoided by running the
 [macos-firewall.sh](../bin/macos-firewall.sh) script to prime the application
-firewall with a rule to allow the connections.
+firewall with a rule to allow the connections:
+
+```sh
+$ sudo ./bin/macos-firewall.sh
+```


### PR DESCRIPTION
This PR updates the documentation around the `macos-firewall.sh` script to note that it should be run using elevated privileges.