### PR TITLE
ci: Updated `prepare-release.js` to not require changelog.json

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -18,7 +18,7 @@ on:
         type: string
         required: false
       changelog_json:
-        description: Whether or not it should generate a changelog.json(should only be for node-newrelic)
+        description: Whether or not it should generate a changelog.json (should only be for node-newrelic)
         type: boolean 
         required: false
 

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -17,6 +17,10 @@ on:
         description: Whether or not to use the new conventional commit release note workflow
         type: string
         required: false
+      changelog_json:
+        description: Whether or not it should generate a changelog.json(should only be for node-newrelic)
+        type: boolean 
+        required: false
 
 jobs:
   generate-release-notes:
@@ -47,6 +51,6 @@ jobs:
         git config user.name $GITHUB_ACTOR
         git config user.email gh-actions-${GITHUB_ACTOR}@github.com
     - name: Create Release Notes
-      run: node ./agent-repo/bin/prepare-release.js --release-type ${{ inputs.release_type }} --branch ${{ github.ref }} --repo ${{ github.repository }} --changelog ${{ inputs.changelog_file }} ${{ inputs.use_new_release == 'true' && '--use-new-release' || '' }}
+      run: node ./agent-repo/bin/prepare-release.js --release-type ${{ inputs.release_type }} --branch ${{ github.ref }} --repo ${{ github.repository }} --changelog ${{ inputs.changelog_file }} ${{ inputs.use_new_release == 'true' && '--use-new-release' || '' }} ${{ inputs.changelog_json == true && '--changelog-json' || ''}}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,3 +15,4 @@ jobs:
     with:
       release_type: ${{ github.event.inputs.release_type }}
       use_new_release: ${{ vars.USE_NEW_RELEASE }}
+      changelog_json: true

--- a/bin/prepare-release.js
+++ b/bin/prepare-release.js
@@ -325,7 +325,7 @@ async function generateReleaseNotes(owner, repo) {
  * @param {string} params.newVersion version to be published
  * @param {string} params.markdownChangelog filepath of markdown changelog
  * @param {boolean} params.generateJsonChangelog indicator if it should update changelog.json
- * @returns {array} generate data of markdown and json
+ * @returns {object[]} generate data of markdown and json
  */
 async function generateConventionalReleaseNotes({
   owner,

--- a/bin/prepare-release.js
+++ b/bin/prepare-release.js
@@ -39,6 +39,10 @@ program.option(
   'newrelic/node-newrelic'
 )
 program.option('--use-new-release', 'use new conventional commit release note process')
+program.option(
+  '--changelog-json',
+  'generate notes with a corresponding changelog.json(only for node-newrelic)'
+)
 
 function stopOnError(err) {
   if (err) {
@@ -119,12 +123,13 @@ async function prepareReleaseNotes() {
     let releaseData
     if (options.useNewRelease) {
       logStep('Create Release Notes - Conventional Commit based')
-      const [markdown] = await generateConventionalReleaseNotes(
+      const [markdown] = await generateConventionalReleaseNotes({
         owner,
         repo,
-        packageInfo.version,
-        options.changelog
-      )
+        newVersion: packageInfo.version,
+        markdownChangelog: options.changelog,
+        generateJsonChangelog: options.changelogJson
+      })
       releaseData = markdown
     } else {
       logStep('Create Release Notes')
@@ -314,12 +319,21 @@ async function generateReleaseNotes(owner, repo) {
 /**
  * Function for generating and writing our release notes based on Conventional Commits
  *
- * @param {string} owner github repo org
- * @param {string} repo github repo name
- * @param {string} newVersion version to be published
- * @param {string} markdownChangelog filepath of markdown changelog
+ * @param {object} params function params
+ * @param {string} params.owner github repo org
+ * @param {string} params.repo github repo name
+ * @param {string} params.newVersion version to be published
+ * @param {string} params.markdownChangelog filepath of markdown changelog
+ * @param {boolean} params.generateJsonChangelog indicator if it should update changelog.json
+ * @returns {array} generate data of markdown and json
  */
-async function generateConventionalReleaseNotes(owner, repo, newVersion, markdownChangelog) {
+async function generateConventionalReleaseNotes({
+  owner,
+  repo,
+  newVersion,
+  markdownChangelog,
+  generateJsonChangelog
+}) {
   const github = new Github(owner, repo)
   const latestRelease = await github.getLatestRelease()
 
@@ -332,15 +346,14 @@ async function generateConventionalReleaseNotes(owner, repo, newVersion, markdow
 
   const commits = await changelog.getFormattedCommits()
 
-  const [markdown, json] = await Promise.all([
-    changelog.generateMarkdownChangelog(commits),
-    changelog.generateJsonChangelog(commits)
-  ])
+  const markdown = await changelog.generateMarkdownChangelog(commits)
+  await changelog.writeMarkdownChangelog(markdown, markdownChangelog)
 
-  await Promise.all([
-    changelog.writeMarkdownChangelog(markdown, markdownChangelog),
-    changelog.writeJsonChangelog(json)
-  ])
+  let json = null
+  if (generateJsonChangelog) {
+    json = await changelog.generateJsonChangelog(commits)
+    await changelog.writeJsonChangelog(json)
+  }
 
   return [markdown, json]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

The `bin/prepare-release.js` script has logic to generate a changelog in both markdown and json.  The json gets written to changelog.json which is subsequently parsed and used to open a docs PR with front matter for the given release.  This logic is only needed for `node-newrelic`.  When we migrated all of our others repos we had to add a changelog.json which writes features, bugs and security fixes but it's never used.  This PR provides the ability to optionally pass in a flag `--changelog-json` to write out the changes to changelog.json which will only be used in node-newrelic, which you can see is being done in `.github/workflows/prepare-release.yml`. Once this is merged we can update all external repos to remove the `changelog.json`

## How to Test

```
npm run unit:scripts
```

## Related Issues
Closes #2105
