### PR TITLE
chore: Updated DatastoreParameters to include collection

### DIFF
--- a/lib/shim/specs/params/datastore.js
+++ b/lib/shim/specs/params/datastore.js
@@ -16,6 +16,8 @@
  *  server.
  * @property {string} database_name
  *  The name of the database being queried or operated on.
+ * @property {string} collection
+ *  The name of the collection or table being queried or operated on.
  */
 
 /**
@@ -31,6 +33,7 @@ class DatastoreParameters {
     this.host = params.host ?? null
     this.port_path_or_id = params.port_path_or_id ?? null
     this.database_name = params.database_name ?? null
+    this.collection = params.collection ?? null
   }
 }
 

--- a/test/unit/instrumentation/mysql/getInstanceParameters.test.js
+++ b/test/unit/instrumentation/mysql/getInstanceParameters.test.js
@@ -34,7 +34,7 @@ tap.test('getInstanceParameters', (t) => {
 
     t.same(
       result,
-      { host: null, port_path_or_id: null, database_name: null },
+      { host: null, port_path_or_id: null, database_name: null, collection: null },
       'should return the default parameters'
     )
     t.ok(
@@ -84,7 +84,12 @@ tap.test('getInstanceParameters', (t) => {
     }
 
     const result = instrumentation.getInstanceParameters(mockShim, mockQueryable, mockQuery)
-    t.same(result, { host: 'example.com', port_path_or_id: '1234', database_name: 'test-database' })
+    t.same(result, {
+      host: 'example.com',
+      port_path_or_id: '1234',
+      database_name: 'test-database',
+      collection: null
+    })
     t.end()
   })
 
@@ -100,7 +105,8 @@ tap.test('getInstanceParameters', (t) => {
     t.same(result, {
       host: 'localhost',
       port_path_or_id: '/var/run/mysqld/mysqld.sock',
-      database_name: 'test-database'
+      database_name: 'test-database',
+      collection: null
     })
     t.end()
   })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
This was missed in #2035. Apparently `collection` is a key on datastores. It is only being used in [AWS SDK instrumentation](https://github.com/newrelic/node-newrelic-aws-sdk/blob/main/lib/util.js#L34). This is a first class attribute unlike the [key attr](https://github.com/newrelic/node-newrelic/blob/main/lib/instrumentation/memcached.js#L49) in memcached.

