### PR TITLE
chore: Updated instrumentation to use type constants instead of raw strings

### DIFF
--- a/lib/instrumentation/amqplib/nr-hooks.js
+++ b/lib/instrumentation/amqplib/nr-hooks.js
@@ -5,16 +5,17 @@
 
 'use strict'
 const amqplib = require('./amqplib')
+const InstrumentationDescriptor = require('../../instrumentation-descriptor')
 
 module.exports = [
   {
     moduleName: 'amqplib/callback_api',
-    type: 'message',
+    type: InstrumentationDescriptor.TYPE_MESSAGE,
     onRequire: amqplib.instrumentCallbackAPI
   },
   {
     moduleName: 'amqplib/channel_api',
-    type: 'message',
+    type: InstrumentationDescriptor.TYPE_MESSAGE,
     onRequire: amqplib.instrumentPromiseAPI
   }
 ]

--- a/lib/instrumentation/grpc-js/nr-hooks.js
+++ b/lib/instrumentation/grpc-js/nr-hooks.js
@@ -5,25 +5,26 @@
 
 'use strict'
 const grpc = require('./grpc')
+const InstrumentationDescriptor = require('../../instrumentation-descriptor')
 
 /**
  * Need to use nr-hooks style for grpc because we're instrumentation a submodule.
  */
 module.exports = [
   {
-    type: 'generic',
+    type: InstrumentationDescriptor.TYPE_GENERIC,
     moduleName: '@grpc/grpc-js/build/src/resolving-call',
     isEsm: true,
     onRequire: grpc.wrapStartResolve
   },
   {
-    type: 'generic',
+    type: InstrumentationDescriptor.TYPE_GENERIC,
     moduleName: '@grpc/grpc-js/build/src/call-stream',
     isEsm: true,
     onRequire: grpc.wrapStartCall
   },
   {
-    type: 'web-framework',
+    type: InstrumentationDescriptor.TYPE_WEB_FRAMEWORK,
     moduleName: '@grpc/grpc-js/build/src/server',
     isEsm: true,
     onRequire: grpc.wrapServer

--- a/lib/instrumentation/langchain/nr-hooks.js
+++ b/lib/instrumentation/langchain/nr-hooks.js
@@ -8,25 +8,26 @@ const toolsInstrumentation = require('./tools')
 const cbManagerInstrumentation = require('./callback-manager')
 const runnableInstrumentation = require('./runnable')
 const vectorstoreInstrumentation = require('./vectorstore')
+const InstrumentationDescriptor = require('../../instrumentation-descriptor')
 
 module.exports = [
   {
-    type: 'generic',
+    type: InstrumentationDescriptor.TYPE_GENERIC,
     moduleName: '@langchain/core/tools',
     onRequire: toolsInstrumentation
   },
   {
-    type: 'generic',
+    type: InstrumentationDescriptor.TYPE_GENERIC,
     moduleName: '@langchain/core/dist/callbacks/manager',
     onRequire: cbManagerInstrumentation
   },
   {
-    type: 'generic',
+    type: InstrumentationDescriptor.TYPE_GENERIC,
     moduleName: '@langchain/core/dist/runnables/base',
     onRequire: runnableInstrumentation
   },
   {
-    type: 'generic',
+    type: InstrumentationDescriptor.TYPE_GENERIC,
     moduleName: '@langchain/core/vectorstores',
     onRequire: vectorstoreInstrumentation
   }

--- a/lib/instrumentation/mysql/nr-hooks.js
+++ b/lib/instrumentation/mysql/nr-hooks.js
@@ -5,20 +5,21 @@
 
 'use strict'
 const instrumentation = require('./mysql')
+const InstrumentationDescriptor = require('../../instrumentation-descriptor')
 
 module.exports = [
   {
-    type: 'datastore',
+    type: InstrumentationDescriptor.TYPE_DATASTORE,
     moduleName: 'mysql',
     onRequire: instrumentation.callbackInitialize
   },
   {
-    type: 'datastore',
+    type: InstrumentationDescriptor.TYPE_DATASTORE,
     moduleName: 'mysql2',
     onRequire: instrumentation.callbackInitialize
   },
   {
-    type: 'datastore',
+    type: InstrumentationDescriptor.TYPE_DATASTORE,
     moduleName: 'mysql2/promise',
     onRequire: instrumentation.promiseInitialize
   }

--- a/lib/instrumentation/pino/nr-hooks.js
+++ b/lib/instrumentation/pino/nr-hooks.js
@@ -5,13 +5,14 @@
 
 'use strict'
 const pino = require('./pino')
+const InstrumentationDescriptor = require('../../instrumentation-descriptor')
 
 /**
  * Need to use nr-hooks style because we are instrumenting a submodule.
  */
 module.exports = [
   {
-    type: 'generic',
+    type: InstrumentationDescriptor.TYPE_GENERIC,
     moduleName: 'pino/lib/tools',
     onRequire: pino
   }

--- a/lib/instrumentation/when/nr-hooks.js
+++ b/lib/instrumentation/when/nr-hooks.js
@@ -5,10 +5,11 @@
 
 'use strict'
 const instrumentation = require('./index')
+const InstrumentationDescriptor = require('../../instrumentation-descriptor')
 
 module.exports = [
   {
-    type: null,
+    type: InstrumentationDescriptor.TYPE_GENERIC,
     moduleName: 'when',
     onRequire: instrumentation
   }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
I noticed after comments in #2161 that certain instrumentation was using `type: <raw-string>` instead of relying on the constants in `instrumentation-descriptor`.  This PR updates that.
