### PR TITLE
chore: Added @azure/openai and @langchain/community/llms/bedrock as tracking packages so we can measure usage with angler

### DIFF
--- a/lib/instrumentations.js
+++ b/lib/instrumentations.js
@@ -55,6 +55,8 @@ module.exports = function instrumentations() {
     'loglevel': { type: MODULE_TYPE.TRACKING },
     'npmlog': { type: MODULE_TYPE.TRACKING },
     'fancy-log': { type: MODULE_TYPE.TRACKING },
-    'knex': { type: MODULE_TYPE.TRACKING }
+    'knex': { type: MODULE_TYPE.TRACKING },
+    '@azure/openai': { type: MODULE_TYPE.TRACKING },
+    '@langchain/community/llms/bedrock': { type: MODULE_TYPE.TRACKING }
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Added `@azure/openai` and `@langchain/community/llms/bedrock` as tracking type modules in `lib/instrumentations.`.  This will produce supportability metrics that angler can load so we can track customers using these packages before deciding to add instrumentation.


## How to Test

In an app
```
npm i @azure/openai @langchain/community
# in index.js
require('@azure/openai')
require('@langchain/community/llms/bedrock')
```

Run npm linked version of agent and check logs.

You will see supportability metrics get logged as such

```sh
[{\"name\":\"Supportability/Features/Instrumentation/OnRequire/@azure/openai\"},[1,0,0,0,0,0]]
[{\"name\":\"Supportability/Features/Instrumentation/OnRequire/@azure/openai/Version/1\"},[1,0,0,0,0,0]]
{\"name\":\"Supportability/Features/Instrumentation/OnRequire/@langchain/community/llms/bedrock\"},[1,0,0,0,0,0]]
[{\"name\":\"Supportability/Features/Instrumentation/OnRequire/@langchain/community/llms/bedrock/Version/0\"},[1,0,0,0,0,0]]
```

## Related Issues

Closes #2045
