### PR TITLE
test: Updated benchmark test results to output result files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ nr-security-home
 !test/integration/moduleLoading/node_modules
 # benchmark results
 benchmark_*.json
+benchmark_*.md

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,4 @@ nr-security-home
 # Needed for testing
 !test/integration/moduleLoading/node_modules
 # benchmark results
-benchmark_*.json
-benchmark_*.md
+benchmark_results

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ test/versioned-external/TEMP_TESTS
 nr-security-home
 # Needed for testing
 !test/integration/moduleLoading/node_modules
+# benchmark results
+benchmark_*.json

--- a/bin/compare-bench-results.js
+++ b/bin/compare-bench-results.js
@@ -110,7 +110,14 @@ const reportResults = async (resultFiles) => {
   content += '### Details\n\n'
   content += '_Lower is better._\n\n'
   content += `${details}\n`
-  const fileName = `benchmark_comparison_${date.getTime()}.md`
+
+  const resultPath = 'benchmark_results'
+  try {
+    await fs.stat(resultPath)
+  } catch (e) {
+    await fs.mkdir(resultPath)
+  }
+  const fileName = `${resultPath}/comparison_${date.getTime()}.md`
   await fs.writeFile(fileName, content)
   console.log(`Done! Benchmark test comparison written to ${fileName}`)
 

--- a/bin/compare-bench-results.js
+++ b/bin/compare-bench-results.js
@@ -72,6 +72,13 @@ const reportResults = (resultFiles) => {
       const results = baseTests
         .sort()
         .map((test) => {
+          if (!base[test] || !down[test]) {
+            console.error(`**** comparison tests are not matched for ${test}!`)
+            console.log('base case test', base)
+            console.log('downstream test', down)
+            return ''
+          }
+
           const passes = compareResults(base[test], down[test])
           filePassing = filePassing && passes
 
@@ -118,9 +125,11 @@ const reportResults = (resultFiles) => {
 
 const iterate = async () => {
   const files = process.argv.slice(2)
-  const results = files.map(async (file) => {
-    return processFile(file)
-  })
+  const results = await Promise.all(
+    files.map(async (file) => {
+      return await processFile(file)
+    })
+  )
   reportResults(results)
 }
 

--- a/bin/compare-bench-results.js
+++ b/bin/compare-bench-results.js
@@ -27,7 +27,7 @@ const processFile = async (file) => {
   }
 }
 
-const reportResults = (resultFiles) => {
+const reportResults = async (resultFiles) => {
   const baseline = resultFiles[0]
   const downstream = resultFiles[1]
 
@@ -72,13 +72,6 @@ const reportResults = (resultFiles) => {
       const results = baseTests
         .sort()
         .map((test) => {
-          if (!base[test] || !down[test]) {
-            console.error(`**** comparison tests are not matched for ${test}!`)
-            console.log('base case test', base)
-            console.log('downstream test', down)
-            return ''
-          }
-
           const passes = compareResults(base[test], down[test])
           filePassing = filePassing && passes
 
@@ -95,8 +88,7 @@ const reportResults = (resultFiles) => {
       allPassing = allPassing && filePassing
 
       return [
-        '<details>',
-        `<summary>${testFile}: ${passMark(filePassing)}</summary>`,
+        `#### ${testFile}: ${passMark(filePassing)}`,
         '',
         results,
         '',
@@ -112,11 +104,15 @@ const reportResults = (resultFiles) => {
     console.log('')
   }
 
-  console.log(`### Benchmark Results: ${passMark(allPassing)}`)
-  console.log('')
-  console.log('### Details')
-  console.log('_Lower is better._')
-  console.log(details)
+  const date = new Date()
+  let content = `### Benchmark Results: ${passMark(allPassing)}\n\n\n\n`
+  content += `${date.toISOString()}\n\n`
+  content += '### Details\n\n'
+  content += '_Lower is better._\n\n'
+  content += `${details}\n`
+  const fileName = `benchmark_comparison_${date.getTime()}.md`
+  await fs.writeFile(fileName, content)
+  console.log(`Done! Benchmark test comparison written to ${fileName}`)
 
   if (!allPassing) {
     process.exitCode = -1

--- a/bin/run-bench.js
+++ b/bin/run-bench.js
@@ -127,9 +127,10 @@ async function run() {
     })
     child.on('exit', function onChildExit(code) {
       if (code) {
-        throw new Error(`Benchmark test ${test} exited with code ${code}`)
+        console.error(`Benchmark test ${test} exited with code ${code}`)
+        return
       }
-      console.log(`The child test ${file} has exited`)
+      console.log(`The child test ${file} has completed`)
     })
     printer.addTest(test, child)
   }

--- a/bin/run-bench.js
+++ b/bin/run-bench.js
@@ -5,8 +5,6 @@
 
 'use strict'
 
-/* eslint sonarjs/cognitive-complexity: ["error", 21] -- TODO: https://issues.newrelic.com/browse/NEWRELIC-5252 */
-
 const cp = require('child_process')
 const glob = require('glob')
 const path = require('path')

--- a/bin/run-bench.js
+++ b/bin/run-bench.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-/* eslint sonarjs/cognitive-complexity: ["error", 23] -- TODO: https://issues.newrelic.com/browse/NEWRELIC-5252 */
+/* eslint sonarjs/cognitive-complexity: ["error", 21] -- TODO: https://issues.newrelic.com/browse/NEWRELIC-5252 */
 
 const cp = require('child_process')
 const glob = require('glob')
@@ -53,7 +53,12 @@ class Printer {
 
     this._tests[name] = new Promise((resolve) => {
       child.stdout.on('end', () => {
-        this._tests[name] = JSON.parse(output)
+        try {
+          this._tests[name] = JSON.parse(output)
+        } catch (e) {
+          console.error(`Error parsing test results for ${name}`, e)
+          this._tests[name] = output
+        }
         resolve()
       })
     })

--- a/bin/run-bench.js
+++ b/bin/run-bench.js
@@ -63,16 +63,21 @@ class Printer {
   }
 
   async finish() {
-    if (opts.json) {
-      const content = JSON.stringify(this._tests, null, 2)
-      const fileName = `benchmark_${new Date().getTime()}.json`
-      await fs.writeFile(fileName, content)
-      console.log(`Done! Test output written to ${fileName}`)
-      return
+    if (opts.console) {
+      /* eslint-disable no-console */
+      console.log(JSON.stringify(this._tests, null, 2))
+      /* eslint-enable no-console */
     }
-    /* eslint-disable no-console */
-    console.log(JSON.stringify(this._tests, null, 2))
-    /* eslint-enable no-console */
+    const resultPath = 'benchmark_results'
+    try {
+      await fs.stat(resultPath)
+    } catch (e) {
+      await fs.mkdir(resultPath)
+    }
+    const content = JSON.stringify(this._tests, null, 2)
+    const fileName = `${resultPath}/benchmark_${new Date().getTime()}.json`
+    await fs.writeFile(fileName, content)
+    console.log(`Done! Test output written to ${fileName}`)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
   },
   "scripts": {
     "bench": "node ./bin/run-bench.js",
+    "benchJson": "node ./bin/run-bench.js --json",
     "docker-env": "./bin/docker-env-vars.sh",
     "docs": "rm -rf ./out && jsdoc -c ./jsdoc-conf.jsonc --private -r .",
     "integration": "npm run prepare-test && npm run sub-install && time c8 -o ./coverage/integration tap --test-regex='(\\/|^test\\/integration\\/.*\\.tap\\.js)$' --timeout=600 --no-coverage --reporter classic",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,6 @@
   },
   "scripts": {
     "bench": "node ./bin/run-bench.js",
-    "benchJson": "node ./bin/run-bench.js --json",
     "docker-env": "./bin/docker-env-vars.sh",
     "docs": "rm -rf ./out && jsdoc -c ./jsdoc-conf.jsonc --private -r .",
     "integration": "npm run prepare-test && npm run sub-install && time c8 -o ./coverage/integration tap --test-regex='(\\/|^test\\/integration\\/.*\\.tap\\.js)$' --timeout=600 --no-coverage --reporter classic",

--- a/test/benchmark/async-hooks.bench.js
+++ b/test/benchmark/async-hooks.bench.js
@@ -9,7 +9,6 @@ const benchmark = require('../lib/benchmark')
 
 const suite = benchmark.createBenchmark({
   name: 'async hooks',
-  async: true,
   fn: runBenchmark
 })
 
@@ -52,10 +51,11 @@ tests.forEach((test) => suite.add(test))
 
 suite.run()
 
-function runBenchmark(agent, cb) {
+function runBenchmark() {
   let p = Promise.resolve()
   for (let i = 0; i < 300; ++i) {
     p = p.then(function noop() {})
   }
-  p.then(cb)
+
+  return p
 }

--- a/test/benchmark/datastore-shim/recordBatch.bench.js
+++ b/test/benchmark/datastore-shim/recordBatch.bench.js
@@ -19,31 +19,34 @@ function makeInit(instrumented) {
 
 suite.add({
   name: 'instrumented operation',
-  async: true,
   initialize: makeInit(true),
   agent: {},
-  fn: function (agent, done) {
-    testDatastore.testBatch('test', done)
+  fn: function () {
+    return new Promise((resolve) => {
+      testDatastore.testBatch('test', resolve)
+    })
   }
 })
 
 suite.add({
   name: 'uninstrumented operation',
   initialize: makeInit(false),
-  async: true,
-  fn: function (agent, done) {
-    testDatastore.testBatch('test', done)
+  fn: function () {
+    return new Promise((resolve) => {
+      testDatastore.testBatch('test', resolve)
+    })
   }
 })
 
 suite.add({
   name: 'instrumented operation in transaction',
-  async: true,
   agent: {},
   initialize: makeInit(true),
   runInTransaction: true,
-  fn: function (agent, done) {
-    testDatastore.testBatch('test', done)
+  fn: function () {
+    return new Promise((resolve) => {
+      testDatastore.testBatch('test', resolve)
+    })
   }
 })
 

--- a/test/benchmark/datastore-shim/recordOperation.bench.js
+++ b/test/benchmark/datastore-shim/recordOperation.bench.js
@@ -19,31 +19,34 @@ function makeInit(instrumented) {
 
 suite.add({
   name: 'instrumented operation in transaction',
-  async: true,
   agent: {},
   initialize: makeInit(true),
   runInTransaction: true,
-  fn: function (agent, done) {
-    testDatastore.testOp(done)
+  fn: function () {
+    return new Promise((resolve) => {
+      testDatastore.testOp(resolve)
+    })
   }
 })
 
 suite.add({
   name: 'instrumented operation',
-  async: true,
   initialize: makeInit(true),
   agent: {},
-  fn: function (agent, done) {
-    testDatastore.testOp(done)
+  fn: function () {
+    return new Promise((resolve) => {
+      testDatastore.testOp(resolve)
+    })
   }
 })
 
 suite.add({
   name: 'uninstrumented operation',
   initialize: makeInit(false),
-  async: true,
-  fn: function (agent, done) {
-    testDatastore.testOp(done)
+  fn: function () {
+    return new Promise((resolve) => {
+      testDatastore.testOp(resolve)
+    })
   }
 })
 

--- a/test/benchmark/datastore-shim/recordQuery.bench.js
+++ b/test/benchmark/datastore-shim/recordQuery.bench.js
@@ -19,31 +19,34 @@ function makeInit(instrumented) {
 
 suite.add({
   name: 'instrumented operation in transaction',
-  async: true,
   agent: {},
   initialize: makeInit(true),
   runInTransaction: true,
-  fn: function (agent, done) {
-    testDatastore.testQuery('test', done)
+  fn: function () {
+    return new Promise((resolve) => {
+      testDatastore.testQuery('test', resolve)
+    })
   }
 })
 
 suite.add({
   name: 'instrumented operation',
-  async: true,
   initialize: makeInit(true),
   agent: {},
-  fn: function (agent, done) {
-    testDatastore.testQuery('test', done)
+  fn: function () {
+    return new Promise((resolve) => {
+      testDatastore.testQuery('test', resolve)
+    })
   }
 })
 
 suite.add({
   name: 'uninstrumented operation',
   initialize: makeInit(false),
-  async: true,
-  fn: function (agent, done) {
-    testDatastore.testQuery('test', done)
+  fn: function () {
+    return new Promise((resolve) => {
+      testDatastore.testQuery('test', resolve)
+    })
   }
 })
 

--- a/test/benchmark/datastore-shim/test-datastore.js
+++ b/test/benchmark/datastore-shim/test-datastore.js
@@ -7,24 +7,15 @@
 
 class TestDatastore {
   testOp(cb) {
-    if (typeof cb === 'function') {
-      return setImmediate(cb)
-    }
-    return cb || 'testOp'
+    setImmediate(cb)
   }
 
   testQuery(query, cb) {
-    if (typeof cb === 'function') {
-      return setImmediate(cb)
-    }
-    return cb || 'testQuery'
+    setImmediate(cb)
   }
 
   testBatch(query, cb) {
-    if (typeof cb === 'function') {
-      return setImmediate(cb)
-    }
-    return cb || 'testBatch'
+    setImmediate(cb)
   }
 }
 

--- a/test/benchmark/http/server.bench.js
+++ b/test/benchmark/http/server.bench.js
@@ -10,40 +10,60 @@ const http = require('http')
 
 const suite = benchmark.createBenchmark({ name: 'http', runs: 5000 })
 
-let server = null
-const PORT = 3000
+const HOST = 'localhost'
+// manage the servers separately
+// since we have to enqueue the server.close
+// to avoid net connect errors
+const servers = {
+  3000: null,
+  3001: null
+}
 
 suite.add({
   name: 'uninstrumented http.Server',
-  async: true,
-  initialize: createServer,
-  fn: (agent, done) => makeRequest(done),
-  teardown: closeServer
+  initialize: createServer(3000),
+  fn: setupRequest(3000),
+  teardown: closeServer(3000)
 })
 
 suite.add({
   name: 'instrumented http.Server',
   agent: {},
-  async: true,
-  initialize: createServer,
-  fn: (agent, done) => makeRequest(done),
-  teardown: closeServer
+  initialize: createServer(3001),
+  fn: setupRequest(3001),
+  teardown: closeServer(3001)
 })
 
 suite.run()
 
-function createServer() {
-  server = http.createServer((req, res) => {
-    res.end()
-  })
-  server.listen(PORT)
+function createServer(port) {
+  return async function makeServer() {
+    return new Promise((resolve, reject) => {
+      servers[port] = http.createServer((req, res) => {
+        res.end()
+      })
+      servers[port].listen(port, HOST, (err) => {
+        if (err) {
+          reject(err)
+        }
+        resolve()
+      })
+    })
+  }
 }
 
-function closeServer() {
-  server && server.close()
-  server = null
+function closeServer(port) {
+  return function close() {
+    setImmediate(() => {
+      servers[port].close()
+    })
+  }
 }
 
-function makeRequest(cb) {
-  http.request({ port: PORT }, cb).end()
+function setupRequest(port) {
+  return async function makeRequest() {
+    return new Promise((resolve) => {
+      http.request({ host: HOST, port }, resolve).end()
+    })
+  }
 }

--- a/test/benchmark/promises/native.bench.js
+++ b/test/benchmark/promises/native.bench.js
@@ -10,7 +10,6 @@ const shared = require('./shared')
 const suite = shared.makeSuite('Promises')
 shared.tests.forEach(function registerTest(testFn) {
   suite.add({
-    defer: true,
     name: testFn.name,
     fn: testFn(Promise),
     agent: {

--- a/test/benchmark/promises/shared.js
+++ b/test/benchmark/promises/shared.js
@@ -8,14 +8,14 @@
 const benchmark = require('../../lib/benchmark')
 
 function makeSuite(name) {
-  return benchmark.createBenchmark({ async: true, name: name, delay: 0.01 })
+  return benchmark.createBenchmark({ name })
 }
 
 const NUM_PROMISES = 300
 
 const tests = [
   function forkedTest(Promise) {
-    return function runTest(agent, cb) {
+    return function runTest() {
       // number of internal nodes on the binary tree of promises
       // this will produce a binary tree with NUM_PROMISES / 2 internal
       // nodes, and NUM_PROMIES / 2 + 1 leaves
@@ -27,79 +27,57 @@ const tests = [
         promises.push(prom.then(function first() {}))
         promises.push(prom.then(function second() {}))
       }
-      Promise.all(promises).then(() => {
-        if (typeof cb === 'function') {
-          return cb()
-        }
-        return cb || true
-      })
+      return Promise.all(promises)
     }
   },
 
   function longTest(Promise) {
-    return function runTest(agent, cb) {
+    return function runTest() {
       let prom = Promise.resolve()
       for (let i = 0; i < NUM_PROMISES; ++i) {
         prom = prom.then(function () {})
       }
-      prom.then(() => {
-        if (typeof cb === 'function') {
-          return cb()
-        }
-        return cb || true
-      })
+      return prom
     }
   },
 
   function longTestWithCatches(Promise) {
-    return function runTest(agent, cb) {
+    return function runTest() {
       let prom = Promise.resolve()
       for (let i = 0; i < NUM_PROMISES / 2; ++i) {
         prom = prom.then(function () {}).catch(function () {})
       }
-      prom.then(() => {
-        if (typeof cb === 'function') {
-          return cb()
-        }
-        return cb || true
-      })
+      return prom
     }
   },
 
   function longThrowToEnd(Promise) {
-    return function runTest(agent, cb) {
+    return function runTest() {
       let prom = Promise.reject()
       for (let i = 0; i < NUM_PROMISES - 1; ++i) {
         prom = prom.then(function () {})
       }
-      prom
-        .catch(function () {})
-        .then(() => {
-          if (typeof cb === 'function') {
-            return cb()
-          }
-          return cb || true
-        })
+      return prom.catch(function () {})
     }
   },
 
   function promiseConstructor(Promise) {
-    return function runTest(agent, cb) {
+    return function runTest() {
+      const promises = []
       for (let i = 0; i < NUM_PROMISES; ++i) {
         /* eslint-disable no-new */
-        new Promise(function (res) {
-          res()
-        })
+        promises.push(
+          new Promise(function (res) {
+            res()
+          })
+        )
       }
-      if (typeof cb === 'function') {
-        return cb()
-      }
-      return cb || true
+      return Promise.all(promises)
     }
   },
 
   function promiseReturningPromise(Promise) {
-    return function runTest(agent, cb) {
+    return function runTest() {
       const promises = []
       for (let i = 0; i < NUM_PROMISES / 2; ++i) {
         promises.push(
@@ -112,17 +90,12 @@ const tests = [
           })
         )
       }
-      Promise.all(promises).then(() => {
-        if (typeof cb === 'function') {
-          return cb()
-        }
-        return cb || true
-      })
+      return Promise.all(promises)
     }
   },
 
   function thenReturningPromise(Promise) {
-    return function runTest(agent, cb) {
+    return function runTest() {
       let prom = Promise.resolve()
       for (let i = 0; i < NUM_PROMISES / 2; ++i) {
         prom = prom.then(function () {
@@ -131,24 +104,15 @@ const tests = [
           })
         })
       }
-      prom.then(() => {
-        if (typeof cb === 'function') {
-          return cb()
-        }
-        return cb || true
-      })
+      return prom
     }
   },
 
   function promiseConstructorThrow(Promise) {
-    return function runTest(agent, cb) {
-      new Promise(function () {
+    return function runTest() {
+      return new Promise(function () {
         throw new Error('Whoops!')
       }).catch(() => {})
-      if (typeof cb === 'function') {
-        return cb()
-      }
-      return cb || true
     }
   }
 ]

--- a/test/lib/benchmark.js
+++ b/test/lib/benchmark.js
@@ -129,7 +129,7 @@ class Benchmark {
       }
 
       if (typeof test.initialize === 'function') {
-        test.initialize(agent)
+        await test.initialize(agent)
       }
 
       const samples = []

--- a/test/lib/benchmark.js
+++ b/test/lib/benchmark.js
@@ -151,8 +151,7 @@ class Benchmark {
 class BenchmarkStats {
   constructor(samples, testName, sampleName) {
     if (samples.length < 1) {
-      console.log(`BenchmarkStats for ${testName} has no samples. SampleName: ${sampleName}`)
-      throw new Error('BenchmarkStats requires more than zero samples')
+      throw new Error(`BenchmarkStats for ${testName} has no samples. SampleName: ${sampleName}`)
     }
 
     let sortedSamples = samples.slice().sort((a, b) => a - b)


### PR DESCRIPTION
## Description

Updated `run-bench.js` and `benchmark.js` to complete asynchronous tests before generating statistics
Updated `run-bench.js` to allow JSON output to a file, and consolidate printing logic
Reduced cognitive complexity in `run-bench.js`

## How to Test

`npm run bench` to run benchmark tests and output json result files to `benchmark_results`
Given two benchJson outputs, `node bin/compare-bench-results.js {file1.json} {file2.json}`  will compare two benchmark runs, and write a markdown file to `benchmark_results`.

## Related Issues

Closes NR-281645