### PR TITLE
chore(deps): pin @newrelic/security-agent to 1.0.1

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -951,7 +951,7 @@ SOFTWARE.
 
 ### @newrelic/security-agent
 
-This product includes source derived from [@newrelic/security-agent](https://github.com/newrelic/csec-node-agent) ([v1.1.0](https://github.com/newrelic/csec-node-agent/tree/v1.1.0)), distributed under the [UNKNOWN License](https://github.com/newrelic/csec-node-agent/blob/v1.1.0/LICENSE):
+This product includes source derived from [@newrelic/security-agent](https://github.com/newrelic/csec-node-agent) ([v1.0.1](https://github.com/newrelic/csec-node-agent/tree/v1.0.1)), distributed under the [UNKNOWN License](https://github.com/newrelic/csec-node-agent/blob/v1.0.1/LICENSE):
 
 ```
 ## New Relic Software License v1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@newrelic/aws-sdk": "^7.3.0",
         "@newrelic/koa": "^9.0.0",
         "@newrelic/ritm": "^7.2.0",
-        "@newrelic/security-agent": "^1.1.0",
+        "@newrelic/security-agent": "1.0.1",
         "@newrelic/superagent": "^7.0.1",
         "@tyriar/fibonacci-heap": "^2.0.7",
         "concat-stream": "^2.0.0",
@@ -961,11 +961,11 @@
       }
     },
     "node_modules/@newrelic/security-agent": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/security-agent/-/security-agent-1.1.0.tgz",
-      "integrity": "sha512-/0/6y8W0pjo2AjUOlbwY+ntt8T5HCQX/cuhJcFXkJri+vu4j6kH+mftyiafKx3rMRfBSSj7YdYYl3wGGWxbt7Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/security-agent/-/security-agent-1.0.1.tgz",
+      "integrity": "sha512-Ao5MTULa6CzI8a2poRdQ31jJA0Exv99eyewfMHYbJGAY3H4rj6TZs08rGtrDK9ZyjNTalM/DHhyyTTDq+FJM+Q==",
       "dependencies": {
-        "axios": "^1.6.8",
+        "axios": "^1.6.5",
         "check-disk-space": "^3.4.0",
         "content-type": "^1.0.5",
         "fast-safe-stringify": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "@newrelic/aws-sdk": "^7.3.0",
     "@newrelic/koa": "^9.0.0",
     "@newrelic/ritm": "^7.2.0",
-    "@newrelic/security-agent": "^1.1.0",
+    "@newrelic/security-agent": "1.0.1",
     "@newrelic/superagent": "^7.0.1",
     "@tyriar/fibonacci-heap": "^2.0.7",
     "concat-stream": "^2.0.0",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Tue Mar 19 2024 14:23:23 GMT+0530 (India Standard Time)",
+  "lastUpdated": "Wed Mar 20 2024 08:44:47 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -108,15 +108,15 @@
       "email": "w@tson.dk",
       "url": "https://twitter.com/wa7son"
     },
-    "@newrelic/security-agent@1.1.0": {
+    "@newrelic/security-agent@1.0.1": {
       "name": "@newrelic/security-agent",
-      "version": "1.1.0",
-      "range": "^1.1.0",
+      "version": "1.0.1",
+      "range": "1.0.1",
       "licenses": "UNKNOWN",
       "repoUrl": "https://github.com/newrelic/csec-node-agent",
-      "versionedRepoUrl": "https://github.com/newrelic/csec-node-agent/tree/v1.1.0",
+      "versionedRepoUrl": "https://github.com/newrelic/csec-node-agent/tree/v1.0.1",
       "licenseFile": "node_modules/@newrelic/security-agent/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/csec-node-agent/blob/v1.1.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/csec-node-agent/blob/v1.0.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "newrelic"
     },


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
We had a nightly failure with security agent.  It turns out the grpc instrumentation in security agent is stomping on our instrumentation.  I've logged https://github.com/newrelic/csec-node-agent/issues/192. Until the IAST team can implement integration tests with our agent before release we will continue to pin the security agent.
