### PR TITLE
chore: Added AI support docs for automation

### DIFF
--- a/.github/workflows/compatibility-report.yml
+++ b/.github/workflows/compatibility-report.yml
@@ -23,6 +23,7 @@ on:
       - main
     paths:
       - 'test/versioned/**/package.json'
+      - 'ai-support.json'
 
 jobs:
   local:

--- a/ai-support.json
+++ b/ai-support.json
@@ -1,5 +1,5 @@
-{
-  "bedrock": {
+[
+  {
     "kind": "gateway",
     "title": "Amazon Bedrock",
     "models": [
@@ -58,7 +58,7 @@
           }
         ]
       },
-      
+
       {
         "name": "Titan",
         "features": [
@@ -75,7 +75,7 @@
     ]
   },
 
-  "langchain": {
+  {
     "kind": "abstraction",
     "title": "Langchain",
     "features": [
@@ -84,7 +84,7 @@
         "supported": true
       },
       {
-        "title": "Agents",
+        "title": "Chains",
         "supported": true
       },
       {
@@ -115,7 +115,7 @@
     ]
   },
 
-  "openai": {
+  {
     "kind": "sdk",
     "title": "OpenAI",
     "features": [
@@ -145,4 +145,4 @@
       }
     ]
   }
-}
+]

--- a/ai-support.json
+++ b/ai-support.json
@@ -1,0 +1,148 @@
+{
+  "bedrock": {
+    "kind": "gateway",
+    "title": "Amazon Bedrock",
+    "models": [
+      {
+        "name": "Claude",
+        "features": [
+          {
+            "title": "Text",
+            "supported": true
+          },
+          {
+            "title": "Image",
+            "supported": false
+          }
+        ]
+      },
+
+      {
+        "name": "Cohere",
+        "features": [
+          {
+            "title": "Text",
+            "supported": true
+          },
+          {
+            "title": "Image",
+            "supported": false
+          }
+        ]
+      },
+
+      {
+        "name": "Jurassic-2",
+        "features": [
+          {
+            "title": "Text",
+            "supported": true
+          },
+          {
+            "title": "Image",
+            "supported": false
+          }
+        ]
+      },
+
+      {
+        "name": "Llama2",
+        "features": [
+          {
+            "title": "Text",
+            "supported": true
+          },
+          {
+            "title": "Image",
+            "supported": false
+          }
+        ]
+      },
+      
+      {
+        "name": "Titan",
+        "features": [
+          {
+            "title": "Text",
+            "supported": true
+          },
+          {
+            "title": "Image",
+            "supported": false
+          }
+        ]
+      }
+    ]
+  },
+
+  "langchain": {
+    "kind": "abstraction",
+    "title": "Langchain",
+    "features": [
+      {
+        "title": "Agents",
+        "supported": true
+      },
+      {
+        "title": "Agents",
+        "supported": true
+      },
+      {
+        "title": "Vectorstores",
+        "supported": true
+      },
+      {
+        "title": "Tools",
+        "supported": true
+      }
+    ],
+    "providers": [
+      {
+        "name": "Azure OpenAI",
+        "supported": false,
+        "transitively": false
+      },
+      {
+        "name": "Amazon Bedrock",
+        "supported": false,
+        "transitively": false
+      },
+      {
+        "name": "OpenAI",
+        "supported": true,
+        "transitively": true
+      }
+    ]
+  },
+
+  "openai": {
+    "kind": "sdk",
+    "title": "OpenAI",
+    "features": [
+      {
+        "title": "Completions",
+        "supported": true
+      },
+      {
+        "title": "Chat",
+        "supported": true
+      },
+      {
+        "title": "Embeddings",
+        "supported": true
+      },
+      {
+        "title": "Files",
+        "supported": false
+      },
+      {
+        "title": "Images",
+        "supported": false
+      },
+      {
+        "title": "Audio",
+        "supported": false
+      }
+    ]
+  }
+}

--- a/ai-support.json
+++ b/ai-support.json
@@ -6,7 +6,7 @@
     "footnote": "Note: if a model supports streaming, we also instrument the streaming variant.",
     "models": [
       {
-        "name": "Claude",
+        "name": "Anthropic Claude",
         "features": [
           {
             "title": "Text",
@@ -34,7 +34,7 @@
       },
 
       {
-        "name": "Jurassic-2",
+        "name": "AI21 Labs Jurassic-2",
         "features": [
           {
             "title": "Text",
@@ -48,7 +48,7 @@
       },
 
       {
-        "name": "Llama2",
+        "name": "Meta Llama2",
         "features": [
           {
             "title": "Text",
@@ -62,7 +62,7 @@
       },
 
       {
-        "name": "Titan",
+        "name": "Amazon Titan",
         "features": [
           {
             "title": "Text",

--- a/ai-support.json
+++ b/ai-support.json
@@ -2,6 +2,8 @@
   {
     "kind": "gateway",
     "title": "Amazon Bedrock",
+    "preamble": "Through the `@aws-sdk/client-bedrock-runtime` module, we support:",
+    "footnote": "Note: if a model supports streaming, we also instrument the streaming variant.",
     "models": [
       {
         "name": "Claude",
@@ -78,6 +80,8 @@
   {
     "kind": "abstraction",
     "title": "Langchain",
+    "featuresPreamble": "The following general features of Langchain are supported:",
+    "providersPreamble": "Models/providers are generally supported transitively by our instrumentation of the provider's module.",
     "features": [
       {
         "title": "Agents",
@@ -118,6 +122,7 @@
   {
     "kind": "sdk",
     "title": "OpenAI",
+    "featuresPreamble": "Through the `openai` module, we support:",
     "features": [
       {
         "title": "Completions",

--- a/ai-support.spec.md
+++ b/ai-support.spec.md
@@ -1,0 +1,66 @@
+# AI Support Spec
+
+This document describes the structure of the [ai-support.json](./ai-support.json)
+file. The JSON file is utilized by an automation to update our documentation
+with the AI libraries/abstractions/gateways that we support.
+
+## Structure
+
+The general structure of the JSON file is that of an object who's keys
+map to a descriptor for a supported AI thing. Each descriptor has a `kind`
+property that indicates what sort of AI thing is being described.
+
+### kind = "abstraction"
+
+An abstraction is a module that provides a single common interface to many
+LLMs or gateways. An abstraction descriptor has the following fields:
+
++ `title` (string): A human readable name for the abstraction.
++ `features` (object[]): An array of feature entities.
++ `providers` (object[]): An array of provider entities.
+
+### kind = "gateway"
+
+A gateway is a service that provides access to multiple large language models
+(LLMs) through a single API. A gateway descriptor has the following fields:
+
++ `title` (string): A human readable name for the gateway.
++ `models` (object[]): An array of model entities.
+
+### kind = "sdk"
+
+A SDK is a module that provides an API that is specific to a single LLM. An SDK
+descriptor has the following fields:
+
++ `title` (string): A human readable name for the SDK.
++ `features` (object[]): An array of feature entities.
+
+## Entities
+
+### Feature
+
+Describes an LLM feature. It is an object with the following fields:
+
++ `title` (string): A human readable name for the feature.
++ `supported` (boolean): Indicates if our instrumentation supports the feature
+or not.
+
+### Model
+
+Describes an LLM, the features it supports, and the features we instrument. It
+is an object with the following fields:
+
++ `name` (string): A human readable name for the LLM.
++ `features` (object[]): An array of feature entities. 
+
+### Provider
+
+Describes an LLM or gateway that is supported by an abstraction. It is an object
+with the following fields:
+
++ `name` (string): A human readable name for the LLM or gateway.
++ `supported` (boolean): Indicates if we instrument this provider within the
+context of the abstraction.
++ `transitively` (boolean): Indicates if we instrument this provider directly
+in the instrumentation for the abstraction (`false`), or if we rely on a
+transitive instrumentation (`true`).

--- a/ai-support.spec.md
+++ b/ai-support.spec.md
@@ -16,6 +16,10 @@ An abstraction is a module that provides a single common interface to many
 LLMs or gateways. An abstraction descriptor has the following fields:
 
 + `title` (string): A human readable name for the abstraction.
++ `featuresPreamble` (string): An optional block of text that should be added
+to the document prior to the features table.
++ `providersPreamble` (string): An optional block of text that should be added
+to the document prior to the providers table.  
 + `features` (object[]): An array of feature entities.
 + `providers` (object[]): An array of provider entities.
 
@@ -25,6 +29,10 @@ A gateway is a service that provides access to multiple large language models
 (LLMs) through a single API. A gateway descriptor has the following fields:
 
 + `title` (string): A human readable name for the gateway.
++ `preamble` (string): An optional block of text that should be added to the
+document prior to the models table.
++ `footnote` (string): An optional block of text that should be added to the
+document subsequent to the models table.
 + `models` (object[]): An array of model entities.
 
 ### kind = "sdk"
@@ -33,6 +41,8 @@ A SDK is a module that provides an API that is specific to a single LLM. An SDK
 descriptor has the following fields:
 
 + `title` (string): A human readable name for the SDK.
++ `featuresPreamble` (string): An optional block of text that should be added
+to the document prior to the features table.
 + `features` (object[]): An array of feature entities.
 
 ## Entities


### PR DESCRIPTION
This PR is in support of #2253.

The purpose of this PR is to add a JSON file we can utilize in our docs automation to add documentation around which "AI" things we support, and how deep that support goes for each thing.

With the `ai-support.json` file in place, when our compatibility document automation is run it will generate a document that looks like the following:

<details>
<summary>Example report</summary>

```markdown
## Instrumented modules

After installation, the agent automatically instruments with our catalog of
supported Node.js libraries and frameworks. This gives you immediate access to
granular information specific to your web apps and servers.  For unsupported
frameworks or libraries, you'll need to instrument the agent yourself using the
[Node.js agent API](https://newrelic.github.io/node-newrelic/API.html).

**Note**: The latest supported version may not reflect the most recent supported
version.

| Package name | Minimum supported version | Latest supported version | Introduced in* |
| --- | --- | --- | --- |
| `@apollo/gateway` | 2.3.0 | 2.8.0 | `@newrelic/apollo-server-plugin@1.0.0` |
| `@apollo/server` | 4.0.0 | 4.10.4 | `@newrelic/apollo-server-plugin@2.1.0` |
| `@aws-sdk/client-bedrock-runtime` | 3.0.0 | 3.592.0 | 11.13.0 |
| `@aws-sdk/client-dynamodb` | 3.0.0 | 3.592.0 | 8.7.1 |
| `@aws-sdk/client-sns` | 3.0.0 | 3.592.0 | 8.7.1 |
| `@aws-sdk/client-sqs` | 3.0.0 | 3.592.0 | 8.7.1 |
| `@aws-sdk/smithy-client` | 3.0.0 | 3.374.0 | 8.7.1 |
| `@elastic/elasticsearch` | 7.16.0 | 8.13.1 | 11.9.0 |
| `@grpc/grpc-js` | 1.4.0 | 1.10.8 | 8.17.0 |
| `@hapi/hapi` | 20.1.2 | 21.3.9 | 9.0.0 |
| `@koa/router` | 2.0.0 | 12.0.1 | 3.2.0 |
| `@langchain/core` | 0.1.17 | 0.2.6 | 11.13.0 |
| `@nestjs/cli` | 8.0.0 | 10.3.2 | 10.1.0 |
| `@prisma/client` | 5.0.0 | 5.15.0 | 11.0.0 |
| `@smithy/smithy-client` | 3.0.0 | 3.1.1 | 11.0.0 |
| `amqplib` | 0.5.0 | 0.10.4 | 2.0.0 |
| `apollo-server` | 2.14.0 | 3.13.0 | `@newrelic/apollo-server-plugin@1.0.0` |
| `apollo-server-express` | 2.14.0 | 3.13.0 | `@newrelic/apollo-server-plugin@1.0.0` |
| `apollo-server-fastify` | 2.14.0 | 3.13.0 | `@newrelic/apollo-server-plugin@1.0.0` |
| `apollo-server-hapi` | 3.0.0 | 3.13.0 | `@newrelic/apollo-server-plugin@1.0.0` |
| `apollo-server-koa` | 2.14.0 | 3.13.0 | `@newrelic/apollo-server-plugin@1.0.0` |
| `apollo-server-lambda` | 2.14.0 | 3.13.0 | `@newrelic/apollo-server-plugin@1.0.0` |
| `aws-sdk` | 2.2.48 | 2.1637.0 | 6.2.0 |
| `bluebird` | 2.0.0 | 3.7.2 | 1.27.0 |
| `bunyan` | 1.8.12 | 1.8.15 | 9.3.0 |
| `cassandra-driver` | 3.4.0 | 4.7.2 | 1.7.1 |
| `connect` | 2.0.0 | 3.7.0 | 2.6.0 |
| `director` | 1.2.0 | 1.2.8 | 2.0.0 |
| `express` | 4.6.0 | 4.19.2 | 2.6.0 |
| `fastify` | 2.0.0 | 4.27.0 | 8.5.0 |
| `generic-pool` | 2.4.0 | 3.9.0 | 0.9.0 |
| `ioredis` | 3.0.0 | 5.4.1 | 1.26.2 |
| `koa` | 2.0.0 | 2.15.3 | 3.2.0 |
| `koa-route` | 2.0.0 | 4.0.1 | 3.2.0 |
| `koa-router` | 2.0.0 | 12.0.1 | 3.2.0 |
| `memcached` | 2.2.0 | 2.2.2 | 1.26.2 |
| `mongodb` | 2.1.0 | 6.7.0 | 1.32.0 |
| `mysql` | 2.2.0 | 2.18.1 | 1.32.0 |
| `mysql2` | 1.3.1 | 3.10.0 | 1.32.0 |
| `next` | 13.0.0 | 14.2.3 | `@newrelic/next@0.7.0` |
| `openai` | 4.0.0 | 4.49.1 | 11.13.0 |
| `pg` | 8.2.0 | 8.12.0 | 9.0.0 |
| `pg-native` | 2.0.0 | 3.1.0 | 9.0.0 |
| `pino` | 7.0.0 | 9.1.0 | 8.11.0 |
| `q` | 1.3.0 | 1.5.1 | 1.26.2 |
| `redis` | 2.0.0 | 4.6.14 | 1.31.0 |
| `restify` | 5.0.0 | 11.1.0 | 2.6.0 |
| `superagent` | 2.0.0 | 9.0.2 | 4.9.0 |
| `undici` | 4.7.0 | 6.18.2 | 11.1.0 |
| `when` | 3.7.0 | 3.7.8 | 1.26.2 |
| `winston` | 3.0.0 | 3.13.0 | 8.11.0 |

*When package is not specified, support is within the `newrelic` package.

## AI Monitoring Support

The Node.js agent supports the following AI platforms and integrations.

### Amazon Bedrock

Through the `@aws-sdk/client-bedrock-runtime` module, we support:

| Model | Image | Text |
| --- | --- | --- |
| Claude | ❌ | ✅ |
| Cohere | ❌ | ✅ |
| Jurassic-2 | ❌ | ✅ |
| Llama2 | ❌ | ✅ |
| Titan | ❌ | ✅ |

Note: if a model supports streaming, we also instrument the streaming variant.


### Langchain

The following general features of Langchain are supported:

| Agents | Chains | Tools | Vectorstores |
| --- | --- | --- | --- |
| ✅ | ✅ | ✅ | ✅ |

Models/providers are generally supported transitively by our instrumentation of the provider's module.

| Provider | Supported | Transitively |
| --- | --- | --- |
| Azure OpenAI | ❌ | ❌ |
| Amazon Bedrock | ❌ | ❌ |
| OpenAI | ✅ | ✅ |


### OpenAI

Through the `openai` module, we support:

| Audio | Chat | Completions | Embeddings | Files | Images |
| --- | --- | --- | --- | --- | --- |
| ❌ | ✅ | ✅ | ✅ | ❌ | ❌ |

```


</details>