### PR TITLE
refactor: Updated remaining instrumentation to construct specs at source instead of within the shim methods

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1266,18 +1266,31 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ### https-proxy-agent
 
-This product includes source derived from [https-proxy-agent](https://github.com/TooTallNate/proxy-agents) ([v7.0.2](https://github.com/TooTallNate/proxy-agents/tree/v7.0.2)), distributed under the [MIT License](https://github.com/TooTallNate/proxy-agents/blob/v7.0.2/README.md):
+This product includes source derived from [https-proxy-agent](https://github.com/TooTallNate/proxy-agents) ([v7.0.3](https://github.com/TooTallNate/proxy-agents/tree/v7.0.3)), distributed under the [MIT License](https://github.com/TooTallNate/proxy-agents/blob/v7.0.3/LICENSE):
 
 ```
-MIT License
+(The MIT License)
 
-Copyright (c) <year> <copyright holders>
+Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
 ### import-in-the-middle
@@ -2933,7 +2946,7 @@ SOFTWARE.
 
 ### lockfile-lint
 
-This product includes source derived from [lockfile-lint](https://github.com/lirantal/lockfile-lint) ([v4.12.1](https://github.com/lirantal/lockfile-lint/tree/v4.12.1)), distributed under the [Apache-2.0 License](https://github.com/lirantal/lockfile-lint/blob/v4.12.1/LICENSE):
+This product includes source derived from [lockfile-lint](https://github.com/lirantal/lockfile-lint) ([v4.13.1](https://github.com/lirantal/lockfile-lint/tree/v4.13.1)), distributed under the [Apache-2.0 License](https://github.com/lirantal/lockfile-lint/blob/v4.13.1/LICENSE):
 
 ```
 

--- a/lib/instrumentation/@elastic/elasticsearch.js
+++ b/lib/instrumentation/@elastic/elasticsearch.js
@@ -4,6 +4,8 @@
  */
 
 'use strict'
+
+const { QuerySpec } = require('../../shim/specs')
 const semver = require('semver')
 const logger = require('../../logger').child({ component: 'ElasticSearch' })
 const { isNotEmpty } = require('../../util/objects')
@@ -33,14 +35,14 @@ module.exports = function initialize(_agent, elastic, _moduleName, shim) {
 
   shim.recordQuery(elastic.Transport.prototype, 'request', function wrapQuery(shim, _, __, args) {
     const ctx = this
-    return {
+    return new QuerySpec({
       query: JSON.stringify(args?.[0]),
       promise: true,
       opaque: true,
       inContext: function inContext() {
         getConnection.call(ctx, shim)
       }
-    }
+    })
   })
 }
 

--- a/lib/instrumentation/@hapi/hapi.js
+++ b/lib/instrumentation/@hapi/hapi.js
@@ -5,6 +5,7 @@
 
 'use strict'
 
+const { MiddlewareSpec, SegmentSpec } = require('../../shim/specs')
 const record = require('../../metrics/recorders/generic')
 // This object defines all the events that we want to wrap extensions
 // for, as they are the only ones associated with requests.
@@ -208,23 +209,29 @@ function wrapPreHandlers(shim, container, path) {
 
 function wrapPreHandler(shim, container, path) {
   return shim.record(container, (shim) => {
-    return { name: [shim.HAPI, ' pre handler: ', '(', path, ')'].join(''), recorder: record }
+    return new SegmentSpec({
+      name: [shim.HAPI, ' pre handler: ', '(', path, ')'].join(''),
+      recorder: record
+    })
   })
 }
 
 function wrapRouteHandler(shim, handler, path) {
-  return shim.recordMiddleware(handler, {
-    route: path,
-    req: function getReq(shim, fn, fnName, args) {
-      const [request] = args
-      return request?.raw?.req
-    },
-    promise: true,
-    params: function getParams(shim, fn, fnName, args) {
-      const [req] = args
-      return req?.params
-    }
-  })
+  return shim.recordMiddleware(
+    handler,
+    new MiddlewareSpec({
+      route: path,
+      req: function getReq(shim, fn, fnName, args) {
+        const [request] = args
+        return request?.raw?.req
+      },
+      promise: true,
+      params: function getParams(shim, fn, fnName, args) {
+        const [req] = args
+        return req?.params
+      }
+    })
+  )
 }
 
 function wrapMiddleware(shim, middleware, event) {
@@ -232,13 +239,16 @@ function wrapMiddleware(shim, middleware, event) {
     return middleware
   }
 
-  return shim.recordMiddleware(middleware, {
-    route: event,
-    type: event === 'onPreResponse' ? shim.ERRORWARE : shim.MIDDLEWARE,
-    promise: true,
-    req: function getReq(_shim, _fn, _fnName, args) {
-      const [req] = args
-      return req?.raw?.req
-    }
-  })
+  return shim.recordMiddleware(
+    middleware,
+    new MiddlewareSpec({
+      route: event,
+      type: event === 'onPreResponse' ? shim.ERRORWARE : shim.MIDDLEWARE,
+      promise: true,
+      req: function getReq(_shim, _fn, _fnName, args) {
+        const [req] = args
+        return req?.raw?.req
+      }
+    })
+  )
 }

--- a/lib/instrumentation/@hapi/vision.js
+++ b/lib/instrumentation/@hapi/vision.js
@@ -6,6 +6,7 @@
 'use strict'
 
 const semver = require('semver')
+const { RenderSpec } = require('../../shim/specs')
 
 module.exports = function initialize(agent, vision, moduleName, shim) {
   const plugin = vision.plugin
@@ -36,7 +37,7 @@ function wrapDecorate(shim, decorate) {
     }
 
     const args = shim.argsToArray.apply(shim, arguments)
-    args[2] = shim.recordRender(handler, { promise: true })
+    args[2] = shim.recordRender(handler, new RenderSpec({ promise: true }))
 
     return decorate.apply(this, args)
   }

--- a/lib/instrumentation/@node-redis/client.js
+++ b/lib/instrumentation/@node-redis/client.js
@@ -4,6 +4,11 @@
  */
 
 'use strict'
+
+const {
+  OperationSpec,
+  params: { DatastoreParameters }
+} = require('../../shim/specs')
 const CLIENT_COMMANDS = ['select', 'quit', 'SELECT', 'QUIT']
 const opts = Symbol('clientOptions')
 
@@ -49,11 +54,11 @@ function instrumentClientCommand(shim, client, cmd) {
       }
     }
 
-    return {
+    return new OperationSpec({
       name: (cmd && cmd.toLowerCase()) || 'other',
       parameters,
       promise: true
-    }
+    })
   })
 }
 
