### PR TITLE
chore: Added language header to serverless metadata

### DIFF
--- a/lib/collector/serverless.js
+++ b/lib/collector/serverless.js
@@ -36,7 +36,8 @@ class ServerlessCollector {
       function_version: null,
       execution_environment: process.env.AWS_EXECUTION_ENV,
       protocol_version: 16,
-      agent_version: agent.version
+      agent_version: agent.version,
+      agent_language: 'nodejs'
     }
     this.payload = {}
     this.pipePath = pipePath || process.env.NEWRELIC_PIPE_PATH || defaultPipePath

--- a/test/integration/agent/serverless-harvest.tap.js
+++ b/test/integration/agent/serverless-harvest.tap.js
@@ -81,7 +81,8 @@ tap.test('Serverless mode harvest', (t) => {
             function_version: TEST_FUNC_VERSION,
             execution_environment: TEST_EX_ENV,
             protocol_version: PROTOCOL_VERSION,
-            agent_version: agent.version
+            agent_version: agent.version,
+            agent_language: 'nodejs'
           },
           'metadata object has expected data'
         )


### PR DESCRIPTION
## Description

Usage metrics are displayed by agent and faceted by `name`, which is derived from the `agent_language` metadata header. While that header's part of the v2 serverless spec, it's still recognized and delivered to NRDB in a v1 payload. This adds the header. 

## How to Test

This value is included in the serverless harvest integration test, but the TDP usage value has been tested using a function instrumented with a custom build of the agent that includes this change.

## Related Issues

Closes #2130 
Closes NR-256299