### PR TITLE
fix: Updated redis instrumentation to parse host/port when a url is not provided

### DIFF
--- a/lib/instrumentation/@node-redis/client.js
+++ b/lib/instrumentation/@node-redis/client.js
@@ -104,8 +104,9 @@ function getRedisParams(clientOpts) {
   }
 
   return new DatastoreParameters({
-    host: clientOpts?.socket?.host || 'localhost',
-    port_path_or_id: clientOpts?.socket?.path || clientOpts?.socket?.port || '6379',
+    host: clientOpts?.host || clientOpts?.socket?.host || 'localhost',
+    port_path_or_id:
+      clientOpts?.port || clientOpts?.socket?.path || clientOpts?.socket?.port || '6379',
     database_name: clientOpts?.database || 0
   })
 }

--- a/test/unit/instrumentation/redis.test.js
+++ b/test/unit/instrumentation/redis.test.js
@@ -26,8 +26,8 @@ tap.test('getRedisParams should behave as expected', function (t) {
   t.test('if host/port are defined incorrectly, should return expected defaults', function (t) {
     const params = getRedisParams({ host: 'myLocalHost', port: '1234' })
     const expected = {
-      host: 'localhost',
-      port_path_or_id: '6379',
+      host: 'myLocalHost',
+      port_path_or_id: '1234',
       database_name: 0
     }
     t.match(params, expected, 'should return sensible defaults if defined without socket')

--- a/test/versioned/redis/redis-v4-legacy-mode.tap.js
+++ b/test/versioned/redis/redis-v4-legacy-mode.tap.js
@@ -30,7 +30,8 @@ test('Redis instrumentation', function (t) {
     const redis = require('redis')
     client = redis.createClient({
       legacyMode: true,
-      socket: { port: params.redis_port, host: params.redis_host }
+      port: params.redis_port,
+      host: params.redis_host
     })
 
     await client.connect()


### PR DESCRIPTION
…ot provided

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This PR addresses handling parsing host/port when provided to connect when assigning host and port on the spans for redis

## How to Test

```sh
npm run versioned:internal redis
```

## Related Issues
Closes #2462 