### PR TITLE
feat: Allow for different base branch for prepare-release CI

### DIFF
--- a/bin/prepare-release.js
+++ b/bin/prepare-release.js
@@ -72,6 +72,7 @@ async function prepareReleaseNotes() {
   const options = program.opts()
   console.log('Script running with following options: ', JSON.stringify(options))
   const [owner, repo] = options.repo.split('/')
+  const [, , baseBranch] = options.branch.split('/')
 
   logStep('Validation')
 
@@ -175,7 +176,7 @@ async function prepareReleaseNotes() {
 
     const prOptions = {
       head: newBranchName,
-      base: 'main',
+      base: baseBranch,
       title,
       body,
       draft: true
@@ -432,6 +433,7 @@ if (require.main === module) {
   module.exports = {
     generateConventionalReleaseNotes,
     getReleaseDate,
-    isValid
+    isValid,
+    prepareReleaseNotes
   }
 }


### PR DESCRIPTION
## Description

Our prepare-release job takes `branch` as an input parameter, but it's ignored when creating the release notes PR, and is overridden with the value `main`. For repos that have a different main branch name, we could use the submitted `branch` option. 

Closes #2098 
Closes NR-252885