@@ -64,11 +69,11 @@ function instrumentClientCommand(shim, client, cmd) {
  * @returns {object} params
  */
 function getRedisParams(clientOpts) {
-  return {
+  return new DatastoreParameters({
     host: clientOpts?.socket?.host || 'localhost',
     port_path_or_id: clientOpts?.socket?.path || clientOpts?.socket?.port || '6379',
     database_name: clientOpts?.database || 0
-  }
+  })
 }
 
 module.exports.getRedisParams = getRedisParams

--- a/lib/instrumentation/@prisma/client.js
+++ b/lib/instrumentation/@prisma/client.js
@@ -5,6 +5,7 @@
 
 'use strict'
 
+const { QuerySpec } = require('../../shim/specs')
 const { prismaConnection, prismaModelCall } = require('../../symbols')
 const { URL } = require('url')
 const logger = require('../../logger').child({ component: 'prisma' })
@@ -172,7 +173,7 @@ module.exports = async function initialize(_agent, prisma, _moduleName, shim) {
     function wrapExecuteRequest(shim, _executeRequest, _fnName, args) {
       const client = this
 
-      return {
+      return new QuerySpec({
         promise: true,
         query: retrieveQuery(args, pkgVersion),
         /**
@@ -201,7 +202,7 @@ module.exports = async function initialize(_agent, prisma, _moduleName, shim) {
             )
           }
         }
-      }
+      })
     }
   )
 }

--- a/lib/instrumentation/amqplib/amqplib.js
+++ b/lib/instrumentation/amqplib/amqplib.js
@@ -5,6 +5,14 @@
 
 'use strict'
 
+const {
+  MessageSpec,
+  MessageSubscribeSpec,
+  OperationSpec,
+  RecorderSpec,
+
+  params: { QueueMessageParameters }
+} = require('../../shim/specs')
 const url = require('url')
 
 module.exports.instrumentPromiseAPI = instrumentChannelAPI
@@ -116,14 +124,14 @@ function wrapConnect(shim, amqp, promiseMode) {
       }
     }
 
-    return {
+    return new OperationSpec({
       name: 'amqplib.connect',
       callback: setCallback(shim, promiseMode),
       promise: promiseMode,
       parameters: params,
       stream: null,
       recorder: null
-    }
+    })
   })
 }
 
@@ -178,13 +186,13 @@ function wrapChannel(shim) {
       exchange = TEMP_RE.test(fields.exchange) ? null : fields.exchange
     }
 
-    return {
+    return new MessageSpec({
       destinationName: exchange,
       destinationType: shim.EXCHANGE,
       routingKey: fields.routingKey,
       headers: fields.headers,
       parameters: getParameters(Object.create(null), fields)
-    }
+    })
   })
 }
 
@@ -193,7 +201,7 @@ function wrapChannel(shim) {
  *
  * @param {object} parameters object used to store the message parameters
  * @param {object} fields fields from the sendMessage method
- * @returns {object} parameters updated parameters
+ * @returns {QueueMessageParameters} parameters updated parameters
  */
 function getParameters(parameters, fields) {
   if (fields.routingKey) {
@@ -206,7 +214,7 @@ function getParameters(parameters, fields) {
     parameters.reply_to = fields.replyTo
   }
 
-  return parameters
+  return new QueueMessageParameters(parameters)
 }
 
 /**
@@ -231,50 +239,62 @@ function wrapModel(shim, Model, promiseMode) {
   }
 
   shim.record(proto, CHANNEL_METHODS, function recordChannelMethod(shim, fn, name) {
-    return {
+    return new RecorderSpec({
       name: 'Channel#' + name,
       callback: setCallback(shim, promiseMode),
       promise: promiseMode
-    }
+    })
   })
 
-  shim.recordConsume(proto, 'get', {
-    destinationName: shim.FIRST,
-    callback: setCallback(shim, promiseMode),
-    promise: promiseMode,
-    messageHandler: function handleConsumedMessage(shim, fn, name, message) {
-      // the message is the param when using the promised based model
-      message = promiseMode ? message : message[1]
-      if (!message) {
-        shim.logger.trace('No results from consume.')
-        return null
+  shim.recordConsume(
+    proto,
+    'get',
+    new MessageSpec({
+      destinationName: shim.FIRST,
+      callback: setCallback(shim, promiseMode),
+      promise: promiseMode,
+      messageHandler: function handleConsumedMessage(shim, fn, name, message) {
+        // the message is the param when using the promised based model
+        message = promiseMode ? message : message[1]
+        if (!message) {
+          shim.logger.trace('No results from consume.')
+          return null
+        }
+        const parameters = Object.create(null)
+        getParameters(parameters, message.fields)
+        getParameters(parameters, message.properties)
+
+        const headers = message?.properties?.headers
+
+        return { parameters, headers }
       }
-      const parameters = Object.create(null)
-      getParameters(parameters, message.fields)
-      getParameters(parameters, message.properties)
-
-      const headers = message?.properties?.headers
-
-      return { parameters, headers }
-    }
-  })
+    })
+  )
 
   shim.recordPurgeQueue(proto, 'purgeQueue', function recordPurge(shim, fn, name, args) {
     let queue = args[0]
     if (TEMP_RE.test(queue)) {
       queue = null
     }
-    return { queue, promise: promiseMode, callback: setCallback(shim, promiseMode) }
+    return new MessageSubscribeSpec({
+      queue,
+      promise: promiseMode,
+      callback: setCallback(shim, promiseMode)
+    })
   })
 
-  shim.recordSubscribedConsume(proto, 'consume', {
-    name: 'amqplib.Channel#consume',
-    queue: shim.FIRST,
-    consumer: shim.SECOND,
-    promise: promiseMode,
-    callback: promiseMode ? null : shim.FOURTH,
-    messageHandler: describeMessage
-  })
+  shim.recordSubscribedConsume(
+    proto,
+    'consume',
+    new MessageSubscribeSpec({
+      name: 'amqplib.Channel#consume',
+      queue: shim.FIRST,
+      consumer: shim.SECOND,
+      promise: promiseMode,
+      callback: promiseMode ? null : shim.FOURTH,
+      messageHandler: describeMessage
+    })
+  )
 }
 
 /**
@@ -302,11 +322,11 @@ function describeMessage(shim, _consumer, _name, args) {
     exchangeName = null
   }
 
-  return {
+  return new MessageSpec({
     destinationName: exchangeName,
     destinationType: shim.EXCHANGE,
     routingKey: message?.fields?.routingKey,
     headers: message.properties.headers,
     parameters
-  }
+  })
 }

--- a/lib/instrumentation/amqplib/amqplib.js
+++ b/lib/instrumentation/amqplib/amqplib.js
@@ -11,7 +11,7 @@ const {
   OperationSpec,
   RecorderSpec,
 
-  params: { QueueMessageParameters }
+  params: { QueueMessageParameters, DatastoreParameters }
 } = require('../../shim/specs')
 const url = require('url')
 
@@ -114,11 +114,11 @@ function setCallback(shim, promiseMode) {
 function wrapConnect(shim, amqp, promiseMode) {
   shim.record(amqp, 'connect', function recordConnect(shim, connect, name, args) {
     let [connArgs] = args
-    let params = null
+    const params = new DatastoreParameters()
 
     if (shim.isString(connArgs)) {
       connArgs = url.parse(connArgs)
-      params = { host: connArgs.hostname }
+      params.host = connArgs.hostname
       if (connArgs.port) {
         params.port = connArgs.port
       }
@@ -218,6 +218,19 @@ function getParameters(parameters, fields) {
 }
 
 /**
+ * Sets the QueueMessageParameters from the amqp message
+ *
+ * @param {object} message queue message
+ * @returns {QueueMessageParameters} parameters from message
+ */
+function getParametersFromMessage(message) {
+  const parameters = Object.create(null)
+  getParameters(parameters, message.fields)
+  getParameters(parameters, message.properties)
+  return parameters
+}
+
+/**
  *
  * Instruments the relevant channel callback_model or channel_model.
  *
@@ -260,9 +273,7 @@ function wrapModel(shim, Model, promiseMode) {
           shim.logger.trace('No results from consume.')
           return null
         }
-        const parameters = Object.create(null)
-        getParameters(parameters, message.fields)
-        getParameters(parameters, message.properties)
+        const parameters = getParametersFromMessage(message)
 
         const headers = message?.properties?.headers
 
@@ -314,8 +325,7 @@ function describeMessage(shim, _consumer, _name, args) {
     return null
   }
 
-  const parameters = getParameters(Object.create(null), message.fields)
-  getParameters(parameters, message.properties)
+  const parameters = getParametersFromMessage(message)
   let exchangeName = message?.fields?.exchange || 'Default'
 
   if (TEMP_RE.test(exchangeName)) {

--- a/lib/instrumentation/cassandra-driver.js
+++ b/lib/instrumentation/cassandra-driver.js
@@ -6,6 +6,7 @@
 'use strict'
 
 const semver = require('semver')
+const { OperationSpec, QuerySpec } = require('../shim/specs')
 
 /**
  * Instruments the `cassandra-driver` module, function that is
@@ -24,13 +25,13 @@ module.exports = function initialize(_agent, cassandra, _moduleName, shim) {
   const ClientProto = cassandra.Client.prototype
   const RequestExecutionProto = shim.require('./lib/request-execution.js').prototype
 
-  shim.recordOperation(ClientProto, ['connect', 'shutdown'], { callback: shim.LAST })
+  shim.recordOperation(ClientProto, ['connect', 'shutdown'],  new OperationSpec({ callback: shim.LAST }))
 
   if (semver.satisfies(cassandraVersion, '>=4.4.0')) {
-    shim.recordQuery(ClientProto, '_execute', {
+    shim.recordQuery(ClientProto, '_execute', new QuerySpec({
       query: shim.FIRST,
       callback: shim.LAST
-    })
+    }))
 
     shim.wrap(
       RequestExecutionProto,
@@ -48,10 +49,11 @@ module.exports = function initialize(_agent, cassandra, _moduleName, shim) {
       }
     )
   } else {
-    shim.recordQuery(ClientProto, '_innerExecute', {
+    shim.recordQuery(ClientProto, '_innerExecute', new QuerySpec({
+      internal: true,
       query: shim.FIRST,
       callback: shim.LAST
-    })
+    }))
 
     shim.wrap(RequestExecutionProto, 'start', function wrapStart(shim, start) {
       return function wrappedStart() {
@@ -89,10 +91,11 @@ module.exports = function initialize(_agent, cassandra, _moduleName, shim) {
     })
   }
 
-  shim.recordBatchQuery(ClientProto, 'batch', {
+  shim.recordBatchQuery(ClientProto, 'batch', new QuerySpec({
+    internal: true,
     query: findBatchQueryArg,
     callback: shim.LAST
-  })
+  }))
 }
 
 /**

--- a/lib/instrumentation/cassandra-driver.js
+++ b/lib/instrumentation/cassandra-driver.js
@@ -61,7 +61,6 @@ module.exports = function initialize(_agent, cassandra, _moduleName, shim) {
       ClientProto,
       '_innerExecute',
       new QuerySpec({
-        internal: true,
         query: shim.FIRST,
         callback: shim.LAST
       })
@@ -107,7 +106,6 @@ module.exports = function initialize(_agent, cassandra, _moduleName, shim) {
     ClientProto,
     'batch',
     new QuerySpec({
-      internal: true,
       query: findBatchQueryArg,
       callback: shim.LAST
     })

--- a/lib/instrumentation/cassandra-driver.js
+++ b/lib/instrumentation/cassandra-driver.js
@@ -25,13 +25,21 @@ module.exports = function initialize(_agent, cassandra, _moduleName, shim) {
   const ClientProto = cassandra.Client.prototype
   const RequestExecutionProto = shim.require('./lib/request-execution.js').prototype
 
-  shim.recordOperation(ClientProto, ['connect', 'shutdown'],  new OperationSpec({ callback: shim.LAST }))
+  shim.recordOperation(
+    ClientProto,
+    ['connect', 'shutdown'],
+    new OperationSpec({ callback: shim.LAST })
+  )
 
   if (semver.satisfies(cassandraVersion, '>=4.4.0')) {
-    shim.recordQuery(ClientProto, '_execute', new QuerySpec({
-      query: shim.FIRST,
-      callback: shim.LAST
-    }))
+    shim.recordQuery(
+      ClientProto,
+      '_execute',
+      new QuerySpec({
+        query: shim.FIRST,
+        callback: shim.LAST
+      })
+    )
 
     shim.wrap(
       RequestExecutionProto,
@@ -49,11 +57,15 @@ module.exports = function initialize(_agent, cassandra, _moduleName, shim) {
       }
     )
   } else {
-    shim.recordQuery(ClientProto, '_innerExecute', new QuerySpec({
-      internal: true,
-      query: shim.FIRST,
-      callback: shim.LAST
-    }))
+    shim.recordQuery(
+      ClientProto,
+      '_innerExecute',
+      new QuerySpec({
+        internal: true,
+        query: shim.FIRST,
+        callback: shim.LAST
+      })
+    )
 
     shim.wrap(RequestExecutionProto, 'start', function wrapStart(shim, start) {
       return function wrappedStart() {
@@ -91,11 +103,15 @@ module.exports = function initialize(_agent, cassandra, _moduleName, shim) {
     })
   }
 
-  shim.recordBatchQuery(ClientProto, 'batch', new QuerySpec({
-    internal: true,
-    query: findBatchQueryArg,
-    callback: shim.LAST
-  }))
+  shim.recordBatchQuery(
+    ClientProto,
+    'batch',
+    new QuerySpec({
+      internal: true,
+      query: findBatchQueryArg,
+      callback: shim.LAST
+    })
+  )
 }
 
 /**

--- a/lib/instrumentation/connect.js
+++ b/lib/instrumentation/connect.js
@@ -5,6 +5,8 @@
 
 'use strict'
 
+const { MiddlewareSpec, MiddlewareMounterSpec } = require('../shim/specs')
+
 module.exports = function initialize(agent, connect, moduleName, shim) {
   if (!connect) {
     shim.logger.debug('Connect not supplied, not instrumenting.')
@@ -21,23 +23,26 @@ module.exports = function initialize(agent, connect, moduleName, shim) {
     (connect && connect.HTTPServer && connect.HTTPServer.prototype) || // v1
     (connect && connect.proto) // v2
 
-  shim.wrapMiddlewareMounter(proto, 'use', {
-    route: shim.FIRST,
-    endpoint: shim.LAST,
-    wrapper: wrapMiddleware
-  })
+  shim.wrapMiddlewareMounter(
+    proto,
+    'use',
+    new MiddlewareMounterSpec({
+      route: shim.FIRST,
+      wrapper: wrapMiddleware
+    })
+  )
 
   wrapConnectExport(shim, connect, !proto)
 }
 
 function wrapMiddleware(shim, middleware, name, route) {
-  const spec = {
+  const spec = new MiddlewareSpec({
     matchArity: true,
     route: route,
     type: shim.MIDDLEWARE,
     next: shim.LAST,
     req: shim.FIRST
-  }
+  })
 
   if (middleware.length === 4) {
     spec.type = shim.ERRORWARE
@@ -60,10 +65,14 @@ function wrapConnectExport(shim, connect, v3) {
       return function wrappedConnect() {
         const res = _fn.apply(this, arguments)
         if (v3) {
-          shim.wrapMiddlewareMounter(res, 'use', {
-            route: shim.FIRST,
-            wrapper: wrapMiddleware
-          })
+          shim.wrapMiddlewareMounter(
+            res,
+            'use',
+            new MiddlewareMounterSpec({
+              route: shim.FIRST,
+              wrapper: wrapMiddleware
+            })
+          )
         }
         return res
       }

--- a/lib/instrumentation/core/child_process.js
+++ b/lib/instrumentation/core/child_process.js
@@ -5,6 +5,8 @@
 
 'use strict'
 
+const { RecorderSpec } = require('../../../lib/shim/specs')
+
 module.exports = initialize
 
 function initialize(agent, childProcess, moduleName, shim) {
@@ -16,7 +18,7 @@ function initialize(agent, childProcess, moduleName, shim) {
   const methods = ['exec', 'execFile']
 
   shim.record(childProcess, methods, function recordExec(shim, fn, name) {
-    return { name: 'child_process.' + name, callback: shim.LAST }
+    return new RecorderSpec({ name: 'child_process.' + name, callback: shim.LAST })
   })
 
   if (childProcess.ChildProcess) {

--- a/lib/instrumentation/core/crypto.js
+++ b/lib/instrumentation/core/crypto.js
@@ -5,6 +5,8 @@
 
 'use strict'
 
+const { RecorderSpec } = require('../../../lib/shim/specs')
+
 module.exports = initialize
 
 function initialize(agent, crypto, moduleName, shim) {
@@ -12,11 +14,11 @@ function initialize(agent, crypto, moduleName, shim) {
     crypto,
     ['pbkdf2', 'randomBytes', 'pseudoRandomBytes', 'randomFill', 'scrypt'],
     function recordCryptoMethod(shim, fn, name) {
-      return {
+      return new RecorderSpec({
         name: 'crypto.' + name,
         callback: shim.LAST,
         callbackRequired: true // sync version used too heavily - too much overhead
-      }
+      })
     }
   )
 }

--- a/lib/instrumentation/core/dns.js
+++ b/lib/instrumentation/core/dns.js
@@ -5,6 +5,8 @@
 
 'use strict'
 
+const { RecorderSpec } = require('../../../lib/shim/specs')
+
 module.exports = initialize
 
 function initialize(agent, dns, moduleName, shim) {
@@ -24,6 +26,6 @@ function initialize(agent, dns, moduleName, shim) {
   ]
 
   shim.record(dns, methods, function recordDnsMethod(shim, fn, name) {
-    return { name: 'dns.' + name, callback: shim.LAST }
+    return new RecorderSpec({ name: 'dns.' + name, callback: shim.LAST })
   })
 }

--- a/lib/instrumentation/core/fs.js
+++ b/lib/instrumentation/core/fs.js
@@ -7,6 +7,7 @@
 
 const record = require('../../metrics/recorders/generic')
 const NAMES = require('../../metrics/names')
+const { RecorderSpec } = require('../../shim/specs')
 
 module.exports = initialize
 
@@ -85,6 +86,6 @@ function initialize(agent, fs, moduleName, shim) {
   })
 
   function recordFs(shim, fn, name) {
-    return { name: NAMES.FS.PREFIX + name, callback: shim.LAST, recorder: record }
+    return new RecorderSpec({ name: NAMES.FS.PREFIX + name, callback: shim.LAST, recorder: record })
   }
 }

--- a/lib/instrumentation/core/timers.js
+++ b/lib/instrumentation/core/timers.js
@@ -5,6 +5,7 @@
 
 'use strict'
 
+const { RecorderSpec } = require('../../shim/specs')
 const symbols = require('../../symbols')
 const Timers = require('timers')
 
@@ -103,7 +104,7 @@ function wrapClearTimeout(_shim, fn) {
  * @returns {object} spec defining how to instrument
  */
 function recordAsynchronizers(shim, _fn, name) {
-  return { name: 'timers.' + name, callback: shim.FIRST }
+  return new RecorderSpec({ name: 'timers.' + name, callback: shim.FIRST })
 }
 
 /**

--- a/lib/instrumentation/core/zlib.js
+++ b/lib/instrumentation/core/zlib.js
@@ -6,6 +6,7 @@
 'use strict'
 
 const recorder = require('../../metrics/recorders/generic')
+const { RecorderSpec } = require('../../shim/specs')
 
 module.exports = initialize
 
@@ -26,7 +27,7 @@ function initialize(agent, zlib, moduleName, shim) {
   }
 
   function recordZLib(shim, fn, name) {
-    return { name: `zlib.${name}`, callback: shim.LAST, recorder }
+    return new RecorderSpec({ name: `zlib.${name}`, callback: shim.LAST, recorder })
   }
 }
 

--- a/lib/instrumentation/director.js
+++ b/lib/instrumentation/director.js
@@ -5,6 +5,8 @@
 
 'use strict'
 
+const { MiddlewareSpec, MiddlewareMounterSpec } = require('../shim/specs')
+
 module.exports = function initialize(agent, director, moduleName, shim) {
   shim.setFramework(shim.DIRECTOR)
 
@@ -14,36 +16,46 @@ module.exports = function initialize(agent, director, moduleName, shim) {
 
   const methods = ['on', 'route']
   const proto = director.Router.prototype
-  shim.wrapMiddlewareMounter(proto, methods, {
-    route: shim.SECOND,
-    wrapper: function wrapMiddleware(shim, middleware, name, path) {
-      return shim.recordMiddleware(middleware, {
-        route: path,
-        req: function getReq() {
-          return this.req
-        },
-        params: function getParams() {
-          return this.params
-        },
-        next: shim.LAST
-      })
-    }
-  })
+  shim.wrapMiddlewareMounter(
+    proto,
+    methods,
+    new MiddlewareMounterSpec({
+      route: shim.SECOND,
+      wrapper: function wrapMiddleware(shim, middleware, name, path) {
+        return shim.recordMiddleware(
+          middleware,
+          new MiddlewareSpec({
+            route: path,
+            req: function getReq() {
+              return this.req
+            },
+            params: function getParams() {
+              return this.params
+            },
+            next: shim.LAST
+          })
+        )
+      }
+    })
+  )
 
   shim.wrap(proto, 'mount', function wrapMount(shim, mount) {
     return function wrappedMount(routes, path) {
       const isAsync = this.async
       shim.wrap(routes, director.http.methods, function wrapRoute(shim, route) {
-        return shim.recordMiddleware(route, {
-          route: path.join('/'),
-          req: function getReq() {
-            return this.req
-          },
-          params: function getParams() {
-            return this.params
-          },
-          next: isAsync ? shim.LAST : null
-        })
+        return shim.recordMiddleware(
+          route,
+          new MiddlewareSpec({
+            route: path.join('/'),
+            req: function getReq() {
+              return this.req
+            },
+            params: function getParams() {
+              return this.params
+            },
+            next: isAsync ? shim.LAST : null
+          })
+        )
       })
       const args = [routes, path]
       return mount.apply(this, args)

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-const { MiddlewareSpec, MiddlewareMounterSpec } = require('../../lib/shim/specs')
+const { MiddlewareSpec, MiddlewareMounterSpec, RenderSpec } = require('../../lib/shim/specs')
 const { MIDDLEWARE_TYPE_NAMES } = require('../../lib/shim/webframework-shim/common')
 
 /**
@@ -88,19 +88,23 @@ function wrapExpress4(shim, express) {
     }
   })
 
-  shim.wrapMiddlewareMounter(express.Router, 'param', {
-    route: shim.FIRST,
-    wrapper: function wrapParamware(shim, middleware, fnName, route) {
-      return shim.recordParamware(
-        middleware,
-        new MiddlewareSpec({
-          name: route,
-          req: shim.FIRST,
-          next: shim.THIRD
-        })
-      )
-    }
-  })
+  shim.wrapMiddlewareMounter(
+    express.Router,
+    'param',
+    new MiddlewareMounterSpec({
+      route: shim.FIRST,
+      wrapper: function wrapParamware(shim, middleware, fnName, route) {
+        return shim.recordParamware(
+          middleware,
+          new MiddlewareSpec({
+            name: route,
+            req: shim.FIRST,
+            next: shim.THIRD
+          })
+        )
+      }
+    })
+  )
 
   wrapResponse(shim, express.response)
 }
@@ -112,20 +116,24 @@ function wrapExpress3(shim, express) {
   // Really we just care about apps being used as `request` event listeners on
   // `http.Server` instances so we'll wrap that instead.
 
-  shim.wrapMiddlewareMounter(express.Router.prototype, 'param', {
-    route: shim.FIRST,
-    wrapper: function wrapParamware(shim, middleware, fnName, route) {
-      return shim.recordParamware(
-        middleware,
-        new MiddlewareSpec({
-          name: route,
-          req: shim.FIRST,
-          next: shim.THIRD,
-          type: MIDDLEWARE_TYPE_NAMES.PARAMWARE
-        })
-      )
-    }
-  })
+  shim.wrapMiddlewareMounter(
+    express.Router.prototype,
+    'param',
+    new MiddlewareMounterSpec({
+      route: shim.FIRST,
+      wrapper: function wrapParamware(shim, middleware, fnName, route) {
+        return shim.recordParamware(
+          middleware,
+          new MiddlewareSpec({
+            name: route,
+            req: shim.FIRST,
+            next: shim.THIRD,
+            type: MIDDLEWARE_TYPE_NAMES.PARAMWARE
+          })
+        )
+      }
+    })
+  )
   shim.wrapMiddlewareMounter(
     express.Router.prototype,
     'use',
@@ -151,34 +159,42 @@ function wrapExpress3(shim, express) {
 
 function wrapRouteMethods(shim, route, path) {
   const methods = ['all', 'delete', 'get', 'head', 'opts', 'post', 'put', 'patch']
-  shim.wrapMiddlewareMounter(route, methods, { route: path, wrapper: wrapMiddleware })
+  shim.wrapMiddlewareMounter(
+    route,
+    methods,
+    new MiddlewareMounterSpec({ route: path, wrapper: wrapMiddleware })
+  )
 }
 
 function wrapResponse(shim, response) {
-  shim.recordRender(response, 'render', {
-    view: shim.FIRST,
-    callback: function bindCallback(shim, render, name, segment, args) {
-      let cbIdx = shim.normalizeIndex(args.length, shim.LAST)
-      if (cbIdx === null) {
-        return
-      }
-
-      const res = this
-      let cb = args[cbIdx]
-      if (!shim.isFunction(cb)) {
-        ++cbIdx
-        cb = function defaultRenderCB(err, str) {
-          // https://github.com/expressjs/express/blob/4.x/lib/response.js#L961-L962
-          if (err) {
-            return res.req.next(err)
-          }
-          res.send(str)
+  shim.recordRender(
+    response,
+    'render',
+    new RenderSpec({
+      view: shim.FIRST,
+      callback: function bindCallback(shim, render, name, segment, args) {
+        let cbIdx = shim.normalizeIndex(args.length, shim.LAST)
+        if (cbIdx === null) {
+          return
         }
-        args.push(cb)
+
+        const res = this
+        let cb = args[cbIdx]
+        if (!shim.isFunction(cb)) {
+          ++cbIdx
+          cb = function defaultRenderCB(err, str) {
+            // https://github.com/expressjs/express/blob/4.x/lib/response.js#L961-L962
+            if (err) {
+              return res.req.next(err)
+            }
+            res.send(str)
+          }
+          args.push(cb)
+        }
+        args[cbIdx] = shim.bindSegment(cb, segment, true)
       }
-      args[cbIdx] = shim.bindSegment(cb, segment, true)
-    }
-  })
+    })
+  )
 }
 
 function wrapMiddleware(shim, middleware, name, route) {

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -10,6 +10,7 @@ const {
   buildMiddlewareSpecForRouteHandler,
   buildMiddlewareSpecForMiddlewareFunction
 } = require('./fastify/spec-builders')
+const { MiddlewareMounterSpec } = require('../shim/specs')
 
 /**
  * These are the events that occur during a fastify
@@ -111,10 +112,10 @@ module.exports = function initialize(agent, fastify, moduleName, shim) {
 }
 
 function setupMiddlewareHandlers(shim, fastify, isv3Plus) {
-  const mounterSpec = {
+  const mounterSpec = new MiddlewareMounterSpec({
     route: shim.FIRST,
     wrapper: wrapMiddleware
-  }
+  })
 
   if (isv3Plus) {
     // Fastify v3+ does not ship with traditional Node.js middleware mounting.

--- a/lib/instrumentation/ioredis.js
+++ b/lib/instrumentation/ioredis.js
@@ -7,6 +7,7 @@
 
 const stringify = require('json-stringify-safe')
 const urltils = require('../util/urltils.js')
+const { OperationSpec } = require('../../lib/shim/specs')
 
 module.exports = function initialize(agent, redis, moduleName, shim) {
   const proto = redis && redis.prototype
@@ -38,10 +39,10 @@ module.exports = function initialize(agent, redis, moduleName, shim) {
       urltils.copyParameters(src, parameters)
     }
 
-    return {
+    return new OperationSpec({
       name: command.name || 'unknown',
       parameters: parameters,
       promise: true
-    }
+    })
   }
 }

--- a/lib/instrumentation/ioredis.js
+++ b/lib/instrumentation/ioredis.js
@@ -7,7 +7,10 @@
 
 const stringify = require('json-stringify-safe')
 const urltils = require('../util/urltils.js')
-const { OperationSpec } = require('../../lib/shim/specs')
+const {
+  OperationSpec,
+  params: { DatastoreParameters }
+} = require('../../lib/shim/specs')
 
 module.exports = function initialize(agent, redis, moduleName, shim) {
   const proto = redis && redis.prototype
@@ -21,11 +24,10 @@ module.exports = function initialize(agent, redis, moduleName, shim) {
   function wrapSendCommand(shim, original, name, args) {
     const command = args[0]
 
-    // TODO: Instance attributes for ioredis
-    const parameters = {
+    const parameters = new DatastoreParameters({
       host: this.connector.options.host,
       port_path_or_id: this.connector.options.port
-    }
+    })
 
     const keys = command.args
     if (keys && typeof keys !== 'function') {
@@ -41,7 +43,7 @@ module.exports = function initialize(agent, redis, moduleName, shim) {
 
     return new OperationSpec({
       name: command.name || 'unknown',
-      parameters: parameters,
+      parameters,
       promise: true
     })
   }

--- a/lib/instrumentation/memcached.js
+++ b/lib/instrumentation/memcached.js
@@ -6,6 +6,7 @@
 'use strict'
 
 const stringify = require('json-stringify-safe')
+const { OperationSpec } = require('../shim/specs')
 
 function wrapKeys(metacall) {
   if (metacall.key) {
@@ -69,12 +70,12 @@ module.exports = function initialize(agent, memcached, moduleName, shim) {
     }
 
     // finally, execute the original command
-    return {
+    return new OperationSpec({
       name: metacall.type || 'Unknown',
       callback: function wrapCallback(shim, fn, fnName, opSegment) {
         shim.bindCallbackSegment(metacall, 'callback', opSegment)
       },
-      parameters: parameters
-    }
+      parameters
+    })
   })
 }

--- a/lib/instrumentation/memcached.js
+++ b/lib/instrumentation/memcached.js
@@ -7,6 +7,7 @@
 
 const stringify = require('json-stringify-safe')
 const { OperationSpec } = require('../shim/specs')
+const DatastoreParameters = require('../shim/specs/params/datastore')
 
 function wrapKeys(metacall) {
   if (metacall.key) {
@@ -43,7 +44,9 @@ module.exports = function initialize(agent, memcached, moduleName, shim) {
     const metacall = args[0]()
     const server = args[1]
     const keys = wrapKeys(metacall)
-    const parameters = Object.create(null)
+    // We add a parameter called key, this is not a DatastoreParameter
+    // however shim attaches all parameters as attributes on the segment.
+    const parameters = new DatastoreParameters()
     try {
       parameters.key = stringify(keys[0])
     } catch (err) {

--- a/lib/instrumentation/mongodb/common.js
+++ b/lib/instrumentation/mongodb/common.js
@@ -4,7 +4,11 @@
  */
 
 'use strict'
-const { QuerySpec, OperationSpec } = require('../../shim/specs')
+const {
+  QuerySpec,
+  OperationSpec,
+  params: { DatastoreParameters }
+} = require('../../shim/specs')
 const { CURSOR_OPS, COLLECTION_OPS, DB_OPS } = require('./constants')
 const common = module.exports
 common.NR_ATTRS = Symbol('NR_ATTRS')
@@ -210,11 +214,7 @@ function setHostPort(shim, connStr, db, client) {
  * @returns {object} db params
  */
 function getInstanceAttributeParameters(shim, mongo) {
-  let params = {
-    host: null,
-    port_path_or_id: null,
-    database_name: null
-  }
+  let params
 
   if (mongo?.s?.topology) {
     shim.logger.trace('Adding datastore instance attributes from mongo.s.db + mongo.s.topology')
@@ -227,6 +227,7 @@ function getInstanceAttributeParameters(shim, mongo) {
     params = getParametersFromHosts(hosts, databaseName)
   } else {
     shim.logger.trace('Could not find datastore instance attributes.')
+    params = new DatastoreParameters()
   }
 
   return params
@@ -247,11 +248,11 @@ function getParametersFromHosts(hosts, database) {
     port = socketPath
     host = 'localhost'
   }
-  return {
+  return new DatastoreParameters({
     host,
     port_path_or_id: port,
     database_name: database
-  }
+  })
 }
 
 /**
@@ -279,11 +280,11 @@ function getParametersFromTopology(conf, database) {
     host = 'localhost'
   }
 
-  return {
+  return new DatastoreParameters({
     host: host,
     port_path_or_id: port,
     database_name: database
-  }
+  })
 }
 
 /**

--- a/lib/instrumentation/mongodb/common.js
+++ b/lib/instrumentation/mongodb/common.js
@@ -4,7 +4,7 @@
  */
 
 'use strict'
-
+const { QuerySpec, OperationSpec } = require('../../shim/specs')
 const { CURSOR_OPS, COLLECTION_OPS, DB_OPS } = require('./constants')
 const common = module.exports
 common.NR_ATTRS = Symbol('NR_ATTRS')
@@ -24,7 +24,7 @@ common.instrumentCursor = function instrumentCursor(shim, Cursor) {
     }
 
     shim.recordQuery(proto, 'each', common.makeQueryDescFunc(shim, 'each'))
-    shim.recordOperation(proto, 'pipe', { opaque: true })
+    shim.recordOperation(proto, 'pipe', new OperationSpec({ opaque: true }))
   }
 }
 
@@ -68,9 +68,9 @@ common.instrumentBulkOperation = function instrumentBulkOperation(shim, BulkOper
 common.instrumentDb = function instrumentDb(shim, Db) {
   if (Db && Db.prototype) {
     const proto = Db.prototype
-    shim.recordOperation(proto, DB_OPS, { callback: shim.LAST, opaque: true })
+    shim.recordOperation(proto, DB_OPS, new OperationSpec({ callback: shim.LAST, opaque: true }))
     // link to client.connect(removed in v4.0)
-    shim.recordOperation(Db, 'connect', { callback: shim.LAST })
+    shim.recordOperation(Db, 'connect', new OperationSpec({ callback: shim.LAST }))
   }
 }
 
@@ -85,7 +85,7 @@ common.makeQueryDescFunc = function makeQueryDescFunc(shim, methodName) {
   if (methodName === 'each') {
     return function eachDescFunc() {
       const parameters = getInstanceAttributeParameters(shim, this)
-      return { query: methodName, parameters, rowCallback: shim.LAST, opaque: true }
+      return new QuerySpec({ query: methodName, parameters, rowCallback: shim.LAST, opaque: true })
     }
   }
 
@@ -93,7 +93,14 @@ common.makeQueryDescFunc = function makeQueryDescFunc(shim, methodName) {
     // segment name does not actually use query string
     // method name is set as query so the query parser has access to the op name
     const parameters = getInstanceAttributeParameters(shim, this)
-    return { query: methodName, parameters, promise: true, callback: shim.LAST, opaque: true }
+    return new QuerySpec({
+      internal: true,
+      query: methodName,
+      parameters,
+      promise: true,
+      callback: shim.LAST,
+      opaque: true
+    })
   }
 }
 
@@ -106,13 +113,13 @@ common.makeQueryDescFunc = function makeQueryDescFunc(shim, methodName) {
 common.makeBulkDescFunc = function makeBulkDescFunc(shim) {
   return function bulkDescFunc() {
     const parameters = getInstanceAttributeParameters(shim, this)
-    return {
+    return new QuerySpec({
       query: this.isOrdered ? 'orderedBulk' : 'unorderedBulk',
       parameters,
       promise: true,
       callback: shim.LAST,
       opaque: true
-    }
+    })
   }
 }
 

--- a/lib/instrumentation/mongodb/common.js
+++ b/lib/instrumentation/mongodb/common.js
@@ -98,7 +98,6 @@ common.makeQueryDescFunc = function makeQueryDescFunc(shim, methodName) {
     // method name is set as query so the query parser has access to the op name
     const parameters = getInstanceAttributeParameters(shim, this)
     return new QuerySpec({
-      internal: true,
       query: methodName,
       parameters,
       promise: true,

--- a/lib/instrumentation/mongodb/v2-mongo.js
+++ b/lib/instrumentation/mongodb/v2-mongo.js
@@ -6,6 +6,7 @@
 'use strict'
 
 const { captureAttributesOnStarted, makeQueryDescFunc } = require('./common')
+const { OperationSpec } = require('../../shim/specs')
 
 /**
  * parser used to grab the collection and operation
@@ -38,7 +39,7 @@ module.exports = function instrument(shim, mongodb) {
     Gridstore: {
       isQuery: false,
       makeDescFunc: function makeGridDesc(opName) {
-        return { name: 'GridFS-' + opName, callback: shim.LAST }
+        return new OperationSpec({ name: 'GridFS-' + opName, callback: shim.LAST })
       }
     },
     OrderedBulkOperation: { isQuery: true, makeDescFunc: makeQueryDescFunc },
@@ -50,7 +51,7 @@ module.exports = function instrument(shim, mongodb) {
     Db: {
       isQuery: false,
       makeDescFunc: function makeDbDesc() {
-        return { callback: shim.LAST }
+        return new OperationSpec({ callback: shim.LAST })
       }
     }
   }
@@ -107,7 +108,7 @@ module.exports = function instrument(shim, mongodb) {
     // the cursor object implements Readable stream and internally calls nextObject on
     // each read, in which case we do not want to record each nextObject() call
     if (/Cursor$/.test(objectName)) {
-      shim.recordOperation(object.prototype, 'pipe')
+      shim.recordOperation(object.prototype, 'pipe', new OperationSpec({ opaque: true }))
     }
   }
 }

--- a/lib/instrumentation/mongodb/v3-mongo.js
+++ b/lib/instrumentation/mongodb/v3-mongo.js
@@ -5,6 +5,7 @@
 
 'use strict'
 
+const {RecorderSpec} = require('../../shim/specs')
 const {
   captureAttributesOnStarted,
   instrumentBulkOperation,
@@ -47,7 +48,7 @@ function instrumentClient(shim, mongodb) {
     // Add the connection url to the MongoClient to retrieve later in the `lib/instrumentation/mongo/common`
     // captureAttributesOnStarted listener
     this[NR_ATTRS] = args[0]
-    return { callback: shim.LAST }
+    return new RecorderSpec({ callback: shim.LAST })
   })
 }
 

--- a/lib/instrumentation/mongodb/v3-mongo.js
+++ b/lib/instrumentation/mongodb/v3-mongo.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-const {RecorderSpec} = require('../../shim/specs')
+const { RecorderSpec } = require('../../shim/specs')
 const {
   captureAttributesOnStarted,
   instrumentBulkOperation,

--- a/lib/instrumentation/mongodb/v4-mongo.js
+++ b/lib/instrumentation/mongodb/v4-mongo.js
@@ -63,6 +63,7 @@ function cmdStartedHandler(shim, evnt) {
 function wrapConnect(shim) {
   this.monitorCommands = true
   this.on('commandStarted', cmdStartedHandler.bind(this, shim))
+  // TODO: update to use a spec
   return { callback: shim.LAST }
 }
 

--- a/lib/instrumentation/mongodb/v4-mongo.js
+++ b/lib/instrumentation/mongodb/v4-mongo.js
@@ -5,6 +5,7 @@
 
 'use strict'
 
+const { OperationSpec } = require('../../shim/specs')
 const { instrumentCollection, instrumentCursor, instrumentDb, parseAddress } = require('./common')
 
 /**
@@ -63,8 +64,7 @@ function cmdStartedHandler(shim, evnt) {
 function wrapConnect(shim) {
   this.monitorCommands = true
   this.on('commandStarted', cmdStartedHandler.bind(this, shim))
-  // TODO: update to use a spec
-  return { callback: shim.LAST }
+  return new OperationSpec({ callback: shim.LAST })
 }
 
 /**

--- a/lib/instrumentation/mysql/mysql.js
+++ b/lib/instrumentation/mysql/mysql.js
@@ -8,6 +8,7 @@
 const dbutils = require('../../db/utils')
 const properties = require('../../util/properties')
 const symbols = require('../../symbols')
+const { QuerySpec } = require('../../shim/specs')
 
 function callbackInitialize(shim, mysql) {
   shim.setDatastore(shim.MYSQL)
@@ -209,25 +210,25 @@ function describeQuery(shim, queryFn, fnName, args) {
     'Query segment descriptor'
   )
 
-  return {
+  return new QuerySpec({
     stream: true,
     query: extractedArgs.query,
     callback: extractedArgs.callback,
     parameters: parameters,
     record: true
-  }
+  })
 }
 
 function describePoolQuery(shim, queryFn, fnName, args) {
   shim.logger.trace('Recording pool query')
   const extractedArgs = extractQueryArgs(shim, args)
-  return {
+  return new QuerySpec({
     stream: true,
     query: null,
     callback: extractedArgs.callback,
     name: 'MySQL Pool#query',
     record: false
-  }
+  })
 }
 
 function getInstanceParameters(shim, queryable, query) {

--- a/lib/instrumentation/mysql/mysql.js
+++ b/lib/instrumentation/mysql/mysql.js
@@ -224,6 +224,7 @@ function describePoolQuery(shim, queryFn, fnName, args) {
   shim.logger.trace('Recording pool query')
   const extractedArgs = extractQueryArgs(shim, args)
   return new QuerySpec({
+    internal: false,
     stream: true,
     query: null,
     callback: extractedArgs.callback,

--- a/lib/instrumentation/mysql/mysql.js
+++ b/lib/instrumentation/mysql/mysql.js
@@ -9,6 +9,7 @@ const dbutils = require('../../db/utils')
 const properties = require('../../util/properties')
 const symbols = require('../../symbols')
 const { QuerySpec } = require('../../shim/specs')
+const DatastoreParameters = require('../../shim/specs/params/datastore')
 
 function callbackInitialize(shim, mysql) {
   shim.setDatastore(shim.MYSQL)
@@ -214,7 +215,7 @@ function describeQuery(shim, queryFn, fnName, args) {
     stream: true,
     query: extractedArgs.query,
     callback: extractedArgs.callback,
-    parameters: parameters,
+    parameters,
     record: true
   })
 }
@@ -232,12 +233,12 @@ function describePoolQuery(shim, queryFn, fnName, args) {
 }
 
 function getInstanceParameters(shim, queryable, query) {
-  const parameters = { host: null, port_path_or_id: null, database_name: null }
+  const parameters = new DatastoreParameters()
   let conf = queryable.config
-  conf = (conf && conf.connectionConfig) || conf
-  let databaseName = queryable[symbols.databaseName] || null
+  conf = conf?.connectionConfig || conf
+  const databaseName = queryable[symbols.databaseName] || null
   if (conf) {
-    parameters.database_name = databaseName = databaseName || conf.database
+    parameters.database_name = databaseName || conf.database
 
     if (properties.hasOwn(conf, 'socketPath') && conf.socketPath) {
       // In the unix domain socket case we force the host to be localhost

--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -6,7 +6,7 @@
 'use strict'
 
 const { nrEsmProxy } = require('../symbols')
-const specs = require('../shim/specs')
+const { RecorderSpec, QuerySpec } = require('../shim/specs')
 
 function getQuery(shim, original, name, args) {
   const config = args[0]
@@ -36,7 +36,7 @@ module.exports = function initialize(agent, pgsql, moduleName, shim) {
     // pg supports event based Client.query when a Query object is passed in,
     // and works similarly in pg version <7.0.0
     if (typeof queryArgs[0] === 'string') {
-      return new specs.QuerySpec({
+      return new QuerySpec({
         callback: shim.LAST,
         query: getQuery,
         promise: true,
@@ -45,7 +45,7 @@ module.exports = function initialize(agent, pgsql, moduleName, shim) {
       })
     }
 
-    return new specs.QuerySpec({
+    return new QuerySpec({
       callback: shim.LAST,
       query: getQuery,
       stream: 'row',
@@ -74,7 +74,7 @@ module.exports = function initialize(agent, pgsql, moduleName, shim) {
     shim.recordQuery(this, 'query', wrapJSClientQuery)
 
     shim.record(this, 'connect', function pgConnectNamer() {
-      return new specs.QuerySpec({
+      return new RecorderSpec({
         name: 'connect',
         callback: shim.LAST
       })

--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -7,6 +7,7 @@
 
 const { nrEsmProxy } = require('../symbols')
 const { RecorderSpec, QuerySpec } = require('../shim/specs')
+const DatastoreParameters = require('../shim/specs/params/datastore')
 
 function getQuery(shim, original, name, args) {
   const config = args[0]
@@ -128,9 +129,9 @@ function updateNative(pg, instrumentPGNative) {
 }
 
 function getInstanceParameters(shim, client) {
-  return {
+  return new DatastoreParameters({
     host: client.host || null,
     port_path_or_id: client.port || null,
     database_name: client.database || null
-  }
+  })
 }

--- a/lib/instrumentation/redis.js
+++ b/lib/instrumentation/redis.js
@@ -7,6 +7,7 @@
 
 const hasOwnProperty = require('../util/properties').hasOwn
 const stringify = require('json-stringify-safe')
+const { OperationSpec } = require('../shim/specs')
 
 module.exports = function initialize(_agent, redis, _moduleName, shim) {
   const proto = redis?.RedisClient?.prototype
@@ -40,7 +41,7 @@ function registerInternalSendCommand(shim, proto) {
 
       parameters.key = stringifyKeys(shim, keys)
 
-      return {
+      return new OperationSpec({
         name: commandObject.command || 'other',
         parameters,
         callback: function bindCallback(shim, _f, _n, segment) {
@@ -59,7 +60,7 @@ function registerInternalSendCommand(shim, proto) {
             )
           }
         }
-      }
+      })
     }
   )
 }
@@ -77,7 +78,7 @@ function registerSendCommand(shim, proto) {
 
     parameters.key = stringifyKeys(shim, keys)
 
-    return {
+    return new OperationSpec({
       name: command || 'other',
       parameters,
       callback: function bindCallback(shim, _f, _n, segment) {
@@ -88,7 +89,7 @@ function registerSendCommand(shim, proto) {
           shim.bindCallbackSegment(last, shim.LAST, segment)
         }
       }
-    }
+    })
   })
 }
 

--- a/lib/instrumentation/redis.js
+++ b/lib/instrumentation/redis.js
@@ -7,7 +7,10 @@
 
 const hasOwnProperty = require('../util/properties').hasOwn
 const stringify = require('json-stringify-safe')
-const { OperationSpec } = require('../shim/specs')
+const {
+  OperationSpec,
+  params: { DatastoreParameters }
+} = require('../shim/specs')
 
 module.exports = function initialize(_agent, redis, _moduleName, shim) {
   const proto = redis?.RedisClient?.prototype
@@ -137,9 +140,9 @@ function getInstanceParameters(shim, client) {
  * @returns {object} datastore parameters
  */
 function doCapture(client = {}, opts = {}) {
-  return {
+  return new DatastoreParameters({
     host: opts.host || 'localhost',
     port_path_or_id: opts.path || opts.port || '6379',
     database_name: client.selected_db || opts.db || 0
-  }
+  })
 }

--- a/lib/instrumentation/restify.js
+++ b/lib/instrumentation/restify.js
@@ -4,10 +4,11 @@
  */
 
 'use strict'
+const { MiddlewareMounterSpec, MiddlewareSpec } = require('../shim/specs')
 
-module.exports = function initialize(agent, restify, moduleName, shim) {
+module.exports = function initialize(_agent, restify, _moduleName, shim) {
   shim.setFramework(shim.RESTIFY)
-  shim.setRouteParser(function routeParser(shim, fn, fnName, route) {
+  shim.setRouteParser(function routeParser(_shim, _fn, _fnName, route) {
     return (route && route.path) || route
   })
   let wrappedServerClass = false
@@ -37,7 +38,7 @@ module.exports = function initialize(agent, restify, moduleName, shim) {
   })
 
   shim.wrapReturn(restify, 'createServer', wrapCreateServer)
-  function wrapCreateServer(shim, fn, fnName, server) {
+  function wrapCreateServer(_shim, _fn, _fnName, server) {
     // If we have not wrapped the server class, now's the time to do that.
     if (server && !wrappedServerClass) {
       wrappedServerClass = true
@@ -48,48 +49,54 @@ module.exports = function initialize(agent, restify, moduleName, shim) {
   function wrapServer(serverProto) {
     // These are all the methods for mounting routed middleware.
     const routings = ['del', 'get', 'head', 'opts', 'post', 'put', 'patch']
-    shim.wrapMiddlewareMounter(serverProto, routings, {
-      route: shim.FIRST,
-      endpoint: shim.LAST,
-      wrapper: function wrapMiddleware(shim, middleware, name, route) {
-        if (shim.isWrapped(middleware)) {
-          return middleware
-        }
-        const spec = {
-          matchArity: true,
-          route,
-          req: shim.FIRST,
-          next: shim.LAST
-        }
-
-        const wrappedMw = shim.recordMiddleware(middleware, spec)
-        if (middleware.constructor.name === 'AsyncFunction') {
-          return async function asyncShim() {
-            return wrappedMw.apply(this, arguments)
-          }
-        }
-        return wrappedMw
-      }
-    })
+    shim.wrapMiddlewareMounter(
+      serverProto,
+      routings,
+      new MiddlewareMounterSpec({
+        route: shim.FIRST,
+        endpoint: shim.LAST,
+        wrapper: wrapMiddleware
+      })
+    )
 
     // These methods do not accept a route, just middleware functions.
     const mounters = ['pre', 'use']
-    shim.wrapMiddlewareMounter(serverProto, mounters, function wrapper(shim, middleware) {
-      if (shim.isWrapped(middleware)) {
-        return middleware
-      }
-      const spec = {
-        matchArity: true,
-        req: shim.FIRST,
-        next: shim.LAST
-      }
-      const wrappedMw = shim.recordMiddleware(middleware, spec)
-      if (middleware.constructor.name === 'AsyncFunction') {
-        return async function asyncShim() {
-          return wrappedMw.apply(this, arguments)
-        }
-      }
-      return wrappedMw
-    })
+    shim.wrapMiddlewareMounter(
+      serverProto,
+      mounters,
+      new MiddlewareMounterSpec({
+        wrapper: wrapMiddleware
+      })
+    )
   }
+}
+
+/**
+ * Wraps the middleware handler. In case of `pre` and `use`
+ * route is not defined.
+ *
+ * @param {object} shim instance of shim
+ * @param {function} middleware function to record
+ * @param {string} _name name of middleware
+ * @param {object|null} route name of route
+ * @returns {function} wrapped middleware function
+ */
+function wrapMiddleware(shim, middleware, _name, route) {
+  if (shim.isWrapped(middleware)) {
+    return middleware
+  }
+  const spec = new MiddlewareSpec({
+    matchArity: true,
+    route,
+    req: shim.FIRST,
+    next: shim.LAST
+  })
+
+  const wrappedMw = shim.recordMiddleware(middleware, spec)
+  if (middleware.constructor.name === 'AsyncFunction') {
+    return async function asyncShim() {
+      return wrappedMw.apply(this, arguments)
+    }
+  }
+  return wrappedMw
 }

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -14,6 +14,9 @@ const ParsedStatement = require('../db/parsed-statement')
 const Shim = require('./shim')
 const urltils = require('../util/urltils')
 const util = require('util')
+const {
+  params: { DatastoreParameters }
+} = require('./specs/')
 
 /**
  * An enumeration of well-known datastores so that new instrumentations can use
@@ -484,11 +487,14 @@ function captureInstanceAttributes(host, port, database) {
   this.logger.trace('Adding db instance attributes to segment %j', segment.name)
 
   // Normalize the instance attributes.
-  const attributes = _normalizeParameters.call(this, {
-    host,
-    port_path_or_id: port,
-    database_name: database
-  })
+  const attributes = _normalizeParameters.call(
+    this,
+    new DatastoreParameters({
+      host,
+      port_path_or_id: port,
+      database_name: database
+    })
+  )
 
   for (const key in attributes) {
     if (attributes[key]) {

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -275,7 +275,7 @@ function recordOperation(nodule, properties, opSpec) {
     if (shim.isFunction(opSpec)) {
       segDesc = opSpec.call(this, shim, fn, fnName, args)
     } else {
-      segDesc = {...opSpec}
+      segDesc = { ...opSpec }
     }
     segDesc.name = segDesc.name || fnName || 'other'
     if (hasOwnProperty(segDesc, 'parameters')) {
@@ -562,11 +562,11 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
 
     queryDesc.name = queryDesc.name || fnName
 
-    const parameters = _normalizeParameters.call(shim, queryDesc.parameters || Object.create(null))
+    const parameters = _normalizeParameters.call(shim, queryDesc.parameters)
 
     // TODO: well this is a mess, we should probably update this
     // instead of passing in a spec and changing it
-    
+
     // If we're not actually recording this, then just return the segment
     // descriptor now.
     if (queryDesc?.record === false) {
@@ -579,7 +579,6 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
 
     // Fetch the query string.
     const queryStr = _extractQueryStr.call(shim, fn, fnName, queryDesc, this, args)
-    console.log('query string', queryStr)
     if (!shim.isString(queryStr)) {
       return null
     }
@@ -590,7 +589,7 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
     shim.logger.trace('Found and parsed query %s -> %s', parsed.type, name)
 
     // Return the segment descriptor.
-    const spec = {
+    return {
       internal: true,
       ...queryDesc,
       // This name and parameters might override those in the original
@@ -603,8 +602,6 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
         }
       }
     }
-    console.log(spec)
-    return spec
   })
 }
 

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -283,6 +283,7 @@ function recordOperation(nodule, properties, opSpec) {
         ...opSpec
       }
     }
+    segDesc.name = segDesc.name || fnName || 'other'
     if (hasOwnProperty(segDesc, 'parameters')) {
       _normalizeParameters.call(shim, segDesc.parameters)
     }
@@ -565,8 +566,8 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
       queryDesc = querySpec.call(this, shim, fn, fnName, args) || Object.create(null)
     }
 
-    // Set some default values, in case they're missing.
-    queryDesc = {
+    queryDesc.name = queryDesc.name || fnName
+    /*queryDesc = {
       name: fnName,
       callback: null,
       rowCallback: null,
@@ -577,9 +578,13 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
       inContext: null,
       ...queryDesc
     }
+    */
 
     const parameters = _normalizeParameters.call(shim, queryDesc.parameters || Object.create(null))
 
+    // TODO: well this is a mess, we should probably update this
+    // instead of passing in a spec and changing it
+    
     // If we're not actually recording this, then just return the segment
     // descriptor now.
     if (queryDesc?.record === false) {

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -275,13 +275,7 @@ function recordOperation(nodule, properties, opSpec) {
     if (shim.isFunction(opSpec)) {
       segDesc = opSpec.call(this, shim, fn, fnName, args)
     } else {
-      segDesc = {
-        name: fnName || 'other',
-        opaque: false,
-        after: null,
-        promise: null,
-        ...opSpec
-      }
+      segDesc = {...opSpec}
     }
     segDesc.name = segDesc.name || fnName || 'other'
     if (hasOwnProperty(segDesc, 'parameters')) {
@@ -567,18 +561,6 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
     }
 
     queryDesc.name = queryDesc.name || fnName
-    /*queryDesc = {
-      name: fnName,
-      callback: null,
-      rowCallback: null,
-      stream: null,
-      after: null,
-      promise: null,
-      opaque: false,
-      inContext: null,
-      ...queryDesc
-    }
-    */
 
     const parameters = _normalizeParameters.call(shim, queryDesc.parameters || Object.create(null))
 
@@ -597,6 +579,7 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
 
     // Fetch the query string.
     const queryStr = _extractQueryStr.call(shim, fn, fnName, queryDesc, this, args)
+    console.log('query string', queryStr)
     if (!shim.isString(queryStr)) {
       return null
     }
@@ -607,7 +590,7 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
     shim.logger.trace('Found and parsed query %s -> %s', parsed.type, name)
 
     // Return the segment descriptor.
-    return {
+    const spec = {
       internal: true,
       ...queryDesc,
       // This name and parameters might override those in the original
@@ -620,6 +603,8 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
         }
       }
     }
+    console.log(spec)
+    return spec
   })
 }
 

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -267,30 +267,17 @@ function recordOperation(nodule, properties, opSpec) {
     opSpec = Object.create(null)
   }
 
-  return this.record(nodule, properties, function opRecorder(shim, fn, fnName, args) {
+  return this.record(nodule, properties, function operationRecorder(shim, fn, fnName, args) {
     shim.logger.trace('Recording datastore operation "%s"', fnName)
 
-    // Derive the segment information, starting from some defaults
-    let segDesc = null
-    if (shim.isFunction(opSpec)) {
-      segDesc = opSpec.call(this, shim, fn, fnName, args)
-    } else {
-      segDesc = { ...opSpec }
-    }
-    segDesc.name = segDesc.name || fnName || 'other'
-    if (hasOwnProperty(segDesc, 'parameters')) {
-      _normalizeParameters.call(shim, segDesc.parameters)
-    }
+    const segDesc = _getSpec.call(this, { spec: opSpec, shim, fn, fnName, args })
 
     // Adjust the segment name with the metric prefix and add a recorder.
     if (!hasOwnProperty(segDesc, 'record') || segDesc.record !== false) {
       segDesc.name = shim._metrics.OPERATION + segDesc.name
       segDesc.recorder = _recordOperationMetrics.bind(shim)
-
-      segDesc.internal = true
     }
 
-    // And done.
     return segDesc
   })
 }
@@ -552,57 +539,74 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
     return nodule
   }
 
-  return this.record(nodule, properties, function queryRecord(shim, fn, fnName, args) {
+  return this.record(nodule, properties, function queryRecorder(shim, fn, fnName, args) {
     shim.logger.trace('Determining query information for %j', fnName)
 
-    let queryDesc = querySpec
-    if (shim.isFunction(querySpec)) {
-      queryDesc = querySpec.call(this, shim, fn, fnName, args) || Object.create(null)
-    }
+    const segDesc = _getSpec.call(this, { spec: querySpec, shim, fn, fnName, args })
 
-    queryDesc.name = queryDesc.name || fnName
-
-    const parameters = _normalizeParameters.call(shim, queryDesc.parameters)
-
-    // TODO: well this is a mess, we should probably update this
-    // instead of passing in a spec and changing it
-
-    // If we're not actually recording this, then just return the segment
-    // descriptor now.
-    if (queryDesc?.record === false) {
-      return {
-        internal: false,
-        ...queryDesc,
-        parameters
+    // Adjust the segment name with the metric prefix and add a recorder.
+    if (!hasOwnProperty(segDesc, 'record') || segDesc.record !== false) {
+      // Fetch the query string.
+      const queryStr = _extractQueryStr.call(shim, fn, fnName, segDesc, this, args)
+      if (!shim.isString(queryStr)) {
+        return null
       }
+
+      // Parse the query and assemble the name.
+      const parsed = shim.parseQuery(queryStr, this)
+      const name = (parsed.collection || 'other') + '/' + parsed.operation + suffix
+      shim.logger.trace('Found and parsed query %s -> %s', parsed.type, name)
+      segDesc.name = shim._metrics.STATEMENT + name
+      segDesc.recorder = _recordQueryMetrics.bind(null, parsed)
     }
 
-    // Fetch the query string.
-    const queryStr = _extractQueryStr.call(shim, fn, fnName, queryDesc, this, args)
-    if (!shim.isString(queryStr)) {
-      return null
-    }
-
-    // Parse the query and assemble the name.
-    const parsed = shim.parseQuery(queryStr, this)
-    const name = (parsed.collection || 'other') + '/' + parsed.operation + suffix
-    shim.logger.trace('Found and parsed query %s -> %s', parsed.type, name)
-
-    // Return the segment descriptor.
-    return {
-      internal: true,
-      ...queryDesc,
-      // This name and parameters might override those in the original
-      // queryDesc.
-      name: shim._metrics.STATEMENT + name,
-      parameters,
-      recorder: function queryRecorder(segment, scope) {
-        if (segment) {
-          parsed.recordMetrics(segment, scope)
-        }
-      }
-    }
+    return segDesc
   })
+}
+
+/**
+ * Compiles spec by calling it if it is a function or cloning original.
+ * This also defaults the name and normalizes the parameters.
+ *
+ * @private
+ * @param {object} params to function
+ * @param {QuerySpec|OperationSpec} params.spec spec for the given shim method
+ * @param {DatastoreShim} params.shim instance of shim
+ * @param {function} params.fn function being instrumented
+ * @param {string} params.fnName name of function being instrumented
+ * @param {Array} params.args arguments to function being instrumented
+ * @returns {QuerySpec|OperationSpec} compiled spec
+ *
+ */
+function _getSpec({ spec, shim, fn, fnName, args }) {
+  let dsSpec = null
+  if (shim.isFunction(spec)) {
+    dsSpec = spec.call(this, shim, fn, fnName, args)
+  } else {
+    dsSpec = { ...spec }
+  }
+
+  dsSpec.name = dsSpec.name || fnName || 'other'
+
+  const parameters = _normalizeParameters.call(shim, dsSpec.parameters)
+  return {
+    ...dsSpec,
+    parameters
+  }
+}
+
+/**
+ * Records all query metrics when a segment is active
+ *
+ * @private
+ * @param {ParsedStatement} parsed instance of ParsedStatement
+ * @param {TraceSegment} segment active segment
+ * @param {string} scope scope of metrics if it exists
+ */
+function _recordQueryMetrics(parsed, segment, scope) {
+  if (segment) {
+    parsed.recordMetrics(segment, scope)
+  }
 }
 
 /**

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -1472,7 +1472,7 @@ function defineProperties(obj, props) {
 
 /**
  * Performs a shallow copy of each property from `defaults` only if `obj` does
- * not already have that property.
+ * not already have that property, or the value of the key on `obj` is `null`.
  *
  * @memberof Shim.prototype
  * @param {object?} obj       - The object to copy the defaults onto.
@@ -1489,7 +1489,7 @@ function setDefaults(obj, defaults) {
 
   for (let i = 0; i < keys.length; ++i) {
     const key = keys[i]
-    if (!hasOwnProperty(obj, key)) {
+    if (hasOwnProperty(obj, key) === false || obj[key] === null) {
       obj[key] = defaults[key]
     }
   }

--- a/lib/shim/specs/index.js
+++ b/lib/shim/specs/index.js
@@ -6,31 +6,24 @@
 'use strict'
 
 const { ARG_INDEXES } = require('./constants')
-const ClassWrapSpec = require('./class')
-const MessageSpec = require('./message')
-const MessageSubscribeSpec = require('./message-subscribe')
-const MiddlewareSpec = require('./middleware')
-const MiddlewareMounterSpec = require('./middleware-mounter')
-const OperationSpec = require('./operation')
-const QuerySpec = require('./query')
-const RecorderSpec = require('./recorder')
-const RenderSpec = require('./render')
-const SegmentSpec = require('./segment')
-const TransactionSpec = require('./transaction')
-const WrapSpec = require('./wrap')
 
 module.exports = {
   ARG_INDEXES,
-  ClassWrapSpec,
-  MessageSpec,
-  MessageSubscribeSpec,
-  MiddlewareSpec,
-  MiddlewareMounterSpec,
-  OperationSpec,
-  QuerySpec,
-  RecorderSpec,
-  RenderSpec,
-  SegmentSpec,
-  TransactionSpec,
-  WrapSpec
+  ClassWrapSpec: require('./class'),
+  MessageSpec: require('./message'),
+  MessageSubscribeSpec: require('./message-subscribe'),
+  MiddlewareSpec: require('./middleware'),
+  MiddlewareMounterSpec: require('./middleware-mounter'),
+  OperationSpec: require('./operation'),
+  QuerySpec: require('./query'),
+  RecorderSpec: require('./recorder'),
+  RenderSpec: require('./render'),
+  SegmentSpec: require('./segment'),
+  TransactionSpec: require('./transaction'),
+  WrapSpec: require('./wrap'),
+
+  params: {
+    DatastoreParameters: require('./params/datastore'),
+    QueueMessageParameters: require('./params/queue-message')
+  }
 }

--- a/lib/shim/specs/message.js
+++ b/lib/shim/specs/message.js
@@ -5,12 +5,12 @@
 
 'use strict'
 
-const RecorderSpec = require('./recorder')
+const OperationSpec = require('./operation')
 
 /* eslint-disable jsdoc/require-property-description */
 /**
  * @typedef {object} MessageSpecParams
- * @mixes RecorderSpecParams
+ * @mixes OperationSpecParams
  * @property {number|string} [destinationName]
  * @property {string|null} [destinationType]
  * @property {Object<string, string>|null} [headers]
@@ -22,7 +22,7 @@ const RecorderSpec = require('./recorder')
 /**
  * Spec that describes how to instrument a message broker.
  */
-class MessageSpec extends RecorderSpec {
+class MessageSpec extends OperationSpec {
   /**
    * If a number, then it indicates the argument position of the name in the
    * instrumented function's parameters list. Otherwise, it is a string name.

--- a/lib/shim/specs/operation.js
+++ b/lib/shim/specs/operation.js
@@ -7,27 +7,11 @@
 
 const RecorderSpec = require('./recorder')
 
-/**
- * Extra parameters which may be added to an operation or query segment. All of
- * these properties are optional.
- *
- * @typedef {object} DatastoreParameters
- * @property {string} host
- *  The host of the database server being interacted with. If provided, along
- *  with `port_path_or_id`, then an instance metric will also be generated for
- *  this database.
- * @property {number|string} port_path_or_id
- *  The port number or path to domain socket used to connect to the database
- *  server.
- * @property {string} database_name
- *  The name of the database being queried or operated on.
- */
-
 /* eslint-disable jsdoc/require-property-description */
 /**
  * @typedef {object} OperationSpecParams
  * @mixes RecorderSpecParams
- * @property {DatastoreParameters|null} [parameters]
+ * @property {DatastoreParameters|QueueMessageParameters|null} [parameters]
  * @property {boolean} [record]
  */
 
@@ -38,7 +22,7 @@ class OperationSpec extends RecorderSpec {
   /**
    * Extra parameters to be set on the metric for the operation.
    *
-   * @type {DatastoreParameters|null}
+   * @type {DatastoreParameters|QueueMessageParameters|null}
    */
   parameters
 

--- a/lib/shim/specs/operation.js
+++ b/lib/shim/specs/operation.js
@@ -43,6 +43,7 @@ class OperationSpec extends RecorderSpec {
 
     this.parameters = params.parameters ?? null
     this.record = params.record ?? true
+    this.internal = params.internal ?? true
   }
 }
 

--- a/lib/shim/specs/params/datastore.js
+++ b/lib/shim/specs/params/datastore.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/**
+ * @typedef {object} DatastoreParametersParams
+ * @property {string} host
+ *  The host of the database server being interacted with. If provided, along
+ *  with `port_path_or_id`, then an instance metric will also be generated for
+ *  this database.
+ * @property {number|string} port_path_or_id
+ *  The port number or path to domain socket used to connect to the database
+ *  server.
+ * @property {string} database_name
+ *  The name of the database being queried or operated on.
+ */
+
+/**
+ * Extra parameters which may be added to an operation or query segment. All of
+ * these properties are optional.
+ */
+class DatastoreParameters {
+  /* eslint-disable jsdoc/require-param-description */
+  /**
+   * @param {DatastoreParametersParams} params
+   */
+  constructor(params) {
+    this.host = params.host ?? null
+    this.port_path_or_id = params.port_path_or_id ?? null
+    this.database_name = params.database_name ?? null
+  }
+}
+
+module.exports = DatastoreParameters

--- a/lib/shim/specs/params/datastore.js
+++ b/lib/shim/specs/params/datastore.js
@@ -27,7 +27,7 @@ class DatastoreParameters {
   /**
    * @param {DatastoreParametersParams} params
    */
-  constructor(params) {
+  constructor(params = {}) {
     this.host = params.host ?? null
     this.port_path_or_id = params.port_path_or_id ?? null
     this.database_name = params.database_name ?? null

--- a/lib/shim/specs/params/queue-message.js
+++ b/lib/shim/specs/params/queue-message.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/* eslint-disable jsdoc/require-property-description */
+/**
+ * @typedef {object} QueueMessageParametersParams
+ * @property {string} [correlation_id]
+ * @property {string} [reply_to]
+ * @property {string} [routing_key]
+ */
+
+/**
+ * Represents the parameters that describe a message queue message.
+ */
+class QueueMessageParameters {
+  /* eslint-disable jsdoc/require-param-description */
+  /**
+   * @param {QueueMessageParametersParams} params
+   */
+  constructor(params) {
+    this.correlation_id = params.correlation_id ?? null
+    this.reply_to = params.reply_to ?? null
+    this.routing_key = params.routing_key ?? null
+  }
+}
+
+module.exports = QueueMessageParameters

--- a/lib/shim/webframework-shim/middleware-mounter.js
+++ b/lib/shim/webframework-shim/middleware-mounter.js
@@ -108,15 +108,12 @@ module.exports = function wrapMiddlewareMounter(nodule, properties, spec) {
     spec = properties
     properties = null
   }
+
+  // TODO: we should remove this. it looks like koa still uses this method
   if (this.isFunction(spec)) {
     // wrapMiddlewareMounter(nodule [, properties], wrapper)
     spec = new MiddlewareMounterSpec({ wrapper: spec })
   }
-
-  spec = this.setDefaults(spec, {
-    route: null,
-    endpoint: null
-  })
 
   const wrapSpec = new MiddlewareMounterSpec({
     wrapper: wrapMounter.bind(null, spec)

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "lint": "eslint ./*.{js,mjs} lib test bin examples",
     "lint:fix": "eslint --fix, ./*.{js,mjs} lib test bin examples",
     "lint:lockfile": "lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --validate-https --validate-integrity",
-    "public-docs": "jsdoc -c ./jsdoc-conf.json --tutorials examples/shim api.js lib/shim/** lib/transaction/handle.js && cp examples/shim/*.png out/",
+    "public-docs": "jsdoc -c ./jsdoc-conf.json --tutorials examples/shim api.js lib/shim/**/* lib/transaction/handle.js && cp examples/shim/*.png out/",
     "publish-docs": "./bin/publish-docs.sh",
     "services": "docker compose up -d --wait",
     "smoke": "npm run ssl && time tap test/smoke/**/**/*.tap.js --timeout=180 --no-coverage",

--- a/test/unit/instrumentation/mysql/describePoolQuery.test.js
+++ b/test/unit/instrumentation/mysql/describePoolQuery.test.js
@@ -24,7 +24,7 @@ tap.test('describeQuery', (t) => {
     const mockArgs = ['SELECT * FROM foo', sinon.stub()]
 
     const result = instrumentation.describePoolQuery(mockShim, null, null, mockArgs)
-    t.same(result, {
+    t.match(result, {
       stream: true,
       query: null,
       callback: 1,

--- a/test/unit/instrumentation/mysql/describeQuery.test.js
+++ b/test/unit/instrumentation/mysql/describeQuery.test.js
@@ -30,7 +30,7 @@ tap.test('describeQuery', (t) => {
       port: '1234'
     }
     const result = instrumentation.describeQuery(mockShim, null, null, mockArgs)
-    t.same(result, {
+    t.match(result, {
       stream: true,
       query: 'SELECT * FROM foo',
       callback: 1,

--- a/test/unit/shim/shim.test.js
+++ b/test/unit/shim/shim.test.js
@@ -2784,14 +2784,14 @@ tap.test('Shim', function (t) {
       t.end()
     })
 
-    t.test('should not replace existing keys', function (t) {
+    t.test('should update existing if existing is null', function (t) {
       const obj = { foo: null }
       const defaults = { foo: 1, bar: 2 }
       const defaulted = shim.setDefaults(obj, defaults)
 
       t.equal(obj, defaulted)
       t.not(obj, defaults)
-      t.same(defaulted, { foo: null, bar: 2 })
+      t.same(defaulted, { foo: 1, bar: 2 })
       t.end()
     })
   })

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -159,16 +159,16 @@
       "publisher": "Max Ogden",
       "email": "max@maxogden.com"
     },
-    "https-proxy-agent@7.0.2": {
+    "https-proxy-agent@7.0.3": {
       "name": "https-proxy-agent",
-      "version": "7.0.2",
+      "version": "7.0.3",
       "range": "^7.0.1",
       "licenses": "MIT",
       "repoUrl": "https://github.com/TooTallNate/proxy-agents",
-      "versionedRepoUrl": "https://github.com/TooTallNate/proxy-agents/tree/v7.0.2",
-      "licenseFile": "node_modules/https-proxy-agent/README.md",
-      "licenseUrl": "https://github.com/TooTallNate/proxy-agents/blob/v7.0.2/README.md",
-      "licenseTextSource": "spdx",
+      "versionedRepoUrl": "https://github.com/TooTallNate/proxy-agents/tree/v7.0.3",
+      "licenseFile": "node_modules/https-proxy-agent/LICENSE",
+      "licenseUrl": "https://github.com/TooTallNate/proxy-agents/blob/v7.0.3/LICENSE",
+      "licenseTextSource": "file",
       "publisher": "Nathan Rajlich",
       "email": "nathan@tootallnate.net",
       "url": "http://n8.io/"
@@ -570,15 +570,15 @@
       "publisher": "Andrey Okonetchnikov",
       "email": "andrey@okonet.ru"
     },
-    "lockfile-lint@4.12.1": {
+    "lockfile-lint@4.13.1": {
       "name": "lockfile-lint",
-      "version": "4.12.1",
+      "version": "4.13.1",
       "range": "^4.9.6",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/lirantal/lockfile-lint",
-      "versionedRepoUrl": "https://github.com/lirantal/lockfile-lint/tree/v4.12.1",
+      "versionedRepoUrl": "https://github.com/lirantal/lockfile-lint/tree/v4.13.1",
       "licenseFile": "node_modules/lockfile-lint/LICENSE",
-      "licenseUrl": "https://github.com/lirantal/lockfile-lint/blob/v4.12.1/LICENSE",
+      "licenseUrl": "https://github.com/lirantal/lockfile-lint/blob/v4.13.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Liran Tal",
       "email": "liran.tal@gmail.com",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This contains all the work @jsumners-nr, @sbrennan, and I did.  The last few commits were the remaining items.  I was able to simplify the datastore-shim logic for `recordQuery` and `recordOperation` to do the same thing. The only difference is that `recordQuery` will extract the query and run a query parser.  Also updated `OperationSpec` to default `internal` to true.  Whoever reviews this, just look at the [last commits from me](https://github.com/newrelic/node-newrelic/pull/2035/files/6187a7958decc3c716d530980cccaa8ab91b7f91..ee5da09d5eacea5354cd7aa1b55735c264c4d7d5) and skip the ones that were already reviewed and merged into this branch

## Additional Context
There a few more items, that I have to log:
 * Attaching specs to shim so they can be used in external repos

After a version of agent is released with the work above...

 * Updating external repos to construct specs

Once the external repos are released with the link above...

 * Pare down the shim methods to no longer construct specs

## Related Links
Closes #2022
