### PR TITLE
chore: Updated mysql2 tests to fix CI issue

### DIFF
--- a/test/versioned/mysql2/package.json
+++ b/test/versioned/mysql2/package.json
@@ -9,8 +9,8 @@
         "node": ">=16"
       },
       "dependencies": {
-        "mysql2": ">=1.3.1 <1.6.2 || >= 1.6.3",
-        "generic-pool": "2.4 <2.5"
+        "mysql2": ">=2.0.0",
+        "generic-pool": ">=2.4 <2.5 || latest"
       },
       "files": [
         "basic-pool.tap.js",
@@ -20,9 +20,5 @@
         "transaction.tap.js"
       ]
     }
-  ],
-  "dependencies": {
-    "generic-pool": "^2.4.6",
-    "mysql2": "^1.5.1 <1.6.2"
-  }
+  ]
 }


### PR DESCRIPTION
This PR fixes an issue in our CI introduced by #2280. The problem is tied to https://github.com/sidorares/node-mysql2/issues/1398. In short, `mysql2@1` relies on `iconv-lite@0.4.8` which does not have an encoding mapping that MySQL server 8+ requires. The fix for the `mysql2` driver is to update to at least version 2.0.0. Given the details outlined in #2269 , I have updated updated our versioned tests to minimally test against `mysql@2.0.0`. The consequence is that we do not have coverage for v1 of `mysql2` (which was last released 2019-08-28 according to npm).

Internally, I can see some usage of the v1 line with v11 of our agent, but the total number at the time of this writing is 16 instances. All other usages of `mysql2@1` are on older versions of the agent and still only totals some where in the 10s (i.e. <100).