### PR TITLE
chore: Always upload status logs in compat report CI

### DIFF
--- a/.github/workflows/compatibility-report.yml
+++ b/.github/workflows/compatibility-report.yml
@@ -46,6 +46,7 @@ jobs:
 
       # Upload generated artifacts for potential debugging purposes.
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: status.log
           path: status.log
@@ -95,6 +96,7 @@ jobs:
 
       # Upload generated artifacts for potential debugging purposes.
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: docs-status.log
           path: docs-status.log


### PR DESCRIPTION
If `nrversions` crashes for whatever reason, we want to still be able to read the log file.