### PR TITLE
ci: Move the docs PR job to before api docs publish

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -36,11 +36,11 @@ jobs:
     - name: Get Created Tag
       id: get_tag
       run: echo "latest_tag=$(cat package.json | jq .version)" >> $GITHUB_OUTPUT
-    - name: Publish API Docs
-      run: npm run publish-docs
     - name: Create Docs Website PR
       run: node ./bin/create-docs-pr.js --tag v${{ steps.get_tag.outputs.latest_tag }}
       env:
         GITHUB_TOKEN: ${{ secrets.NODE_AGENT_GH_TOKEN }}
         GITHUB_USER: ${{ vars.NODE_AGENT_CI_USER_NAME }}
         GITHUB_EMAIL: ${{ vars.NODE_AGENT_CI_USER_EMAIL }}
+    - name: Publish API Docs
+      run: npm run publish-docs


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
We have failures at times with publishing API docs to the `gh-pages` branch.  The fix is unknown. In order to get the other important post release jobs done i'm moving the docs PR before the publish API docs.
