### PR TITLE
chore: Updated versioned tests due to update in @newrelic/security-agent V1.3.0

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -539,7 +539,7 @@ SOFTWARE.
 
 ### @newrelic/security-agent
 
-This product includes source derived from [@newrelic/security-agent](https://github.com/newrelic/csec-node-agent) ([v1.2.0](https://github.com/newrelic/csec-node-agent/tree/v1.2.0)), distributed under the [UNKNOWN License](https://github.com/newrelic/csec-node-agent/blob/v1.2.0/LICENSE):
+This product includes source derived from [@newrelic/security-agent](https://github.com/newrelic/csec-node-agent) ([v1.3.0](https://github.com/newrelic/csec-node-agent/tree/v1.3.0)), distributed under the [UNKNOWN License](https://github.com/newrelic/csec-node-agent/blob/v1.3.0/LICENSE):
 
 ```
 ## New Relic Software License v1.0
@@ -886,7 +886,7 @@ SOFTWARE.
 
 ### @aws-sdk/client-s3
 
-This product includes source derived from [@aws-sdk/client-s3](https://github.com/aws/aws-sdk-js-v3) ([v3.582.0](https://github.com/aws/aws-sdk-js-v3/tree/v3.582.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.582.0/LICENSE):
+This product includes source derived from [@aws-sdk/client-s3](https://github.com/aws/aws-sdk-js-v3) ([v3.587.0](https://github.com/aws/aws-sdk-js-v3/tree/v3.587.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.587.0/LICENSE):
 
 ```
                                 Apache License
@@ -1095,7 +1095,7 @@ This product includes source derived from [@aws-sdk/client-s3](https://github.co
 
 ### @aws-sdk/s3-request-presigner
 
-This product includes source derived from [@aws-sdk/s3-request-presigner](https://github.com/aws/aws-sdk-js-v3) ([v3.582.0](https://github.com/aws/aws-sdk-js-v3/tree/v3.582.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.582.0/LICENSE):
+This product includes source derived from [@aws-sdk/s3-request-presigner](https://github.com/aws/aws-sdk-js-v3) ([v3.587.0](https://github.com/aws/aws-sdk-js-v3/tree/v3.587.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.587.0/LICENSE):
 
 ```
                                 Apache License
@@ -2493,7 +2493,7 @@ THE SOFTWARE.
 
 ### aws-sdk
 
-This product includes source derived from [aws-sdk](https://github.com/aws/aws-sdk-js) ([v2.1626.0](https://github.com/aws/aws-sdk-js/tree/v2.1626.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js/blob/v2.1626.0/LICENSE.txt):
+This product includes source derived from [aws-sdk](https://github.com/aws/aws-sdk-js) ([v2.1631.0](https://github.com/aws/aws-sdk-js/tree/v2.1631.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js/blob/v2.1631.0/LICENSE.txt):
 
 ```
 
@@ -2892,7 +2892,7 @@ THE SOFTWARE.
 
 ### eslint-plugin-jsdoc
 
-This product includes source derived from [eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc) ([v48.2.5](https://github.com/gajus/eslint-plugin-jsdoc/tree/v48.2.5)), distributed under the [BSD-3-Clause License](https://github.com/gajus/eslint-plugin-jsdoc/blob/v48.2.5/LICENSE):
+This product includes source derived from [eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc) ([v48.2.7](https://github.com/gajus/eslint-plugin-jsdoc/tree/v48.2.7)), distributed under the [BSD-3-Clause License](https://github.com/gajus/eslint-plugin-jsdoc/blob/v48.2.7/LICENSE):
 
 ```
 Copyright (c) 2018, Gajus Kuizinas (http://gajus.com/)

--- a/compatibility.md
+++ b/compatibility.md
@@ -22,7 +22,7 @@ version.
 | `@grpc/grpc-js` | 1.4.0 | 1.10.8 | 8.17.0 |
 | `@hapi/hapi` | 20.1.2 | 21.3.9 | 9.0.0 |
 | `@koa/router` | 2.0.0 | 12.0.1 | 3.2.0 |
-| `@langchain/core` | 0.1.17 | 0.2.2 | 11.13.0 |
+| `@langchain/core` | 0.1.17 | 0.2.3 | 11.13.0 |
 | `@nestjs/cli` | 8.0.0 | 10.3.2 | 10.1.0 |
 | `@prisma/client` | 5.0.0 | 5.14.0 | 11.0.0 |
 | `@smithy/smithy-client` | 3.0.0 | 3.0.1 | 11.0.0 |
@@ -33,7 +33,7 @@ version.
 | `apollo-server-hapi` | 3.0.0 | 3.13.0 | `@newrelic/apollo-server-plugin@1.0.0` |
 | `apollo-server-koa` | 2.14.0 | 3.13.0 | `@newrelic/apollo-server-plugin@1.0.0` |
 | `apollo-server-lambda` | 2.14.0 | 3.13.0 | `@newrelic/apollo-server-plugin@1.0.0` |
-| `aws-sdk` | 2.2.48 | 2.1629.0 | 6.2.0 |
+| `aws-sdk` | 2.2.48 | 2.1630.0 | 6.2.0 |
 | `bluebird` | 2.0.0 | 3.7.2 | 1.27.0 |
 | `bunyan` | 1.8.12 | 1.8.15 | 9.3.0 |
 | `cassandra-driver` | 3.4.0 | 4.7.2 | 1.7.1 |
@@ -46,7 +46,8 @@ version.
 | `koa` | 2.0.0 | 2.15.3 | 3.2.0 |
 | `koa-route` | 2.0.0 | 4.0.1 | 3.2.0 |
 | `koa-router` | 2.0.0 | 12.0.1 | 3.2.0 |
-| `mongodb` | 2.1.0 | 6.6.2 | 1.32.0 |
+| `memcached` | 2.2.0 | 2.2.2 | 1.26.2 |
+| `mongodb` | 2.1.0 | 6.7.0 | 1.32.0 |
 | `mysql` | 2.2.0 | 2.18.1 | 1.32.0 |
 | `mysql2` | 1.3.1 | 3.9.9 | 1.32.0 |
 | `next` | 13.0.0 | 14.2.3 | `@newrelic/next@0.7.0` |
@@ -54,10 +55,12 @@ version.
 | `pg` | 8.2.0 | 8.11.5 | 9.0.0 |
 | `pg-native` | 2.0.0 | 3.0.1 | 9.0.0 |
 | `pino` | 7.0.0 | 9.1.0 | 8.11.0 |
+| `q` | 1.3.0 | 1.5.1 | 1.26.2 |
 | `redis` | 2.0.0 | 4.6.14 | 1.31.0 |
 | `restify` | 5.0.0 | 11.1.0 | 2.6.0 |
 | `superagent` | 2.0.0 | 9.0.2 | 4.9.0 |
 | `undici` | 4.7.0 | 6.18.2 | 11.1.0 |
+| `when` | 3.7.0 | 3.7.8 | 1.26.2 |
 | `winston` | 3.0.0 | 3.13.0 | 8.11.0 |
 
 *When package is not specified, support is within the `newrelic` package.

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "@grpc/grpc-js": "^1.9.4",
     "@grpc/proto-loader": "^0.7.5",
     "@newrelic/ritm": "^7.2.0",
-    "@newrelic/security-agent": "^1.1.1",
+    "@newrelic/security-agent": "^1.3.0",
     "@tyriar/fibonacci-heap": "^2.0.7",
     "concat-stream": "^2.0.0",
     "https-proxy-agent": "^7.0.1",

--- a/test/versioned/express/ignoring.tap.js
+++ b/test/versioned/express/ignoring.tap.js
@@ -38,7 +38,7 @@ test('ignoring an Express route', function (t) {
 
     const metrics = agent.metrics._metrics.unscoped
     // loading k2 adds instrumentation metrics for things it loads
-    const expectedMetrics = helper.isSecurityAgentEnabled(agent) ? 9 : 3
+    const expectedMetrics = helper.isSecurityAgentEnabled(agent) ? 11 : 3
     t.equal(
       Object.keys(metrics).length,
       expectedMetrics,

--- a/test/versioned/hapi/ignoring.tap.js
+++ b/test/versioned/hapi/ignoring.tap.js
@@ -29,7 +29,7 @@ test('ignoring a Hapi route', function (t) {
 
     const metrics = agent.metrics._metrics.unscoped
     // loading k2 adds instrumentation metrics for packages it instruments
-    const expectedMetrics = helper.isSecurityAgentEnabled(agent) ? 10 : 3
+    const expectedMetrics = helper.isSecurityAgentEnabled(agent) ? 11 : 3
     t.equal(
       Object.keys(metrics).length,
       expectedMetrics,

--- a/test/versioned/restify/pre-7/ignoring.tap.js
+++ b/test/versioned/restify/pre-7/ignoring.tap.js
@@ -8,14 +8,12 @@
 const test = require('tap').test
 const helper = require('../../../lib/agent_helper')
 const API = require('../../../../api')
-const semver = require('semver')
 
 test('Restify router introspection', function (t) {
   t.plan(7)
 
   const agent = helper.instrumentMockedAgent()
   const api = new API(agent)
-  const { version: pkgVersion } = require('restify/package')
   const server = require('restify').createServer()
 
   t.teardown(function () {
@@ -39,11 +37,7 @@ test('Restify router introspection', function (t) {
     // loading k2 adds instrumentation metrics for things it registers
     // this also differs between major versions of restify. 6+ also loads
     // k2 child_process instrumentation, fun fun fun
-    const expectedMetrics = helper.isSecurityAgentEnabled(agent)
-      ? semver.lt(pkgVersion, 'v6.0.0')
-        ? 14
-        : 15
-      : 7
+    const expectedMetrics = helper.isSecurityAgentEnabled(agent) ? 15 : 7
     t.equal(
       Object.keys(metrics).length,
       expectedMetrics,

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Wed May 29 2024 17:25:34 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Mon Jun 03 2024 11:14:52 GMT+0530 (India Standard Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -82,15 +82,15 @@
       "email": "w@tson.dk",
       "url": "https://twitter.com/wa7son"
     },
-    "@newrelic/security-agent@1.2.0": {
+    "@newrelic/security-agent@1.3.0": {
       "name": "@newrelic/security-agent",
-      "version": "1.2.0",
-      "range": "^1.1.1",
+      "version": "1.3.0",
+      "range": "^1.3.0",
       "licenses": "UNKNOWN",
       "repoUrl": "https://github.com/newrelic/csec-node-agent",
-      "versionedRepoUrl": "https://github.com/newrelic/csec-node-agent/tree/v1.2.0",
+      "versionedRepoUrl": "https://github.com/newrelic/csec-node-agent/tree/v1.3.0",
       "licenseFile": "node_modules/@newrelic/security-agent/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/csec-node-agent/blob/v1.2.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/csec-node-agent/blob/v1.3.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "newrelic"
     },
@@ -226,28 +226,28 @@
     }
   },
   "devDependencies": {
-    "@aws-sdk/client-s3@3.582.0": {
+    "@aws-sdk/client-s3@3.587.0": {
       "name": "@aws-sdk/client-s3",
-      "version": "3.582.0",
+      "version": "3.587.0",
       "range": "^3.556.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/aws/aws-sdk-js-v3",
-      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.582.0",
+      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.587.0",
       "licenseFile": "node_modules/@aws-sdk/client-s3/LICENSE",
-      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.582.0/LICENSE",
+      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.587.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "AWS SDK for JavaScript Team",
       "url": "https://aws.amazon.com/javascript/"
     },
-    "@aws-sdk/s3-request-presigner@3.582.0": {
+    "@aws-sdk/s3-request-presigner@3.587.0": {
       "name": "@aws-sdk/s3-request-presigner",
-      "version": "3.582.0",
+      "version": "3.587.0",
       "range": "^3.556.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/aws/aws-sdk-js-v3",
-      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.582.0",
+      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.587.0",
       "licenseFile": "node_modules/@aws-sdk/s3-request-presigner/LICENSE",
-      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.582.0/LICENSE",
+      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.587.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "AWS SDK for JavaScript Team",
       "url": "https://aws.amazon.com/javascript/"
@@ -376,15 +376,15 @@
       "licenseTextSource": "file",
       "publisher": "Caolan McMahon"
     },
-    "aws-sdk@2.1626.0": {
+    "aws-sdk@2.1631.0": {
       "name": "aws-sdk",
-      "version": "2.1626.0",
+      "version": "2.1631.0",
       "range": "^2.1604.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/aws/aws-sdk-js",
-      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js/tree/v2.1626.0",
+      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js/tree/v2.1631.0",
       "licenseFile": "node_modules/aws-sdk/LICENSE.txt",
-      "licenseUrl": "https://github.com/aws/aws-sdk-js/blob/v2.1626.0/LICENSE.txt",
+      "licenseUrl": "https://github.com/aws/aws-sdk-js/blob/v2.1631.0/LICENSE.txt",
       "licenseTextSource": "file",
       "publisher": "Amazon Web Services",
       "url": "https://aws.amazon.com/"
@@ -480,15 +480,15 @@
       "publisher": "Michael Radionov",
       "url": "https://github.com/mradionov"
     },
-    "eslint-plugin-jsdoc@48.2.5": {
+    "eslint-plugin-jsdoc@48.2.7": {
       "name": "eslint-plugin-jsdoc",
-      "version": "48.2.5",
+      "version": "48.2.7",
       "range": "^48.0.5",
       "licenses": "BSD-3-Clause",
       "repoUrl": "https://github.com/gajus/eslint-plugin-jsdoc",
-      "versionedRepoUrl": "https://github.com/gajus/eslint-plugin-jsdoc/tree/v48.2.5",
+      "versionedRepoUrl": "https://github.com/gajus/eslint-plugin-jsdoc/tree/v48.2.7",
       "licenseFile": "node_modules/eslint-plugin-jsdoc/LICENSE",
-      "licenseUrl": "https://github.com/gajus/eslint-plugin-jsdoc/blob/v48.2.5/LICENSE",
+      "licenseUrl": "https://github.com/gajus/eslint-plugin-jsdoc/blob/v48.2.7/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Gajus Kuizinas",
       "email": "gajus@gajus.com",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
* Updated @newrelic/security-agent to V1.3.0.
* Updated versioned tests for express, restify and hapi due to update in @newrelic/security-agent v1.3.0
* Due to update in invocation of instrumentation module for security agent, metric count has been changed.
## How to Test

```
npm run versioned:security
```
