### PR TITLE
ci: Updated minimum version of lib-dynamo to work around peer dependency resolution

### DIFF
--- a/test/versioned/aws-sdk-v3/package.json
+++ b/test/versioned/aws-sdk-v3/package.json
@@ -188,9 +188,9 @@
       },
       "dependencies": {
         "@aws-sdk/util-dynamodb": "latest",
-        "@aws-sdk/client-dynamodb": "3.476.0",
+        "@aws-sdk/client-dynamodb": "latest",
         "@aws-sdk/lib-dynamodb": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
+          "versions": ">3.377.0 ",
           "samples": 10
         }
       },


### PR DESCRIPTION
It's been a while since we've had to work around aws sdk quirks. This PR updates the minimum of the dynamo peer deps to work around resolution issues