### PR TITLE
refactor: got rid of redundant isExpected in the Exception class

### DIFF
--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -31,19 +31,15 @@ class Exception {
 
   getErrorDetails(config) {
     const errorDetails = errorHelper.extractErrorInformation(null, this.error, config)
-    errorDetails.expected = this.isExpected(config, errorDetails)
+    errorDetails.expected = errorHelper.isExpected(
+      errorDetails.type,
+      errorDetails.message,
+      null,
+      config,
+      urltils
+    )
 
     return errorDetails
-  }
-
-  isExpected(config, { type, message }) {
-    if (typeof this._expected === 'undefined') {
-      this._expected =
-        errorHelper.isExpectedErrorClass(config, type) ||
-        errorHelper.isExpectedErrorMessage(config, type, message)
-    }
-
-    return this._expected
   }
 }
 

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -31,13 +31,16 @@ class Exception {
 
   getErrorDetails(config) {
     const errorDetails = errorHelper.extractErrorInformation(null, this.error, config)
-    errorDetails.expected = errorHelper.isExpected(
-      errorDetails.type,
-      errorDetails.message,
-      null,
-      config,
-      urltils
-    )
+    if (typeof this._expected === 'undefined') {
+      this._expected = errorHelper.isExpected(
+        errorDetails.type,
+        errorDetails.message,
+        null,
+        config,
+        urltils
+      )
+    }
+    errorDetails.expected = this._expected
 
     return errorDetails
   }


### PR DESCRIPTION
- Got rid of the `isExpected` function in the Exception class to avoid duplication with the `isExpected` function in the error helper.