### PR TITLE
ci: Updated the langchain vectorstore test to reference the correct version of `@langchain/core` getting tested

### DIFF
--- a/test/versioned/langchain/vectorstore.tap.js
+++ b/test/versioned/langchain/vectorstore.tap.js
@@ -10,7 +10,17 @@ const helper = require('../../lib/agent_helper')
 const { removeModules } = require('../../lib/cache-buster')
 // load the assertSegments assertion
 require('../../lib/metrics_helper')
-const { version: pkgVersion } = require('@langchain/core/package.json')
+const fs = require('fs')
+let pkgVersion
+try {
+  ;({ version: pkgVersion } = JSON.parse(
+    fs.readFileSync(
+      `${__dirname}/node_modules/@langchain/community/node_modules/@langchain/core/package.json`
+    )
+  ))
+} catch {
+  ;({ version: pkgVersion } = require('@langchain/core/package.json'))
+}
 const createOpenAIMockServer = require('../openai/mock-server')
 const { filterLangchainEvents, filterLangchainEventsByType } = require('./common')
 const { DESTINATIONS } = require('../../../lib/config/attribute-filter')


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

In the case where `@langchain/core` is different than `@langchain/community`, the version of `@langchain/core` getting instrumented varies.  We have a test that asserts the `Supportability/Nodejs/ML/Langchain/<version` metric and it needed to be updated to get the right version.  This adds a try catch and tries to assert the `@langchain/core` version from `@langchain/community` first and if it does not exist falls back to the shared `@langchain/core` version.

## How to Test

```npm run versioned:internal langchain```

## Related Issues

Closes #2201
