### PR TITLE
docs: Fixed images in markdown tutorials

### DIFF
--- a/examples/shim/Context-Preservation.md
+++ b/examples/shim/Context-Preservation.md
@@ -230,9 +230,7 @@ transaction, the work done in `secondJob` would be incorrectly associated with
 `'firstTransaction'`.  Now that we have a test case we can start writing our
 instrumentation for the work queue.  This behavior can be seen in the UI:
 
-<div style="text-align:center">
-  [<img src="./confounded-txns.png" style="width:100%" />][5]
-</div>
+[<img src="./confounded-txns.png" alt="confounded transactions" style="text-align:center;width:100%" />][5]
 
 The instrumentation will be relatively simple, we just need to call {@link
 Shim#bindSegment} on the jobs as they are passed in.  The purpose of this
@@ -308,9 +306,7 @@ The correct instrumentation should be noticeable in the UI as now both
 transactions appear, and the timer used by the work queue appears as a segment
 in `'firstTransaction'`
 
-<div style="text-align:center">
-  [<img src="./proper-txns.png" style="width:100%" />][5]
-</div>
+[<img src="./proper-txns.png" alt="transaction breakdown" style="text-align:center;width:100%" />][5]
 
 
 ### Questions?

--- a/examples/shim/Datastore-Simple.md
+++ b/examples/shim/Datastore-Simple.md
@@ -67,9 +67,7 @@ server.get('/shim-demo', function(req, res, next) {
 })
 ```
 
-<div style="text-align:center">
-  [![transaction breakdown](./tx-breakdown.png)][4]
-</div>
+[<img src="./tx-breakdown.png" alt="transaction breakdown" style="text-align:center;width:100%" />][4]
 
 
 --------------------------------------------------------------------------------
@@ -101,9 +99,7 @@ one of the [predefined datastore names]{@link DatastoreShim.DATASTORE_NAMES},
 but we could have also passed in a string like `"Cassandra"` instead. This name
 will show up on the [New Relic APM Databases page][2] like this:
 
-<div style="text-align:center">
-  [![databases overview](./db-overview.png)][2]
-</div>
+[<img src="./db-overview.png" alt="databases overview" style="text-align:center;width:100%" />][2]
 
 
 ### Recording Operations
@@ -125,9 +121,7 @@ them to name our metrics. We can see the results of this on APM in the
 transaction breakdown graph. The green layer labeled `Cassandra connect` is from
 our recorded operation.
 
-<div style="text-align:center">
-  [![transaction breakdown](./tx-breakdown.png)][4]
-</div>
+[<img src="./tx-breakdown.png" alt="transaction breakdown" style="text-align:center;width:100%" />][4]
 
 The third parameter is the ["spec" for this operation]{@link OperationSpec}.
 Specs are simply objects that describe the interface for a function. For

--- a/examples/shim/Instrumentation-Basics.md
+++ b/examples/shim/Instrumentation-Basics.md
@@ -5,9 +5,7 @@ Instrumentation for Node.js holds two purposes. The first is to give users
 detailed information about what happens on their server. The more things
 instrumented, the more detailed this graph can be.
 
-<div style="text-align:center">
-  ![application overview](./overview.png)
-</div>
+[<img src="./overview.png" alt="application overview" style="text-align:center;width:100%" />]
 
 The second purpose is to maintain the transaction context. In order to properly
 associate chunks of work with the correct transactions we must link the context

--- a/examples/shim/Messaging-Simple.md
+++ b/examples/shim/Messaging-Simple.md
@@ -108,9 +108,7 @@ The first thing the instrumentation should specify is the name of the message br
   shim.setLibrary(shim.RABBITMQ)
 ```
 
-<div style="text-align:center">
-  <img src="./messaging-breakdown-table.png" alt="transaction breakdown"/>
-</div>
+[<img src="./messaging-breakdown-table.png" style="text-align:center;width:100$" alt="transaction breakdown"/>]
 
 ### Producing Messages
 
@@ -157,15 +155,11 @@ The `recordProduce` method wraps the `publish` function, so that when it's calle
 
 The call would be displayed in the transaction trace as:
 
-<div style="text-align:center">
-  <img src="./messaging-produce-segment.png" alt="transaction trace with produce segment"/>
-</div>
+[<img src="./messaging-produce-segment.png" style="text-align:center;width:100%" alt="transaction trace with produce segment"/>]
 
 The transaction trace window also has the Messages tab, which shows all of the messages produced or consumed during the transaction:
 
-<div style="text-align:center">
-  <img src="./messaging-produce-messages.png" alt="transaction trace with produce segment"/>
-</div>
+[<img src="./messaging-produce-messages.png" style="text-align:center;width:100%" alt="transaction trace with produce segment"/>]
 
 The agent will also record a metric that can be be queried in Insights. The format of the metric is:  `MessageBroker/[libraryName]/Queue/Produce/Named/[queueName]`.
 
@@ -210,9 +204,7 @@ Similarly to the produce-messages case, `recordConsume` wraps the function used 
 
 The call would be displayed in the transaction trace as:
 
-<div style="text-align:center">
-  <img src="./messaging-consume-segment.png" alt="transaction trace with consume segment"/>
-</div>
+[<img src="./messaging-consume-segment.png" style="text-align:center;width:100%" alt="transaction trace with consume segment"/>]
 
 The agent will also record a metric that can be be queried in Insights. The format of the metric is `MessageBroker/[libraryName]/Queue/Produce/Named/[queueName]`.
 
@@ -250,9 +242,7 @@ The `messageHandler` parameter works the same as in the `recordConsume` case. Wh
 
 Each message processing will be shown as a separate transaction:
 
-<div style="text-align:center">
-  <img src="./messaging-consume-transaction.png" alt="message transaction"/>
-</div>
+[<img src="./messaging-consume-transaction.png" style="text-align:center;width:100%" alt="message transaction"/>]
 
 ### Cross application traces
 

--- a/examples/shim/Webframework-Simple.md
+++ b/examples/shim/Webframework-Simple.md
@@ -85,9 +85,7 @@ attributes. It is also displayed in the Environment view.
   shim.setFramework('MyCustom')
 ```
 
-<div style="text-align:center">
-  ![transaction breakdown](./breakdown-table-web-framework.png)
-</div>
+[<img src="./breakdown-table-web-framework.png" alt="transaction breakdown" style="text-align:center;width:100%" />]
 
 ### What to Record
 
@@ -128,9 +126,8 @@ the HTTP request or pass control to another middleware.
 Since there can be many middlewares executed for a single request, it is useful to know
 how much time is spent in each middleware when troubleshooting performance.
 
-<div style="text-align:center">
-  ![transaction breakdown](./tx-breakdown-web-api.png)
-</div>
+[<img src="./tx-breakdown-web-api.png" alt="transaction breakdown" style="text-align:center;width:100%" />]
+
 
 There are two API functions related to middleware - {@link WebFrameworkShim#recordMiddleware}
 and {@link WebFrameworkShim#wrapMiddlewareMounter}. Based on our web app code, we would
@@ -226,9 +223,7 @@ shim.recordRender(Server.prototype, 'render', {
 })
 ```
 
-<div style="text-align:center">
-  ![view segment](./trace-summary-view.png)
-</div>
+[<img src="./trace-summary-view.png" alt="view segment" style="text-align:center;width:100%" />]
 
 Note that in some cases (e.g. in Express) the `render` function may be directly
 on the `req` object and may be invoked without accepting a callback. In this


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Some images were invalid markdown in html divs. I just unified this with the same injection.

## How to Test

```sh
npm run public-docs
open out/index.html
```

Check all Tutorials in the dropdown.

## Related Issues

Closes #2152
