### PR TITLE
chore: Updated test/integration/core/dns reverse test to remove flaki…

### DIFF
--- a/test/integration/core/dns.tap.js
+++ b/test/integration/core/dns.tap.js
@@ -128,26 +128,19 @@ test('resolveSrv', function (t) {
 })
 
 test('reverse', function (t) {
+  const reverse = dns.reverse
+  dns.reverse = (addr, cb) => {
+    cb(undefined, ['localhost'])
+  }
+  t.teardown(() => {
+    dns.reverse = reverse
+  })
+
   const agent = setupAgent(t)
   helper.runInTransaction(agent, function () {
     dns.reverse('127.0.0.1', function (err, names) {
-      t.notOk(err, 'should not error')
-      let expected = []
-      if (names.length > 0) {
-        if (process.env.DOCKERIZED) {
-          if (names.length === 2) {
-            expected = ['127.0.0.1', 'localhost']
-          } else {
-            expected = ['localhost']
-          }
-        } else {
-          expected = ['nettuno', 'travis', 'vagrant']
-        }
-      }
-
-      expected.forEach((name) => {
-        t.not(names.indexOf(name), -1, 'should have expected name')
-      })
+      t.error(err, 'should not error')
+      t.not(names.indexOf('localhost'), -1, 'should have expected name')
       verifySegments(t, agent, 'dns.reverse')
     })
   })


### PR DESCRIPTION
Our CI has been routinely failing when running the `dns` integration test suite due to some inconsistency in the environment. See https://github.com/newrelic/node-newrelic/actions/runs/8542018079/job/23403475945#step:6:155. This PR changes the test to always resolve `127.0.0.1` to the known array `['localhost']` in order to remove the flakiness.