### PR TITLE
test: Updated langchain versioned tests to separate the vectorstore and other tests. This is to avoid peer resolution of `@langchain/community` package that is being used to test the elasticsearch vectorstore

### DIFF
--- a/test/versioned/langchain/package.json
+++ b/test/versioned/langchain/package.json
@@ -13,9 +13,23 @@
       },
       "dependencies": {
         "@langchain/core": ">=0.1.17",
-        "@langchain/openai": "latest",
-        "@langchain/community": "latest",
-        "@elastic/elasticsearch": "latest"
+        "@langchain/openai": "0.0.34"
+      },
+      "files": [
+        "tools.tap.js",
+        "runnables.tap.js",
+        "runnables-streaming.tap.js"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=18"
+      },
+      "dependencies": {
+        "@langchain/core": ">=0.1.17",
+        "@langchain/openai": "0.0.34",
+        "@langchain/community": "0.2.2",
+        "@elastic/elasticsearch": "8.13.1"
       },
       "files": [
         "tools.tap.js",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
We have issues when running langchain tests when the version of `@langchain/core` differs from `@langchain/community@0.2.3`.

```
/home/runner/work/node-newrelic/node-newrelic/test/versioned/langchain/tools.tap.js @langchain/core@0.2.2 @langchain/openai@0.0.34 @langchain/community@0.2.3 @elastic/elasticsearch@8.13.1
stdout

---------------------------------------------------------------
stderr
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: langchain-tests@0.0.0
npm error Found: @google-ai/generativelanguage@0.2.1
npm error node_modules/@google-ai/generativelanguage
npm error   peerOptional @google-ai/generativelanguage@"^0.2.1" from langchain@0.1.37
npm error   node_modules/langchain
npm error     peerOptional langchain@"~0.1.19" from @getzep/zep-cloud@1.0.3
npm error     node_modules/@getzep/zep-cloud
npm error       peerOptional @getzep/zep-cloud@"~1.0.0" from @langchain/community@0.2.3
npm error       node_modules/@langchain/community
npm error         @langchain/community@"0.2.3" from the root project
npm error
npm error Could not resolve dependency:
npm error peerOptional @google-ai/generativelanguage@"^2.5.0" from @langchain/community@0.2.3
npm error node_modules/@langchain/community
npm error   @langchain/community@"0.2.3" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /home/runner/.npm/_logs/2024-05-28T16_50_37_812Z-eresolve-report.txt

npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2024-05-28T16_50_37_812Z-debug-0.log
Failed to execute npm install --no-save --no-package-lock --no-audit --no-fund @langchain/core@0.2.2 @langchain/openai@0.0.34 @langchain/community@0.2.3 @elastic/elasticsearch@8.13.1

===============================================================
Versions executed
```

I worked around this by pinning a version of `@langchain/community`, elasticsearch in a separate test stanza. The library under test is `@langchain/core` so it'll be ok to pin the other versions until `@langchain/core` breaks with the pinned versions, which may or may happen in the future


## How to Test

```
npm run versioned:internal langchain
```
