### PR TITLE
feat!: Removed support for `redis` < 2.6.0

### DIFF
--- a/lib/instrumentation/redis.js
+++ b/lib/instrumentation/redis.js
@@ -5,7 +5,6 @@
 
 'use strict'
 
-const hasOwnProperty = require('../util/properties').hasOwn
 const stringify = require('json-stringify-safe')
 const {
   OperationSpec,
@@ -20,15 +19,19 @@ module.exports = function initialize(_agent, redis, _moduleName, shim) {
 
   shim.setDatastore(shim.REDIS)
 
-  if (proto.internal_send_command) {
-    registerInternalSendCommand(shim, proto)
-  } else {
-    registerSendCommand(shim, proto)
+  if (!proto.internal_send_command) {
+    shim.logger.warn(
+      'New Relic Node.js agent no longer supports redis < 2.6.0, current version %s. Please downgrade to v11 for support, if needed',
+      shim.pkgVersion
+    )
+    return
   }
+
+  registerInternalSendCommand(shim, proto)
 }
 
 /**
- * Instrumentation used in versions of redis > 2.6.1 < 4 to record all redis commands
+ * Instrumentation used in versions of redis >= 2.6.0 < 4 to record all redis commands
  *
  * @param {Shim} shim instance of shim
  * @param {object} proto RedisClient prototype
@@ -40,7 +43,7 @@ function registerInternalSendCommand(shim, proto) {
     function wrapInternalSendCommand(shim, _, __, args) {
       const commandObject = args[0]
       const keys = commandObject.args
-      const parameters = getInstanceParameters(shim, this)
+      const parameters = getInstanceParameters(this)
 
       parameters.key = stringifyKeys(shim, keys)
 
@@ -68,34 +71,6 @@ function registerInternalSendCommand(shim, proto) {
   )
 }
 
-/**
- * Instrumentation used in versions of redis < 2.6.1 to record all redis commands
- *
- * @param {Shim} shim instance of shim
- * @param {object} proto RedisClient prototype
- */
-function registerSendCommand(shim, proto) {
-  shim.recordOperation(proto, 'send_command', function wrapSendCommand(shim, _, __, args) {
-    const [command, keys] = args
-    const parameters = getInstanceParameters(shim, this)
-
-    parameters.key = stringifyKeys(shim, keys)
-
-    return new OperationSpec({
-      name: command || 'other',
-      parameters,
-      callback: function bindCallback(shim, _f, _n, segment) {
-        const last = args[args.length - 1]
-        if (shim.isFunction(last)) {
-          shim.bindCallbackSegment(null, args, shim.LAST, segment)
-        } else if (shim.isArray(last) && shim.isFunction(last[last.length - 1])) {
-          shim.bindCallbackSegment(null, last, shim.LAST, segment)
-        }
-      }
-    })
-  })
-}
-
 function stringifyKeys(shim, keys) {
   let key = null
   if (keys && keys.length && !shim.isFunction(keys)) {
@@ -111,35 +86,14 @@ function stringifyKeys(shim, keys) {
 }
 
 /**
- * Captures the necessary datastore parameters based on the specific version of redis
+ * Captures the necessary datastore parameters from redis client
  *
- * @param {Shim} shim instance of shim
  * @param {object} client instance of redis client
  * @returns {object} datastore parameters
  */
-function getInstanceParameters(shim, client) {
-  if (hasOwnProperty(client, 'connection_options')) {
-    // for redis 2.4.0 - 2.6.2
-    return doCapture(client, client.connection_options)
-  } else if (hasOwnProperty(client, 'connectionOption')) {
-    // for redis 0.12 - 2.2.5
-    return doCapture(client, client.connectionOption)
-  } else if (hasOwnProperty(client, 'options')) {
-    // for redis 2.3.0 - 2.3.1
-    return doCapture(client, client.options)
-  }
-  shim.logger.debug('Could not access instance attributes on connection.')
-  return doCapture()
-}
+function getInstanceParameters(client = {}) {
+  const opts = client?.connection_options
 
-/**
- * Extracts the relevant datastore parameters
- *
- * @param {object} client instance of redis client
- * @param {object} opts options for the client instance
- * @returns {object} datastore parameters
- */
-function doCapture(client = {}, opts = {}) {
   return new DatastoreParameters({
     host: opts.host || 'localhost',
     port_path_or_id: opts.path || opts.port || '6379',


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

The jira ticket stated removing support for <2.6.1 however after testing it's <2.6.0.  I was able to cleanup other parsing of the client to get the host/port/db.

## How to Test

```
npm run versioned:internal redis
```
## Related Issues
No Github issue but Jira:

Closes NR-95813