### PR TITLE
chore: Updated GitHub Actions versions

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -147,12 +147,12 @@ jobs:
     - name: Archive Integration Test Coverage
       uses: actions/upload-artifact@v4
       with:
-        name: integration-tests-${{ matrix.node-version }}
+        name: integration-tests-cjs-${{ matrix.node-version }}
         path: ./coverage/integration/lcov.info
     - name: Archive Integration (ESM) Test Coverage
       uses: actions/upload-artifact@v4
       with:
-        name: integration-tests-${{ matrix.node-version }}
+        name: integration-tests-esm-${{ matrix.node-version }}
         path: ./coverage/integration-esm/lcov.info
 
   versioned-internal:
@@ -200,7 +200,7 @@ jobs:
       run: tar cvzf ./logs-${{ matrix.node-version }}.tgz ./logs-${{ matrix.node-version }}
     - name: Upload logs to GitHub
       if: failure()
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v4
       with:
         name: logs-${{ matrix.node-version }}.tgz
         path: ./logs-${{ matrix.node-version }}.tgz

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: filter
         with:
           filters: |
@@ -53,9 +53,9 @@ jobs:
         node-version: [lts/*]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
@@ -77,9 +77,9 @@ jobs:
         node-version: [lts/*]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
@@ -101,9 +101,9 @@ jobs:
         node-version: [16.x, 18.x, 20.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
@@ -111,7 +111,7 @@ jobs:
     - name: Run Unit Tests
       run: npm run unit
     - name: Archive Unit Test Coverage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: unit-tests-${{ matrix.node-version }}
         path: ./coverage/unit/lcov.info
@@ -133,9 +133,9 @@ jobs:
         node-version: [16.x, 18.x, 20.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
@@ -145,12 +145,12 @@ jobs:
     - name: Run ESM Integration Tests
       run: npm run integration:esm
     - name: Archive Integration Test Coverage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: integration-tests-${{ matrix.node-version }}
         path: ./coverage/integration/lcov.info
     - name: Archive Integration (ESM) Test Coverage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: integration-tests-${{ matrix.node-version }}
         path: ./coverage/integration-esm/lcov.info
@@ -169,9 +169,9 @@ jobs:
         node-version: [16.x, 18.x, 20.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
@@ -186,13 +186,13 @@ jobs:
         JOBS: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER && 16 ||  4 }}
         C8_REPORTER: lcovonly
     - name: Archive Versioned Test Coverage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: versioned-tests-${{ matrix.node-version }}
         path: ./coverage/versioned/lcov.info
     - name: Collect docker logs on failure
       if: failure()
-      uses: jwalton/gh-docker-logs@v2
+      uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e
       with:
         dest: ./logs-${{ matrix.node-version }}
     - name: Tar logs
@@ -220,9 +220,9 @@ jobs:
         node-version: [16.x, 18.x, 20.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
@@ -243,23 +243,23 @@ jobs:
         node-version: [16.x, 18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Post Unit Test Coverage
-        uses: codecov/codecov-action@v3
+        uses: code-cov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: unit-tests-${{ matrix.node-version }}
           flags: unit-tests-${{ matrix.node-version }}
       - name: Post Integration Test Coverage
-        uses: codecov/codecov-action@v3
+        uses: code-cov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: integration-tests-${{ matrix.node-version }}
           flags: integration-tests-${{ matrix.node-version }}
       - name: Post Versioned Test Coverage
-        uses: codecov/codecov-action@v3
+        uses: code-cov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: versioned-tests-${{ matrix.node-version }}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -247,19 +247,19 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
       - name: Post Unit Test Coverage
-        uses: code-cov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c
+        uses: codecov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: unit-tests-${{ matrix.node-version }}
           flags: unit-tests-${{ matrix.node-version }}
       - name: Post Integration Test Coverage
-        uses: code-cov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c
+        uses: codecov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: integration-tests-${{ matrix.node-version }}
           flags: integration-tests-${{ matrix.node-version }}
       - name: Post Versioned Test Coverage
-        uses: code-cov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c
+        uses: codecov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: versioned-tests-${{ matrix.node-version }}

--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -9,9 +9,9 @@ jobs:
   checking-pending-prs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: lts/*
     - name: Install Dependencies

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -18,13 +18,13 @@ jobs:
         node-version: [lts/*]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # The script `publish-docs` below needs to perform a merge, so
         # it needs the full history to perform this merge.
         fetch-depth: 0
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -27,16 +27,16 @@ jobs:
 
     steps:
     # Check out caller repo
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     # check out agent repo to agent-repo for the bin folders
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: newrelic/node-newrelic
         path: agent-repo
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     # Only need to install deps in agent-repo because of the bin scripts

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -12,9 +12,9 @@ jobs:
         node-version: [lts/*]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3 # https://github.com/actions/setup-node
+      uses: actions/setup-node@v4 # https://github.com/actions/setup-node
       with:
         node-version: ${{ matrix.node-version }}
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release-creation.yml
+++ b/.github/workflows/release-creation.yml
@@ -30,14 +30,14 @@ jobs:
 
     steps:
     # Check out caller repo
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     # check out agent repo to agent-repo for the bin folders
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: newrelic/node-newrelic
         path: agent-repo
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -15,14 +15,14 @@ jobs:
     steps:
       - name: Test Default Branch
         id: default-branch
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const data = await github.rest.repos.get(context.repo)
             return data.data && data.data.default_branch === context.ref.split('/').slice(-1)[0]
       - name: Checkout Self
         if: ${{ steps.default-branch.outputs.result == 'true' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Repolinter
         if: ${{ steps.default-branch.outputs.result == 'true' }}
         uses: newrelic/repolinter-action@v1

--- a/.github/workflows/smoke-test-workflow.yml
+++ b/.github/workflows/smoke-test-workflow.yml
@@ -19,9 +19,9 @@ jobs:
         node-version: [16.x, 18.x, 20.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies

--- a/.github/workflows/update-snyk-prs.yml
+++ b/.github/workflows/update-snyk-prs.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     if:  ${{ github.event.sender.login == 'snyk-bot' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js LTS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: lts/*
       - name: Install Dependencies

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Pull Request Title is Conventional
         id: lint_pr_title
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825
         with:
           # Recommended Prefixes from https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/config-conventional/README.md#type-enum
           types: |
@@ -37,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: failure()
         name: Add PR comment if failed
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
         with:
           header: pr-title-lint-error
           message: |
@@ -48,7 +48,7 @@ jobs:
             ```
       - if: success()
         name: Remove PR comment if valid
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
         with:
           header: pr-title-lint-error
           delete: true

--- a/.github/workflows/versioned-coverage.yml
+++ b/.github/workflows/versioned-coverage.yml
@@ -21,9 +21,9 @@ jobs:
         node-version: [16.x, 18.x, 20.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies

--- a/.github/workflows/versioned-security-agent.yml
+++ b/.github/workflows/versioned-security-agent.yml
@@ -66,9 +66,9 @@ jobs:
         node-version: [16.x, 18.x, 20.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies


### PR DESCRIPTION
This PR updates all of the versions of the various actions we utilize.

1. It solves warnings like: 
![image](https://github.com/newrelic/node-newrelic/assets/150050532/82cb4d35-c0bf-4709-9da6-3f14fb091faa)
2. It limits our usage of third party actions to specific commits. This is a guard against a potential attack where the action's floating `vX` tag could be re-pointed to a malicious commit. The only third party actions we "trust" are the actions under the `actions/` namespace (i.e. the ones maintained by GitHub directly).
3. There should not be any noticeable change in the outcome of the actions. The deprecation of version of Node used by actions does not affect the version of Node used by jobs.
4. GitHub is already forcing the change behind the scenes https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

A successful run of the main CI workflow with this changes can be seen at https://github.com/newrelic/node-newrelic/actions/runs/9487225943