### PR TITLE
fix: Updated instrumentation to handle the different exports in 4.40.1 of `openai`

### DIFF
--- a/lib/instrumentation/openai.js
+++ b/lib/instrumentation/openai.js
@@ -15,6 +15,7 @@ const { RecorderSpec } = require('../../lib/shim/specs')
 
 const MIN_VERSION = '4.0.0'
 const MIN_STREAM_VERSION = '4.12.2'
+const WRAP_EXPORTS = '4.40.1'
 const { AI } = require('../../lib/metrics/names')
 const { OPENAI } = AI
 const semver = require('semver')
@@ -218,6 +219,15 @@ module.exports = function initialize(agent, openai, moduleName, shim) {
   // initially declaring the variable.
   TRACKING_METRIC = `${TRACKING_METRIC}/${shim.pkgVersion}`
 
+  if (semver.gte(shim.pkgVersion, WRAP_EXPORTS)) {
+    instrumentExport({ openai: openai.OpenAI, shim })
+  } else {
+    instrumentExport({ openai, shim })
+  }
+}
+
+function instrumentExport({ openai, shim }) {
+  const { agent } = shim
   /**
    * Instrumentation is only done to get the response headers and attach
    * to the active segment as openai hides the headers from the functions we are

--- a/test/versioned/openai/common.js
+++ b/test/versioned/openai/common.js
@@ -23,7 +23,7 @@ common.beforeHook = async function beforeHook(t) {
   t.context.port = port
   t.context.server = server
   t.context.agent = helper.instrumentMockedAgent(config)
-  const OpenAI = require('openai')
+  const OpenAI = require('openai').default
   t.context.client = new OpenAI({
     apiKey: 'fake-versioned-test-key',
     baseURL: `http://${host}:${port}`


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
This updates instrumentation to handle the update to `openai` in [4.40.1](https://github.com/openai/openai-node/issues/816).  I'm not sure we should release this fix as I think openai needs to issue a fix for this.  But this will unblock our CI for now. 

Also, FWIW `import-in-the-middle` causes OpenAI to crash

```
node ---loader=import-in-the-middle/hook.mjs --input-type=module -e "import OpenAI from 'openai'; const a = new OpenAI();"
```

## How to Test

`npm run versioned:internal openai`

## Related Issues

