### PR TITLE
chore: Limited superagent tests to avoid new breaking release

### DIFF
--- a/test/versioned/superagent/package.json
+++ b/test/versioned/superagent/package.json
@@ -9,7 +9,7 @@
     },
     "dependencies": {
       "superagent": {
-        "versions": ">=3 <7.1.0 ||  >=7.1.1",
+        "versions": ">=3 <7.1.0 ||  >=7.1.1 && <10.0.0",
         "samples": 5
       }
     },


### PR DESCRIPTION
This PR omits the latest `superagent` release (https://github.com/ladjs/superagent/releases/tag/v10.0.0) from the versioned test matrix as it causes test failures. This will allow our CI to continue working while we investigate.