### PR TITLE
chore: Updated versioned security agent workflow

### DIFF
--- a/.github/workflows/versioned-security-agent.yml
+++ b/.github/workflows/versioned-security-agent.yml
@@ -21,9 +21,49 @@ on:
         required: false
   schedule:
     - cron:  '0 9 * * 1-5'
+  pull_request:
+    branches:
+      - main
 
 jobs:
+  should_run:
+    # Used to determine if the `@newrelic/security-agent` dependency has
+    # been updated in any new pull requests. This job _must_ always run because
+    # the `security-agent-tests` job depends on the outputs of this job. Thus,
+    # we cannot put a conditional on this job to only run if the event name
+    # is "pull_request".
+    name: Should Run
+    runs-on: ubuntu-latest
+    outputs:
+      previous_version: ${{steps.versions.outputs.PREVIOUS_VAL}}
+      current_version: ${{steps.versions.outputs.CURRENT_VAL}}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: tj-actions/changed-files@v44
+        id: changed_files
+        with:
+          files: package.json
+      - name: Get dependency versions
+        id: versions
+        if: steps.changed_files.outputs.any_changed == 'true'
+        run: |
+          current_val=$(cat package.json | jq -r --arg pkg "@newrelic/security-agent" '.dependencies[$pkg]')
+          echo "current_val=${current_val}" >> $GITHUB_OUTPUT
+          
+          git checkout origin/${{github.base_ref}}
+          previous_val=$(cat package.json | jq -r --arg pkg "@newrelic/security-agent" '.dependencies[$pkg]')
+          echo "previous_val=${previous_val}" >> $GITHUB_OUTPUT
+          
+          git checkout ${{github.sha}}
+
   security-agent-tests:
+    needs: [should_run]
+    if: github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      needs.should_run.outputs.previous_version != needs.should_run.outputs.current_version
+
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
This PR resolves #2088. It adds a new job to the `versioned-security-agent` workflow that detects if the `package.json` has been updated, and if so, whether or not the `@newrelic/security-agent` version number has been changed. The results of this job are utilized by the already existing job to determine if it should run. After this PR there are three cases where the versioned tests will run with the security agent enabled:

1. When the workflow is directly run through the GitHub interface.
2. When nightly scheduled job is executed.
3. When a pull request includes a change in the version for the `@newrelic/security-agent` dependency.

-----

Note: the CI run https://github.com/newrelic/node-newrelic/actions/runs/8455455203/job/23162959574?pr=2100 as a result of opening this PR shows that the security agent enabled tests do not run for every PR (this PR does not change the dependency version).