### PR TITLE
ci: Added benchmark test GitHub Action

### DIFF
--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -1,9 +1,9 @@
 name: Benchmark Tests
 
 on:
-  push:
-  pull_request:
   workflow_dispatch:
+  schedule:
+    - cron:  '0 10 * * 1'
 
 env:
   # Enable versioned runner quiet mode to make CI output easier to read:

--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -10,42 +10,7 @@ env:
   OUTPUT_MODE: quiet
 
 jobs:
-  should_run:
-    # We only want the test suites to run when code has changed, or when
-    # a dependency update has occurred.
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      javascript_changed: ${{ steps.filter.outputs.javascript }}
-      deps_changed: ${{ steps.deps.outputs.divergent }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
-        id: filter
-        with:
-          filters: |
-            javascript:
-              - 'api.js'
-              - 'esm-loader.mjs'
-              - 'index.js'
-              - 'stub_api.js'
-              - 'lib/**/*.{js,json,mjs,cjs}'
-              - 'test/**/*.{js,json,mjs,cjs}'
-      - uses: jsumners-nr/gha-node-deps-divergent@643628fe0da51ec025e984c4644f17fd9f9e93f6
-        id: deps
-        with:
-          base-sha: ${{ github.base_ref || 'main' }}
-          current-sha: ${{ github.sha }}
-
   benchmarks:
-    needs:
-      - should_run
-    if: github.event_name == 'workflow_dispatch' ||
-      (needs.should_run.outputs.javascript_changed == 'true' ||
-      needs.should_run.outputs.deps_changed == 'true')
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -30,4 +30,9 @@ jobs:
       run: node ./bin/run-bench.js --filename=${{ github.base_ref || 'main' }}_${{ matrix.node-version }}
     - name: Verify Benchmark Output
       run: ls benchmark_results
+    - name: Archive Benchmark Test
+      uses: actions/upload-artifact@v4
+      with:
+        name: benchmark-tests-${{ github.base_ref || 'main' }}-${{ matrix.node-version }}
+        path: ./benchmark_results
 

--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -1,0 +1,68 @@
+name: Benchmark Tests
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  # Enable versioned runner quiet mode to make CI output easier to read:
+  OUTPUT_MODE: quiet
+
+jobs:
+  should_run:
+    # We only want the test suites to run when code has changed, or when
+    # a dependency update has occurred.
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      javascript_changed: ${{ steps.filter.outputs.javascript }}
+      deps_changed: ${{ steps.deps.outputs.divergent }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+        id: filter
+        with:
+          filters: |
+            javascript:
+              - 'api.js'
+              - 'esm-loader.mjs'
+              - 'index.js'
+              - 'stub_api.js'
+              - 'lib/**/*.{js,json,mjs,cjs}'
+              - 'test/**/*.{js,json,mjs,cjs}'
+      - uses: jsumners-nr/gha-node-deps-divergent@643628fe0da51ec025e984c4644f17fd9f9e93f6
+        id: deps
+        with:
+          base-sha: ${{ github.base_ref || 'main' }}
+          current-sha: ${{ github.sha }}
+
+  benchmarks:
+    needs:
+      - should_run
+    if: github.event_name == 'workflow_dispatch' ||
+      (needs.should_run.outputs.javascript_changed == 'true' ||
+      needs.should_run.outputs.deps_changed == 'true')
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [16.x, 18.x, 20.x, 22.x]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install Dependencies
+      run: npm install
+    - name: Run Benchmark Tests
+      run: node ./bin/run-bench.js --filename=${{ github.base_ref || 'main' }}_${{ matrix.node-version }}
+    - name: Verify Benchmark Output
+      run: ls benchmark_results
+

--- a/bin/run-bench.js
+++ b/bin/run-bench.js
@@ -20,7 +20,11 @@ const globs = []
 const opts = Object.create(null)
 
 process.argv.slice(2).forEach(function forEachFileArg(file) {
-  if (/^--/.test(file)) {
+  if (/^--/.test(file) && file.indexOf('=') > -1) {
+    // this one has a value assigned
+    const arg = file.substring(2).split('=')
+    opts[arg[0]] = arg[1]
+  } else if (/^--/.test(file)) {
     opts[file.substring(2)] = true
   } else if (/[*]/.test(file)) {
     globs.push(path.join(benchpath, file))
@@ -69,13 +73,14 @@ class Printer {
       /* eslint-enable no-console */
     }
     const resultPath = 'benchmark_results'
+    const filePrefix = opts.filename ? `${opts.filename}` : 'benchmark'
     try {
       await fs.stat(resultPath)
     } catch (e) {
       await fs.mkdir(resultPath)
     }
     const content = JSON.stringify(this._tests, null, 2)
-    const fileName = `${resultPath}/benchmark_${new Date().getTime()}.json`
+    const fileName = `${resultPath}/${filePrefix}_${new Date().getTime()}.json`
     await fs.writeFile(fileName, content)
     console.log(`Done! Test output written to ${fileName}`)
   }


### PR DESCRIPTION
## Description

Added benchmark test GitHub Action, which automatically writes the output to a file in `benchmark_results`. The file is named with the git branch and Node version, which are supplied by the action. 

## How to Test

When this action is run, it verifies that it's written a file to the output by running `ls` on the output directory. File contents aren't inspected, but it's a baseline check that the benchmark test did not fail.

## Related Issues

Closes #2118 
Closes NR-255566