### PR TITLE
ci: Added ability to run a build step in create release

### DIFF
--- a/.github/workflows/release-creation.yml
+++ b/.github/workflows/release-creation.yml
@@ -13,6 +13,11 @@ on:
         type: string
         required: false
         default: ci-workflow.yml
+      build:
+        description: Flag to run `npm run build` before publishing
+        type: boolean
+        required: false
+        default: false
     secrets:
       # Cannot rely on environment secrets(i.e. from node-newrelic settings or org level)
       # in a reusable workflow.  We must pass it in, see create-release.yml
@@ -48,6 +53,9 @@ jobs:
         npm install
         # Install deps in agent repo
         npm install --prefix agent-repo
+    - name: Build project
+      if: ${{ inputs.build }}
+      run: npm run build
     - name: Setup GitHub Credentials
       run: |
         git config user.name $GITHUB_ACTOR


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

The serverless plugin uses this workflow.  It needs to run a build step before publishing. We never had this ability. This PR addes a new workflow input that allows you to pass in a boolean of `build: true` which will run build before publishing.
