### PR TITLE
chore: Removed targets for kafka versioned tests

### DIFF
--- a/test/versioned/kafkajs/package.json
+++ b/test/versioned/kafkajs/package.json
@@ -1,6 +1,5 @@
 {
   "name": "kafka-tests",
-  "targets": [{"name":"kafkajs","minAgentVersion":"11.19.0"}],
   "version": "0.0.0",
   "private": true,
   "tests": [


### PR DESCRIPTION
This PR removes the `targets` definition for the `kafkajs` temporarily so that https://github.com/newrelic/node-newrelic/pull/2234 can advance while we work on this instrumentation.