### PR TITLE
chore: Updated docker compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
 
   elasticsearch:
@@ -63,7 +62,7 @@ services:
 
   mongodb_3:
     container_name: nr_node_mongodb
-    platform: linux/amd64
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     image: library/mongo:3
     ports:
       - "27017:27017"
@@ -86,6 +85,8 @@ services:
 
   mysql:
     container_name: nr_node_mysql
+    # The `mysql:5` image does not have a `linux/arm64` build.
+    # We cannot use the latest mysql image because our tests fail.
     platform: linux/amd64
     image: mysql:5
     ports:
@@ -111,15 +112,15 @@ services:
 
   cassandra:
     container_name: nr_node_cassandra
-    platform: linux/amd64
-    image: zmarcantel/cassandra
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
+    image: cassandra
     ports:
       - "9042:9042"
     healthcheck:
       test: [ "CMD", "cqlsh", "-u cassandra", "-p cassandra"]
       interval: 5s
       timeout: 10s
-      retries: 6
+      retries: 20
 
   # pg 9.2 has built in healthcheck
   pg:

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "lint:fix": "eslint --fix, ./*.{js,mjs} lib test bin examples",
     "public-docs": "jsdoc -c ./jsdoc-conf.jsonc && cp examples/shim/*.png out/",
     "publish-docs": "./bin/publish-docs.sh",
-    "services": "docker compose up -d --wait",
+    "services": "DOCKER_PLATFORM=linux/$(uname -m) docker compose up -d --wait",
     "services:stop": "docker compose down",
     "smoke": "npm run ssl && time tap test/smoke/**/**/*.tap.js --timeout=180 --no-coverage",
     "ssl": "./bin/ssl.sh",


### PR DESCRIPTION
It seems there was a release of Docker around 2024-06-11 that started showing what looks like a warning but is really an error that terminates `docker-compose up`:

https://github.com/newrelic/node-newrelic/actions/runs/9479735600/job/26126953241
> [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/zmarcantel/cassandra:latest to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/

This PR fixes it by updating the configuration.