### PR TITLE
chore: Made elastic versioned tests work on Node 16

### DIFF
--- a/test/versioned/elastic/package.json
+++ b/test/versioned/elastic/package.json
@@ -25,7 +25,7 @@
         "node": "16"
       },
       "dependencies": {
-        "@elastic/elasticsearch": ">=7.16.0",
+        "@elastic/elasticsearch": ">=7.16.0 <=8.13.1",
         "@elastic/transport": "8.4.1"
       },
       "files": [


### PR DESCRIPTION
`@elastic/elasticsearch` 8.14.0 no longer works on Node 16 https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/8.14/changelog-client.html

The cause is https://github.com/elastic/elasticsearch-js/pull/2277.