### PR TITLE
test: Updated unit tests that were missing constructing specs at instrumentation source

### DIFF
--- a/lib/instrumentation/amqplib/amqplib.js
+++ b/lib/instrumentation/amqplib/amqplib.js
@@ -289,7 +289,7 @@ function wrapModel(shim, Model, promiseMode) {
     if (TEMP_RE.test(queue)) {
       queue = null
     }
-    return new MessageSubscribeSpec({
+    return new MessageSpec({
       queue,
       promise: promiseMode,
       callback: setCallback(shim, promiseMode)

--- a/test/unit/metric/datastore-instance.test.js
+++ b/test/unit/metric/datastore-instance.test.js
@@ -10,6 +10,7 @@ const tap = require('tap')
 const helper = require('../../lib/agent_helper')
 const DatastoreShim = require('../../../lib/shim/datastore-shim')
 const tests = require('../../lib/cross_agent_tests/datastores/datastore_instances')
+const DatastoreParameters = require('../../../lib/shim/specs/params/datastore')
 
 tap.test('Datastore instance metrics collected via the datastore shim', function (t) {
   t.autoend()
@@ -53,10 +54,10 @@ tap.test('Datastore instance metrics collected via the datastore shim', function
           port = test.unix_socket || test.database_path || test.port
         }
         return {
-          parameters: {
+          parameters: new DatastoreParameters({
             host: dbHost,
             port_path_or_id: port
-          }
+          })
         }
       })
 

--- a/test/unit/shim/message-shim.test.js
+++ b/test/unit/shim/message-shim.test.js
@@ -10,6 +10,7 @@ const DESTINATIONS = require('../../../lib/config/attribute-filter').DESTINATION
 const hashes = require('../../../lib/util/hashes')
 const helper = require('../../lib/agent_helper')
 const MessageShim = require('../../../lib/shim/message-shim')
+const { MessageSpec, MessageSubscribeSpec } = require('../../../lib/shim/specs')
 
 tap.test('MessageShim', function (t) {
   t.autoend()
@@ -201,7 +202,7 @@ tap.test('MessageShim', function (t) {
 
     t.test('should create a produce segment', function (t) {
       shim.recordProduce(wrappable, 'getActiveSegment', function () {
-        return { destinationName: 'foobar' }
+        return new MessageSpec({ destinationName: 'foobar' })
       })
 
       helper.runInTransaction(agent, function (tx) {
@@ -217,10 +218,10 @@ tap.test('MessageShim', function (t) {
 
     t.test('should add parameters to segment', function (t) {
       shim.recordProduce(wrappable, 'getActiveSegment', function () {
-        return {
+        return new MessageSpec({
           routingKey: 'foo.bar',
           parameters: { a: 'a', b: 'b' }
-        }
+        })
       })
 
       helper.runInTransaction(agent, function () {
@@ -236,12 +237,12 @@ tap.test('MessageShim', function (t) {
     t.test('should not add parameters when disabled', function (t) {
       agent.config.message_tracer.segment_parameters.enabled = false
       shim.recordProduce(wrappable, 'getActiveSegment', function () {
-        return {
+        return new MessageSpec({
           parameters: {
             a: 'a',
             b: 'b'
           }
-        }
+        })
       })
 
       helper.runInTransaction(agent, function () {
@@ -278,7 +279,7 @@ tap.test('MessageShim', function (t) {
         t.equal(this, wrappable)
         t.same(args, ['a', 'b', 'c'])
 
-        return { destinationName: 'foobar' }
+        return new MessageSpec({ destinationName: 'foobar' })
       })
 
       helper.runInTransaction(agent, function () {
@@ -302,7 +303,7 @@ tap.test('MessageShim', function (t) {
       }
 
       const wrapped = shim.recordProduce(toWrap, function () {
-        return { callback: shim.LAST }
+        return new MessageSpec({ callback: shim.LAST })
       })
 
       helper.runInTransaction(agent, function () {
@@ -322,7 +323,7 @@ tap.test('MessageShim', function (t) {
       }
 
       const wrapped = shim.recordProduce(toWrap, function () {
-        return { promise: true }
+        return new MessageSpec({ promise: true })
       })
 
       return helper.runInTransaction(agent, function () {
@@ -339,7 +340,7 @@ tap.test('MessageShim', function (t) {
 
     t.test('should create a child segment when `opaque` is false', function (t) {
       shim.recordProduce(wrappable, 'withNested', function () {
-        return { destinationName: 'foobar', opaque: false }
+        return new MessageSpec({ destinationName: 'foobar', opaque: false })
       })
 
       helper.runInTransaction(agent, (tx) => {
@@ -356,7 +357,7 @@ tap.test('MessageShim', function (t) {
 
     t.test('should not create a child segment when `opaque` is true', function (t) {
       shim.recordProduce(wrappable, 'withNested', function () {
-        return { destinationName: 'foobar', opaque: true }
+        return new MessageSpec({ destinationName: 'foobar', opaque: true })
       })
 
       helper.runInTransaction(agent, (tx) => {
@@ -374,7 +375,7 @@ tap.test('MessageShim', function (t) {
       agent.config.distributed_tracing.enabled = false
       const headers = {}
       shim.recordProduce(wrappable, 'getActiveSegment', function () {
-        return { headers: headers }
+        return new MessageSpec({ headers })
       })
 
       helper.runInTransaction(agent, function () {
@@ -389,7 +390,7 @@ tap.test('MessageShim', function (t) {
       let transaction = null
 
       shim.recordProduce(wrappable, 'getActiveSegment', function () {
-        return { destinationName: 'my-queue' }
+        return new MessageSpec({ destinationName: 'my-queue' })
       })
 
       helper.runInTransaction(agent, function (tx) {
@@ -450,7 +451,7 @@ tap.test('MessageShim', function (t) {
 
     t.test('should create a consume segment', function (t) {
       shim.recordConsume(wrappable, 'getActiveSegment', function () {
-        return { destinationName: 'foobar' }
+        return new MessageSpec({ destinationName: 'foobar' })
       })
 
       helper.runInTransaction(agent, function (tx) {
@@ -468,7 +469,7 @@ tap.test('MessageShim', function (t) {
       const cb = function () {}
 
       const wrapped = shim.recordConsume(helper.checkWrappedCb.bind(t, shim, cb), function () {
-        return { callback: shim.LAST }
+        return new MessageSpec({ callback: shim.LAST })
       })
 
       helper.runInTransaction(agent, function () {
@@ -559,7 +560,7 @@ tap.test('MessageShim', function (t) {
         executed = true
       }
       const wrapped = shim.recordConsume(toWrap, function () {
-        return { destinationName: 'foo' }
+        return new MessageSpec({ destinationName: 'foo' })
       })
 
       helper.runInTransaction(agent, function () {
@@ -572,7 +573,7 @@ tap.test('MessageShim', function (t) {
 
     t.test('should create a child segment when `opaque` is false', function (t) {
       shim.recordConsume(wrappable, 'withNested', function () {
-        return { destinationName: 'foobar', opaque: false }
+        return new MessageSpec({ destinationName: 'foobar', opaque: false })
       })
 
       helper.runInTransaction(agent, function (tx) {
@@ -589,7 +590,7 @@ tap.test('MessageShim', function (t) {
 
     t.test('should not create a child segment when `opaque` is true', function (t) {
       shim.recordConsume(wrappable, 'withNested', function () {
-        return { destinationName: 'foobar', opaque: true }
+        return new MessageSpec({ destinationName: 'foobar', opaque: true })
       })
 
       helper.runInTransaction(agent, function (tx) {
@@ -603,7 +604,7 @@ tap.test('MessageShim', function (t) {
 
     t.test('should create message broker metrics', function (t) {
       shim.recordConsume(wrappable, 'getActiveSegment', function () {
-        return { destinationName: 'foobar' }
+        return new MessageSpec({ destinationName: 'foobar' })
       })
 
       helper.runInTransaction(agent, function (tx) {
@@ -669,7 +670,7 @@ tap.test('MessageShim', function (t) {
     })
 
     t.test('should create a purge segment and metric', function (t) {
-      shim.recordPurgeQueue(wrappable, 'getActiveSegment', { queue: shim.FIRST })
+      shim.recordPurgeQueue(wrappable, 'getActiveSegment', new MessageSpec({ queue: shim.FIRST }))
 
       helper.runInTransaction(agent, function (tx) {
         const startingSegment = agent.tracer.getSegment()
@@ -687,7 +688,7 @@ tap.test('MessageShim', function (t) {
 
       shim.recordPurgeQueue(wrappable, 'getActiveSegment', function () {
         called = true
-        return { queue: shim.FIRST }
+        return new MessageSpec({ queue: shim.FIRST })
       })
 
       helper.runInTransaction(agent, function () {
@@ -716,9 +717,12 @@ tap.test('MessageShim', function (t) {
     t.test('should bind the callback if there is one', function (t) {
       const cb = function () {}
 
-      const wrapped = shim.recordPurgeQueue(helper.checkWrappedCb.bind(t, shim, cb), {
-        callback: shim.LAST
-      })
+      const wrapped = shim.recordPurgeQueue(
+        helper.checkWrappedCb.bind(t, shim, cb),
+        new MessageSpec({
+          callback: shim.LAST
+        })
+      )
 
       helper.runInTransaction(agent, function () {
         wrapped(cb)
@@ -730,15 +734,12 @@ tap.test('MessageShim', function (t) {
       const val = {}
       let segment = null
 
-      const wrapped = shim.recordPurgeQueue(
-        function () {
-          segment = shim.getSegment()
-          return new Promise(function (res) {
-            setTimeout(res, DELAY, val)
-          })
-        },
-        { promise: true }
-      )
+      const wrapped = shim.recordPurgeQueue(function () {
+        segment = shim.getSegment()
+        return new Promise(function (res) {
+          setTimeout(res, DELAY, val)
+        })
+      }, new MessageSpec({ promise: true }))
 
       return helper.runInTransaction(agent, function () {
         return wrapped().then(function (v) {
@@ -754,7 +755,7 @@ tap.test('MessageShim', function (t) {
 
     t.test('should create message broker metrics', function (t) {
       let transaction = null
-      shim.recordPurgeQueue(wrappable, 'getActiveSegment', { queue: shim.FIRST })
+      shim.recordPurgeQueue(wrappable, 'getActiveSegment', new MessageSpec({ queue: shim.FIRST }))
 
       helper.runInTransaction(agent, function (tx) {
         transaction = tx
@@ -867,7 +868,7 @@ tap.test('MessageShim', function (t) {
           if (messageHandler) {
             return messageHandler.apply(this, arguments)
           }
-          return {
+          return new MessageSubscribeSpec({
             destinationName: 'exchange.foo',
             destinationType: shim.EXCHANGE,
             routingKey: 'routing.key',
@@ -875,7 +876,7 @@ tap.test('MessageShim', function (t) {
               queue_name: 'amq.randomQueueName'
             },
             parameters: { a: 'a', b: 'b' }
-          }
+          })
         }
       })
     })
@@ -914,7 +915,7 @@ tap.test('MessageShim', function (t) {
 
     t.test('should end the transaction based on a promise', function (t) {
       messageHandler = function () {
-        return { promise: true }
+        return new MessageSpec({ promise: true })
       }
 
       wrapped('my.queue', function consumer() {
@@ -936,7 +937,7 @@ tap.test('MessageShim', function (t) {
 
     t.test('should properly time promise based consumers', function (t) {
       messageHandler = function () {
-        return { promise: true }
+        return new MessageSpec({ promise: true })
       }
 
       let segment
@@ -1050,7 +1051,7 @@ tap.test('MessageShim', function (t) {
         consumer: shim.SECOND,
         callback: shim.LAST,
         messageHandler: function () {
-          return {}
+          return new MessageSpec({})
         }
       })
 
@@ -1072,10 +1073,10 @@ tap.test('MessageShim', function (t) {
       ]
 
       messageHandler = function () {
-        return {
+        return new MessageSpec({
           destinationName: null,
           destinationType: shim.EXCHANGE
-        }
+        })
       }
 
       wrapped('my.queue', function consumer() {
@@ -1110,11 +1111,11 @@ tap.test('MessageShim', function (t) {
           NewRelicTransaction: txHeader
         }
 
-        return {
+        return new MessageSpec({
           destinationName: 'foo',
           destingationType: shim.EXCHANGE,
           headers: catHeaders
-        }
+        })
       }
 
       wrapped('my.queue', function consumer() {
@@ -1183,10 +1184,10 @@ tap.test('MessageShim', function (t) {
         functions: ['eachMessage'],
         messageHandler: function (shim, args) {
           t.same(args[0], message)
-          return {
+          return new MessageSpec({
             destinationName: 'exchange.foo',
             destinationType: shim.EXCHANGE
-          }
+          })
         }
       })
       wrapped({

--- a/test/unit/shim/shim.test.js
+++ b/test/unit/shim/shim.test.js
@@ -10,6 +10,7 @@ const { EventEmitter } = require('events')
 const helper = require('../../lib/agent_helper')
 const Shim = require('../../../lib/shim/shim')
 const symbols = require('../../../lib/symbols')
+const { RecorderSpec } = require('../../../lib/shim/specs')
 
 tap.test('Shim', function (t) {
   t.autoend()
@@ -911,7 +912,7 @@ tap.test('Shim', function (t) {
 
     t.test('should not create a child segment', function (t) {
       shim.record(wrappable, 'getActiveSegment', function () {
-        return { name: 'internal test segment', internal: true }
+        return new RecorderSpec({ name: 'internal test segment', internal: true })
       })
 
       helper.runInTransaction(agent, function (tx) {
@@ -934,7 +935,7 @@ tap.test('Shim', function (t) {
           t.end()
         },
         function () {
-          return { name: 'test segment', internal: true, callback: shim.LAST }
+          return new RecorderSpec({ name: 'test segment', internal: true, callback: shim.LAST })
         }
       )
 
@@ -955,12 +956,12 @@ tap.test('Shim', function (t) {
             t.equal(agent.getTransaction(), null)
           },
           function () {
-            return {
+            return new RecorderSpec({
               name: 'test segment',
               internal: true,
               callback: shim.LAST,
               parent: tx.trace.root
-            }
+            })
           }
         )
         t.doesNotThrow(function () {
@@ -976,7 +977,7 @@ tap.test('Shim', function (t) {
           return 'result'
         }
         const wrapped = shim.record(testAfter, function () {
-          return {
+          return new RecorderSpec({
             name: 'test segment',
             callback: shim.LAST,
             after(args) {
@@ -988,7 +989,7 @@ tap.test('Shim', function (t) {
               t.equal(name, testAfter.name)
               t.equal(result, 'result')
             }
-          }
+          })
         })
         t.doesNotThrow(function () {
           wrapped()
@@ -1006,7 +1007,7 @@ tap.test('Shim', function (t) {
             throw err
           }
           const wrapped = shim.record(testAfter, function () {
-            return {
+            return new RecorderSpec({
               name: 'test segment',
               callback: shim.LAST,
               after(args) {
@@ -1018,7 +1019,7 @@ tap.test('Shim', function (t) {
                 t.same(fn, testAfter)
                 t.equal(name, testAfter.name)
               }
-            }
+            })
           })
           t.throws(function () {
             wrapped()
@@ -1051,7 +1052,7 @@ tap.test('Shim', function (t) {
 
     t.test('should make the segment translucent when `end` is emitted', function (t) {
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment', stream: true, opaque: true }
+        return new RecorderSpec({ name: 'test segment', stream: true, opaque: true })
       })
 
       helper.runInTransaction(agent, function () {
@@ -1069,7 +1070,7 @@ tap.test('Shim', function (t) {
 
     t.test('should touch the segment when `end` is emitted', function (t) {
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment', stream: true }
+        return new RecorderSpec({ name: 'test segment', stream: true })
       })
 
       helper.runInTransaction(agent, function () {
@@ -1087,7 +1088,7 @@ tap.test('Shim', function (t) {
 
     t.test('should make the segment translucent when `error` is emitted', function (t) {
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment', stream: true, opaque: true }
+        return new RecorderSpec({ name: 'test segment', stream: true, opaque: true })
       })
 
       helper.runInTransaction(agent, function () {
@@ -1106,7 +1107,7 @@ tap.test('Shim', function (t) {
 
     t.test('should touch the segment when `error` is emitted', function (t) {
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment', stream: true }
+        return new RecorderSpec({ name: 'test segment', stream: true })
       })
 
       helper.runInTransaction(agent, function () {
@@ -1125,7 +1126,7 @@ tap.test('Shim', function (t) {
 
     t.test('should throw if there are no other `error` handlers', function (t) {
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment', stream: true }
+        return new RecorderSpec({ name: 'test segment', stream: true })
       })
 
       helper.runInTransaction(agent, function () {
@@ -1141,7 +1142,7 @@ tap.test('Shim', function (t) {
 
     t.test('should bind emit to a child segment', function (t) {
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment', stream: 'foobar' }
+        return new RecorderSpec({ name: 'test segment', stream: 'foobar' })
       })
 
       helper.runInTransaction(agent, function () {
@@ -1159,7 +1160,7 @@ tap.test('Shim', function (t) {
 
     t.test('should create an event segment if an event name is given', function (t) {
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment', stream: 'foobar' }
+        return new RecorderSpec({ name: 'test segment', stream: 'foobar' })
       })
 
       helper.runInTransaction(agent, function () {
@@ -1220,7 +1221,7 @@ tap.test('Shim', function (t) {
 
     t.test('should make the segment translucent when promise resolves', function (t) {
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment', promise: true, opaque: true }
+        return new RecorderSpec({ name: 'test segment', promise: true, opaque: true })
       })
 
       const result = {}
@@ -1245,7 +1246,7 @@ tap.test('Shim', function (t) {
 
     t.test('should touch the segment when promise resolves', function (t) {
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment', promise: true }
+        return new RecorderSpec({ name: 'test segment', promise: true })
       })
 
       const result = {}
@@ -1270,7 +1271,7 @@ tap.test('Shim', function (t) {
 
     t.test('should make the segment translucent when promise rejects', function (t) {
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment', promise: true, opaque: true }
+        return new RecorderSpec({ name: 'test segment', promise: true, opaque: true })
       })
 
       const result = {}
@@ -1300,7 +1301,7 @@ tap.test('Shim', function (t) {
 
     t.test('should touch the segment when promise rejects', function (t) {
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment', promise: true }
+        return new RecorderSpec({ name: 'test segment', promise: true })
       })
 
       const result = {}
@@ -1330,7 +1331,7 @@ tap.test('Shim', function (t) {
 
     t.test('should not affect unhandledRejection event', function (t) {
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment', promise: true }
+        return new RecorderSpec({ name: 'test segment', promise: true })
       })
 
       const result = {}
@@ -1357,7 +1358,7 @@ tap.test('Shim', function (t) {
       const segmentName = 'test segment'
       const expectedResult = { returned: true }
       const wrapped = shim.record(toWrap, function () {
-        return {
+        return new RecorderSpec({
           name: segmentName,
           promise: true,
           after(args) {
@@ -1370,7 +1371,7 @@ tap.test('Shim', function (t) {
             t.equal(segment.name, segmentName)
             t.end()
           }
-        }
+        })
       })
 
       helper.runInTransaction(agent, function () {
@@ -1387,7 +1388,7 @@ tap.test('Shim', function (t) {
       const segmentName = 'test segment'
       const expectedResult = { returned: true }
       const wrapped = shim.record(toWrap, function () {
-        return {
+        return new RecorderSpec({
           name: segmentName,
           promise: true,
           after(args) {
@@ -1399,7 +1400,7 @@ tap.test('Shim', function (t) {
             t.equal(segment.name, segmentName)
             t.end()
           }
-        }
+        })
       })
 
       helper.runInTransaction(agent, function () {
@@ -1419,7 +1420,7 @@ tap.test('Shim', function (t) {
     t.afterEach(afterEach)
     t.test('should not create a segment', function (t) {
       shim.record(wrappable, 'getActiveSegment', function () {
-        return { name: 'test segment' }
+        return new RecorderSpec({ name: 'test segment' })
       })
 
       const segment = wrappable.getActiveSegment()
@@ -1433,7 +1434,7 @@ tap.test('Shim', function (t) {
         executed = true
       }
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment' }
+        return new RecorderSpec({ name: 'test segment' })
       })
 
       t.notOk(executed)
@@ -1463,7 +1464,7 @@ tap.test('Shim', function (t) {
       }
 
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment', callback: shim.LAST }
+        return new RecorderSpec({ name: 'test segment', callback: shim.LAST })
       })
       wrapped(cb)
     })
@@ -1472,7 +1473,7 @@ tap.test('Shim', function (t) {
       const cb = function () {}
 
       const wrapped = shim.record(checkNotWrapped.bind(t, cb), function () {
-        return { name: 'test segment', rowCallback: shim.LAST }
+        return new RecorderSpec({ name: 'test segment', rowCallback: shim.LAST })
       })
       wrapped(cb)
     })
@@ -1484,7 +1485,7 @@ tap.test('Shim', function (t) {
     t.afterEach(afterEach)
     t.test('should create a segment', function (t) {
       shim.record(wrappable, 'getActiveSegment', function () {
-        return { name: 'test segment' }
+        return new RecorderSpec({ name: 'test segment' })
       })
 
       helper.runInTransaction(agent, function (tx) {
@@ -1504,7 +1505,7 @@ tap.test('Shim', function (t) {
         executed = true
       }
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment' }
+        return new RecorderSpec({ name: 'test segment' })
       })
 
       helper.runInTransaction(agent, function () {
@@ -1548,7 +1549,7 @@ tap.test('Shim', function (t) {
       }
 
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment', callback: shim.LAST }
+        return new RecorderSpec({ name: 'test segment', callback: shim.LAST })
       })
 
       helper.runInTransaction(agent, function () {
@@ -1560,7 +1561,7 @@ tap.test('Shim', function (t) {
       const cb = function () {}
 
       const wrapped = shim.record(helper.checkWrappedCb.bind(t, shim, cb), function () {
-        return { name: 'test segment', rowCallback: shim.LAST }
+        return new RecorderSpec({ name: 'test segment', rowCallback: shim.LAST })
       })
 
       helper.runInTransaction(agent, function () {
@@ -1588,7 +1589,11 @@ tap.test('Shim', function (t) {
       }
 
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment', callback: shim.LAST, callbackRequired: true }
+        return new RecorderSpec({
+          name: 'test segment',
+          callback: shim.LAST,
+          callbackRequired: true
+        })
       })
 
       helper.runInTransaction(agent, function () {
@@ -1609,7 +1614,11 @@ tap.test('Shim', function (t) {
       }
 
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment', callback: shim.LAST, callbackRequired: true }
+        return new RecorderSpec({
+          name: 'test segment',
+          callback: shim.LAST,
+          callbackRequired: true
+        })
       })
 
       helper.runInTransaction(agent, function () {
@@ -1629,7 +1638,7 @@ tap.test('Shim', function (t) {
     t.afterEach(afterEach)
     t.test('should not create a segment', function (t) {
       shim.record(wrappable, 'getActiveSegment', function () {
-        return { name: 'test segment' }
+        return new RecorderSpec({ name: 'test segment' })
       })
 
       helper.runInTransaction(agent, function (tx) {
@@ -1647,7 +1656,7 @@ tap.test('Shim', function (t) {
         executed = true
       }
       const wrapped = shim.record(toWrap, function () {
-        return { name: 'test segment' }
+        return new RecorderSpec({ name: 'test segment' })
       })
 
       helper.runInTransaction(agent, function (tx) {
@@ -1676,7 +1685,7 @@ tap.test('Shim', function (t) {
     t.test('should not bind the callback if there is one', function (t) {
       const cb = function () {}
       const wrapped = shim.record(checkNotWrapped.bind(t, cb), function () {
-        return { name: 'test segment', callback: shim.LAST }
+        return new RecorderSpec({ name: 'test segment', callback: shim.LAST })
       })
 
       helper.runInTransaction(agent, function (tx) {
@@ -1688,7 +1697,7 @@ tap.test('Shim', function (t) {
     t.test('should not bind the rowCallback if there is one', function (t) {
       const cb = function () {}
       const wrapped = shim.record(checkNotWrapped.bind(t, cb), function () {
-        return { name: 'test segment', rowCallback: shim.LAST }
+        return new RecorderSpec({ name: 'test segment', rowCallback: shim.LAST })
       })
 
       helper.runInTransaction(agent, function (tx) {

--- a/test/unit/spans/span-event.test.js
+++ b/test/unit/spans/span-event.test.js
@@ -10,6 +10,8 @@ const DatastoreShim = require('../../../lib/shim/datastore-shim')
 const helper = require('../../lib/agent_helper')
 const https = require('https')
 const SpanEvent = require('../../../lib/spans/span-event')
+const DatastoreParameters = require('../../../lib/shim/specs/params/datastore')
+const { QuerySpec } = require('../../../lib/shim/specs')
 
 tap.test('#constructor() should construct an empty span event', (t) => {
   const attrs = {}
@@ -204,16 +206,20 @@ tap.test('fromSegment()', (t) => {
     while (Buffer.byteLength(longQuery, 'utf8') < 2001) {
       longQuery += 'a'
     }
-    shim.recordQuery(dsConn, 'myDbOp', {
-      callback: shim.LAST,
-      query: shim.FIRST,
-      parameters: {
-        host: 'my-db-host',
-        port_path_or_id: '/path/to/db.sock',
-        database_name: 'my-database',
-        collection: 'my-collection'
-      }
-    })
+    shim.recordQuery(
+      dsConn,
+      'myDbOp',
+      new QuerySpec({
+        callback: shim.LAST,
+        query: shim.FIRST,
+        parameters: new DatastoreParameters({
+          host: 'my-db-host',
+          port_path_or_id: '/path/to/db.sock',
+          database_name: 'my-database',
+          collection: 'my-collection'
+        })
+      })
+    )
 
     shim.setParser((query) => {
       return {

--- a/test/unit/spans/streaming-span-event.test.js
+++ b/test/unit/spans/streaming-span-event.test.js
@@ -10,6 +10,10 @@ const DatastoreShim = require('../../../lib/shim/datastore-shim')
 const helper = require('../../lib/agent_helper')
 const https = require('https')
 const StreamingSpanEvent = require('../../../lib/spans/streaming-span-event')
+const {
+  QuerySpec,
+  params: { DatastoreParameters }
+} = require('../../../lib/shim/specs')
 
 const CATEGORIES = {
   HTTP: 'http',
@@ -195,16 +199,20 @@ tap.test('fromSegment()', (t) => {
     while (Buffer.byteLength(longQuery, 'utf8') < 2001) {
       longQuery += 'a'
     }
-    shim.recordQuery(dsConn, 'myDbOp', {
-      callback: shim.LAST,
-      query: shim.FIRST,
-      parameters: {
-        host: 'my-db-host',
-        port_path_or_id: '/path/to/db.sock',
-        database_name: 'my-database',
-        collection: 'my-collection'
-      }
-    })
+    shim.recordQuery(
+      dsConn,
+      'myDbOp',
+      new QuerySpec({
+        callback: shim.LAST,
+        query: shim.FIRST,
+        parameters: new DatastoreParameters({
+          host: 'my-db-host',
+          port_path_or_id: '/path/to/db.sock',
+          database_name: 'my-database',
+          collection: 'my-collection'
+        })
+      })
+    )
 
     shim.setParser((query) => {
       return {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
I noticed a few unit tests were not constructing specs while doing kafkajs work.  This PR updates all places where tests are using shim and to properly construct specs/params for info it passes to the shim helper method.
