### PR TITLE
ci: Pin Node 22 to 22.4.1

### DIFF
--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.4.1]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.4.1]
 
     steps:
     - uses: actions/checkout@v4
@@ -130,7 +130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.4.1]
 
     steps:
     - uses: actions/checkout@v4
@@ -166,7 +166,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.4.1]
 
     steps:
     - uses: actions/checkout@v4
@@ -217,7 +217,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.4.1]
 
     steps:
     - uses: actions/checkout@v4
@@ -240,7 +240,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.4.1]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/smoke-test-workflow.yml
+++ b/.github/workflows/smoke-test-workflow.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.4.1]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/versioned-coverage.yml
+++ b/.github/workflows/versioned-coverage.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.4.1]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/versioned-security-agent.yml
+++ b/.github/workflows/versioned-security-agent.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.4.1]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Looks like [Node 22.5.0](https://github.com/nodejs/node/issues/53902) broke npm install.  This PR pins to 22.4.1 so our CI can continue to run properly.
