### PR TITLE
chore: Updated mysql tests to use MySQL 8.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,10 +85,15 @@ services:
 
   mysql:
     container_name: nr_node_mysql
-    # The `mysql:5` image does not have a `linux/arm64` build.
-    # We cannot use the latest mysql image because our tests fail.
-    platform: linux/amd64
-    image: mysql:5
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
+    # We cannot use an image later than 8.3 because they have fully removed
+    # the configuration option we need in order to switch back to the native
+    # authentication method. We must use the native authentication method
+    # because the `mysql` package does not support the `caching_sha2_password`
+    # authentication method.
+    image: mysql:8.3
+    volumes:
+      - "./docker/mysql:/etc/mysql/conf.d"
     ports:
       - "3306:3306"
     environment:

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -1,0 +1,21 @@
+This directory contains resources for Docker containers that are used in
+our versioned tests. A typical case would be to mount a directory as a volume.
+For example:
+
+```yaml
+  mysql:
+    container_name: nr_node_mysql
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
+    image: mysql:8.3
+    volumes:
+      - "./docker/mysql:/etc/mysql/conf.d"
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+    healthcheck:
+      test: ["CMD", "mysql" ,"-h", "mysql", "-P", "3306", "-u", "root", "-e", "SELECT 1"]
+      interval: 1s
+      timeout: 10s
+      retries: 30
+```

--- a/docker/mysql/my.cnf
+++ b/docker/mysql/my.cnf
@@ -1,0 +1,7 @@
+[mysqld]
+# Without changing the verbosity to 1, we will get a warning about the
+# authentication method deprecation _every second_.
+log_error_verbosity=1
+
+# Switch us back to the pre-8.0 authentication method.
+default-authentication-plugin=mysql_native_password

--- a/test/versioned/mysql/helpers.js
+++ b/test/versioned/mysql/helpers.js
@@ -38,6 +38,8 @@ async function createDb(mysql, user, db) {
   await runCommand(client, `CREATE USER ${user}`)
   await runCommand(client, `GRANT ALL ON *.* TO ${user}`)
   await runCommand(client, `CREATE DATABASE IF NOT EXISTS ${db}`)
+  await runCommand(client, `FLUSH PRIVILEGES`)
+  await runCommand(client, `FLUSH TABLES`)
   client.end()
 }
 
@@ -52,7 +54,8 @@ async function createTable(mysql, user, db, table) {
   await runCommand(
     client,
     [
-      `CREATE TABLE IF NOT EXISTS ${table} (`,
+      `CREATE TABLE IF NOT EXISTS ${table}
+         (`,
       '  `id`         INTEGER(10) PRIMARY KEY AUTO_INCREMENT,',
       '  `test_value` VARCHAR(255)',
       ')'


### PR DESCRIPTION
This PR resolves #2269.

We limit the Docker image to `mysql:8.3` because in 8.4 they removed the configuration we need in order to make our tests work with the `mysql` npm package. See 

+ https://dev.mysql.com/doc/refman/8.4/en/native-pluggable-authentication.html
+ https://web.archive.org/web/20240522184559/https://dnsmichi.at/2024/05/11/docker-compose-ghost-msql-8-4-msql-native-password-startup-errors-mitigation-solution/
+ https://github.com/mysqljs/mysql/pull/2233