### PR TITLE
chore: Fixed aws-sdk-v3 bedrock tests

### DIFF
--- a/test/versioned/aws-sdk-v3/bedrock-chat-completions.tap.js
+++ b/test/versioned/aws-sdk-v3/bedrock-chat-completions.tap.js
@@ -11,8 +11,22 @@ const helper = require('../../lib/agent_helper')
 require('../../lib/metrics_helper')
 const createAiResponseServer = require('../../lib/aws-server-stubs/ai-server')
 const { FAKE_CREDENTIALS } = require('../../lib/aws-server-stubs')
-const { version: pkgVersion } = require('@smithy/smithy-client/package.json')
 const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
+
+const pkgVersion = (function () {
+  try {
+    const { version } = require('@smithy/smithy-client/package.json')
+    return version
+  } catch {
+    try {
+      const {
+        version
+      } = require('./node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/smithy-client/package.json')
+      return version
+    } catch {}
+  }
+  /* eslint-disable-next-line */
+}())
 
 const requests = {
   ai21: (prompt, modelId) => ({


### PR DESCRIPTION
It seems that prior to #2208 we somehow lucked into always having `@smithy/smithy-client` available in the BedRock chat completions test suite import paths. But post that PR, the resolution will sometimes make it not directly available to that suite. This PR solves the issue by requiring it from the known good paths for it.