### PR TITLE
chore: Added workflow for generating compatibility doc

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,6 +1,19 @@
 name: Node Agent CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '**/*.js'
+      - '**/*.cjs'
+      - '**/*.mjs'
+      - '**/*.json'
+  pull_request:
+    paths:
+      - '**/*.js'
+      - '**/*.cjs'
+      - '**/*.mjs'
+      - '**/*.json'
 
 env:
   # Enable versioned runner quiet mode to make CI output easier to read:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,19 +1,6 @@
 name: Node Agent CI
 
-on:
-  workflow_dispatch:
-  push:
-    paths:
-      - '**/*.js'
-      - '**/*.cjs'
-      - '**/*.mjs'
-      - '**/*.json'
-  pull_request:
-    paths:
-      - '**/*.js'
-      - '**/*.cjs'
-      - '**/*.mjs'
-      - '**/*.json'
+on: [push, pull_request, workflow_dispatch]
 
 env:
   # Enable versioned runner quiet mode to make CI output easier to read:

--- a/.github/workflows/compatibility-report.yml
+++ b/.github/workflows/compatibility-report.yml
@@ -13,6 +13,11 @@ on:
           - docs
           - both
 
+  workflow_run:
+    workflows: [ "Create Release" ]
+    types:
+      - completed
+
   push:
     branches:
       - main
@@ -24,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     if:
       github.event_name == 'push' ||
+      (github.event.workflow_run && github.event.workflow_run.conclusion == 'success') ||
       (github.event_name == 'workflow_dispatch' &&
       (inputs.repo_target == 'local' || inputs.repo_target == 'both'))
     steps:

--- a/.github/workflows/compatibility-report.yml
+++ b/.github/workflows/compatibility-report.yml
@@ -1,0 +1,48 @@
+name: Generate Compatibility Report
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo_target:
+        description: Generate the report for the local repo, the docs repo, or both.
+        required: true
+        type: choice
+        default: both
+        options:
+          - local
+          - docs
+          - both
+
+  pull_request:
+    paths:
+      - 'test/versioned/**/package.json'
+
+jobs:
+  local:
+    runs-on: ubuntu-latest
+    if:
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'workflow_dispatch' &&
+      (input.repo_target == 'local' || input.repo_target == 'both'))
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jaxxstorm/action-install-gh-release@71d17cb091aa850acb2a1a4cf87258d183eb941b
+        with:
+          repo: newrelic/newrelic-node-versions
+          platform: linux
+          arch: amd64
+          cache: enable
+      - run: |
+          nrversions -v -r . 2>status.log >./compatibility.md
+#      - run: |
+#          git config user.name $GITHUB_ACTOR
+#          git config user.email gh-actions-${GITHUB_ACTOR}@github.com
+      - uses: actions/upload-artifact@v4
+        with:
+          name: status.log
+          path: status.log
+      - uses: actions/upload-artifact@v4
+        with:
+          name: compatibility.md
+          path: compatibility.md
+

--- a/.github/workflows/compatibility-report.yml
+++ b/.github/workflows/compatibility-report.yml
@@ -13,7 +13,9 @@ on:
           - docs
           - both
 
-  pull_request:
+  push:
+    branches:
+      - main
     paths:
       - 'test/versioned/**/package.json'
 
@@ -21,9 +23,9 @@ jobs:
   local:
     runs-on: ubuntu-latest
     if:
-      github.event_name == 'pull_request' ||
+      github.event_name == 'push' ||
       (github.event_name == 'workflow_dispatch' &&
-      (input.repo_target == 'local' || input.repo_target == 'both'))
+      (inputs.repo_target == 'local' || inputs.repo_target == 'both'))
     steps:
       - uses: actions/checkout@v4
       - uses: jaxxstorm/action-install-gh-release@71d17cb091aa850acb2a1a4cf87258d183eb941b
@@ -34,9 +36,8 @@ jobs:
           cache: enable
       - run: |
           nrversions -v -r . 2>status.log >./compatibility.md
-#      - run: |
-#          git config user.name $GITHUB_ACTOR
-#          git config user.email gh-actions-${GITHUB_ACTOR}@github.com
+
+      # Upload generated artifacts for potential debugging purposes.
       - uses: actions/upload-artifact@v4
         with:
           name: status.log
@@ -45,4 +46,19 @@ jobs:
         with:
           name: compatibility.md
           path: compatibility.md
+
+      # Generate the new PR to update the doc in the repo.
+      - run: |
+          git config user.name $GITHUB_ACTOR
+          git config user.email gh-actions-${GITHUB_ACTOR}@github.com
+      - run: |
+          rm -f status.log
+      - uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e
+        with:
+          title: "docs: Updated compatibility report"
+          commit-message: "docs: Updated compatibility report"
+          branch: "compatibility-report/auto-update"
+          delete-branch: true
+          base: main
+          labels: "documentation"
 


### PR DESCRIPTION
This PR resolves #2178. The result will be: after any PR is merged to `main` that contains changes to any json files under `test/versioned/` a new PR will be automatically opened that updates the `compatibility.md` document in the root of the repository.

The workflow can also be triggered manually.

The automatic PR will continually update the same branch+PR until such time as that PR has been merged. Subsequent changes will result in new PRs.