### PR TITLE
chore: Fixed CI jobs

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,6 +1,9 @@
 name: Node Agent CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 env:
   # Enable versioned runner quiet mode to make CI output easier to read:
@@ -40,8 +43,9 @@ jobs:
   lint:
     needs:
       - should_run
-    if: needs.should_run.outputs.javascript_changed == 'true' ||
-      needs.should_run.outputs.deps_changed == 'true'
+    if: github.event_name == 'workflow_dispatch' ||
+      (needs.should_run.outputs.javascript_changed == 'true' ||
+      needs.should_run.outputs.deps_changed == 'true')
     runs-on: ubuntu-latest
 
     strategy:
@@ -62,8 +66,9 @@ jobs:
   ci:
     needs:
       - should_run
-    if: needs.should_run.outputs.javascript_changed == 'true' ||
-      needs.should_run.outputs.deps_changed == 'true'
+    if: github.event_name == 'workflow_dispatch' ||
+      (needs.should_run.outputs.javascript_changed == 'true' ||
+      needs.should_run.outputs.deps_changed == 'true')
     runs-on: ubuntu-latest
 
     strategy:
@@ -85,8 +90,9 @@ jobs:
   unit:
     needs:
       - should_run
-    if: needs.should_run.outputs.javascript_changed == 'true' ||
-      needs.should_run.outputs.deps_changed == 'true'
+    if: github.event_name == 'workflow_dispatch' ||
+      (needs.should_run.outputs.javascript_changed == 'true' ||
+      needs.should_run.outputs.deps_changed == 'true')
     runs-on: ubuntu-latest
 
     strategy:
@@ -113,8 +119,9 @@ jobs:
   integration:
     needs:
       - should_run
-    if: needs.should_run.outputs.javascript_changed == 'true' ||
-      needs.should_run.outputs.deps_changed == 'true'
+    if: github.event_name == 'workflow_dispatch' ||
+      (needs.should_run.outputs.javascript_changed == 'true' ||
+      needs.should_run.outputs.deps_changed == 'true')
     runs-on: ubuntu-latest
 
     env:
@@ -153,8 +160,9 @@ jobs:
   versioned-internal:
     needs:
       - should_run
-    if: needs.should_run.outputs.javascript_changed == 'true' ||
-      needs.should_run.outputs.deps_changed == 'true'
+    if: github.event_name == 'workflow_dispatch' ||
+      (needs.should_run.outputs.javascript_changed == 'true' ||
+      needs.should_run.outputs.deps_changed == 'true')
     runs-on: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER || 'ubuntu-latest' }}
 
     strategy:
@@ -203,8 +211,9 @@ jobs:
   versioned-external:
     needs:
       - should_run
-    if: needs.should_run.outputs.javascript_changed == 'true' ||
-      needs.should_run.outputs.deps_changed == 'true'
+    if: github.event_name == 'workflow_dispatch' ||
+      (needs.should_run.outputs.javascript_changed == 'true' ||
+      needs.should_run.outputs.deps_changed == 'true')
     runs-on: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER || 'ubuntu-latest' }}
 
     strategy:

--- a/.github/workflows/compatibility-report.yml
+++ b/.github/workflows/compatibility-report.yml
@@ -90,13 +90,17 @@ jobs:
           arch: amd64
           cache: enable
       - run: |
-          nrversions -v -r agent -R ${DOCS_TARGET} 2>docs-status.log
+          nrversions -v -r agent -R ./docs/${DOCS_TARGET} 2>docs-status.log
 
       # Upload generated artifacts for potential debugging purposes.
       - uses: actions/upload-artifact@v4
         with:
           name: docs-status.log
           path: docs-status.log
+      - uses: actions/upload-artifact@v4
+        with:
+          name: compatibility-requirements-nodejs-agent.mdx
+          path: docs/${{ env.DOCS_TARGET }}
 
       # Generate the new PR to update the doc in the repo.
       - run: |
@@ -109,4 +113,5 @@ jobs:
           branch: "nodejs-compatibility-report/auto-update"
           delete-branch: true
           base: develop
+          path: docs
           labels: "documentation"


### PR DESCRIPTION
This PR is a follow-up to #2157. It:

1. Fixes generation of the pull request to the docs site.
2. Adds a workflow dispatch case to enable direct CI job runs.

We can see:

1. A successful run of the docs website PR generation at https://github.com/newrelic/node-newrelic/actions/runs/9273360076 (resulting in https://github.com/newrelic/docs-website/pull/17465)
2. Manual CI invocations ignoring the result of `should_run` and running all jobs at https://github.com/newrelic/node-newrelic/actions/runs/9273527204