### PR TITLE
ci: Updated security agent workflow to use large runners when available

### DIFF
--- a/.github/workflows/versioned-security-agent.yml
+++ b/.github/workflows/versioned-security-agent.yml
@@ -58,7 +58,7 @@ jobs:
       github.event_name == 'schedule' ||
       needs.should_run.outputs.sec_agent_did_change == 'true'
 
-    runs-on: ubuntu-latest
+    runs-on: {{ vars.NR_RUNNER || 'ubuntu-latest' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We've had flappy nightly runs with versioned tests with security agent and memcached tests.

```sh
 # Subtest: captures datastore instance attributes with multiple hosts
        # Subtest: separate gets
            not ok 1 - timeout!
              ---
              expired: memcached instrumentation
              test: separate gets
              ...
            
            1..1
            # failed 1 test
        not ok 1 - separate gets # time=36.22ms
        
        # Subtest: multi-get
            not ok 1 - Maximum call stack size exceeded
              ---
              stack: |
                Client.stubbedCommand (memcached.tap.js:654:9)
                Client.stubbedCommand (memcached.tap.js:654:21)
                Client.stubbedCommand (memcached.tap.js:654:21)
                Client.stubbedCommand (memcached.tap.js:654:21)
                Client.stubbedCommand (memcached.tap.js:654:21)
                Client.stubbedCommand (memcached.tap.js:654:21)
                Client.stubbedCommand (memcached.tap.js:654:21)
                Client.stubbedCommand (memcached.tap.js:654:21)
                Client.stubbedCommand (memcached.tap.js:654:21)
                Client.stubbedCommand (memcached.tap.js:654:21)
              at:
                line: 654
                column: 9
                file: memcached.tap.js
                function: Client.stubbedCommand
              type: RangeError
              tapCaught: testFunctionThrow
              test: multi-get
              source: |2
                        /* eslint-enable no-unused-vars */
                        origCommand.call(this, queryCompiler, realServer)
                --------^
```

I suspect it's the limitations of running with the default runner. This PR uses the larger runner.

