### PR TITLE
fix: Updated docker container ID parsing regex

### DIFF
--- a/lib/utilization/docker-info.js
+++ b/lib/utilization/docker-info.js
@@ -197,7 +197,7 @@ function fetchDockerVendorInfo(agent, callback, logger = log) {
  * @param {object} [logger] internal logger instance
  */
 function parseCGroupsV2(data, callback, logger = log) {
-  const containerLine = new RegExp('/docker/containers/([0-9a-f]{64})/')
+  const containerLine = new RegExp('/containers/([0-9a-f]{64})/')
   const line = containerLine.exec(data)
   if (line) {
     callback(null, { id: line[1] })


### PR DESCRIPTION
## Description

For cgroup V2 containers, the agent parses `/proc/self/mountinfo` for the container ID. We expected these to be in the format `/docker/containers/{id}` where ID is a 64 character string. 

A customer recently reported that their APM telemetry was not linked to infra telemetry, and APM logs showed that the container ID was not parsed successfully. On inspecting the contents of `mountinfo`, we found no id-containing strings with the expected format, but `/containers/{id}` strings were present. This change would find matches for either case. 

## How to Test

Cross-agent tests reference container ID; they're run in integration tests. 

## Related Issues

Closes NR-293133