### PR TITLE
fix: Refactored benchmark tests to complete async functions

### DIFF
--- a/test/benchmark/datastore-shim/test-datastore.js
+++ b/test/benchmark/datastore-shim/test-datastore.js
@@ -7,15 +7,24 @@
 
 class TestDatastore {
   testOp(cb) {
-    setImmediate(cb)
+    if (typeof cb === 'function') {
+      return setImmediate(cb)
+    }
+    return cb || 'testOp'
   }
 
   testQuery(query, cb) {
-    setImmediate(cb)
+    if (typeof cb === 'function') {
+      return setImmediate(cb)
+    }
+    return cb || 'testQuery'
   }
 
   testBatch(query, cb) {
-    setImmediate(cb)
+    if (typeof cb === 'function') {
+      return setImmediate(cb)
+    }
+    return cb || 'testBatch'
   }
 }
 

--- a/test/benchmark/promises/shared.js
+++ b/test/benchmark/promises/shared.js
@@ -27,7 +27,12 @@ const tests = [
         promises.push(prom.then(function first() {}))
         promises.push(prom.then(function second() {}))
       }
-      Promise.all(promises).then(cb)
+      Promise.all(promises).then(() => {
+        if (typeof cb === 'function') {
+          return cb()
+        }
+        return cb || true
+      })
     }
   },
 
@@ -37,7 +42,12 @@ const tests = [
       for (let i = 0; i < NUM_PROMISES; ++i) {
         prom = prom.then(function () {})
       }
-      prom.then(cb)
+      prom.then(() => {
+        if (typeof cb === 'function') {
+          return cb()
+        }
+        return cb || true
+      })
     }
   },
 
@@ -47,7 +57,12 @@ const tests = [
       for (let i = 0; i < NUM_PROMISES / 2; ++i) {
         prom = prom.then(function () {}).catch(function () {})
       }
-      prom.then(cb)
+      prom.then(() => {
+        if (typeof cb === 'function') {
+          return cb()
+        }
+        return cb || true
+      })
     }
   },
 
@@ -57,7 +72,14 @@ const tests = [
       for (let i = 0; i < NUM_PROMISES - 1; ++i) {
         prom = prom.then(function () {})
       }
-      prom.catch(function () {}).then(cb)
+      prom
+        .catch(function () {})
+        .then(() => {
+          if (typeof cb === 'function') {
+            return cb()
+          }
+          return cb || true
+        })
     }
   },
 
@@ -69,7 +91,10 @@ const tests = [
           res()
         })
       }
-      cb()
+      if (typeof cb === 'function') {
+        return cb()
+      }
+      return cb || true
     }
   },
 
@@ -87,7 +112,12 @@ const tests = [
           })
         )
       }
-      Promise.all(promises).then(cb)
+      Promise.all(promises).then(() => {
+        if (typeof cb === 'function') {
+          return cb()
+        }
+        return cb || true
+      })
     }
   },
 
@@ -101,7 +131,12 @@ const tests = [
           })
         })
       }
-      prom.then(cb)
+      prom.then(() => {
+        if (typeof cb === 'function') {
+          return cb()
+        }
+        return cb || true
+      })
     }
   },
 
@@ -110,7 +145,10 @@ const tests = [
       new Promise(function () {
         throw new Error('Whoops!')
       }).catch(() => {})
-      cb()
+      if (typeof cb === 'function') {
+        return cb()
+      }
+      return cb || true
     }
   }
 ]

--- a/test/lib/benchmark.js
+++ b/test/lib/benchmark.js
@@ -74,7 +74,7 @@ class Benchmark {
       const testFn = test.fn
 
       if (test.async) {
-        return testFn(agent, () => after(test, next, executeCb, prevCpu))
+        return await testFn(agent, () => after(test, next, executeCb, prevCpu))
       }
       await testFn(agent)
       return after(test, next, executeCb, prevCpu)
@@ -108,7 +108,7 @@ class Benchmark {
       if (idx >= suite.tests.length) {
         return true
       }
-      return initiator(initiator, suite.tests[idx], idx)
+      return await initiator(initiator, suite.tests[idx], idx)
     }
 
     const afterTestRuns = (initiator, test, samples, idx) => {

--- a/test/lib/benchmark.js
+++ b/test/lib/benchmark.js
@@ -73,9 +73,6 @@ class Benchmark {
       const prevCpu = process.cpuUsage()
       const testFn = test.fn
 
-      if (test.async) {
-        return await testFn(agent, () => after(test, next, executeCb, prevCpu))
-      }
       await testFn(agent)
       return after(test, next, executeCb, prevCpu)
     }


### PR DESCRIPTION
## Description

Benchmark tests for datastore-shim and promises were throwing an error: when run, and benchmark stats were generated, the stat constructor failed, as there were no values in samples. The tests used both callbacks and async/await, so the stats were invoked before the async promises were resolved. This PR removes the async-handling callback code path, so async tests aren't expected to fire a callback on completion. 

## How to Test

`npm run bench datastore-shim`
`npm run bench promises`

## Related Issues

Closes NR-67805
Closes NR-281838