### PR TITLE
refactor: reduce duplication in the error-collector

### DIFF
--- a/lib/errors/error-collector.js
+++ b/lib/errors/error-collector.js
@@ -88,6 +88,51 @@ class ErrorCollector {
     return false
   }
 
+  _getIterableProperty(transaction, errorType) {
+    let iterableProperty = null
+    if (errorType === 'user' && transaction.userErrors.length) {
+      iterableProperty = transaction.userErrors
+    }
+    if (errorType === 'transactionException') {
+      iterableProperty = transaction.exceptions
+    }
+    return iterableProperty
+  }
+
+  /**
+   * Helper method for processing errors that are created with .noticeError(), exceptions
+   * on the transaction (transaction.exceptions array), and inferred errors based on Transaction metadata.
+   *
+   * @param {Transaction} transaction the collected exception's transaction
+   * @param {number} collectedErrors the number of errors we've succesfully .collect()-ed
+   * @param {number} expectedErrors the number of errors marked as expected in noticeError
+   * @param {string} errorType the type of error to be processed; "user", "transactionException", "transaction"
+   * @returns {Array.<number>} the updated [collectedErrors, expectedErrors] numbers post processing
+   */
+  _processErrors(transaction, collectedErrors, expectedErrors, errorType) {
+    const iterableProperty = this._getIterableProperty(transaction, errorType)
+    if (iterableProperty) {
+      iterableProperty.forEach((exception) => {
+        if (this.collect(transaction, exception)) {
+          ++collectedErrors
+          if (
+            urltils.isExpectedError(this.config, transaction.statusCode) ||
+            errorHelper.isExpectedException(transaction, exception, this.config, urltils)
+          ) {
+            ++expectedErrors
+          }
+        }
+      })
+    } else if (errorType === 'transaction' && this.collect(transaction)) {
+      ++collectedErrors
+      if (urltils.isExpectedError(this.config, transaction.statusCode)) {
+        ++expectedErrors
+      }
+    }
+
+    return [collectedErrors, expectedErrors]
+  }
+
   /**
    * Helper method for processing errors that are created with .noticeError()
    *
@@ -183,10 +228,11 @@ class ErrorCollector {
 
     // errors from noticeError are currently exempt from
     // ignore and exclude rules
-    ;[collectedErrors, expectedErrors] = this._processUserErrors(
+    ;[collectedErrors, expectedErrors] = this._processErrors(
       transaction,
       collectedErrors,
-      expectedErrors
+      expectedErrors,
+      'user'
     )
 
     const isErroredTransaction = urltils.isError(this.config, transaction.statusCode)
@@ -194,16 +240,18 @@ class ErrorCollector {
 
     // collect other exceptions only if status code is not ignored
     if (transaction.exceptions.length && !isIgnoredErrorStatusCode) {
-      ;[collectedErrors, expectedErrors] = this._processTransactionExceptions(
+      ;[collectedErrors, expectedErrors] = this._processErrors(
         transaction,
         collectedErrors,
-        expectedErrors
+        expectedErrors,
+        'transactionException'
       )
     } else if (isErroredTransaction) {
-      ;[collectedErrors, expectedErrors] = this._processTransactionErrors(
+      ;[collectedErrors, expectedErrors] = this._processErrors(
         transaction,
         collectedErrors,
-        expectedErrors
+        expectedErrors,
+        'transaction'
       )
     }
 

--- a/lib/errors/error-collector.js
+++ b/lib/errors/error-collector.js
@@ -88,6 +88,12 @@ class ErrorCollector {
     return false
   }
 
+  /**
+   * Gets the iterable property from the transaction based on the error type
+   * @param {Transaction} transaction the collected exception's transaction
+   * @param {string} errorType the type of error to be processed; "user", "transactionException", "transaction"
+   * @returns
+   */
   _getIterableProperty(transaction, errorType) {
     let iterableProperty = null
     if (errorType === 'user' && transaction.userErrors.length) {
@@ -124,79 +130,6 @@ class ErrorCollector {
         }
       })
     } else if (errorType === 'transaction' && this.collect(transaction)) {
-      ++collectedErrors
-      if (urltils.isExpectedError(this.config, transaction.statusCode)) {
-        ++expectedErrors
-      }
-    }
-
-    return [collectedErrors, expectedErrors]
-  }
-
-  /**
-   * Helper method for processing errors that are created with .noticeError()
-   *
-   * @param {Transaction} transaction the collected exception's transaction
-   * @param {number} collectedErrors the number of errors we've successfully .collect()-ed
-   * @param {number} expectedErrors the number of errors marked as expected in noticeError
-   * @returns {Array.<number>} the updated [collectedErrors, expectedErrors] numbers post-processing
-   */
-  _processUserErrors(transaction, collectedErrors, expectedErrors) {
-    if (transaction.userErrors.length) {
-      for (let i = 0; i < transaction.userErrors.length; i++) {
-        const exception = transaction.userErrors[i]
-        if (this.collect(transaction, exception)) {
-          ++collectedErrors
-          // if we could collect it, then check if expected
-          if (
-            urltils.isExpectedError(this.config, transaction.statusCode) ||
-            errorHelper.isExpectedException(transaction, exception, this.config, urltils)
-          ) {
-            ++expectedErrors
-          }
-        }
-      }
-    }
-
-    return [collectedErrors, expectedErrors]
-  }
-
-  /**
-   * Helper method for processing exceptions on the transaction (transaction.exceptions array)
-   *
-   * @param {Transaction} transaction the transaction being processed
-   * @param {number} collectedErrors the number of errors successfully .collect()-ed
-   * @param {number} expectedErrors the number of collected errors that were expected
-   * @returns {Array.<number>} the updated [collectedErrors, expectedErrors] numbers post-processing
-   */
-  _processTransactionExceptions(transaction, collectedErrors, expectedErrors) {
-    for (let i = 0; i < transaction.exceptions.length; i++) {
-      const exception = transaction.exceptions[i]
-      if (this.collect(transaction, exception)) {
-        ++collectedErrors
-        // if we could collect it, then check if expected
-        if (
-          urltils.isExpectedError(this.config, transaction.statusCode) ||
-          errorHelper.isExpectedException(transaction, exception, this.config, urltils)
-        ) {
-          ++expectedErrors
-        }
-      }
-    }
-
-    return [collectedErrors, expectedErrors]
-  }
-
-  /**
-   * Helper method for processing an inferred error based on Transaction metadata
-   *
-   * @param {Transaction} transaction the transaction being processed
-   * @param {number} collectedErrors the number of errors successfully .collect()-ed
-   * @param {number} expectedErrors the number of collected errors that were expected
-   * @returns {Array.<number>} the updated [collectedErrors, expectedErrors] numbers post-processing
-   */
-  _processTransactionErrors(transaction, collectedErrors, expectedErrors) {
-    if (this.collect(transaction)) {
       ++collectedErrors
       if (urltils.isExpectedError(this.config, transaction.statusCode)) {
         ++expectedErrors

--- a/lib/errors/error-collector.js
+++ b/lib/errors/error-collector.js
@@ -93,11 +93,11 @@ class ErrorCollector {
    *
    * @param {Transaction} transaction the collected exception's transaction
    * @param {string} errorType the type of error: "user", "transactionException", "transaction"
-   * @returns {Array} the iterable property from the transaction based on the error type
+   * @returns {object[]} the iterable property from the transaction based on the error type
    */
   _getIterableProperty(transaction, errorType) {
     let iterableProperty = null
-    if (errorType === 'user' && transaction.userErrors.length) {
+    if (errorType === 'user') {
       iterableProperty = transaction.userErrors
     }
     if (errorType === 'transactionException') {

--- a/lib/errors/error-collector.js
+++ b/lib/errors/error-collector.js
@@ -90,9 +90,10 @@ class ErrorCollector {
 
   /**
    * Gets the iterable property from the transaction based on the error type
+   *
    * @param {Transaction} transaction the collected exception's transaction
-   * @param {string} errorType the type of error to be processed: "user", "transactionException", "transaction"
-   * @returns
+   * @param {string} errorType the type of error: "user", "transactionException", "transaction"
+   * @returns {Array} the iterable property from the transaction based on the error type
    */
   _getIterableProperty(transaction, errorType) {
     let iterableProperty = null
@@ -117,25 +118,33 @@ class ErrorCollector {
    */
   _processErrors(transaction, collectedErrors, expectedErrors, errorType) {
     const iterableProperty = this._getIterableProperty(transaction, errorType)
-    if (iterableProperty) {
-      iterableProperty.forEach((exception) => {
-        if (this.collect(transaction, exception)) {
-          ++collectedErrors
-          if (
-            urltils.isExpectedError(this.config, transaction.statusCode) ||
-            errorHelper.isExpectedException(transaction, exception, this.config, urltils)
-          ) {
-            ++expectedErrors
-          }
+    if (iterableProperty === null && errorType === 'transaction') {
+      if (this.collect(transaction)) {
+        collectedErrors++
+        if (urltils.isExpectedError(this.config, transaction.statusCode)) {
+          expectedErrors++
         }
-      })
-    } else if (errorType === 'transaction' && this.collect(transaction)) {
-      ++collectedErrors
-      if (urltils.isExpectedError(this.config, transaction.statusCode)) {
-        ++expectedErrors
       }
+      return [collectedErrors, expectedErrors]
     }
 
+    if (iterableProperty === null) {
+      return [collectedErrors, expectedErrors]
+    }
+
+    for (let i = 0; i < iterableProperty.length; i++) {
+      const exception = iterableProperty[i]
+      if (!this.collect(transaction, exception)) {
+        continue
+      }
+      collectedErrors++
+      if (
+        urltils.isExpectedError(this.config, transaction.statusCode) ||
+        errorHelper.isExpectedException(transaction, exception, this.config, urltils)
+      ) {
+        expectedErrors++
+      }
+    }
     return [collectedErrors, expectedErrors]
   }
 

--- a/lib/errors/error-collector.js
+++ b/lib/errors/error-collector.js
@@ -91,7 +91,7 @@ class ErrorCollector {
   /**
    * Gets the iterable property from the transaction based on the error type
    * @param {Transaction} transaction the collected exception's transaction
-   * @param {string} errorType the type of error to be processed; "user", "transactionException", "transaction"
+   * @param {string} errorType the type of error to be processed: "user", "transactionException", "transaction"
    * @returns
    */
   _getIterableProperty(transaction, errorType) {
@@ -110,7 +110,7 @@ class ErrorCollector {
    * on the transaction (transaction.exceptions array), and inferred errors based on Transaction metadata.
    *
    * @param {Transaction} transaction the collected exception's transaction
-   * @param {number} collectedErrors the number of errors we've succesfully .collect()-ed
+   * @param {number} collectedErrors the number of errors we've successfully .collect()-ed
    * @param {number} expectedErrors the number of errors marked as expected in noticeError
    * @param {string} errorType the type of error to be processed; "user", "transactionException", "transaction"
    * @returns {Array.<number>} the updated [collectedErrors, expectedErrors] numbers post processing

--- a/test/unit/errors/error-collector.test.js
+++ b/test/unit/errors/error-collector.test.js
@@ -2370,3 +2370,80 @@ test('When using the async listener', (t) => {
     })
   }
 })
+
+tap.test('_processErrors', (t) => {
+  t.autoend()
+  let agent = null
+  let transaction = null
+  let errorCollector = null
+
+  t.beforeEach(() => {
+    if (agent) {
+      helper.unloadAgent(agent)
+    }
+    agent = helper.loadMockedAgent({
+      attributes: {
+        enabled: true
+      }
+    })
+    transaction = new Transaction(agent)
+    transaction.url = '/'
+    errorCollector = agent.errors
+  })
+
+  t.afterEach(() => {
+    helper.unloadAgent(agent)
+  })
+
+  t.test('invalid errorType should return no iterableProperty', (t) => {
+    const errorType = 'invalid'
+    const result = errorCollector._getIterableProperty(transaction, errorType)
+
+    t.equal(result, null)
+    t.end()
+  })
+
+  t.test('if errorType is transaction, should return no iterableProperty', (t) => {
+    const errorType = 'transaction'
+    const result = errorCollector._getIterableProperty(transaction, errorType)
+
+    t.equal(result, null)
+    t.end()
+  })
+
+  t.test('if type is user, return an array of objects', (t) => {
+    const errorType = 'user'
+    const result = errorCollector._getIterableProperty(transaction, errorType)
+
+    t.same(result, [])
+    t.end()
+  })
+
+  t.test('if type is transactionException, return an array of objects', (t) => {
+    const errorType = 'transactionException'
+    const result = errorCollector._getIterableProperty(transaction, errorType)
+
+    t.same(result, [])
+    t.end()
+  })
+
+  t.test(
+    'if iterableProperty is null and errorType is not transaction, do not modify collectedErrors or expectedErrors',
+    (t) => {
+      const errorType = 'error'
+      const collectedErrors = 0
+      const expectedErrors = 0
+      const result = errorCollector._processErrors(
+        transaction,
+        collectedErrors,
+        expectedErrors,
+        errorType
+      )
+
+      t.same(result, [collectedErrors, expectedErrors])
+      t.end()
+    }
+  )
+
+  t.end()
+})

--- a/test/unit/errors/error-collector.test.js
+++ b/test/unit/errors/error-collector.test.js
@@ -2372,27 +2372,23 @@ test('When using the async listener', (t) => {
 })
 
 tap.test('_processErrors', (t) => {
-  t.autoend()
-  let agent = null
   let transaction = null
   let errorCollector = null
 
   t.beforeEach(() => {
-    if (agent) {
-      helper.unloadAgent(agent)
-    }
-    agent = helper.loadMockedAgent({
+    t.context.agent = helper.loadMockedAgent({
       attributes: {
         enabled: true
       }
     })
-    transaction = new Transaction(agent)
+
+    transaction = new Transaction(t.context.agent)
     transaction.url = '/'
-    errorCollector = agent.errors
+    errorCollector = t.context.agent.errors
   })
 
   t.afterEach(() => {
-    helper.unloadAgent(agent)
+    helper.unloadAgent(t.context.agent)
   })
 
   t.test('invalid errorType should return no iterableProperty', (t) => {

--- a/test/unit/errors/error-collector.test.js
+++ b/test/unit/errors/error-collector.test.js
@@ -2372,26 +2372,25 @@ test('When using the async listener', (t) => {
 })
 
 tap.test('_processErrors', (t) => {
-  let transaction = null
-  let errorCollector = null
-
-  t.beforeEach(() => {
+  t.beforeEach((t) => {
     t.context.agent = helper.loadMockedAgent({
       attributes: {
         enabled: true
       }
     })
 
-    transaction = new Transaction(t.context.agent)
+    const transaction = new Transaction(t.context.agent)
     transaction.url = '/'
-    errorCollector = t.context.agent.errors
+    t.context.transaction = transaction
+    t.context.errorCollector = t.context.agent.errors
   })
 
-  t.afterEach(() => {
+  t.afterEach((t) => {
     helper.unloadAgent(t.context.agent)
   })
 
   t.test('invalid errorType should return no iterableProperty', (t) => {
+    const { errorCollector, transaction } = t.context
     const errorType = 'invalid'
     const result = errorCollector._getIterableProperty(transaction, errorType)
 
@@ -2400,6 +2399,7 @@ tap.test('_processErrors', (t) => {
   })
 
   t.test('if errorType is transaction, should return no iterableProperty', (t) => {
+    const { errorCollector, transaction } = t.context
     const errorType = 'transaction'
     const result = errorCollector._getIterableProperty(transaction, errorType)
 
@@ -2408,6 +2408,7 @@ tap.test('_processErrors', (t) => {
   })
 
   t.test('if type is user, return an array of objects', (t) => {
+    const { errorCollector, transaction } = t.context
     const errorType = 'user'
     const result = errorCollector._getIterableProperty(transaction, errorType)
 
@@ -2416,6 +2417,7 @@ tap.test('_processErrors', (t) => {
   })
 
   t.test('if type is transactionException, return an array of objects', (t) => {
+    const { errorCollector, transaction } = t.context
     const errorType = 'transactionException'
     const result = errorCollector._getIterableProperty(transaction, errorType)
 
@@ -2426,6 +2428,7 @@ tap.test('_processErrors', (t) => {
   t.test(
     'if iterableProperty is null and errorType is not transaction, do not modify collectedErrors or expectedErrors',
     (t) => {
+      const { errorCollector, transaction } = t.context
       const errorType = 'error'
       const collectedErrors = 0
       const expectedErrors = 0


### PR DESCRIPTION
- Refactored _processUserErrors, _processTransactionExceptions, and _processTransactionErrors into a single function: _processErrors

Original Ticket:
- There's a lot of duplication here--for example, in the error-collector, _processUserErrors and _processTransactionExceptions are nearly identical, apart from the property they inspect. _processTransactionErrors behaves only slightly differently. Those three could be collapsed into one processor.
- First half of this Jira ticket (https://new-relic.atlassian.net/browse/NR-96722)