### PR TITLE
ci: Include date created when adding new issue/pr to board

### DIFF
--- a/.github/workflows/board.yml
+++ b/.github/workflows/board.yml
@@ -82,9 +82,11 @@ jobs:
             }' -f org=newrelic -F number=$PROJECT_ID > project_data.json
           # Save the values of project id, status field id and the todo and needs pr column ids
           echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
+          echo 'DATE_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Date created") | .id' project_data.json) >> $GITHUB_ENV
           echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
           echo 'TODO_OPTION_ID='$(jq -r --arg TODO_COL_NAME "$TODO_COL_NAME" '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name==$TODO_COL_NAME) |.id' project_data.json) >> $GITHUB_ENV
           echo 'PR_OPTION_ID='$(jq -r --arg PR_COL_NAME "$PR_COL_NAME" '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name==$PR_COL_NAME) |.id' project_data.json) >> $GITHUB_ENV
+          echo 'DATE='$(date +"%Y-%m-%d") >> $GITHUB_ENV
     - name: Assign Issue/PR to Project
       run: |
         # Add Issue/PR to board depending on event type
@@ -97,12 +99,15 @@ jobs:
             }
           }' -f project=$PROJECT_ID -f id=$ISSUE_OR_PR_ID --jq '.data.addProjectV2ItemById.item.id')"
           # Update the status to Triage Needed/Needs PR Review depending on event type
+          # and update the date so it shows on top of column
           gh api graphql -f query='
             mutation (
               $project: ID!
               $item: ID!
               $status_field: ID!
               $status_value: String!
+              $date_field: ID!
+              $date_value: Date!
             ) {
               set_status: updateProjectV2ItemFieldValue(input: {
                 projectId: $project
@@ -116,6 +121,18 @@ jobs:
                   id
                   }
               }
-            }' -f project=$PROJECT_ID -f item=$item_id -f status_field=$STATUS_FIELD_ID -f status_value=${{ github.event_name == 'pull_request_target' && env.PR_OPTION_ID || env.TODO_OPTION_ID }} --silent
+              set_date_posted: updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $date_field
+                value: {
+                  date: $date_value
+                }
+              }) {
+                projectV2Item {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f item=$item_id -f status_field=$STATUS_FIELD_ID -f status_value=${{ github.event_name == 'pull_request_target' && env.PR_OPTION_ID || env.TODO_OPTION_ID }} -f date_field=$DATE_FIELD_ID -f date_value=$DATE --silent
       env:
         ISSUE_OR_PR_ID: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.node_id || github.event.issue.node_id }}


### PR DESCRIPTION
## Description

I added a new custom field called `Date created` to the project board and backfilled all issues, didn't worry about PRs. but now you can set the sort order by date created to see most recent at top of every column

<img width="1440" alt="screenshot 2024-07-17 at 4 25 53 PM" src="https://github.com/user-attachments/assets/a401ba06-08b2-4256-ae30-9b61cfbc3822">


