### PR TITLE
fix: Updated aws-sdk v3 instrumentation to custom middleware last to properly get the external http span to add aws.* attributes

### DIFF
--- a/lib/instrumentation/aws-sdk/v3/common.js
+++ b/lib/instrumentation/aws-sdk/v3/common.js
@@ -95,6 +95,7 @@ module.exports.middlewareConfig = [
     config: {
       name: 'NewRelicDeserialize',
       step: 'deserialize',
+      priority: 'low',
       override: true
     }
   }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

I think the bug describes it all.  I was worried about this fix after digging deep into the middleware that get called.  However, it was just explicitly stating the priority to ensure the response from our middleware is the IncomingMessage and we can get the active external http span

## How to Test

```sh
npm run versioned:internal aws-sdk-v3
```

## Related Issues
Closes #2378
