### PR TITLE
test: Removed server.start in grpc tests as it is deprecated and no longer needed

### DIFF
--- a/test/integration/grpc/reconnect.tap.js
+++ b/test/integration/grpc/reconnect.tap.js
@@ -218,7 +218,6 @@ function setupServer(t, sslOpts, recordSpan) {
         if (err) {
           reject(err)
         }
-        server.start()
         resolve(port)
         // shutdown server when tests finish
         t.teardown(() => {

--- a/test/integration/infinite-tracing-connection.tap.js
+++ b/test/integration/infinite-tracing-connection.tap.js
@@ -276,8 +276,6 @@ const infiniteTracingService = grpc.loadPackageDefinition(packageDefinition).com
           server = createGrpcServer(sslOpts, services, (err, port) => {
             t.error(err)
 
-            server.start()
-
             agent = helper.loadMockedAgent({
               license_key: EXPECTED_LICENSE_KEY,
               apdex_t: Number.MIN_VALUE, // force transaction traces


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

I noticed when adding support for Node 22 we had some deprecation warnings.  

```sh
(node:98461) DeprecationWarning: Calling start() is no longer necessary. It can be safely omitted.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

When adding `--trace-deprecation` to the entire integration run I discovered

```sh
(node:99014) DeprecationWarning: Calling start() is no longer necessary. It can be safely omitted.
    at /Users/revans/code/pull-requests/node-newrelic/test/integration/grpc/reconnect.tap.js:221:16
    at /Users/revans/code/pull-requests/node-newrelic/node_modules/@grpc/grpc-js/src/server.ts:869:11
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

It also existed in another grpc test.  

## How to Test

`node test/integration/grpc/reconnect.tap.js`

The deprecation warning is gone.

## Additional Information

There is still this warning

```sh
(node:20389) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

But it is safe because if/when Node.js removes `punycode` the `unicode-length` package will use its 3rd party dep of punycode based on this [copy](https://github.com/mathiasbynens/punycode.js?tab=readme-ov-file#installation)

> ⚠️ Note that userland modules don't hide core modules. For example, require('punycode') still imports the deprecated core module even if you executed npm install punycode. Use require('punycode/') to import userland modules rather than core modules.

