### PR TITLE
chore: Add missing is_response to LangChain completion messages

### DIFF
--- a/lib/instrumentation/langchain/runnable.js
+++ b/lib/instrumentation/langchain/runnable.js
@@ -109,7 +109,9 @@ function recordCompletions({ events, completionSummary, agent, segment, shim }) 
       content: msgString,
       completionId: completionSummary.id,
       segment,
-      runId: segment[langchainRunId]
+      runId: segment[langchainRunId],
+      // We call the final output in a LangChain "chain" the "response":
+      isResponse: i === events.length - 1
     })
 
     common.recordEvent({

--- a/lib/llm-events/langchain/chat-completion-message.js
+++ b/lib/llm-events/langchain/chat-completion-message.js
@@ -14,6 +14,8 @@ const { makeId } = require('../../util/hashes')
  * @property {string} content The text of the response received from LangChain.
  * @property {number} [sequence=0] The order of the message in the response.
  * @property {string} [completionId] An identifier for the message.
+ * @property {boolean|undefined} [isResponse] Indicates if the completion
+ * message represents a response from the remote service.
  */
 /**
  * @type {LangChainCompletionMessageParams}
@@ -21,13 +23,15 @@ const { makeId } = require('../../util/hashes')
 const defaultParams = {
   content: '',
   sequence: 0,
-  completionId: makeId(36)
+  completionId: makeId(36),
+  isResponse: undefined
 }
 
 class LangChainCompletionMessage extends LangChainEvent {
   content
   sequence
   completion_id
+  is_response
 
   constructor(params = defaultParams) {
     params = Object.assign({}, defaultParams, params)
@@ -42,6 +46,7 @@ class LangChainCompletionMessage extends LangChainEvent {
     this.content = params.content
     this.sequence = params.sequence
     this.completion_id = params.completionId
+    this.is_response = params.isResponse ?? false
   }
 }
 

--- a/test/versioned/langchain/common.js
+++ b/test/versioned/langchain/common.js
@@ -72,9 +72,11 @@ function assertLangChainChatCompletionMessages({ tx, chatMsgs, chatSummary, with
     if (msg[1].sequence === 0) {
       expectedChatMsg.sequence = 0
       expectedChatMsg.content = '{"topic":"scientist"}'
+      expectedChatMsg.is_response = false
     } else if (msg[1].sequence === 1) {
       expectedChatMsg.sequence = 1
       expectedChatMsg.content = '212 degrees Fahrenheit is equal to 100 degrees Celsius.'
+      expectedChatMsg.is_response = true
     }
 
     this.equal(msg[0].type, 'LlmChatCompletionMessage')


### PR DESCRIPTION
This PR fixes an oversight from previous work.