### PR TITLE
chore: Removed outdated Slack reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,13 +37,6 @@ For more information about CLAs, please check out Alex Russell’s excellent
 post, [“Why Do I Need to Sign
 This?”](https://infrequently.org/2008/06/why-do-i-need-to-sign-this/).
 
-### Slack
-
-We host a public Slack with a dedicated channel for contributors and
-maintainers of open source projects hosted by New Relic. If you are
-contributing to this project, you're welcome to request access to the
-\#oss-contributors channel in the newrelicusers.slack.com workspace. To request access, please use this [link](https://join.slack.com/t/newrelicusers/shared_invite/zt-1ayj69rzm-~go~Eo1whIQGYnu3qi15ng).
-
 ## PR Guidelines
 
 ### Version Support


### PR DESCRIPTION
This PR is to resolve NR-149383 for this repo. The ticket suggests replacing the link with one to https://forum.newrelic.com/s/, but that just dumps people to a forums index where it is unclear what the user should be doing. I also don't know who monitors those forums; I know that our team does not currently do so. So I don't think it is worth adding the link.