### PR TITLE
feat: Added instrumentation for `initializeUnorderedBulkOp`, and `initializeOrderedBulkOp` in mongodb 4+

### DIFF
--- a/lib/instrumentation/mongodb/v4-mongo.js
+++ b/lib/instrumentation/mongodb/v4-mongo.js
@@ -6,7 +6,13 @@
 'use strict'
 
 const { OperationSpec } = require('../../shim/specs')
-const { instrumentCollection, instrumentCursor, instrumentDb, parseAddress } = require('./common')
+const {
+  instrumentBulkOperation,
+  instrumentCollection,
+  instrumentCursor,
+  instrumentDb,
+  parseAddress
+} = require('./common')
 
 /**
  * parser used to grab the collection and operation
@@ -18,8 +24,11 @@ function queryParser(operation) {
   let collection = this.collectionName || 'unknown'
 
   // cursor methods have collection on namespace.collection
-  if (this.namespace && this.namespace.collection) {
+  if (this?.namespace?.collection) {
     collection = this.namespace.collection
+    // (un)ordered bulk operations have collection on different key
+  } else if (this?.s?.collection?.collectionName) {
+    collection = this.s.collection.collectionName
   }
 
   return { operation, collection }
@@ -88,4 +97,5 @@ module.exports = function instrument(shim, mongodb) {
   instrumentCursor(shim, mongodb.AggregationCursor)
   instrumentCollection(shim, mongodb.Collection)
   instrumentDb(shim, mongodb.Db)
+  instrumentBulkOperation(shim, shim.require('./lib/bulk/common'))
 }

--- a/test/versioned/mongodb/bulk.tap.js
+++ b/test/versioned/mongodb/bulk.tap.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const common = require('./collection-common')
+const { STATEMENT_PREFIX } = require('./common')
+
+common.test('unorderedBulkOp', async function unorderedBulkOpTest(t, collection, verify) {
+  const bulk = collection.initializeUnorderedBulkOp()
+  bulk
+    .find({
+      i: 1
+    })
+    .updateOne({
+      $set: { foo: 'bar' }
+    })
+  bulk
+    .find({
+      i: 2
+    })
+    .updateOne({
+      $set: { foo: 'bar' }
+    })
+
+  await bulk.execute()
+  verify(null, [`${STATEMENT_PREFIX}/unorderedBulk/batch`], ['unorderedBulk'], { strict: false })
+})
+
+common.test('orderedBulkOp', async function unorderedBulkOpTest(t, collection, verify) {
+  const bulk = collection.initializeOrderedBulkOp()
+  bulk
+    .find({
+      i: 1
+    })
+    .updateOne({
+      $set: { foo: 'bar' }
+    })
+
+  bulk
+    .find({
+      i: 2
+    })
+    .updateOne({
+      $set: { foo: 'bar' }
+    })
+
+  await bulk.execute()
+  verify(null, [`${STATEMENT_PREFIX}/orderedBulk/batch`], ['orderedBulk'], { strict: false })
+})

--- a/test/versioned/mongodb/package.json
+++ b/test/versioned/mongodb/package.json
@@ -31,6 +31,7 @@
         "mongodb": ">=4.1.4"
       },
       "files": [
+        "bulk.tap.js",
         "collection-find.tap.js",
         "collection-index.tap.js",
         "collection-misc.tap.js",


### PR DESCRIPTION
- **feat: Added support for Mongo v5+**
- **feat: Added instrumentation for `initializeUnorderedBulkOp`**

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

**Note**: This is based off of my mongo-5 branch so this will need to rebased after #2085 is merged. The relevant commit is this [one](https://github.com/newrelic/node-newrelic/pull/2086/commits/9b13aaed2842cb629bc30db0f243ae6fbbc9b1fd)

I'm not sure what 2022 me was doing but this was rather straightforward.  This Pr adds instrumentation for `initializeUnorderedBulkOp` and `initializeOrderedBulkOp`.


## How to Test

`npm run versioned:internal mongodb`

## Related Issues

Closes #1122
