### PR TITLE
chore: Fixed superagent versioned tests

### DIFF
--- a/test/versioned/superagent/superagent.tap.js
+++ b/test/versioned/superagent/superagent.tap.js
@@ -7,24 +7,32 @@
 
 const tap = require('tap')
 const helper = require('../../lib/agent_helper')
+const testServer = require('./test-server')
 const { removeModules } = require('../../lib/cache-buster')
-const EXTERNAL_NAME = /External\/newrelic.com(:443)*\//
+const EXTERNAL_NAME = /External\/127.0.0.1:\d+\//
 
 tap.test('SuperAgent instrumentation', (t) => {
-  t.beforeEach((t) => {
+  t.beforeEach(async (t) => {
+    const { address, server, stopServer } = await testServer()
+    t.context.address = address
+    t.context.server = server
+    t.context.stopServer = stopServer
+
     t.context.agent = helper.instrumentMockedAgent()
     t.context.request = require('superagent')
   })
-  t.afterEach((t) => {
+  t.afterEach(async (t) => {
     helper.unloadAgent(t.context.agent)
     removeModules(['superagent'])
+
+    await t.context.stopServer()
   })
 
   t.test('should maintain transaction context with callbacks', (t) => {
-    const { agent, request } = t.context
+    const { address, agent, request } = t.context
 
     helper.runInTransaction(agent, (tx) => {
-      request.get('https://newrelic.com', function testCallback() {
+      request.get(address, function testCallback() {
         t.ok(tx)
 
         const mainSegment = tx.trace.root.children[0]
@@ -42,17 +50,17 @@ tap.test('SuperAgent instrumentation', (t) => {
   })
 
   t.test('should not create a segment for callback if not in transaction', (t) => {
-    const { agent, request } = t.context
-    request.get('https://newrelic.com', function testCallback() {
+    const { address, agent, request } = t.context
+    request.get(address, function testCallback() {
       t.notOk(agent.getTransaction(), 'should not have a transaction')
       t.end()
     })
   })
 
   t.test('should maintain transaction context with promises', (t) => {
-    const { agent, request } = t.context
+    const { address, agent, request } = t.context
     helper.runInTransaction(agent, (tx) => {
-      request.get('https://newrelic.com').then(function testThen() {
+      request.get(address).then(function testThen() {
         t.ok(tx)
 
         const mainSegment = tx.trace.root.children[0]
@@ -70,8 +78,8 @@ tap.test('SuperAgent instrumentation', (t) => {
   })
 
   t.test('should not create segment for a promise if not in a transaction', (t) => {
-    const { agent, request } = t.context
-    request.get('https://newrelic.com').then(function testThen() {
+    const { address, agent, request } = t.context
+    request.get(address).then(function testThen() {
       t.notOk(agent.getTransaction(), 'should not have a transaction')
       t.end()
     })

--- a/test/versioned/superagent/test-server.js
+++ b/test/versioned/superagent/test-server.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const http = require('http')
+
+module.exports = async function testServer() {
+  const server = http.createServer()
+
+  server.on('request', (req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end('"ok"')
+  })
+
+  let address = await new Promise((resolve, reject) => {
+    server.listen(0, '127.0.0.1', (error) => {
+      if (error) {
+        return reject(error)
+      }
+      return resolve(server.address())
+    })
+  })
+
+  address = `http://${address.address}:${address.port}`
+
+  return { address, server, stopServer }
+
+  async function stopServer() {
+    await new Promise((resolve, reject) => {
+      if (server.closeAllConnections) {
+        // Node.js 16 does not support this method.
+        server.closeAllConnections()
+      }
+      server.close((error) => {
+        if (error) {
+          return reject(error)
+        }
+        return resolve()
+      })
+    })
+  }
+}


### PR DESCRIPTION
The superagent tests were making requests to the live `https://newrelic.com` server. Sometime between 2024-05-09 and 2024-05-10, that server started returning a 301 for requests in order to append a device parameter, e.g. `?device=desktop`.

This PR resolves that issue by making these tests query a local server.