### PR TITLE
chore: Remove promise resolvers from callback based agent unit tests

### DIFF
--- a/test/unit/agent/synthetics.test.js
+++ b/test/unit/agent/synthetics.test.js
@@ -7,7 +7,6 @@
 
 const test = require('node:test')
 const assert = require('node:assert')
-const promiseResolvers = require('../../lib/promise-resolvers')
 const helper = require('../../lib/agent_helper')
 
 test('synthetics transaction traces', async (t) => {
@@ -22,9 +21,8 @@ test('synthetics transaction traces', async (t) => {
     helper.unloadAgent(ctx.nr.agent)
   })
 
-  await t.test('should include synthetic intrinsics if header is set', async (t) => {
+  await t.test('should include synthetic intrinsics if header is set', (t, end) => {
     const { agent } = t.nr
-    const { promise, resolve } = promiseResolvers()
 
     helper.runInTransaction(agent, function (tx) {
       tx.syntheticsData = {
@@ -41,9 +39,7 @@ test('synthetics transaction traces', async (t) => {
       assert.equal(trace.intrinsics.synthetics_job_id, 'jobId')
       assert.equal(trace.intrinsics.synthetics_monitor_id, 'monId')
 
-      resolve()
+      end()
     })
-
-    await promise
   })
 })


### PR DESCRIPTION
This PR removes the promise resolvers workaround from the agent unit tests. I discovered that the test function supports a second `done`/`end` parameter that is a function to be invoked when the test is complete.

Note:

```js
// This test will not work as the promise from the `async` takes precedence:
test('something', async (t, end) => {
	someCallback('does something', (error) => {
		end(error)
	})
})

// This test will work as expected because no promises are involved:
test('something', (t, end) => {
	someCallback('does something', (error) => {
		end(error)
	})
})

// If we need async operations, we should still use promise resolvers:
test('something', async (t) => {
	const { promise, resolve, reject } = Promise.withResolvers()
	const aThing = await getThing()
	someCallback('does something', { with: aThing }, (error) => {
		if (error) { return reject(error) }
		resolve()
	})
	await promise
})
```