### PR TITLE
chore: Added flag for verbosity during docs publishing

### DIFF
--- a/bin/publish-docs.sh
+++ b/bin/publish-docs.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-set -e
+set -ex
 
 # Copyright 2020 New Relic Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
This should help diagnose why https://github.com/newrelic/node-newrelic/actions/runs/8144608511/job/22260190806 is failing and provide ongoing insight in the future.