### PR TITLE
chore: Updated flaky when test

### DIFF
--- a/test/versioned/when/when.tap.js
+++ b/test/versioned/when/when.tap.js
@@ -583,13 +583,12 @@ test('Promise#yield', function (t) {
 })
 
 test('Promise#delay', function (t) {
-  testPromiseInstanceMethod(t, 3, function (p, name) {
+  testPromiseInstanceMethod(t, 2, function (p, name) {
     const start = Date.now()
     return p.delay(100).then(function (x) {
       const end = Date.now()
       t.same(x, [1, 2, 3, name], name + 'should resolve with original promise')
-      t.ok(end - start > 98, name + 'should wait close to correct time')
-      t.ok(end - start < 125, name + 'should wait close to correct time')
+      t.ok(end - start >= 100, name + 'should delay at least the specified duration')
     })
   })
 })


### PR DESCRIPTION
This PR updates a flaky test in the `when` suite. An instance of the failure can be seen at https://github.com/newrelic/node-newrelic/actions/runs/9364306171/job/25777040589#step:7:1319. The issue is that the GitHub Actions environment is inconsistent. It routinely runs things slower than they would otherwise execute. Given the variability of JavaScript timers, we really only need to verify that the provided delay is met.