### PR TITLE
chore: Added otel compliant attributes for database spans

### DIFF
--- a/lib/spans/span-event.js
+++ b/lib/spans/span-event.js
@@ -266,7 +266,7 @@ class DatastoreSpanEvent extends SpanEvent {
       if (attributes.port_path_or_id) {
         const address = `${attributes.host}:${attributes.port_path_or_id}`
         this.addAttribute('peer.address', address)
-        this.addAttribute('server.port', attributes.port_path_or_id)
+        this.addAttribute('server.port', attributes.port_path_or_id, true)
         attributes.port_path_or_id = null
       }
       attributes.host = null

--- a/lib/spans/span-event.js
+++ b/lib/spans/span-event.js
@@ -231,6 +231,7 @@ class DatastoreSpanEvent extends SpanEvent {
 
     if (attributes.product) {
       this.intrinsics.component = attributes.product
+      this.addAttribute('db.system', attributes.product)
       attributes.product = null
     }
 
@@ -260,10 +261,12 @@ class DatastoreSpanEvent extends SpanEvent {
 
     if (attributes.host) {
       this.addAttribute('peer.hostname', attributes.host)
+      this.addAttribute('server.address', attributes.host)
 
       if (attributes.port_path_or_id) {
         const address = `${attributes.host}:${attributes.port_path_or_id}`
         this.addAttribute('peer.address', address)
+        this.addAttribute('server.port', attributes.port_path_or_id)
         attributes.port_path_or_id = null
       }
       attributes.host = null

--- a/lib/spans/streaming-span-event.js
+++ b/lib/spans/streaming-span-event.js
@@ -278,7 +278,7 @@ class StreamingDatastoreSpanEvent extends StreamingSpanEvent {
       if (agentAttributes.port_path_or_id) {
         const address = `${agentAttributes.host}:${agentAttributes.port_path_or_id}`
         this.addAgentAttribute('peer.address', address)
-        this.addAgentAttribute('server.port', agentAttributes.port_path_or_id)
+        this.addAgentAttribute('server.port', agentAttributes.port_path_or_id, true)
         agentAttributes.port_path_or_id = null
       }
 

--- a/lib/spans/streaming-span-event.js
+++ b/lib/spans/streaming-span-event.js
@@ -243,6 +243,7 @@ class StreamingDatastoreSpanEvent extends StreamingSpanEvent {
 
     if (agentAttributes.product) {
       this.addIntrinsicAttribute('component', agentAttributes.product)
+      this.addAgentAttribute('db.system', agentAttributes.product)
       agentAttributes.product = null
     }
 
@@ -272,10 +273,12 @@ class StreamingDatastoreSpanEvent extends StreamingSpanEvent {
 
     if (agentAttributes.host) {
       this.addAgentAttribute('peer.hostname', agentAttributes.host)
+      this.addAgentAttribute('server.address', agentAttributes.host)
 
       if (agentAttributes.port_path_or_id) {
         const address = `${agentAttributes.host}:${agentAttributes.port_path_or_id}`
         this.addAgentAttribute('peer.address', address)
+        this.addAgentAttribute('server.port', agentAttributes.port_path_or_id)
         agentAttributes.port_path_or_id = null
       }
 

--- a/test/unit/spans/span-event.test.js
+++ b/test/unit/spans/span-event.test.js
@@ -115,6 +115,7 @@ tap.test('fromSegment()', (t) => {
         // Should have no datastore properties.
         t.notOk(hasOwnAttribute('db.statement'))
         t.notOk(hasOwnAttribute('db.instance'))
+        t.notOk(hasOwnAttribute('db.system'))
         t.notOk(hasOwnAttribute('peer.hostname'))
         t.notOk(hasOwnAttribute('peer.address'))
 
@@ -182,6 +183,7 @@ tap.test('fromSegment()', (t) => {
           const hasOwnAttribute = Object.hasOwnProperty.bind(attributes)
           t.notOk(hasOwnAttribute('db.statement'))
           t.notOk(hasOwnAttribute('db.instance'))
+          t.notOk(hasOwnAttribute('db.system'))
           t.notOk(hasOwnAttribute('peer.hostname'))
           t.notOk(hasOwnAttribute('peer.address'))
 
@@ -191,7 +193,7 @@ tap.test('fromSegment()', (t) => {
     })
   })
 
-  t.test('should create an datastore span with an datastore segment', (t) => {
+  t.test('should create a datastore span with a datastore segment', (t) => {
     agent.config.transaction_tracer.record_sql = 'raw'
 
     const shim = new DatastoreShim(agent, 'test-data-store')
@@ -270,6 +272,9 @@ tap.test('fromSegment()', (t) => {
         t.equal(attributes['db.collection'], 'my-collection')
         t.equal(attributes['peer.hostname'], 'my-db-host')
         t.equal(attributes['peer.address'], 'my-db-host:/path/to/db.sock')
+        t.equal(attributes['db.system'], 'TestStore') // same as intrinsics.component
+        t.equal(attributes['server.address'], 'my-db-host')
+        t.equal(attributes['server.port'], '/path/to/db.sock')
 
         const statement = attributes['db.statement']
         t.ok(statement)

--- a/test/unit/spans/span-event.test.js
+++ b/test/unit/spans/span-event.test.js
@@ -263,7 +263,6 @@ tap.test('fromSegment()', (t) => {
         // Should have not http properties.
         const hasOwnAttribute = Object.hasOwnProperty.bind(attributes)
         t.notOk(hasOwnAttribute('http.url'))
-        t.notOk(hasOwnAttribute('server.address'))
         t.notOk(hasOwnAttribute('http.method'))
         t.notOk(hasOwnAttribute('http.request.method'))
 

--- a/test/unit/spans/streaming-span-event.test.js
+++ b/test/unit/spans/streaming-span-event.test.js
@@ -251,7 +251,6 @@ tap.test('fromSegment()', (t) => {
         // Should have not http properties.
         const hasOwnAttribute = Object.hasOwnProperty.bind(agentAttributes)
         t.notOk(hasOwnAttribute('http.url'))
-        t.notOk(hasOwnAttribute('server.address'))
         t.notOk(hasOwnAttribute('http.method'))
         t.notOk(hasOwnAttribute('http.request.method'))
 

--- a/test/unit/spans/streaming-span-event.test.js
+++ b/test/unit/spans/streaming-span-event.test.js
@@ -107,6 +107,7 @@ tap.test('fromSegment()', (t) => {
         // Should have no datastore properties.
         t.notOk(hasOwnAttribute('db.statement'))
         t.notOk(hasOwnAttribute('db.instance'))
+        t.notOk(hasOwnAttribute('db.system'))
         t.notOk(hasOwnAttribute('peer.hostname'))
         t.notOk(hasOwnAttribute('peer.address'))
 
@@ -167,6 +168,7 @@ tap.test('fromSegment()', (t) => {
           const hasOwnAttribute = Object.hasOwnProperty.bind(agentAttributes)
           t.notOk(hasOwnAttribute('db.statement'))
           t.notOk(hasOwnAttribute('db.instance'))
+          t.notOk(hasOwnAttribute('db.system'))
           t.notOk(hasOwnAttribute('peer.hostname'))
           t.notOk(hasOwnAttribute('peer.address'))
 
@@ -176,7 +178,7 @@ tap.test('fromSegment()', (t) => {
     })
   })
 
-  t.test('should create an datastore span with an datastore segment', (t) => {
+  t.test('should create a datastore span with a datastore segment', (t) => {
     agent.config.transaction_tracer.record_sql = 'raw'
 
     const shim = new DatastoreShim(agent, 'test-data-store')
@@ -258,6 +260,9 @@ tap.test('fromSegment()', (t) => {
         t.same(agentAttributes['db.collection'], { [STRING_TYPE]: 'my-collection' })
         t.same(agentAttributes['peer.hostname'], { [STRING_TYPE]: 'my-db-host' })
         t.same(agentAttributes['peer.address'], { [STRING_TYPE]: 'my-db-host:/path/to/db.sock' })
+        t.same(agentAttributes['db.system'], { [STRING_TYPE]: 'TestStore' }) // same as intrinsics.component
+        t.same(agentAttributes['server.address'], { [STRING_TYPE]: 'my-db-host' })
+        t.same(agentAttributes['server.port'], { [STRING_TYPE]: '/path/to/db.sock' })
 
         const statement = agentAttributes['db.statement']
         t.ok(statement)


### PR DESCRIPTION
## Description

Added OTEL-compliant `db.system`, `server.address`, and `server.port` properties to db spans.

## How to Test

This PR includes additions to `test/unit/spans/span-event.test.js` and `test/unit/spans/streaming-span-event.test.js`, so running unit tests will include these.

## Related Issues

Closes #2149 
Closes NR-260092