### PR TITLE
chore: Fixed should-run CI step

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: jsumners-nr/gha-node-deps-divergent@643628fe0da51ec025e984c4644f17fd9f9e93f6
         id: deps
         with:
-          base-sha: ${{ github.base_ref }}
+          base-sha: ${{ github.base_ref || 'main' }}
           current-sha: ${{ github.sha }}
 
   lint:


### PR DESCRIPTION
This PR is a follow-up to #2157. The `github.base_ref` value is only available on pull request events. So we need a fallback for other events (e.g. a merge event).