### PR TITLE
ci: increase the limit of installs from 2 to a bigger number

### DIFF
--- a/bin/run-versioned-tests.sh
+++ b/bin/run-versioned-tests.sh
@@ -100,4 +100,4 @@ then
 fi
 export NR_LOADER=./esm-loader.mjs
 
-time $C8 ./node_modules/.bin/versioned-tests $VERSIONED_MODE --print $OUTPUT_MODE -i 2 --all --strict --samples $SAMPLES $JOBS_ARGS ${directories[@]}
+time $C8 ./node_modules/.bin/versioned-tests $VERSIONED_MODE --print $OUTPUT_MODE -i 100 --all --strict --samples $SAMPLES $JOBS_ARGS ${directories[@]}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

While I was helping Amy refactor `@newrelic/test-utilitites`. I noticed we manage [2 separate queues for running tests and installing packages within the test](https://github.com/newrelic/node-test-utilities/blob/main/lib/versioned/suite.js#L140).  The install limit is 1 but we set it to 2 and the test limit defaults to number of CPUs or in CI we default to 4 if not using the larger runner.  However since the test is kicked off first then queues up the install, you'll have a discrepancy in waiting for concurrent test runs and it'll show a `waiting`.  This PR increases the install limit to a larger number 100 which can't really go above the jobs limit but it should speed up the tests slighty as it's not queueing up installs of tests.  I plan on removing this 2nd queue in test utils but wanted to get this out beforehand.
