### PR TITLE
chore: Forced re-creation of API docs on gh-pages

### DIFF
--- a/bin/publish-docs.sh
+++ b/bin/publish-docs.sh
@@ -8,13 +8,13 @@ PACKAGE_VERSION=$(node -e 'console.log(require("./package").version)')
 
 git fetch origin gh-pages
 git checkout gh-pages
-git merge -
+git checkout main
+git branch -fd gh-pages
+git checkout -b gh-pages
 npm run public-docs
-sleep 1
-git rm -r docs
 sleep 1
 mv out docs
 sleep 1
 git add docs
 git commit -m "docs: update for ${PACKAGE_VERSION}"
-git push origin gh-pages
+git push --force origin gh-pages


### PR DESCRIPTION
This PR resolves #2301. Instead of trying to merge in changes to the `gh-pages` branch, we simply recreate it every time.