### PR TITLE
chore: Added some delays to docs publishing

### DIFF
--- a/bin/publish-docs.sh
+++ b/bin/publish-docs.sh
@@ -10,8 +10,11 @@ git fetch origin gh-pages
 git checkout gh-pages
 git merge -
 npm run public-docs
+sleep 1
 git rm -r docs
+sleep 1
 mv out docs
+sleep 1
 git add docs
 git commit -m "docs: update for ${PACKAGE_VERSION}"
 git push origin gh-pages


### PR DESCRIPTION
After adding verbosity to docs gen (https://github.com/newrelic/node-newrelic/actions/runs/8145456792/job/22261755414) it looks like some operations are happening out-of-order (it could just be the way GitHub Actions records the logs, though). This PR adds some delays to try and solve that problem. 