### PR TITLE
fix: Updated amqplib instrumentation to properly parse host/port from connect

### DIFF
--- a/lib/instrumentation/amqplib/amqplib.js
+++ b/lib/instrumentation/amqplib/amqplib.js
@@ -9,10 +9,10 @@ const {
   OperationSpec,
   params: { DatastoreParameters }
 } = require('../../shim/specs')
-const url = require('url')
 const wrapModel = require('./channel-model')
-const { setCallback } = require('./utils')
+const { setCallback, parseConnectionArgs } = require('./utils')
 const wrapChannel = require('./channel')
+const { amqpConnection } = require('../../symbols')
 
 module.exports.instrumentPromiseAPI = instrumentChannelAPI
 module.exports.instrumentCallbackAPI = instrumentCallbackAPI
@@ -73,31 +73,52 @@ function instrumentAMQP(shim, amqp, promiseMode) {
 /**
  *
  * Instruments the connect method
+ * We have to both wrap and record because
+ * we need the host/port for all subsequent calls on the model/channel
+ * but record only completes in an active transaction
  *
  * @param {Shim} shim instance of shim
  * @param {object} amqp amqplib object
  * @param {boolean} promiseMode is this promise based?
  */
 function wrapConnect(shim, amqp, promiseMode) {
-  shim.record(amqp, 'connect', function recordConnect(shim, connect, name, args) {
-    let [connArgs] = args
-    const params = new DatastoreParameters()
-
-    if (shim.isString(connArgs)) {
-      connArgs = url.parse(connArgs)
-      params.host = connArgs.hostname
-      if (connArgs.port) {
-        params.port = connArgs.port
+  shim.wrap(amqp, 'connect', function recordConnect(shim, connect) {
+    return function wrappedConnect() {
+      const args = shim.argsToArray.apply(shim, arguments)
+      const [connArgs] = args
+      const params = parseConnectionArgs({ shim, connArgs })
+      const cb = args[args.length - 1]
+      if (!promiseMode) {
+        args[args.length - 1] = function wrappedCallback() {
+          const cbArgs = shim.argsToArray.apply(shim, arguments)
+          const [, c] = cbArgs
+          c.connection[amqpConnection] = params
+          return cb.apply(this, cbArgs)
+        }
       }
-    }
 
+      const result = connect.apply(this, args)
+      if (promiseMode) {
+        return result.then((c) => {
+          c.connection[amqpConnection] = params
+          return c
+        })
+      }
+      return result
+    }
+  })
+
+  shim.record(amqp, 'connect', function recordConnect(shim, connect, name, args) {
+    const [connArgs] = args
+    const params = parseConnectionArgs({ shim, connArgs })
     return new OperationSpec({
       name: 'amqplib.connect',
       callback: setCallback(shim, promiseMode),
       promise: promiseMode,
-      parameters: params,
-      stream: null,
-      recorder: null
+      parameters: new DatastoreParameters({
+        host: params.host,
+        port_path_or_id: params.port
+      })
     })
   })
 }

--- a/lib/instrumentation/amqplib/channel-model.js
+++ b/lib/instrumentation/amqplib/channel-model.js
@@ -5,6 +5,7 @@
 
 'use strict'
 const { MessageSpec, MessageSubscribeSpec, RecorderSpec } = require('../../shim/specs')
+const { amqpConnection } = require('../../symbols')
 const CHANNEL_METHODS = [
   'close',
   'open',
@@ -22,13 +23,7 @@ const CHANNEL_METHODS = [
   'prefetch',
   'recover'
 ]
-const {
-  describeMessage,
-  setCallback,
-  parseConnect,
-  getParametersFromMessage,
-  TEMP_RE
-} = require('./utils')
+const { describeMessage, setCallback, getParametersFromMessage, TEMP_RE } = require('./utils')
 
 /**
  *
@@ -89,7 +84,7 @@ function recordPurge({ shim, proto, promiseMode }) {
 
 function recordGet({ shim, proto, promiseMode }) {
   shim.recordConsume(proto, 'get', function wrapGet() {
-    const { host, port } = parseConnect(this?.connection?.stream)
+    const { host, port } = this?.connection?.[amqpConnection] || {}
     return new MessageSpec({
       destinationName: shim.FIRST,
       callback: setCallback(shim, promiseMode),
@@ -115,7 +110,7 @@ function recordGet({ shim, proto, promiseMode }) {
 
 function recordConsume({ shim, proto, promiseMode }) {
   shim.recordSubscribedConsume(proto, 'consume', function consume() {
-    const { host, port } = parseConnect(this?.connection?.stream)
+    const { host, port } = this?.connection?.[amqpConnection] || {}
     return new MessageSubscribeSpec({
       name: 'amqplib.Channel#consume',
       queue: shim.FIRST,

--- a/lib/instrumentation/amqplib/channel.js
+++ b/lib/instrumentation/amqplib/channel.js
@@ -5,7 +5,8 @@
 
 'use strict'
 const { MessageSpec } = require('../../shim/specs')
-const { parseConnect, getParameters, TEMP_RE } = require('./utils')
+const { amqpConnection } = require('../../symbols')
+const { getParameters, TEMP_RE } = require('./utils')
 
 /**
  *
@@ -47,24 +48,26 @@ module.exports = function wrapChannel(shim) {
     }
   })
 
-  shim.recordProduce(proto, 'sendMessage', function recordSendMessage(shim, fn, n, args) {
-    const fields = args[0]
-    if (!fields) {
-      return null
-    }
-    const isDefault = fields.exchange === ''
-    let exchange = 'Default'
-    if (!isDefault) {
-      exchange = TEMP_RE.test(fields.exchange) ? null : fields.exchange
-    }
-    const { host, port } = parseConnect(this?.connection?.stream)
+  shim.recordProduce(proto, 'sendMessage', recordSendMessage)
+}
 
-    return new MessageSpec({
-      destinationName: exchange,
-      destinationType: shim.EXCHANGE,
-      routingKey: fields.routingKey,
-      headers: fields.headers,
-      parameters: getParameters({ parameters: Object.create(null), fields, host, port })
-    })
+function recordSendMessage(shim, fn, n, args) {
+  const fields = args[0]
+  if (!fields) {
+    return null
+  }
+  const isDefault = fields.exchange === ''
+  let exchange = 'Default'
+  if (!isDefault) {
+    exchange = TEMP_RE.test(fields.exchange) ? null : fields.exchange
+  }
+  const { host, port } = this?.connection?.[amqpConnection] || {}
+
+  return new MessageSpec({
+    destinationName: exchange,
+    destinationType: shim.EXCHANGE,
+    routingKey: fields.routingKey,
+    headers: fields.headers,
+    parameters: getParameters({ parameters: Object.create(null), fields, host, port })
   })
 }

--- a/lib/instrumentation/amqplib/utils.js
+++ b/lib/instrumentation/amqplib/utils.js
@@ -8,7 +8,7 @@ const {
   MessageSpec,
   params: { QueueMessageParameters }
 } = require('../../shim/specs')
-const { amqpConnection } = require('../../symbols')
+const url = require('url')
 const TEMP_RE = /^amq\./
 
 /**
@@ -101,25 +101,6 @@ function getParametersFromMessage({ message, host, port }) {
 }
 
 /**
- * Extracts the host/port from the amqp socket connection.
- * Stores on connection as symbol to only parse once.
- *
- * @param {Socket} socket amqp connection
- * @returns {object} {host, port } of connection
- */
-function parseConnect(socket) {
-  if (socket[amqpConnection]) {
-    return socket[amqpConnection]
-  }
-  const host = ['127.0.0.1', '::1', '[::1]'].includes(socket?.remoteAddress)
-    ? 'localhost'
-    : socket?.remoteAddress
-  const port = socket?.remotePort
-  socket[amqpConnection] = { host, port }
-  return { host, port }
-}
-
-/**
  * Helper to set the appropriate value of the callback property
  * in the spec. If it's a promise set to null otherwise set it to `shim.LAST`
  *
@@ -131,11 +112,33 @@ function setCallback(shim, promiseMode) {
   return promiseMode ? null : shim.LAST
 }
 
+/**
+ * Parses the connection args to return host/port
+ *
+ * @param {string|object} connArgs connection arguments
+ * @returns {object} {host, port }
+ */
+function parseConnectionArgs({ shim, connArgs }) {
+  const params = {}
+  if (shim.isString(connArgs)) {
+    connArgs = url.parse(connArgs)
+    params.host = connArgs.hostname
+    if (connArgs.port) {
+      params.port = parseInt(connArgs.port, 10)
+    }
+  } else {
+    params.port = parseInt(connArgs.port, 10) || connArgs.protocol === 'amqp:' ? 5672 : 5671
+    params.host = connArgs.hostname
+  }
+
+  return params
+}
+
 module.exports = {
   describeMessage,
   getParameters,
   getParametersFromMessage,
-  parseConnect,
+  parseConnectionArgs,
   setCallback,
   TEMP_RE
 }


### PR DESCRIPTION
## Description
This PR does further instrumentation of connect and assigns the host/port from the connection to the model/channel to be used later to assign the host/port on the relevant spans. I also fixed the connect record to properly record `server.address` and `server.port` and added assertions to the versioned tests.

## How to Test

```sh
npm run versioned:internal amqplib
```

## Related Issues
Closes #2459 