### PR TITLE
chore: Fixed comment about transaction_tracer.transaction_threshold

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -519,12 +519,13 @@ defaultConfig.definition = () => ({
       env: 'NEW_RELIC_TRACER_ENABLED'
     },
     /**
-     * The duration at below which the slow transaction tracer should collect a
-     * transaction trace. If set to 'apdex_f', the threshold will be set to
+     * Sets the time, in seconds, for a transaction to be considered slow.
+     * When a transaction exceeds this threshold it will be marked as a slow
+     * transaction. When set to 'apdex_f', the threshold will be set to
      * 4 * apdex_t, which with a default apdex_t value of 500 milliseconds will
      * be 2 seconds.
      *
-     * If a time is provided, it is set in seconds.
+     * If a number is provided, it is set in seconds.
      */
     transaction_threshold: {
       formatter: float,


### PR DESCRIPTION
This PR fixes a comment in our configuration defaults. Basically, the comment had the intention inverted. The best documentation I could find to verify the configuration setting in general is in the Java agent's code -- https://github.com/newrelic/newrelic-java-agent/blob/a4187358aeeda79d9b9d0b7ca87faf378bd35d82/newrelic-agent/src/main/resources/newrelic.yml#L195-L213. This meshes with our actual implementation: https://github.com/newrelic/node-newrelic/blob/46924e519f49f738907b1a639a90d19e48eb5516/lib/transaction/trace/aggregator.js#L231-L292