### PR TITLE
feat: Added `guid` attribute to `TransactionError` events

### DIFF
--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -240,6 +240,7 @@ function _getErrorEventIntrinsicAttrs(transaction, errorClass, message, expected
     }
 
     attributes['nr.transactionGuid'] = transaction.id
+    attributes.guid = transaction.id
 
     if (transaction.port) {
       attributes.port = transaction.port

--- a/test/unit/errors/error-collector.test.js
+++ b/test/unit/errors/error-collector.test.js
@@ -1937,6 +1937,7 @@ tap.test('Errors', (t) => {
         t.equal(attributes.type, 'TransactionError')
         t.ok(typeof attributes['error.class'] === 'string')
         t.ok(typeof attributes['error.message'] === 'string')
+        t.ok(attributes.guid === transaction.id)
         t.ok(Math.abs(attributes.timestamp - nowSeconds) <= 1)
         t.equal(attributes.transactionName, transaction.name)
         t.end()
@@ -2021,6 +2022,13 @@ tap.test('Errors', (t) => {
           transaction.end()
           const attributes = getFirstEventIntrinsicAttributes(aggregator, t)
           t.equal(attributes['nr.transactionGuid'], transaction.id)
+          t.end()
+        })
+
+        t.test('includes guid attribute', (t) => {
+          transaction.end()
+          const attributes = getFirstEventIntrinsicAttributes(aggregator, t)
+          t.equal(attributes.guid, transaction.id)
           t.end()
         })
 

--- a/test/unit/errors/error-collector.test.js
+++ b/test/unit/errors/error-collector.test.js
@@ -237,6 +237,50 @@ tap.test('Errors', (t) => {
     })
   })
 
+  t.test('guid attribute with distributed tracing enabled', (t) => {
+    t.autoend()
+    let errorJSON
+    let transaction
+    let error
+
+    t.beforeEach(() => {
+      agent.config.distributed_tracing.enabled = true
+      error = new Error('this is an error')
+    })
+
+    t.test('should have a guid attribute when there is a transaction', (t) => {
+      transaction = new Transaction(agent)
+      const aggregator = agent.errors
+
+      agent.errors.add(transaction, error)
+      agent.errors.onTransactionFinished(transaction)
+
+      const errorTraces = getErrorTraces(agent.errors)
+      errorJSON = errorTraces[0]
+      const attributes = getFirstEventIntrinsicAttributes(aggregator, t)
+
+      const transactionId = errorJSON[5]
+      t.equal(transactionId, transaction.id)
+      t.equal(attributes.guid, transaction.id)
+      transaction.end()
+      t.end()
+    })
+
+    t.test('should not have a guid attribute when there is no transaction', (t) => {
+      agent.errors.add(null, error)
+      const aggregator = agent.errors
+
+      const errorTraces = getErrorTraces(agent.errors)
+      errorJSON = errorTraces[0]
+      const attributes = getFirstEventIntrinsicAttributes(aggregator, t)
+
+      const transactionId = errorJSON[5]
+      t.notOk(transactionId)
+      t.notOk(attributes.guid)
+      t.end()
+    })
+  })
+
   t.test('transaction id with distributed tracing disabled', (t) => {
     t.autoend()
     let errorJSON
@@ -271,6 +315,50 @@ tap.test('Errors', (t) => {
 
       const transactionId = errorJSON[5]
       t.notOk(transactionId)
+      t.end()
+    })
+  })
+
+  t.test('guid attribute with distributed tracing disabled', (t) => {
+    t.autoend()
+    let errorJSON
+    let transaction
+    let error
+
+    t.beforeEach(() => {
+      agent.config.distributed_tracing.enabled = false
+      error = new Error('this is an error')
+    })
+
+    t.test('should have a guid attribute when there is a transaction', (t) => {
+      transaction = new Transaction(agent)
+      const aggregator = agent.errors
+
+      agent.errors.add(transaction, error)
+      agent.errors.onTransactionFinished(transaction)
+
+      const errorTraces = getErrorTraces(agent.errors)
+      errorJSON = errorTraces[0]
+      const attributes = getFirstEventIntrinsicAttributes(aggregator, t)
+
+      const transactionId = errorJSON[5]
+      t.equal(transactionId, transaction.id)
+      t.equal(attributes.guid, transaction.id)
+      transaction.end()
+      t.end()
+    })
+
+    t.test('should not have a guid attribute when there is no transaction', (t) => {
+      agent.errors.add(null, error)
+      const aggregator = agent.errors
+
+      const errorTraces = getErrorTraces(agent.errors)
+      errorJSON = errorTraces[0]
+      const attributes = getFirstEventIntrinsicAttributes(aggregator, t)
+
+      const transactionId = errorJSON[5]
+      t.notOk(transactionId)
+      t.notOk(attributes.guid)
       t.end()
     })
   })
@@ -1768,6 +1856,15 @@ tap.test('Errors', (t) => {
           t.end()
         })
 
+        t.test('should not contain guid intrinsic attributes', (t) => {
+          const error = new Error('some error')
+          aggregator.add(null, error)
+
+          const attributes = getFirstEventIntrinsicAttributes(aggregator, t)
+          t.notOk(attributes.guid)
+          t.end()
+        })
+
         t.test('should set transactionName to Unknown', (t) => {
           const error = new Error('some error')
           aggregator.add(null, error)
@@ -1937,7 +2034,7 @@ tap.test('Errors', (t) => {
         t.equal(attributes.type, 'TransactionError')
         t.ok(typeof attributes['error.class'] === 'string')
         t.ok(typeof attributes['error.message'] === 'string')
-        t.ok(attributes.guid === transaction.id)
+        t.equal(attributes.guid, transaction.id)
         t.ok(Math.abs(attributes.timestamp - nowSeconds) <= 1)
         t.equal(attributes.transactionName, transaction.name)
         t.end()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
Our agents needs to add `guid` to `TransactionError` events. This is the final step needed in order for Errors Inbox team to link `TransactionError` events and `ErrorTrace` events when errors happen within a transaction. 

## How to Test
Added unit tests. Also ran a sample errors app and verified in the query builder that there is a `guid` on `TransactionError` events when distributed tracing is enabled or disabled. 

#### Distributed tracing enabled - error trace:
<img width="993" alt="dt-on-error-trace" src="https://github.com/newrelic/node-newrelic/assets/50715937/400657a9-3f77-4a0c-a090-62ccda756fe3">


#### Distributed tracing enabled - transaction error:
<img width="1002" alt="dt-on-transaction-error" src="https://github.com/newrelic/node-newrelic/assets/50715937/4437c751-4aa3-4073-a0ca-f3227e16cc58">

#### Distributed tracing disabled - error trace:
<img width="998" alt="dt-off-error-trace" src="https://github.com/newrelic/node-newrelic/assets/50715937/52dff5b5-a12f-4cdb-9acd-ca3b6568e554">

#### Distributed tracing disabled - transaction error:
<img width="847" alt="dt-off-transaction-error" src="https://github.com/newrelic/node-newrelic/assets/50715937/cad6cd52-05b3-4ae5-84bb-0b2286f53a37">

## Related Issues

Relates to this pr #1954 
Closes #2076 