### PR TITLE
feat: Added setLlmTokenCountCallback API endpoint to register a callback for calculating token count when none is provided

### DIFF
--- a/api.js
+++ b/api.js
@@ -1839,7 +1839,7 @@ API.prototype.setErrorGroupCallback = function setErrorGroupCallback(callback) {
   )
   metric.incrementCallCount()
 
-  if (!this.shim.isFunction(callback) || this.shim.isPromise(callback)) {
+  if (!this.shim.isFunction(callback) || this.shim.isAsyncFunction(callback)) {
     logger.warn(
       'Error Group callback must be a synchronous function, Error Group attribute will not be added'
     )
@@ -1847,6 +1847,39 @@ API.prototype.setErrorGroupCallback = function setErrorGroupCallback(callback) {
   }
 
   this.agent.errors.errorGroupCallback = callback
+}
+
+/**
+ * Registers a callback which will be used for calculating token counts on Llm events when they are not
+ * available. This function will typically only be used if `ai_monitoring.record_content.enabled` is false
+ * and you want to still capture token counts for Llm events.
+ *
+ * Provided callbacks must return an integer value for the token count for a given piece of content.
+ *
+ * @param {Function} callback - synchronous function called to calculate token count for content.
+ * @example
+ * // @param {string} model - name of model (i.e. gpt-3.5-turbo)
+ * // @param {string} content - prompt or completion response
+ * function tokenCallback(model, content) {
+ *  // calculate tokens based on model and content
+ *  // return token count
+ *  return 40
+ * }
+ */
+API.prototype.setLlmTokenCountCallback = function setLlmTokenCountCallback(callback) {
+  const metric = this.agent.metrics.getOrCreateMetric(
+    NAMES.SUPPORTABILITY.API + '/setLlmTokenCountCallback'
+  )
+  metric.incrementCallCount()
+
+  if (!this.shim.isFunction(callback) || this.shim.isAsyncFunction(callback)) {
+    logger.warn(
+      'Llm token count callback must be a synchronous function, callback will not be registered.'
+    )
+    return
+  }
+
+  this.agent.llm.tokenCountCallback = callback
 }
 
 module.exports = API

--- a/lib/instrumentation/restify.js
+++ b/lib/instrumentation/restify.js
@@ -93,7 +93,7 @@ function wrapMiddleware(shim, middleware, _name, route) {
   })
 
   const wrappedMw = shim.recordMiddleware(middleware, spec)
-  if (middleware.constructor.name === 'AsyncFunction') {
+  if (shim.isAsyncFunction(middleware)) {
     return async function asyncShim() {
       return wrappedMw.apply(this, arguments)
     }

--- a/lib/llm-events/openai/chat-completion-message.js
+++ b/lib/llm-events/openai/chat-completion-message.js
@@ -20,9 +20,13 @@ module.exports = class LlmChatCompletionMessage extends LlmEvent {
     }
 
     if (this.is_response) {
-      this.token_count = response?.usage?.completion_tokens
+      this.token_count =
+        response?.usage?.completion_tokens ||
+        agent.llm?.tokenCountCallback?.(this['response.model'], message?.content)
     } else {
-      this.token_count = response?.usage?.prompt_tokens
+      this.token_count =
+        response?.usage?.prompt_tokens ||
+        agent.llm?.tokenCountCallback?.(request.model || request.engine, message?.content)
     }
   }
 }

--- a/lib/llm-events/openai/embedding.js
+++ b/lib/llm-events/openai/embedding.js
@@ -14,6 +14,8 @@ module.exports = class LlmEmbedding extends LlmEvent {
     if (agent.config.ai_monitoring.record_content.enabled === true) {
       this.input = request.input?.toString()
     }
-    this.token_count = response?.usage?.prompt_tokens
+    this.token_count =
+      response?.usage?.prompt_tokens ||
+      agent.llm?.tokenCountCallback?.(this['request.model'], request.input?.toString())
   }
 }

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -125,6 +125,7 @@ Shim.prototype.getName = getName
 Shim.prototype.isObject = isObject
 Shim.prototype.isFunction = isFunction
 Shim.prototype.isPromise = isPromise
+Shim.prototype.isAsyncFunction = isAsyncFunction
 Shim.prototype.isString = isString
 Shim.prototype.isNumber = isNumber
 Shim.prototype.isBoolean = isBoolean
@@ -1343,6 +1344,20 @@ function isArray(obj) {
  */
 function isPromise(obj) {
   return obj && typeof obj.then === 'function'
+}
+
+/**
+ * Determines if function is an async function.
+ * Note it does not test if the return value of function is a
+ * promise or async function
+ *
+ * @memberof Shim.prototype
+ * @param fn
+ * @param (function) function to test if async
+ * @returns {boolean} True if the function is an async function
+ */
+function isAsyncFunction(fn) {
+  return fn.constructor.name === 'AsyncFunction'
 }
 
 /**

--- a/test/unit/api/api-set-error-group-callback.test.js
+++ b/test/unit/api/api-set-error-group-callback.test.js
@@ -84,8 +84,8 @@ tap.test('Agent API = set Error Group callback', (t) => {
   })
 
   t.test('should not attach the callback when async function', (t) => {
-    function callback() {
-      return new Promise((resolve) => {
+    async function callback() {
+      return await new Promise((resolve) => {
         setTimeout(() => {
           resolve()
         }, 200)

--- a/test/unit/api/stub.test.js
+++ b/test/unit/api/stub.test.js
@@ -8,7 +8,7 @@
 const tap = require('tap')
 const API = require('../../../stub_api')
 
-const EXPECTED_API_COUNT = 34
+const EXPECTED_API_COUNT = 35
 
 tap.test('Agent API - Stubbed Agent API', (t) => {
   t.autoend()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
Adds `setLlmTokenCountCallback` to register callback to be called to get token counts when they are not present on events.  This function must be synchronous and return token count.  

## Related Issues
Closes #2055
