### PR TITLE
feat: Added token_count to LlmEmbedding and LlmChatCompletionMessage for openai

### DIFF
--- a/lib/llm-events/openai/chat-completion-message.js
+++ b/lib/llm-events/openai/chat-completion-message.js
@@ -18,5 +18,11 @@ module.exports = class LlmChatCompletionMessage extends LlmEvent {
     if (agent.config.ai_monitoring.record_content.enabled === true) {
       this.content = message?.content
     }
+
+    if (this.is_response) {
+      this.token_count = response?.usage?.completion_tokens
+    } else {
+      this.token_count = response?.usage?.prompt_tokens
+    }
   }
 }

--- a/lib/llm-events/openai/embedding.js
+++ b/lib/llm-events/openai/embedding.js
@@ -14,5 +14,6 @@ module.exports = class LlmEmbedding extends LlmEvent {
     if (agent.config.ai_monitoring.record_content.enabled === true) {
       this.input = request.input?.toString()
     }
+    this.token_count = response?.usage?.prompt_tokens
   }
 }

--- a/test/unit/llm-events/openai/chat-completion-message.test.js
+++ b/test/unit/llm-events/openai/chat-completion-message.test.js
@@ -64,6 +64,7 @@ tap.test('LlmChatCompletionMessage', (t) => {
         expected.content = chatRes.choices[0].message.content
         expected.role = chatRes.choices[0].message.role
         expected.is_response = true
+        expected.token_count = 20
         t.same(chatMessageEvent, expected)
         t.end()
       })

--- a/test/unit/llm-events/openai/common.js
+++ b/test/unit/llm-events/openai/common.js
@@ -17,7 +17,7 @@ const res = {
   },
   model: 'gpt-3.5-turbo-0613',
   usage: {
-    total_tokens: '100',
+    total_tokens: '30',
     prompt_tokens: '10'
   }
 }
@@ -28,7 +28,7 @@ const chatRes = {
   choices: [{ finish_reason: 'stop', message: { content: 'a lot', role: 'know-it-all' } }]
 }
 
-chatRes.usage.completion_tokens = 10
+chatRes.usage.completion_tokens = 20
 
 const req = {
   model: 'gpt-3.5-turbo-0613',
@@ -60,7 +60,7 @@ function getExpectedResult(tx, event, type, completionId) {
     'duration': trace.children[0].getDurationInMillis(),
     'request.model': 'gpt-3.5-turbo-0613',
     'response.organization': 'new-relic',
-    'response.usage.total_tokens': '100',
+    'response.usage.total_tokens': '30',
     'response.usage.prompt_tokens': '10',
     'response.headers.llmVersion': '1.0.0',
     'response.headers.ratelimitLimitRequests': '100',
@@ -75,6 +75,7 @@ function getExpectedResult(tx, event, type, completionId) {
       expected = { ...expected, ...resKeys }
       expected.input = 'This is my test input'
       expected.error = false
+      expected.token_count = 10
       break
     case 'summary':
       expected = {
@@ -83,7 +84,7 @@ function getExpectedResult(tx, event, type, completionId) {
         ['request.max_tokens']: '1000000',
         ['request.temperature']: 'medium-rare',
         ['response.number_of_messages']: 3,
-        ['response.usage.completion_tokens']: 10,
+        ['response.usage.completion_tokens']: 20,
         ['response.choices.finish_reason']: 'stop',
         error: false
       }
@@ -95,6 +96,7 @@ function getExpectedResult(tx, event, type, completionId) {
         role: 'inquisitive-kid',
         sequence: 0,
         completion_id: completionId,
+        token_count: 10,
         is_response: false
       }
   }

--- a/test/versioned/openai/chat-completions.tap.js
+++ b/test/versioned/openai/chat-completions.tap.js
@@ -96,7 +96,8 @@ tap.test('OpenAI instrumentation - chat completions', (t) => {
         model,
         id: 'chatcmpl-87sb95K4EF2nuJRcTs43Tm9ntTeat',
         resContent: '1 plus 2 is 3.',
-        reqContent: content
+        reqContent: content,
+        tokenUsage: true
       })
 
       const chatSummary = events.filter(([{ type }]) => type === 'LlmChatCompletionSummary')[0]

--- a/test/versioned/openai/common.js
+++ b/test/versioned/openai/common.js
@@ -39,7 +39,15 @@ common.afterHook = function afterHook(t) {
   t.context.agent && helper.unloadAgent(t.context.agent)
 }
 
-function assertChatCompletionMessages({ tx, chatMsgs, id, model, reqContent, resContent }) {
+function assertChatCompletionMessages({
+  tx,
+  chatMsgs,
+  id,
+  model,
+  reqContent,
+  resContent,
+  tokenUsage
+}) {
   const baseMsg = {
     'appName': 'New Relic for Node.js tests',
     'request_id': '49dbbffbd3c3f4612aa48def69059aad',
@@ -60,16 +68,25 @@ function assertChatCompletionMessages({ tx, chatMsgs, id, model, reqContent, res
       expectedChatMsg.sequence = 0
       expectedChatMsg.id = `${id}-0`
       expectedChatMsg.content = reqContent
+      if (tokenUsage) {
+        expectedChatMsg.token_count = 53
+      }
     } else if (msg[1].sequence === 1) {
       expectedChatMsg.sequence = 1
       expectedChatMsg.id = `${id}-1`
       expectedChatMsg.content = 'What does 1 plus 1 equal?'
+      if (tokenUsage) {
+        expectedChatMsg.token_count = 53
+      }
     } else {
       expectedChatMsg.sequence = 2
       expectedChatMsg.role = 'assistant'
       expectedChatMsg.id = `${id}-2`
       expectedChatMsg.content = resContent
       expectedChatMsg.is_response = true
+      if (tokenUsage) {
+        expectedChatMsg.token_count = 11
+      }
     }
 
     this.equal(msg[0].type, 'LlmChatCompletionMessage')

--- a/test/versioned/openai/embeddings.tap.js
+++ b/test/versioned/openai/embeddings.tap.js
@@ -100,6 +100,7 @@ tap.test('OpenAI instrumentation - embedding', (t) => {
         'response.organization': 'new-relic-nkmd8b',
         'response.usage.total_tokens': 6,
         'response.usage.prompt_tokens': 6,
+        'token_count': 6,
         'response.headers.llmVersion': '2020-10-01',
         'response.headers.ratelimitLimitRequests': '200',
         'response.headers.ratelimitLimitTokens': '150000',


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
To support calculating token counts downstream for Llm events that lack counts(i.e. streaming or disabling capturing content), we have added `token_count` to LlmEmbedding, and LlmChatCompletionMessage.  This only adds and does not remove the old attributes for capturing token counts on prompts and completions. That will be handled in #2057


## Related Issues
Closes #2056
