### PR TITLE
fix: Handled assigning headers in LambdaProxyWebRequest when there are no headers present

### DIFF
--- a/lib/serverless/api-gateway.js
+++ b/lib/serverless/api-gateway.js
@@ -80,7 +80,7 @@ function normalizeHeaders(event, lowerCaseKey = false) {
   const headers = event.multiValueHeaders ?? event.headers
 
   if (!headers) {
-    return
+    return {}
   }
 
   return Object.fromEntries(

--- a/test/unit/serverless/api-gateway-v2.test.js
+++ b/test/unit/serverless/api-gateway-v2.test.js
@@ -272,3 +272,17 @@ tap.test('should capture request headers', (t) => {
     t.end()
   }
 })
+
+tap.test('should not crash when headers are non-existent', (t) => {
+  const { lambda, event, functionContext, responseBody } = t.context
+  delete event.headers
+
+  const wrappedHandler = lambda.patchLambdaHandler((event, context, callback) => {
+    callback(null, responseBody)
+  })
+
+  t.doesNotThrow(() => {
+    wrappedHandler(event, functionContext, () => {})
+  })
+  t.end()
+})


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Added defensive code to handle when no headers are present.

## How to Test

```sh
node test/unit/serverless/api-gateway-v2.test.js
```

## Related Issues
Fixes #2291
