### PR TITLE
chore: Removed scrollbar styling in generated API docs

### DIFF
--- a/jsdoc-conf.json
+++ b/jsdoc-conf.json
@@ -4,7 +4,8 @@
     "readme": "./README.md",
     "template": "./node_modules/clean-jsdoc-theme",
     "theme_opts": {
-      "search": false
+      "search": false,
+      "shouldRemoveScrollbarStyle": true
     }
   },
   "source": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "ajv": "^6.12.6",
         "async": "^3.2.4",
         "c8": "^8.0.1",
-        "clean-jsdoc-theme": "^4.2.4",
+        "clean-jsdoc-theme": "^4.2.18",
         "commander": "^7.0.0",
         "conventional-changelog-conventionalcommits": "^5.0.0",
         "conventional-changelog-writer": "^5.0.1",
@@ -4925,9 +4925,9 @@
       }
     },
     "node_modules/clean-jsdoc-theme": {
-      "version": "4.2.17",
-      "resolved": "https://registry.npmjs.org/clean-jsdoc-theme/-/clean-jsdoc-theme-4.2.17.tgz",
-      "integrity": "sha512-5SbJNXcQHUXd7N13g+3OpGFiBQdxz36xwEP3p1r1vbo/apLcDRtugaFdUZ56H6Rvlb68Q33EChoBkajSlnD11w==",
+      "version": "4.2.18",
+      "resolved": "https://registry.npmjs.org/clean-jsdoc-theme/-/clean-jsdoc-theme-4.2.18.tgz",
+      "integrity": "sha512-iPz34GEhTZGW33Oi25IUgW1suGFuQZoDoCjn82BEI7Ck83CvJisrrxYv3WLjHA/wz8g82wy8WsUyRiTGajUZdw==",
       "dev": true,
       "dependencies": {
         "@jsdoc/salty": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "ajv": "^6.12.6",
     "async": "^3.2.4",
     "c8": "^8.0.1",
-    "clean-jsdoc-theme": "^4.2.4",
+    "clean-jsdoc-theme": "^4.2.18",
     "commander": "^7.0.0",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "conventional-changelog-writer": "^5.0.1",


### PR DESCRIPTION
See:

+ https://github.com/ankitskvmdam/clean-jsdoc-theme/issues/281
+ https://github.com/ankitskvmdam/clean-jsdoc-theme/commit/9c6d7538c39bd74a1f223dd4c52d45cab6d8d37a

## How to test

```sh
npm run public-docs
open out/index.html
```
