### PR TITLE
chore: Add test configs for defined targets in the aws test suite

### DIFF
--- a/test/versioned/aws-sdk-v3/package.json
+++ b/test/versioned/aws-sdk-v3/package.json
@@ -149,6 +149,10 @@
         "@aws-sdk/client-sns": {
           "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
           "samples": 10
+        },
+        "@aws-sdk/smithy-client": {
+          "versions": ">=3.47.0 <3.370.0",
+          "samples": 3
         }
       },
       "files": [
@@ -204,7 +208,11 @@
         "node": ">=16.0"
       },
       "dependencies": {
-        "@aws-sdk/client-bedrock-runtime": "^3.474.0"
+        "@aws-sdk/client-bedrock-runtime": "^3.474.0",
+        "@smithy/smithy-client": {
+          "versions": ">=2.0.0",
+          "samples": 3
+        }
       },
       "files": [
         "bedrock-chat-completions.tap.js",

--- a/test/versioned/aws-sdk-v3/package.json
+++ b/test/versioned/aws-sdk-v3/package.json
@@ -152,7 +152,7 @@
         },
         "@aws-sdk/smithy-client": {
           "versions": ">=3.47.0 <3.370.0",
-          "samples": 3
+          "samples": 1
         }
       },
       "files": [
@@ -211,7 +211,7 @@
         "@aws-sdk/client-bedrock-runtime": "^3.474.0",
         "@smithy/smithy-client": {
           "versions": ">=2.0.0",
-          "samples": 3
+          "samples": 1
         }
       },
       "files": [


### PR DESCRIPTION
This should fix an issue exposed in #2401. The versions used as minimums were derived by examining what was available when support was first added to the agent.