### PR TITLE
test: Migrated `memcached` tests to versioned tests

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -140,8 +140,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
       run: npm install
-    - name: Run Docker Services
-      run: npm run services
     - name: Run Integration Tests
       run: npm run integration
     - name: Run ESM Integration Tests

--- a/package.json
+++ b/package.json
@@ -247,7 +247,6 @@
     "koa-router": "^12.0.1",
     "lint-staged": "^11.0.0",
     "lockfile-lint": "^4.9.6",
-    "memcached": ">=0.2.8",
     "nock": "11.8.0",
     "proxy": "^2.1.1",
     "proxyquire": "^1.8.0",

--- a/test/lib/agent_helper.js
+++ b/test/lib/agent_helper.js
@@ -9,7 +9,6 @@ const path = require('path')
 const fs = require('fs').promises
 const Agent = require('../../lib/agent')
 const API = require('../../api')
-const params = require('../lib/params')
 const zlib = require('zlib')
 const copy = require('../../lib/util/copy')
 const { defaultAttributeConfig } = require('./fixtures')
@@ -310,21 +309,6 @@ helper.runInSegment = (agent, name, callback) => {
   const tracer = agent.tracer
 
   return tracer.addSegment(name, null, null, null, callback)
-}
-
-/**
- * Stub to bootstrap a memcached instance
- *
- * @param {Function} callback The operations to be performed while the server
- *                            is running.
- */
-helper.bootstrapMemcached = (callback) => {
-  const Memcached = require('memcached')
-  const memcached = new Memcached(params.memcached_host + ':' + params.memcached_port)
-  memcached.flush((err) => {
-    memcached.end()
-    callback(err)
-  })
 }
 
 /**

--- a/test/versioned/memcached/newrelic.js
+++ b/test/versioned/memcached/newrelic.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+exports.config = {
+  app_name: ['My Application'],
+  license_key: 'license key here',
+  utilization: {
+    detect_aws: false,
+    detect_pcf: false,
+    detect_azure: false,
+    detect_gcp: false,
+    detect_docker: false
+  },
+  logging: {
+    enabled: false
+  }
+}

--- a/test/versioned/memcached/package.json
+++ b/test/versioned/memcached/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "memcached-test",
+  "targets": [{"name":"memcached","minAgentVersion":"1.26.2"}],
+  "version": "0.0.0",
+  "private": true,
+  "tests": [
+    {
+      "engines": {
+        "node": ">=16"
+      },
+      "dependencies": {
+        "memcached": ">=2.2.0"
+      },
+      "files": [
+        "memcached.tap.js"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Migrated `memcached` tests to versioned tests. I put the minimum range at 2.2.0 as anything earlier than that fails to install on node 18/20

## How to Test

```
npm run versioned:internal memcached
```

## Related Issues
Closes #2227 