### PR TITLE
feat: Added instrumentation support for Express 5 beta

### DIFF
--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -6,7 +6,6 @@
 'use strict'
 
 const { MiddlewareSpec, MiddlewareMounterSpec, RenderSpec } = require('../../lib/shim/specs')
-const { MIDDLEWARE_TYPE_NAMES } = require('../../lib/shim/webframework-shim/common')
 
 /**
  * Express middleware generates traces where middleware are considered siblings
@@ -25,25 +24,6 @@ module.exports = function initialize(agent, express, moduleName, shim) {
     return err !== 'route' && err !== 'router'
   })
 
-  if (express.Router.use) {
-    wrapExpress4(shim, express)
-  } else {
-    wrapExpress3(shim, express)
-  }
-}
-
-function wrapExpress4(shim, express) {
-  // Wrap `use` and `route` which are hung off `Router` directly, not on a
-  // prototype.
-  shim.wrapMiddlewareMounter(
-    express.Router,
-    'use',
-    new MiddlewareMounterSpec({
-      route: shim.FIRST,
-      wrapper: wrapMiddleware
-    })
-  )
-
   shim.wrapMiddlewareMounter(
     express.application,
     'use',
@@ -53,7 +33,21 @@ function wrapExpress4(shim, express) {
     })
   )
 
-  shim.wrap(express.Router, 'route', function wrapRoute(shim, fn) {
+  wrapExpressRouter(shim, express.Router.use ? express.Router : express.Router.prototype)
+  wrapResponse(shim, express.response)
+}
+
+function wrapExpressRouter(shim, router) {
+  shim.wrapMiddlewareMounter(
+    router,
+    'use',
+    new MiddlewareMounterSpec({
+      route: shim.FIRST,
+      wrapper: wrapMiddleware
+    })
+  )
+
+  shim.wrap(router, 'route', function wrapRoute(shim, fn) {
     if (!shim.isFunction(fn)) {
       return fn
     }
@@ -89,7 +83,7 @@ function wrapExpress4(shim, express) {
   })
 
   shim.wrapMiddlewareMounter(
-    express.Router,
+    router,
     'param',
     new MiddlewareMounterSpec({
       route: shim.FIRST,
@@ -105,56 +99,6 @@ function wrapExpress4(shim, express) {
       }
     })
   )
-
-  wrapResponse(shim, express.response)
-}
-
-function wrapExpress3(shim, express) {
-  // In Express 3 the app returned from `express()` is actually a `connect` app
-  // which we have no access to before creation. We can not easily wrap the app
-  // because there are a lot of methods dangling on it that act on the app itself.
-  // Really we just care about apps being used as `request` event listeners on
-  // `http.Server` instances so we'll wrap that instead.
-
-  shim.wrapMiddlewareMounter(
-    express.Router.prototype,
-    'param',
-    new MiddlewareMounterSpec({
-      route: shim.FIRST,
-      wrapper: function wrapParamware(shim, middleware, fnName, route) {
-        return shim.recordParamware(
-          middleware,
-          new MiddlewareSpec({
-            name: route,
-            req: shim.FIRST,
-            next: shim.THIRD,
-            type: MIDDLEWARE_TYPE_NAMES.PARAMWARE
-          })
-        )
-      }
-    })
-  )
-  shim.wrapMiddlewareMounter(
-    express.Router.prototype,
-    'use',
-    new MiddlewareMounterSpec({
-      route: shim.FIRST,
-      wrapper: wrapMiddleware
-    })
-  )
-  shim.wrapMiddlewareMounter(
-    express.application,
-    'use',
-    new MiddlewareMounterSpec({
-      route: shim.FIRST,
-      wrapper: wrapMiddleware
-    })
-  )
-
-  // NOTE: Do not wrap application route methods in Express 3, they all just
-  // forward their arguments to the router.
-  wrapRouteMethods(shim, express.Router.prototype, shim.FIRST)
-  wrapResponse(shim, express.response)
 }
 
 function wrapRouteMethods(shim, route, path) {

--- a/test/lib/metrics_helper.js
+++ b/test/lib/metrics_helper.js
@@ -48,7 +48,7 @@ function assertMetrics(metrics, expected, exclusive, assertValues) {
   for (let i = 0, len = expected.length; i < len; i++) {
     const expectedMetric = expected[i]
     const metric = metrics.getMetric(expectedMetric[0].name, expectedMetric[0].scope)
-    this.ok(metric)
+    this.ok(metric, `should find ${expectedMetric[0].name}`)
     if (assertValues) {
       this.same(metric.toJSON(), expectedMetric[1])
     }

--- a/test/versioned/express-esm/package.json
+++ b/test/versioned/express-esm/package.json
@@ -10,9 +10,22 @@
         "node": ">=18"
       },
       "dependencies": {
-        "express": ">=4.6.0",
-        "express-enrouten": "1.1",
-        "ejs": "2.5.9"
+        "express": {
+          "versions": ">=4.6.0",
+          "samples": 5
+        }
+      },
+      "files": [
+        "segments.tap.mjs",
+        "transaction-naming.tap.mjs"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=18"
+      },
+      "dependencies": {
+        "express": "5.0.0-beta.3"
       },
       "files": [
         "segments.tap.mjs",

--- a/test/versioned/express-esm/segments.tap.mjs
+++ b/test/versioned/express-esm/segments.tap.mjs
@@ -3,15 +3,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import semver from 'semver'
 import helper from '../../lib/agent_helper.js'
 import NAMES from '../../../lib/metrics/names.js'
-import '../../lib/metrics_helper.js'
+import { findSegment } from '../../lib/metrics_helper.js'
 import { test } from 'tap'
 import expressHelpers from './helpers.mjs'
 const { setup, makeRequestAndFinishTransaction } = expressHelpers
 const assertSegmentsOptions = {
-  exact: true
+  exact: true,
+  // in Node 8 the http module sometimes creates a setTimeout segment
+  // the query and expressInit middleware are registered under the hood up until express 5
+  exclude: [NAMES.EXPRESS.MIDDLEWARE + 'query', NAMES.EXPRESS.MIDDLEWARE + 'expressInit']
 }
+// import expressPkg from 'express/package.json' assert {type: 'json'}
+// const pkgVersion = expressPkg.version
+import { readFileSync } from 'node:fs'
+const { version: pkgVersion } = JSON.parse(readFileSync('./node_modules/express/package.json'))
+// TODO: change to 5.0.0 when officially released
+const isExpress5 = semver.gte(pkgVersion, '5.0.0-beta.3')
 
 test('transaction segments tests', (t) => {
   t.autoend()
@@ -35,12 +45,7 @@ test('transaction segments tests', (t) => {
     const { rootSegment, transaction } = await runTest({ app, t })
     t.assertSegments(
       rootSegment,
-      [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
-        'Expressjs/Route Path: /test',
-        [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>']
-      ],
+      ['Expressjs/Route Path: /test', [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>']],
       assertSegmentsOptions
     )
 
@@ -70,12 +75,7 @@ test('transaction segments tests', (t) => {
     const { rootSegment, transaction } = await runTest({ app, t })
     t.assertSegments(
       rootSegment,
-      [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
-        'Expressjs/Route Path: /test',
-        [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>']
-      ],
+      ['Expressjs/Route Path: /test', [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>']],
       assertSegmentsOptions
     )
 
@@ -92,12 +92,7 @@ test('transaction segments tests', (t) => {
     const { rootSegment, transaction } = await runTest({ app, t })
     t.assertSegments(
       rootSegment,
-      [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
-        'Expressjs/Route Path: /test',
-        [NAMES.EXPRESS.MIDDLEWARE + 'myHandler']
-      ],
+      ['Expressjs/Route Path: /test', [NAMES.EXPRESS.MIDDLEWARE + 'myHandler']],
       assertSegmentsOptions
     )
 
@@ -111,9 +106,12 @@ test('transaction segments tests', (t) => {
       res.send()
     })
 
-    const { rootSegment, transaction } = await runTest({ app, t, endpoint: '/test/1' })
-    const routeSegment = rootSegment.children[2]
-    t.equal(routeSegment.name, NAMES.EXPRESS.MIDDLEWARE + 'handler//test/:id')
+    const { transaction } = await runTest({ app, t, endpoint: '/test/1' })
+    const routeSegment = findSegment(
+      transaction.trace.root,
+      NAMES.EXPRESS.MIDDLEWARE + 'handler//test/:id'
+    )
+    t.ok(routeSegment)
 
     checkMetrics(
       t,
@@ -140,8 +138,6 @@ test('transaction segments tests', (t) => {
     t.assertSegments(
       rootSegment,
       [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
         'Expressjs/Route Path: /test',
         [NAMES.EXPRESS.MIDDLEWARE + 'handler1', NAMES.EXPRESS.MIDDLEWARE + 'handler2']
       ],
@@ -168,8 +164,6 @@ test('transaction segments tests', (t) => {
     t.assertSegments(
       rootSegment,
       [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
         'Expressjs/Router: /router1',
         ['Expressjs/Route Path: /test', [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>']]
       ],
@@ -203,8 +197,6 @@ test('transaction segments tests', (t) => {
     t.assertSegments(
       rootSegment,
       [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
         'Expressjs/Router: /',
         'Expressjs/Router: /',
         ['Expressjs/Route Path: /test', [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>']]
@@ -223,15 +215,14 @@ test('transaction segments tests', (t) => {
       res.send('test')
     })
 
-    app.get('*', router1)
+    const path = isExpress5 ? '(.*)' : '*'
+    app.get(path, router1)
 
     const { rootSegment, transaction } = await runTest({ app, t })
     t.assertSegments(
       rootSegment,
       [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
-        'Expressjs/Route Path: /*',
+        `Expressjs/Route Path: /${path}`,
         [
           'Expressjs/Router: /',
           ['Expressjs/Route Path: /test', [NAMES.EXPRESS.MIDDLEWARE + 'testHandler']]
@@ -243,8 +234,8 @@ test('transaction segments tests', (t) => {
     checkMetrics(
       t,
       transaction.metrics,
-      [NAMES.EXPRESS.MIDDLEWARE + 'testHandler//*/test'],
-      '/*/test'
+      [`${NAMES.EXPRESS.MIDDLEWARE}testHandler//${path}/test`],
+      `/${path}/test`
     )
   })
 
@@ -262,8 +253,6 @@ test('transaction segments tests', (t) => {
     t.assertSegments(
       rootSegment,
       [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
         'Expressjs/Router: /router1',
         ['Expressjs/Route Path: /test', [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>']]
       ],
@@ -289,35 +278,26 @@ test('transaction segments tests', (t) => {
     app.use('/subapp1', subapp)
 
     const { rootSegment, transaction } = await runTest({ app, t, endpoint: '/subapp1/test' })
+    // express 5 no longer handles child routers as mounted applications
+    const firstSegment = isExpress5
+      ? NAMES.EXPRESS.MIDDLEWARE + 'app//subapp1'
+      : 'Expressjs/Mounted App: /subapp1'
+
     t.assertSegments(
       rootSegment,
-      [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
-        'Expressjs/Mounted App: /subapp1',
-        [
-          NAMES.EXPRESS.MIDDLEWARE + 'query',
-          NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
-          'Expressjs/Route Path: /test',
-          [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>']
-        ]
-      ],
+      [firstSegment, ['Expressjs/Route Path: /test', [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>']]],
       assertSegmentsOptions
     )
 
     checkMetrics(
       t,
       transaction.metrics,
-      [
-        NAMES.EXPRESS.MIDDLEWARE + 'query//subapp1',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit//subapp1',
-        NAMES.EXPRESS.MIDDLEWARE + '<anonymous>//subapp1/test'
-      ],
+      [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>//subapp1/test'],
       '/subapp1/test'
     )
   })
 
-  t.test('segments for sub-app', async function (t) {
+  t.test('segments for sub-app router', async function (t) {
     const { app, express } = await setup()
 
     const subapp = express()
@@ -337,15 +317,16 @@ test('transaction segments tests', (t) => {
     app.use('/subapp1', subapp)
 
     const { rootSegment, transaction } = await runTest({ app, t, endpoint: '/subapp1/test' })
+    // express 5 no longer handles child routers as mounted applications
+    const firstSegment = isExpress5
+      ? NAMES.EXPRESS.MIDDLEWARE + 'app//subapp1'
+      : 'Expressjs/Mounted App: /subapp1'
+
     t.assertSegments(
       rootSegment,
       [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
-        'Expressjs/Mounted App: /subapp1',
+        firstSegment,
         [
-          NAMES.EXPRESS.MIDDLEWARE + 'query',
-          NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
           'Expressjs/Route Path: /test',
           [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>', NAMES.EXPRESS.MIDDLEWARE + '<anonymous>'],
           'Expressjs/Route Path: /test',
@@ -358,11 +339,7 @@ test('transaction segments tests', (t) => {
     checkMetrics(
       t,
       transaction.metrics,
-      [
-        NAMES.EXPRESS.MIDDLEWARE + 'query//subapp1',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit//subapp1',
-        NAMES.EXPRESS.MIDDLEWARE + '<anonymous>//subapp1/test'
-      ],
+      [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>//subapp1/test'],
       '/subapp1/test'
     )
   })
@@ -378,30 +355,21 @@ test('transaction segments tests', (t) => {
     app.use('/subapp1', subapp)
 
     const { rootSegment, transaction } = await runTest({ app, t, endpoint: '/subapp1/test' })
+    // express 5 no longer handles child routers as mounted applications
+    const firstSegment = isExpress5
+      ? NAMES.EXPRESS.MIDDLEWARE + 'app//subapp1'
+      : 'Expressjs/Mounted App: /subapp1'
+
     t.assertSegments(
       rootSegment,
-      [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
-        'Expressjs/Mounted App: /subapp1',
-        [
-          NAMES.EXPRESS.MIDDLEWARE + 'query',
-          NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
-          'Expressjs/Route Path: /:app',
-          [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>']
-        ]
-      ],
+      [firstSegment, ['Expressjs/Route Path: /:app', [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>']]],
       assertSegmentsOptions
     )
 
     checkMetrics(
       t,
       transaction.metrics,
-      [
-        NAMES.EXPRESS.MIDDLEWARE + 'query//subapp1',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit//subapp1',
-        NAMES.EXPRESS.MIDDLEWARE + '<anonymous>//subapp1/:app'
-      ],
+      [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>//subapp1/:app'],
       '/subapp1/:app'
     )
   })
@@ -422,21 +390,16 @@ test('transaction segments tests', (t) => {
       t,
       endpoint: '/router1/subapp1/test'
     })
+    // express 5 no longer handles child routers as mounted applications
+    const subAppSegment = isExpress5
+      ? NAMES.EXPRESS.MIDDLEWARE + 'app//subapp1'
+      : 'Expressjs/Mounted App: /subapp1'
+
     t.assertSegments(
       rootSegment,
       [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
         'Expressjs/Router: /router1',
-        [
-          'Expressjs/Mounted App: /subapp1',
-          [
-            NAMES.EXPRESS.MIDDLEWARE + 'query',
-            NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
-            'Expressjs/Route Path: /test',
-            [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>']
-          ]
-        ]
+        [subAppSegment, ['Expressjs/Route Path: /test', [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>']]]
       ],
       assertSegmentsOptions
     )
@@ -444,11 +407,7 @@ test('transaction segments tests', (t) => {
     checkMetrics(
       t,
       transaction.metrics,
-      [
-        NAMES.EXPRESS.MIDDLEWARE + 'query//router1/subapp1',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit//router1/subapp1',
-        NAMES.EXPRESS.MIDDLEWARE + '<anonymous>//router1/subapp1/test'
-      ],
+      [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>//router1/subapp1/test'],
       '/router1/subapp1/test'
     )
   })
@@ -463,11 +422,7 @@ test('transaction segments tests', (t) => {
     const { rootSegment, transaction } = await runTest({ app, t })
     t.assertSegments(
       rootSegment,
-      [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
-        NAMES.EXPRESS.MIDDLEWARE + 'myHandler//test'
-      ],
+      [NAMES.EXPRESS.MIDDLEWARE + 'myHandler//test'],
       assertSegmentsOptions
     )
 
@@ -489,8 +444,6 @@ test('transaction segments tests', (t) => {
     t.assertSegments(
       rootSegment,
       [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
         'Expressjs/Route Path: /test',
         [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>'],
         NAMES.EXPRESS.MIDDLEWARE + 'myErrorHandler'
@@ -530,8 +483,6 @@ test('transaction segments tests', (t) => {
     t.assertSegments(
       rootSegment,
       [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
         'Expressjs/Router: /router',
         [
           'Expressjs/Route Path: /test',
@@ -576,8 +527,6 @@ test('transaction segments tests', (t) => {
     t.assertSegments(
       rootSegment,
       [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
         'Expressjs/Router: /router1',
         [
           'Expressjs/Router: /router2',
@@ -622,8 +571,6 @@ test('transaction segments tests', (t) => {
     t.assertSegments(
       rootSegment,
       [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
         'Expressjs/Router: /router',
         ['Expressjs/Route Path: /test', [NAMES.EXPRESS.MIDDLEWARE + '<anonymous>']],
         NAMES.EXPRESS.MIDDLEWARE + 'myErrorHandler'
@@ -665,8 +612,6 @@ test('transaction segments tests', (t) => {
     t.assertSegments(
       rootSegment,
       [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
         'Expressjs/Router: /router1',
         [
           'Expressjs/Router: /router2',
@@ -698,12 +643,7 @@ test('transaction segments tests', (t) => {
     const { rootSegment, transaction } = await runTest({ app, t, endpoint: '/a/b' })
     t.assertSegments(
       rootSegment,
-      [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
-        'Expressjs/Route Path: /:foo/:bar',
-        [NAMES.EXPRESS.MIDDLEWARE + 'myHandler']
-      ],
+      ['Expressjs/Route Path: /:foo/:bar', [NAMES.EXPRESS.MIDDLEWARE + 'myHandler']],
       assertSegmentsOptions
     )
 
@@ -718,23 +658,19 @@ test('transaction segments tests', (t) => {
   t.test('when using a string pattern in path', async function (t) {
     const { app } = await setup()
 
-    app.get('/ab?cd', function myHandler(req, res) {
+    const path = isExpress5 ? /ab?cd/ : '/ab?cd'
+    app.get(path, function myHandler(req, res) {
       res.end()
     })
 
     const { rootSegment, transaction } = await runTest({ app, t, endpoint: '/abcd' })
     t.assertSegments(
       rootSegment,
-      [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
-        'Expressjs/Route Path: /ab?cd',
-        [NAMES.EXPRESS.MIDDLEWARE + 'myHandler']
-      ],
+      [`Expressjs/Route Path: ${path}`, [NAMES.EXPRESS.MIDDLEWARE + 'myHandler']],
       assertSegmentsOptions
     )
 
-    checkMetrics(t, transaction.metrics, [NAMES.EXPRESS.MIDDLEWARE + 'myHandler//ab?cd'], '/ab?cd')
+    checkMetrics(t, transaction.metrics, [`${NAMES.EXPRESS.MIDDLEWARE}myHandler/${path}`], path)
   })
 
   t.test('when using a regular expression in path', async function (t) {
@@ -747,12 +683,7 @@ test('transaction segments tests', (t) => {
     const { rootSegment, transaction } = await runTest({ app, t, endpoint: '/a' })
     t.assertSegments(
       rootSegment,
-      [
-        NAMES.EXPRESS.MIDDLEWARE + 'query',
-        NAMES.EXPRESS.MIDDLEWARE + 'expressInit',
-        'Expressjs/Route Path: /a/',
-        [NAMES.EXPRESS.MIDDLEWARE + 'myHandler']
-      ],
+      ['Expressjs/Route Path: /a/', [NAMES.EXPRESS.MIDDLEWARE + 'myHandler']],
       assertSegmentsOptions
     )
 
@@ -781,16 +712,7 @@ function checkMetrics(t, metrics, expected, path) {
     [{ name: 'DurationByCaller/Unknown/Unknown/Unknown/Unknown/all' }],
     [{ name: 'DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb' }],
     [{ name: 'Apdex/Expressjs/GET/' + path }],
-    [{ name: 'Apdex' }],
-    [{ name: NAMES.EXPRESS.MIDDLEWARE + 'query//' }],
-    [{ name: NAMES.EXPRESS.MIDDLEWARE + 'expressInit//' }],
-    [{ name: NAMES.EXPRESS.MIDDLEWARE + 'query//', scope: 'WebTransaction/Expressjs/GET/' + path }],
-    [
-      {
-        name: NAMES.EXPRESS.MIDDLEWARE + 'expressInit//',
-        scope: 'WebTransaction/Expressjs/GET/' + path
-      }
-    ]
+    [{ name: 'Apdex' }]
   ]
 
   for (let i = 0; i < expected.length; i++) {
@@ -799,5 +721,5 @@ function checkMetrics(t, metrics, expected, path) {
     expectedAll.push([{ name: metric, scope: 'WebTransaction/Expressjs/GET/' + path }])
   }
 
-  t.assertMetrics(metrics, expectedAll, true, false)
+  t.assertMetrics(metrics, expectedAll, false, false)
 }

--- a/test/versioned/express/app-use.tap.js
+++ b/test/versioned/express/app-use.tap.js
@@ -8,8 +8,11 @@
 const test = require('tap').test
 const helper = require('../../lib/agent_helper')
 const http = require('http')
+const { isExpress5 } = require('./utils')
 
-test('app should be at top of stack when mounted', function (t) {
+// This test is no longer applicable in express 5 as mounting a child router does not emit the same
+// mount event
+test('app should be at top of stack when mounted', { skip: isExpress5 }, function (t) {
   const agent = helper.instrumentMockedAgent()
   const express = require('express')
 

--- a/test/versioned/express/async-handlers.tap.js
+++ b/test/versioned/express/async-handlers.tap.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { makeRequest, setup } = require('./utils')
+const { test } = require('tap')
+
+test('should properly track async handlers', (t) => {
+  setup(t)
+  const { app } = t.context
+  const mwTimeout = 20
+  const handlerTimeout = 25
+
+  app.use(async function (req, res, next) {
+    await new Promise((resolve) => {
+      setTimeout(() => {
+        resolve()
+      }, mwTimeout)
+    })
+    next()
+  })
+  app.use('/test', async function handler(req, res) {
+    await new Promise((resolve) => {
+      setTimeout(resolve, handlerTimeout)
+    })
+    res.send('ok')
+  })
+
+  runTest(t, '/test', (tx) => {
+    const [children] = tx.trace.root.children
+    const [mw, handler] = children.children
+    t.ok(
+      Math.ceil(mw.getDurationInMillis()) >= mwTimeout,
+      `should be at least ${mwTimeout} for middleware segment`
+    )
+    t.ok(
+      Math.ceil(handler.getDurationInMillis()) >= handlerTimeout,
+      `should be at least ${handlerTimeout} for handler segment`
+    )
+    t.end()
+  })
+})
+
+test('should properly handle errors in async handlers', (t) => {
+  setup(t)
+  const { app } = t.context
+
+  app.use(() => {
+    return Promise.reject(new Error('whoops i failed'))
+  })
+  app.use('/test', function handler(req, res) {
+    t.fail('should not call handler on error')
+    res.send('ok')
+  })
+  // eslint-disable-next-line no-unused-vars
+  app.use(function (error, req, res, next) {
+    res.status(400).end()
+  })
+
+  runTest(t, '/test', (tx) => {
+    const errors = tx.agent.errors.traceAggregator.errors
+    t.equal(errors.length, 1)
+    const [error] = errors
+    t.equal(error[2], 'HttpError 400', 'should return 400 from custom error handler')
+    t.end()
+  })
+})
+
+function runTest(t, endpoint, callback) {
+  const { agent, app } = t.context
+
+  agent.on('transactionFinished', callback)
+
+  const server = app.listen(function () {
+    makeRequest(this, endpoint, function (response) {
+      response.resume()
+    })
+  })
+
+  t.teardown(() => {
+    server.close()
+  })
+}

--- a/test/versioned/express/bare-router.tap.js
+++ b/test/versioned/express/bare-router.tap.js
@@ -53,7 +53,7 @@ test('Express router introspection', function (t) {
       const url = 'http://localhost:' + port + '/test'
       helper.makeGetRequest(url, { json: true }, function (error, res, body) {
         t.equal(res.statusCode, 200, 'nothing exploded')
-        t.deepEqual(body, { status: 'ok' }, 'got expected response')
+        t.same(body, { status: 'ok' }, 'got expected response')
       })
     })
   })

--- a/test/versioned/express/client-disconnect.tap.js
+++ b/test/versioned/express/client-disconnect.tap.js
@@ -51,14 +51,12 @@ tap.test('Client Premature Disconnection', (t) => {
       [
         'WebTransaction/Expressjs/POST//test',
         [
-          'Nodejs/Middleware/Expressjs/query',
-          'Nodejs/Middleware/Expressjs/expressInit',
           'Nodejs/Middleware/Expressjs/jsonParser',
           'Expressjs/Route Path: /test',
           ['Nodejs/Middleware/Expressjs/controller', ['timers.setTimeout']]
         ]
       ],
-      { exact: true }
+      { exact: false }
     )
 
     t.equal(agent.getTransaction(), null, 'should have ended the transaction')

--- a/test/versioned/express/errors.tap.js
+++ b/test/versioned/express/errors.tap.js
@@ -5,67 +5,80 @@
 
 'use strict'
 
-const helper = require('../../lib/agent_helper')
 const http = require('http')
 const tap = require('tap')
+const { setup, makeRequest } = require('./utils')
 
-let express
-let agent
-let app
+tap.test('reports error when thrown from a route', function (t) {
+  setup(t)
+  const { app } = t.context
 
-runTests({
-  express_segments: false
+  app.get('/test', function () {
+    throw new Error('some error')
+  })
+
+  runTest(t, function (errors, statusCode) {
+    t.equal(errors.length, 1)
+    t.equal(statusCode, 500)
+    t.end()
+  })
 })
 
-runTests({
-  express_segments: true
+tap.test('reports error when thrown from a middleware', function (t) {
+  setup(t)
+  const { app } = t.context
+
+  app.use(function () {
+    throw new Error('some error')
+  })
+
+  runTest(t, function (errors, statusCode) {
+    t.equal(errors.length, 1)
+    t.equal(statusCode, 500)
+    t.end()
+  })
 })
 
-function runTests(flags) {
-  tap.test('reports error when thrown from a route', function (t) {
-    setup(t)
+tap.test('reports error when called in next from a middleware', function (t) {
+  setup(t)
+  const { app } = t.context
 
-    app.get('/test', function () {
-      throw new Error('some error')
-    })
-
-    runTest(t, function (errors, statusCode) {
-      t.equal(errors.length, 1)
-      t.equal(statusCode, 500)
-      t.end()
-    })
+  app.use(function (req, res, next) {
+    next(new Error('some error'))
   })
 
-  tap.test('reports error when thrown from a middleware', function (t) {
-    setup(t)
+  runTest(t, function (errors, statusCode) {
+    t.equal(errors.length, 1)
+    t.equal(statusCode, 500)
+    t.end()
+  })
+})
 
-    app.use(function () {
-      throw new Error('some error')
-    })
+tap.test('should not report error when error handler responds', function (t) {
+  setup(t)
+  const { app } = t.context
 
-    runTest(t, function (errors, statusCode) {
-      t.equal(errors.length, 1)
-      t.equal(statusCode, 500)
-      t.end()
-    })
+  app.get('/test', function () {
+    throw new Error('some error')
   })
 
-  tap.test('reports error when called in next from a middleware', function (t) {
-    setup(t)
-
-    app.use(function (req, res, next) {
-      next(new Error('some error'))
-    })
-
-    runTest(t, function (errors, statusCode) {
-      t.equal(errors.length, 1)
-      t.equal(statusCode, 500)
-      t.end()
-    })
+  // eslint-disable-next-line no-unused-vars
+  app.use(function (error, req, res, next) {
+    res.end()
   })
 
-  tap.test('should not report error when error handler responds', function (t) {
+  runTest(t, function (errors, statusCode) {
+    t.equal(errors.length, 0)
+    t.equal(statusCode, 200)
+    t.end()
+  })
+})
+
+tap.test(
+  'should report error when error handler responds, but sets error status code',
+  function (t) {
     setup(t)
+    const { app } = t.context
 
     app.get('/test', function () {
       throw new Error('some error')
@@ -73,214 +86,183 @@ function runTests(flags) {
 
     // eslint-disable-next-line no-unused-vars
     app.use(function (error, req, res, next) {
-      res.end()
+      res.status(400).end()
     })
 
     runTest(t, function (errors, statusCode) {
-      t.equal(errors.length, 0)
-      t.equal(statusCode, 200)
-      t.end()
-    })
-  })
-
-  tap.test(
-    'should report error when error handler responds, but sets error status code',
-    function (t) {
-      setup(t)
-
-      app.get('/test', function () {
-        throw new Error('some error')
-      })
-
-      // eslint-disable-next-line no-unused-vars
-      app.use(function (error, req, res, next) {
-        res.status(400).end()
-      })
-
-      runTest(t, function (errors, statusCode) {
-        t.equal(errors.length, 1)
-        t.equal(errors[0][2], 'some error')
-        t.equal(statusCode, 400)
-        t.end()
-      })
-    }
-  )
-
-  tap.test('should report errors passed out of errorware', function (t) {
-    setup(t)
-
-    app.get('/test', function () {
-      throw new Error('some error')
-    })
-
-    app.use(function (error, req, res, next) {
-      next(error)
-    })
-
-    runTest(t, function (errors, statuscode) {
       t.equal(errors.length, 1)
-      t.equal(statuscode, 500)
+      t.equal(errors[0][2], 'some error')
+      t.equal(statusCode, 400)
       t.end()
-    })
-  })
-
-  tap.test('should report errors from errorware followed by routes', function (t) {
-    setup(t)
-
-    app.use(function () {
-      throw new Error('some error')
-    })
-
-    app.use(function (error, req, res, next) {
-      next(error)
-    })
-
-    app.get('/test', function (req, res) {
-      res.end()
-    })
-
-    runTest(t, function (errors, statuscode) {
-      t.equal(errors.length, 1)
-      t.equal(statuscode, 500)
-      t.end()
-    })
-  })
-
-  tap.test('should not report errors swallowed by errorware', function (t) {
-    setup(t)
-
-    app.get('/test', function () {
-      throw new Error('some error')
-    })
-
-    app.use(function (err, req, res, next) {
-      next()
-    })
-
-    app.get('/test', function (req, res) {
-      res.end()
-    })
-
-    runTest(t, function (errors, statuscode) {
-      t.equal(errors.length, 0)
-      t.equal(statuscode, 200)
-      t.end()
-    })
-  })
-
-  tap.test('should not report errors handled by errorware outside router', function (t) {
-    setup(t)
-
-    const router1 = express.Router() // eslint-disable-line new-cap
-    router1.get('/test', function () {
-      throw new Error('some error')
-    })
-
-    app.use(router1)
-
-    // eslint-disable-next-line no-unused-vars
-    app.use(function (error, req, res, next) {
-      res.end()
-    })
-
-    runTest(t, function (errors, statuscode) {
-      t.equal(errors.length, 0)
-      t.equal(statuscode, 200)
-      t.end()
-    })
-  })
-
-  tap.test('does not error when request is aborted', function (t) {
-    t.plan(3)
-    setup(t)
-
-    let request = null
-
-    app.get('/test', function (req, res, next) {
-      t.comment('middleware')
-      t.ok(agent.getTransaction(), 'transaction exists')
-
-      // generate error after client has aborted
-      request.abort()
-      setTimeout(function () {
-        t.comment('timed out')
-        t.ok(agent.getTransaction() == null, 'transaction has already ended')
-        next(new Error('some error'))
-      }, 100)
-    })
-
-    // eslint-disable-next-line no-unused-vars
-    app.use(function (error, req, res, next) {
-      t.comment('errorware')
-      t.ok(agent.getTransaction() == null, 'no active transaction when responding')
-      res.end()
-    })
-
-    const server = app.listen(function () {
-      t.comment('making request')
-      const port = this.address().port
-      request = http.request(
-        {
-          hostname: 'localhost',
-          port: port,
-          path: '/test'
-        },
-        function () {}
-      )
-      request.end()
-
-      // add error handler, otherwise aborting will cause an exception
-      request.on('error', function (err) {
-        t.comment('request errored: ' + err)
-      })
-      request.on('abort', function () {
-        t.comment('request aborted')
-      })
-    })
-
-    t.teardown(function () {
-      server.close()
-    })
-  })
-
-  function setup(t) {
-    agent = helper.instrumentMockedAgent(flags)
-
-    express = require('express')
-    app = express()
-    t.teardown(function () {
-      helper.unloadAgent(agent)
     })
   }
+)
 
-  function runTest(t, callback) {
-    let statusCode
-    let errors
+tap.test('should report errors passed out of errorware', function (t) {
+  setup(t)
+  const { app } = t.context
 
-    agent.on('transactionFinished', function () {
-      errors = agent.errors.traceAggregator.errors
-      if (statusCode) {
+  app.get('/test', function () {
+    throw new Error('some error')
+  })
+
+  app.use(function (error, req, res, next) {
+    next(error)
+  })
+
+  runTest(t, function (errors, statuscode) {
+    t.equal(errors.length, 1)
+    t.equal(statuscode, 500)
+    t.end()
+  })
+})
+
+tap.test('should report errors from errorware followed by routes', function (t) {
+  setup(t)
+  const { app } = t.context
+
+  app.use(function () {
+    throw new Error('some error')
+  })
+
+  app.use(function (error, req, res, next) {
+    next(error)
+  })
+
+  app.get('/test', function (req, res) {
+    res.end()
+  })
+
+  runTest(t, function (errors, statuscode) {
+    t.equal(errors.length, 1)
+    t.equal(statuscode, 500)
+    t.end()
+  })
+})
+
+tap.test('should not report errors swallowed by errorware', function (t) {
+  setup(t)
+  const { app } = t.context
+
+  app.get('/test', function () {
+    throw new Error('some error')
+  })
+
+  app.use(function (err, req, res, next) {
+    next()
+  })
+
+  app.get('/test', function (req, res) {
+    res.end()
+  })
+
+  runTest(t, function (errors, statuscode) {
+    t.equal(errors.length, 0)
+    t.equal(statuscode, 200)
+    t.end()
+  })
+})
+
+tap.test('should not report errors handled by errorware outside router', function (t) {
+  setup(t)
+  const { app, express } = t.context
+
+  const router1 = express.Router() // eslint-disable-line new-cap
+  router1.get('/test', function () {
+    throw new Error('some error')
+  })
+
+  app.use(router1)
+
+  // eslint-disable-next-line no-unused-vars
+  app.use(function (error, req, res, next) {
+    res.end()
+  })
+
+  runTest(t, function (errors, statuscode) {
+    t.equal(errors.length, 0)
+    t.equal(statuscode, 200)
+    t.end()
+  })
+})
+
+tap.test('does not error when request is aborted', function (t) {
+  t.plan(3)
+  setup(t)
+  const { app, agent } = t.context
+
+  let request = null
+
+  app.get('/test', function (req, res, next) {
+    t.comment('middleware')
+    t.ok(agent.getTransaction(), 'transaction exists')
+
+    // generate error after client has aborted
+    request.abort()
+    setTimeout(function () {
+      t.comment('timed out')
+      t.ok(agent.getTransaction() == null, 'transaction has already ended')
+      next(new Error('some error'))
+    }, 100)
+  })
+
+  // eslint-disable-next-line no-unused-vars
+  app.use(function (error, req, res, next) {
+    t.comment('errorware')
+    t.ok(agent.getTransaction() == null, 'no active transaction when responding')
+    res.end()
+  })
+
+  const server = app.listen(function () {
+    t.comment('making request')
+    const port = this.address().port
+    request = http.request(
+      {
+        hostname: 'localhost',
+        port: port,
+        path: '/test'
+      },
+      function () {}
+    )
+    request.end()
+
+    // add error handler, otherwise aborting will cause an exception
+    request.on('error', function (err) {
+      t.comment('request errored: ' + err)
+    })
+    request.on('abort', function () {
+      t.comment('request aborted')
+    })
+  })
+
+  t.teardown(function () {
+    server.close()
+  })
+})
+
+function runTest(t, callback) {
+  let statusCode
+  let errors
+  const { agent, app } = t.context
+
+  agent.on('transactionFinished', function () {
+    errors = agent.errors.traceAggregator.errors
+    if (statusCode) {
+      callback(errors, statusCode)
+    }
+  })
+
+  const endpoint = '/test'
+  const server = app.listen(function () {
+    makeRequest(this, endpoint, function (response) {
+      statusCode = response.statusCode
+      if (errors) {
         callback(errors, statusCode)
       }
+      response.resume()
     })
-
-    const endpoint = '/test'
-    const server = app.listen(function () {
-      makeRequest(this, endpoint, function (response) {
-        statusCode = response.statusCode
-        if (errors) {
-          callback(errors, statusCode)
-        }
-        response.resume()
-      })
-    })
-    t.teardown(function () {
-      server.close()
-    })
-  }
-
-  function makeRequest(server, path, callback) {
-    const port = server.address().port
-    http.request({ port: port, path: path }, callback).end()
-  }
+  })
+  t.teardown(function () {
+    server.close()
+  })
 }

--- a/test/versioned/express/middleware-name.tap.js
+++ b/test/versioned/express/middleware-name.tap.js
@@ -16,19 +16,9 @@ test('should name middleware correctly', function (t) {
   app.use('/', testMiddleware)
 
   const server = app.listen(0, function () {
-    t.equal(app._router.stack.length, 3, '3 middleware functions: query parser, Express, router')
-
-    let count = 0
-    for (let i = 0; i < app._router.stack.length; i++) {
-      const layer = app._router.stack[i]
-
-      // route middleware doesn't have a name, sentinel is our error handler,
-      // neither should be wrapped.
-      if (layer.handle.name && layer.handle.name === 'testMiddleware') {
-        count++
-      }
-    }
-    t.equal(count, 1, 'should find only one testMiddleware function')
+    const router = app._router || app.router
+    const mwLayer = router.stack.filter((layer) => layer.name === 'testMiddleware')
+    t.equal(mwLayer.length, 1, 'should only find one testMiddleware function')
     t.end()
   })
 

--- a/test/versioned/express/newrelic.js
+++ b/test/versioned/express/newrelic.js
@@ -9,8 +9,7 @@ exports.config = {
   app_name: ['My Application'],
   license_key: 'license key here',
   logging: {
-    level: 'trace',
-    filepath: '../../../newrelic_agent.log'
+    level: 'trace'
   },
   utilization: {
     detect_aws: false,

--- a/test/versioned/express/package.json
+++ b/test/versioned/express/package.json
@@ -1,6 +1,11 @@
 {
   "name": "express-tests",
-  "targets": [{"name":"express","minAgentVersion":"2.6.0"}],
+  "targets": [
+    {
+      "name": "express",
+      "minAgentVersion": "2.6.0"
+    }
+  ],
   "version": "0.0.0",
   "private": true,
   "tests": [
@@ -9,7 +14,10 @@
         "node": ">=18"
       },
       "dependencies": {
-        "express": ">=4.6.0",
+        "express": {
+          "versions": ">=4.6.0",
+          "samples": 5
+        },
         "express-enrouten": "1.1",
         "ejs": "2.5.9"
       },
@@ -32,7 +40,34 @@
         "segments.tap.js",
         "transaction-naming.tap.js"
       ]
+    },
+    {
+      "engines": {
+        "node": ">=18"
+      },
+      "dependencies": {
+        "express": "5.0.0-beta.3",
+        "ejs": "2.5.9"
+      },
+      "files": [
+        "app-use.tap.js",
+        "async-handlers.tap.js",
+        "async-error.tap.js",
+        "bare-router.tap.js",
+        "captures-params.tap.js",
+        "client-disconnect.tap.js",
+        "errors.tap.js",
+        "ignoring.tap.js",
+        "issue171.tap.js",
+        "middleware-name.tap.js",
+        "render.tap.js",
+        "require.tap.js",
+        "route-iteration.tap.js",
+        "route-param.tap.js",
+        "router-params.tap.js",
+        "segments.tap.js",
+        "transaction-naming.tap.js"
+      ]
     }
-  ],
-  "dependencies": {}
+  ]
 }

--- a/test/versioned/express/render.tap.js
+++ b/test/versioned/express/render.tap.js
@@ -28,622 +28,607 @@ const BODY =
   '</body>\n' +
   '</html>\n'
 
-runTests({
-  license_key: 'test',
-  feature_flag: { express_segments: false }
+// Regression test for issue 154
+// https://github.com/newrelic/node-newrelic/pull/154
+test('using only the express router', function (t) {
+  const agent = helper.instrumentMockedAgent()
+  const router = require('express').Router() // eslint-disable-line new-cap
+  t.teardown(() => {
+    helper.unloadAgent(agent)
+  })
+
+  router.get('/test', function () {
+    //
+  })
+
+  router.get('/test2', function () {
+    //
+  })
+
+  // just try not to blow up
+  t.end()
 })
 
-runTests({
-  license_key: 'test',
-  feature_flag: { express_segments: true }
+test('the express router should go through a whole request lifecycle', function (t) {
+  const agent = helper.instrumentMockedAgent()
+  const router = require('express').Router() // eslint-disable-line new-cap
+  const finalhandler = require('finalhandler')
+
+  t.plan(2)
+
+  t.teardown(() => {
+    helper.unloadAgent(agent)
+  })
+
+  router.get('/test', function (_, res) {
+    t.ok(true)
+    res.end()
+  })
+
+  const server = require('http').createServer(function onRequest(req, res) {
+    router(req, res, finalhandler(req, res))
+  })
+  server.listen(0, function () {
+    const port = server.address().port
+    helper.makeRequest('http://localhost:' + port + '/test', function (error) {
+      server.close()
+
+      t.error(error)
+      t.end()
+    })
+  })
 })
 
-function runTests(conf) {
-  // Regression test for issue 154
-  // https://github.com/newrelic/node-newrelic/pull/154
-  test('using only the express router', function (t) {
-    const agent = helper.instrumentMockedAgent(conf)
-    const router = require('express').Router() // eslint-disable-line new-cap
+test('agent instrumentation of Express', function (t) {
+  t.plan(7)
 
-    t.teardown(() => {
-      helper.unloadAgent(agent)
-    })
+  let agent = null
+  let app = null
+  let server = null
 
-    router.get('/test', function () {
-      //
-    })
+  t.beforeEach(function () {
+    agent = helper.instrumentMockedAgent()
 
-    router.get('/test2', function () {
-      //
-    })
-
-    // just try not to blow up
-    t.end()
+    app = require('express')()
+    server = require('http').createServer(app)
   })
 
-  test('the express router should go through a whole request lifecycle', function (t) {
-    const agent = helper.instrumentMockedAgent(conf)
-    const router = require('express').Router() // eslint-disable-line new-cap
+  t.afterEach(function () {
+    server.close()
+    helper.unloadAgent(agent)
 
-    t.plan(2)
-
-    t.teardown(() => {
-      helper.unloadAgent(agent)
-    })
-
-    router.get('/test', function (_, res) {
-      t.ok(true)
-      res.end()
-    })
-
-    const server = require('http').createServer(router)
-    server.listen(0, function () {
-      const port = server.address().port
-      helper.makeRequest('http://localhost:' + port + '/test', function (error) {
-        server.close()
-
-        t.error(error)
-        t.end()
-      })
-    })
+    agent = null
+    app = null
+    server = null
   })
 
-  test('agent instrumentation of Express', function (t) {
-    t.plan(7)
+  t.test('for a normal request', { timeout: 1000 }, function (t) {
+    // set apdexT so apdex stats will be recorded
+    agent.config.apdex_t = 1
 
-    let agent = null
-    let app = null
-    let server = null
-
-    t.beforeEach(function () {
-      agent = helper.instrumentMockedAgent(conf)
-
-      app = require('express')()
-      server = require('http').createServer(app)
-    })
-
-    t.afterEach(function () {
-      server.close()
-      helper.unloadAgent(agent)
-
-      agent = null
-      app = null
-      server = null
-    })
-
-    t.test('for a normal request', { timeout: 1000 }, function (t) {
-      // set apdexT so apdex stats will be recorded
-      agent.config.apdex_t = 1
-
-      app.get(TEST_PATH, function (req, res) {
-        res.send({ yep: true })
-      })
-
-      server.listen(0, TEST_HOST, function () {
-        const port = server.address().port
-        helper.makeGetRequest(TEST_URL + port + TEST_PATH, function (error, response, body) {
-          t.error(error, 'should not fail making request')
-
-          t.ok(
-            /application\/json/.test(response.headers['content-type']),
-            'got correct content type'
-          )
-
-          t.same(body, { yep: true }, 'Express correctly serves.')
-
-          let stats
-
-          stats = agent.metrics.getMetric('WebTransaction/Expressjs/GET//test')
-          t.ok(stats, 'found unscoped stats for request path')
-          t.equal(stats.callCount, 1, '/test was only requested once')
-
-          stats = agent.metrics.getMetric('Apdex/Expressjs/GET//test')
-          t.ok(stats, 'found apdex stats for request path')
-          t.equal(stats.satisfying, 1, 'got satisfactory response time')
-          t.equal(stats.tolerating, 0, 'got no tolerable requests')
-          t.equal(stats.frustrating, 0, 'got no frustrating requests')
-
-          stats = agent.metrics.getMetric('WebTransaction')
-          t.ok(stats, 'found roll-up statistics for web requests')
-          t.equal(stats.callCount, 1, 'only one web request was made')
-
-          stats = agent.metrics.getMetric('HttpDispatcher')
-          t.ok(stats, 'found HTTP dispatcher statistics')
-          t.equal(stats.callCount, 1, 'only one HTTP-dispatched request was made')
-
-          const serialized = JSON.stringify(agent.metrics._toPayloadSync())
-          t.ok(
-            serialized.match(/WebTransaction\/Expressjs\/GET\/\/test/),
-            'serialized metrics as expected'
-          )
-
-          t.end()
-        })
-      })
-    })
-
-    t.test('ignore apdex when ignoreApdex is true on transaction', { timeout: 1000 }, function (t) {
-      // set apdexT so apdex stats will be recorded
-      agent.config.apdex_t = 1
-
-      app.get(TEST_PATH, function (req, res) {
-        const tx = agent.getTransaction()
-        tx.ignoreApdex = true
-        res.send({ yep: true })
-      })
-
-      server.listen(0, TEST_HOST, function () {
-        const port = server.address().port
-        helper.makeGetRequest(TEST_URL + port + TEST_PATH, function () {
-          let stats
-
-          stats = agent.metrics.getMetric('WebTransaction/Expressjs/GET//test')
-          t.ok(stats, 'found unscoped stats for request path')
-          t.equal(stats.callCount, 1, '/test was only requested once')
-
-          stats = agent.metrics.getMetric('Apdex/Expressjs/GET//test')
-          t.notOk(stats, 'should not have apdex metrics')
-
-          stats = agent.metrics.getMetric('WebTransaction')
-          t.ok(stats, 'found roll-up statistics for web requests')
-          t.equal(stats.callCount, 1, 'only one web request was made')
-
-          stats = agent.metrics.getMetric('HttpDispatcher')
-          t.ok(stats, 'found HTTP dispatcher statistics')
-          t.equal(stats.callCount, 1, 'only one HTTP-dispatched request was made')
-          t.end()
-        })
-      })
-    })
-
-    t.test('using EJS templates', { timeout: 1000 }, function (t) {
-      app.set('views', __dirname + '/views')
-      app.set('view engine', 'ejs')
-
-      app.get(TEST_PATH, function (req, res) {
-        res.render('index', { title: 'yo dawg' })
-      })
-
-      agent.once('transactionFinished', function () {
-        const stats = agent.metrics.getMetric('View/index/Rendering')
-        t.equal(stats.callCount, 1, 'should note the view rendering')
-      })
-
-      server.listen(0, TEST_HOST, function () {
-        const port = server.address().port
-        helper.makeGetRequest(TEST_URL + port + TEST_PATH, function (error, response, body) {
-          t.error(error, 'should not error making request')
-
-          t.equal(response.statusCode, 200, 'response code should be 200')
-          t.equal(body, BODY, 'template should still render fine')
-
-          t.end()
-        })
-      })
-    })
-
-    t.test('should generate rum headers', { timeout: 1000 }, function (t) {
-      const api = new API(agent)
-
-      agent.config.application_id = '12345'
-      agent.config.browser_monitoring.browser_key = '12345'
-      agent.config.browser_monitoring.js_agent_loader = 'function() {}'
-
-      app.set('views', __dirname + '/views')
-      app.set('view engine', 'ejs')
-
-      app.get(TEST_PATH, function (req, res) {
-        const rum = api.getBrowserTimingHeader()
-        t.equal(rum.substring(0, 7), '<script')
-        res.render('index', { title: 'yo dawg', rum: rum })
-      })
-
-      agent.once('transactionFinished', function () {
-        const stats = agent.metrics.getMetric('View/index/Rendering')
-        t.equal(stats.callCount, 1, 'should note the view rendering')
-      })
-
-      server.listen(0, TEST_HOST, function () {
-        const port = server.address().port
-        helper.makeGetRequest(TEST_URL + port + TEST_PATH, function (error, response, body) {
-          t.error(error, 'should not error making request')
-
-          t.equal(response.statusCode, 200, 'response code should be 200')
-          t.equal(body, BODY, 'template should still render fine')
-
-          t.end()
-        })
-      })
-    })
-
-    t.test('should trap errors correctly', function (t) {
-      app.get(TEST_PATH, function () {
-        let hmm
-        hmm.ohno.failure.is.terrible()
-      })
-
-      server.listen(0, TEST_HOST, function () {
-        for (let i = 0; i < app._router.stack.length; i++) {
-          const layer = app._router.stack[i]
-          // route middleware doesn't have a name, sentinel is our error handler,
-          // neither should be wrapped.
-          if (layer.route === undefined && layer.handle.name !== 'sentinel') {
-            t.equal(
-              typeof layer.handle[symbols.original],
-              'function',
-              'all middlewares are wrapped'
-            )
-          }
-        }
-
-        const port = server.address().port
-        helper.makeGetRequest(TEST_URL + port + TEST_PATH, function (error, response, body) {
-          t.error(error, 'should not error making request')
-
-          t.ok(response, 'got a response from Express')
-          t.ok(body, 'got back a body')
-
-          const errors = agent.errors.traceAggregator.errors
-          t.ok(errors, 'errors were found')
-          t.equal(errors.length, 1, 'Only one error thrown.')
-
-          const first = errors[0]
-          t.ok(first, 'have the first error')
-
-          // The error msg changed in v16.9
-          // change assertion to check for an include of
-          // diff msgs
-          const expectedError = [
-            "Cannot read property 'ohno' of undefined",
-            "Cannot read properties of undefined (reading 'ohno')"
-          ]
-          t.ok(
-            expectedError.includes(first[2]),
-            "Cannot read property 'ohno' of undefined",
-            'got the expected error'
-          )
-
-          t.end()
-        })
-      })
-    })
-
-    t.test('measure request duration properly (NA-46)', { timeout: 2000 }, function (t) {
-      app.get(TEST_PATH, function (req, res) {
-        t.ok(agent.getTransaction(), 'should have transaction inside middleware')
-        setTimeout(function () {
-          res.send(BODY)
-        }, DELAY)
-      })
-
-      server.listen(0, TEST_HOST, function ready() {
-        const port = server.address().port
-        helper.makeGetRequest(TEST_URL + port + TEST_PATH, function (error, response, body) {
-          t.error(error, 'should not fail making request')
-
-          const isFramework = agent.environment.get('Framework').indexOf('Expressjs') > -1
-          t.ok(isFramework, 'should indicate that express is a framework')
-
-          t.notOk(agent.getTransaction(), "transaction shouldn't be visible from request")
-          t.equal(body, BODY, 'response and original page text match')
-
-          const stats = agent.metrics.getMetric('WebTransaction/Expressjs/GET//test')
-          t.ok(stats, 'Statistics should have been found for request.')
-
-          const timing = stats.total * 1000
-          t.ok(timing > DELAY - 50, 'should have expected timing (within reason)')
-
-          t.end()
-        })
-      })
-    })
-
-    t.test('should capture URL correctly with a prefix', { timeout: 2000 }, function (t) {
-      app.use(TEST_PATH, function (req, res) {
-        t.ok(agent.getTransaction(), 'should maintain transaction state in middleware')
-        t.equal(req.url, '/ham', 'should have correct test url')
-        res.send(BODY)
-      })
-
-      server.listen(0, TEST_HOST, function ready() {
-        const port = server.address().port
-        const url = TEST_URL + port + TEST_PATH + '/ham'
-        helper.makeGetRequest(url, function (error, response, body) {
-          t.error(error, 'should not fail making request')
-
-          t.notOk(agent.getTransaction(), "transaction shouldn't be visible from request")
-          t.equal(body, BODY, 'response and original page text match')
-
-          const stats = agent.metrics.getMetric('WebTransaction/Expressjs/GET//test')
-          t.ok(stats, 'Statistics should have been found for request.')
-
-          t.end()
-        })
-      })
-    })
-  })
-
-  test('trapping errors', function (t) {
-    t.autoend()
-
-    t.test('collects the actual error object that is thrown', function (t) {
-      const agent = helper.instrumentMockedAgent(conf)
-
-      const app = require('express')()
-      const server = require('http').createServer(app)
-
-      t.teardown(() => {
-        server.close()
-        helper.unloadAgent(agent)
-      })
-
-      app.get(TEST_PATH, function () {
-        throw new Error('some error')
-      })
-
-      server.listen(0, TEST_HOST, function () {
-        const port = server.address().port
-        helper.makeGetRequest(TEST_URL + port + TEST_PATH, function () {
-          const errors = agent.errors.traceAggregator.errors
-          t.equal(errors.length, 1, 'there should be one error')
-          t.equal(errors[0][2], 'some error', 'got the expected error')
-          t.ok(errors[0][4].stack_trace, 'has stack trace')
-
-          const metric = agent.metrics.getMetric('Apdex')
-          t.ok(metric.frustrating === 1, 'apdex should be frustrating')
-
-          t.end()
-        })
-      })
-    })
-
-    t.test('does not occur with custom defined error handlers', function (t) {
-      const agent = helper.instrumentMockedAgent(conf)
-
-      const app = require('express')()
-      const server = require('http').createServer(app)
-
-      t.teardown(() => {
-        server.close()
-        helper.unloadAgent(agent)
-      })
-      const error = new Error('some error')
-
-      app.get(TEST_PATH, function () {
-        throw error
-      })
-
-      app.use(function (err, req, res, next) {
-        t.equal(err, error, 'should see the same error in the error handler')
-        next()
-      })
-
-      server.listen(0, TEST_HOST, function () {
-        const port = server.address().port
-        helper.makeGetRequest(TEST_URL + port + TEST_PATH, function () {
-          const errors = agent.errors.traceAggregator.errors
-          t.equal(errors.length, 0, 'there should be no errors')
-
-          const metric = agent.metrics.getMetric('Apdex')
-          t.ok(metric.frustrating === 0, 'apdex should not be frustrating')
-
-          t.end()
-        })
-      })
-    })
-
-    t.test('does not occur with custom defined error handlers', function (t) {
-      const agent = helper.instrumentMockedAgent(conf)
-
-      const app = require('express')()
-      const server = require('http').createServer(app)
-
-      t.teardown(() => {
-        server.close()
-        helper.unloadAgent(agent)
-      })
-      const error = new Error('some error')
-
-      app.get(TEST_PATH, function (req, res, next) {
-        next(error)
-      })
-
-      app.use(function (err, req, res, next) {
-        t.equal(err, error, 'should see the same error in the error handler')
-        next()
-      })
-
-      server.listen(0, TEST_HOST, function () {
-        const port = server.address().port
-        helper.makeGetRequest(TEST_URL + port + TEST_PATH, function () {
-          const errors = agent.errors.traceAggregator.errors
-          t.equal(errors.length, 0, 'there should be no errors')
-
-          const metric = agent.metrics.getMetric('Apdex')
-          t.ok(metric.frustrating === 0, 'apdex should not be frustrating')
-
-          t.end()
-        })
-      })
-    })
-
-    t.test('collects the error message when string is thrown', function (t) {
-      const agent = helper.instrumentMockedAgent(conf)
-
-      const app = require('express')()
-      const server = require('http').createServer(app)
-
-      t.teardown(() => {
-        server.close()
-        helper.unloadAgent(agent)
-      })
-
-      app.get(TEST_PATH, function () {
-        throw 'some error'
-      })
-
-      server.listen(0, TEST_HOST, function () {
-        const port = server.address().port
-        helper.makeGetRequest(TEST_URL + port + TEST_PATH, function () {
-          const errors = agent.errors.traceAggregator.errors
-          t.equal(errors.length, 1, 'there should be one error')
-          t.equal(errors[0][2], 'some error', 'got the expected error')
-
-          const metric = agent.metrics.getMetric('Apdex')
-          t.ok(metric.frustrating === 1, 'apdex should be frustrating')
-
-          t.end()
-        })
-      })
-    })
-
-    t.test('collects the actual error object when error handler is used', function (t) {
-      const agent = helper.instrumentMockedAgent(conf)
-
-      const app = require('express')()
-      const server = require('http').createServer(app)
-
-      t.teardown(() => {
-        server.close()
-        helper.unloadAgent(agent)
-      })
-
-      app.get(TEST_PATH, function () {
-        throw new Error('some error')
-      })
-
-      // eslint-disable-next-line no-unused-vars
-      app.use(function (err, rer, res, next) {
-        res.status(400).end()
-      })
-
-      server.listen(0, TEST_HOST, function () {
-        const port = server.address().port
-        helper.makeGetRequest(TEST_URL + port + TEST_PATH, function () {
-          const errors = agent.errors.traceAggregator.errors
-          t.equal(errors.length, 1, 'there should be one error')
-          t.equal(errors[0][2], 'some error', 'got the expected error')
-          t.ok(errors[0][4].stack_trace, 'has stack trace')
-
-          const metric = agent.metrics.getMetric('Apdex')
-          t.ok(metric.frustrating === 1, 'apdex should be frustrating')
-
-          t.end()
-        })
-      })
-    })
-
-    // Some error handlers might sanitize the error object, removing stack and/or message
-    // properties, so that it can be serialized and sent back in the response body.
-    // We use message and stack properties to identify an Error object, so in this case
-    // we want to at least collect the HTTP error based on the status code.
-    t.test('should report errors without message or stack sent to res.send', function (t) {
-      const agent = helper.instrumentMockedAgent(conf)
-
-      const app = require('express')()
-      const server = require('http').createServer(app)
-
-      t.teardown(() => {
-        server.close()
-        helper.unloadAgent(agent)
-      })
-
-      const error = new Error('some error')
-      app.get(TEST_PATH, function () {
-        throw error
-      })
-
-      // eslint-disable-next-line no-unused-vars
-      app.use(function (err, rer, res, next) {
-        delete err.message
-        delete err.stack
-        res.status(400).send(err)
-      })
-
-      server.listen(0, TEST_HOST, function () {
-        const port = server.address().port
-        helper.makeGetRequest(TEST_URL + port + TEST_PATH, function () {
-          const errors = agent.errors.traceAggregator.errors
-          t.equal(errors.length, 1, 'there should be one error')
-          t.equal(errors[0][2], 'HttpError 400', 'got the expected error')
-
-          const metric = agent.metrics.getMetric('Apdex')
-          t.ok(metric.frustrating === 1, 'apdex should be frustrating')
-
-          t.end()
-        })
-      })
-    })
-
-    t.test('should report errors without message or stack sent to next', function (t) {
-      const agent = helper.instrumentMockedAgent(conf)
-
-      const app = require('express')()
-      const server = require('http').createServer(app)
-
-      t.teardown(() => {
-        server.close()
-        helper.unloadAgent(agent)
-      })
-
-      const error = new Error('some error')
-      app.get(TEST_PATH, function () {
-        throw error
-      })
-
-      app.use(function errorHandler(err, rer, res, next) {
-        delete err.message
-        delete err.stack
-        next(err)
-      })
-
-      server.listen(0, TEST_HOST, function () {
-        const port = server.address().port
-        helper.makeGetRequest(TEST_URL + port + TEST_PATH, function () {
-          const errors = agent.errors.traceAggregator.errors
-          t.equal(errors.length, 1, 'there should be one error')
-          t.equal(errors[0][2], 'HttpError 500', 'got the expected error')
-
-          const metric = agent.metrics.getMetric('Apdex')
-          t.ok(metric.frustrating === 1, 'apdex should be frustrating')
-
-          t.end()
-        })
-      })
-    })
-  })
-
-  test('layer wrapping', function (t) {
-    t.plan(1)
-
-    // Set up the test.
-    const agent = helper.instrumentMockedAgent(conf)
-    const app = require('express')()
-    const server = require('http').createServer(app)
-    t.teardown(() => {
-      server.close()
-      helper.unloadAgent(agent)
-    })
-
-    // Add our route.
     app.get(TEST_PATH, function (req, res) {
-      res.send('bar')
+      res.send({ yep: true })
     })
 
-    // Proxy the last layer on the stack.
-    const stack = app._router.stack
-    stack[stack.length - 1] = makeProxyLayer(stack[stack.length - 1])
-
-    // Make our request.
     server.listen(0, TEST_HOST, function () {
       const port = server.address().port
-      helper.makeGetRequest(TEST_URL + port + TEST_PATH, function (err, response, body) {
-        t.equal(body, 'bar', 'should not fail with a proxy layer')
+      helper.makeGetRequest(TEST_URL + port + TEST_PATH, function (error, response, body) {
+        t.error(error, 'should not fail making request')
+
+        t.ok(/application\/json/.test(response.headers['content-type']), 'got correct content type')
+
+        t.same(body, { yep: true }, 'Express correctly serves.')
+
+        let stats
+
+        stats = agent.metrics.getMetric('WebTransaction/Expressjs/GET//test')
+        t.ok(stats, 'found unscoped stats for request path')
+        t.equal(stats.callCount, 1, '/test was only requested once')
+
+        stats = agent.metrics.getMetric('Apdex/Expressjs/GET//test')
+        t.ok(stats, 'found apdex stats for request path')
+        t.equal(stats.satisfying, 1, 'got satisfactory response time')
+        t.equal(stats.tolerating, 0, 'got no tolerable requests')
+        t.equal(stats.frustrating, 0, 'got no frustrating requests')
+
+        stats = agent.metrics.getMetric('WebTransaction')
+        t.ok(stats, 'found roll-up statistics for web requests')
+        t.equal(stats.callCount, 1, 'only one web request was made')
+
+        stats = agent.metrics.getMetric('HttpDispatcher')
+        t.ok(stats, 'found HTTP dispatcher statistics')
+        t.equal(stats.callCount, 1, 'only one HTTP-dispatched request was made')
+
+        const serialized = JSON.stringify(agent.metrics._toPayloadSync())
+        t.ok(
+          serialized.match(/WebTransaction\/Expressjs\/GET\/\/test/),
+          'serialized metrics as expected'
+        )
+
         t.end()
       })
     })
   })
-}
+
+  t.test('ignore apdex when ignoreApdex is true on transaction', { timeout: 1000 }, function (t) {
+    // set apdexT so apdex stats will be recorded
+    agent.config.apdex_t = 1
+
+    app.get(TEST_PATH, function (req, res) {
+      const tx = agent.getTransaction()
+      tx.ignoreApdex = true
+      res.send({ yep: true })
+    })
+
+    server.listen(0, TEST_HOST, function () {
+      const port = server.address().port
+      helper.makeGetRequest(TEST_URL + port + TEST_PATH, function () {
+        let stats
+
+        stats = agent.metrics.getMetric('WebTransaction/Expressjs/GET//test')
+        t.ok(stats, 'found unscoped stats for request path')
+        t.equal(stats.callCount, 1, '/test was only requested once')
+
+        stats = agent.metrics.getMetric('Apdex/Expressjs/GET//test')
+        t.notOk(stats, 'should not have apdex metrics')
+
+        stats = agent.metrics.getMetric('WebTransaction')
+        t.ok(stats, 'found roll-up statistics for web requests')
+        t.equal(stats.callCount, 1, 'only one web request was made')
+
+        stats = agent.metrics.getMetric('HttpDispatcher')
+        t.ok(stats, 'found HTTP dispatcher statistics')
+        t.equal(stats.callCount, 1, 'only one HTTP-dispatched request was made')
+        t.end()
+      })
+    })
+  })
+
+  t.test('using EJS templates', { timeout: 1000 }, function (t) {
+    app.set('views', __dirname + '/views')
+    app.set('view engine', 'ejs')
+
+    app.get(TEST_PATH, function (req, res) {
+      res.render('index', { title: 'yo dawg' })
+    })
+
+    agent.once('transactionFinished', function () {
+      const stats = agent.metrics.getMetric('View/index/Rendering')
+      t.equal(stats.callCount, 1, 'should note the view rendering')
+    })
+
+    server.listen(0, TEST_HOST, function () {
+      const port = server.address().port
+      helper.makeGetRequest(TEST_URL + port + TEST_PATH, function (error, response, body) {
+        t.error(error, 'should not error making request')
+
+        t.equal(response.statusCode, 200, 'response code should be 200')
+        t.equal(body, BODY, 'template should still render fine')
+
+        t.end()
+      })
+    })
+  })
+
+  t.test('should generate rum headers', { timeout: 1000 }, function (t) {
+    const api = new API(agent)
+
+    agent.config.application_id = '12345'
+    agent.config.browser_monitoring.browser_key = '12345'
+    agent.config.browser_monitoring.js_agent_loader = 'function() {}'
+
+    app.set('views', __dirname + '/views')
+    app.set('view engine', 'ejs')
+
+    app.get(TEST_PATH, function (req, res) {
+      const rum = api.getBrowserTimingHeader()
+      t.equal(rum.substring(0, 7), '<script')
+      res.render('index', { title: 'yo dawg', rum: rum })
+    })
+
+    agent.once('transactionFinished', function () {
+      const stats = agent.metrics.getMetric('View/index/Rendering')
+      t.equal(stats.callCount, 1, 'should note the view rendering')
+    })
+
+    server.listen(0, TEST_HOST, function () {
+      const port = server.address().port
+      helper.makeGetRequest(TEST_URL + port + TEST_PATH, function (error, response, body) {
+        t.error(error, 'should not error making request')
+
+        t.equal(response.statusCode, 200, 'response code should be 200')
+        t.equal(body, BODY, 'template should still render fine')
+
+        t.end()
+      })
+    })
+  })
+
+  t.test('should trap errors correctly', function (t) {
+    app.get(TEST_PATH, function () {
+      let hmm
+      hmm.ohno.failure.is.terrible()
+    })
+
+    server.listen(0, TEST_HOST, function () {
+      const router = app._router || app.router
+      for (let i = 0; i < router.stack.length; i++) {
+        const layer = router.stack[i]
+        // route middleware doesn't have a name, sentinel is our error handler,
+        // neither should be wrapped.
+        if (layer.route === undefined && layer.handle.name !== 'sentinel') {
+          t.equal(typeof layer.handle[symbols.original], 'function', 'all middlewares are wrapped')
+        }
+      }
+
+      const port = server.address().port
+      helper.makeGetRequest(TEST_URL + port + TEST_PATH, function (error, response, body) {
+        t.error(error, 'should not error making request')
+
+        t.ok(response, 'got a response from Express')
+        t.ok(body, 'got back a body')
+
+        const errors = agent.errors.traceAggregator.errors
+        t.ok(errors, 'errors were found')
+        t.equal(errors.length, 1, 'Only one error thrown.')
+
+        const first = errors[0]
+        t.ok(first, 'have the first error')
+
+        // The error msg changed in v16.9
+        // change assertion to check for an include of
+        // diff msgs
+        const expectedError = [
+          "Cannot read property 'ohno' of undefined",
+          "Cannot read properties of undefined (reading 'ohno')"
+        ]
+        t.ok(
+          expectedError.includes(first[2]),
+          "Cannot read property 'ohno' of undefined",
+          'got the expected error'
+        )
+
+        t.end()
+      })
+    })
+  })
+
+  t.test('measure request duration properly (NA-46)', { timeout: 2000 }, function (t) {
+    app.get(TEST_PATH, function (req, res) {
+      t.ok(agent.getTransaction(), 'should have transaction inside middleware')
+      setTimeout(function () {
+        res.send(BODY)
+      }, DELAY)
+    })
+
+    server.listen(0, TEST_HOST, function ready() {
+      const port = server.address().port
+      helper.makeGetRequest(TEST_URL + port + TEST_PATH, function (error, response, body) {
+        t.error(error, 'should not fail making request')
+
+        const isFramework = agent.environment.get('Framework').indexOf('Expressjs') > -1
+        t.ok(isFramework, 'should indicate that express is a framework')
+
+        t.notOk(agent.getTransaction(), "transaction shouldn't be visible from request")
+        t.equal(body, BODY, 'response and original page text match')
+
+        const stats = agent.metrics.getMetric('WebTransaction/Expressjs/GET//test')
+        t.ok(stats, 'Statistics should have been found for request.')
+
+        const timing = stats.total * 1000
+        t.ok(timing > DELAY - 50, 'should have expected timing (within reason)')
+
+        t.end()
+      })
+    })
+  })
+
+  t.test('should capture URL correctly with a prefix', { timeout: 2000 }, function (t) {
+    app.use(TEST_PATH, function (req, res) {
+      t.ok(agent.getTransaction(), 'should maintain transaction state in middleware')
+      t.equal(req.url, '/ham', 'should have correct test url')
+      res.send(BODY)
+    })
+
+    server.listen(0, TEST_HOST, function ready() {
+      const port = server.address().port
+      const url = TEST_URL + port + TEST_PATH + '/ham'
+      helper.makeGetRequest(url, function (error, response, body) {
+        t.error(error, 'should not fail making request')
+
+        t.notOk(agent.getTransaction(), "transaction shouldn't be visible from request")
+        t.equal(body, BODY, 'response and original page text match')
+
+        const stats = agent.metrics.getMetric('WebTransaction/Expressjs/GET//test')
+        t.ok(stats, 'Statistics should have been found for request.')
+
+        t.end()
+      })
+    })
+  })
+})
+
+test('trapping errors', function (t) {
+  t.autoend()
+
+  t.test('collects the actual error object that is thrown', function (t) {
+    const agent = helper.instrumentMockedAgent()
+
+    const app = require('express')()
+    const server = require('http').createServer(app)
+
+    t.teardown(() => {
+      server.close()
+      helper.unloadAgent(agent)
+    })
+
+    app.get(TEST_PATH, function () {
+      throw new Error('some error')
+    })
+
+    server.listen(0, TEST_HOST, function () {
+      const port = server.address().port
+      helper.makeGetRequest(TEST_URL + port + TEST_PATH, function () {
+        const errors = agent.errors.traceAggregator.errors
+        t.equal(errors.length, 1, 'there should be one error')
+        t.equal(errors[0][2], 'some error', 'got the expected error')
+        t.ok(errors[0][4].stack_trace, 'has stack trace')
+
+        const metric = agent.metrics.getMetric('Apdex')
+        t.ok(metric.frustrating === 1, 'apdex should be frustrating')
+
+        t.end()
+      })
+    })
+  })
+
+  t.test('does not occur with custom defined error handlers', function (t) {
+    const agent = helper.instrumentMockedAgent()
+
+    const app = require('express')()
+    const server = require('http').createServer(app)
+
+    t.teardown(() => {
+      server.close()
+      helper.unloadAgent(agent)
+    })
+    const error = new Error('some error')
+
+    app.get(TEST_PATH, function () {
+      throw error
+    })
+
+    app.use(function (err, req, res, next) {
+      t.equal(err, error, 'should see the same error in the error handler')
+      next()
+    })
+
+    server.listen(0, TEST_HOST, function () {
+      const port = server.address().port
+      helper.makeGetRequest(TEST_URL + port + TEST_PATH, function () {
+        const errors = agent.errors.traceAggregator.errors
+        t.equal(errors.length, 0, 'there should be no errors')
+
+        const metric = agent.metrics.getMetric('Apdex')
+        t.ok(metric.frustrating === 0, 'apdex should not be frustrating')
+
+        t.end()
+      })
+    })
+  })
+
+  t.test('does not occur with custom defined error handlers', function (t) {
+    const agent = helper.instrumentMockedAgent()
+
+    const app = require('express')()
+    const server = require('http').createServer(app)
+
+    t.teardown(() => {
+      server.close()
+      helper.unloadAgent(agent)
+    })
+    const error = new Error('some error')
+
+    app.get(TEST_PATH, function (req, res, next) {
+      next(error)
+    })
+
+    app.use(function (err, req, res, next) {
+      t.equal(err, error, 'should see the same error in the error handler')
+      next()
+    })
+
+    server.listen(0, TEST_HOST, function () {
+      const port = server.address().port
+      helper.makeGetRequest(TEST_URL + port + TEST_PATH, function () {
+        const errors = agent.errors.traceAggregator.errors
+        t.equal(errors.length, 0, 'there should be no errors')
+
+        const metric = agent.metrics.getMetric('Apdex')
+        t.ok(metric.frustrating === 0, 'apdex should not be frustrating')
+
+        t.end()
+      })
+    })
+  })
+
+  t.test('collects the error message when string is thrown', function (t) {
+    const agent = helper.instrumentMockedAgent()
+
+    const app = require('express')()
+    const server = require('http').createServer(app)
+
+    t.teardown(() => {
+      server.close()
+      helper.unloadAgent(agent)
+    })
+
+    app.get(TEST_PATH, function () {
+      throw 'some error'
+    })
+
+    server.listen(0, TEST_HOST, function () {
+      const port = server.address().port
+      helper.makeGetRequest(TEST_URL + port + TEST_PATH, function () {
+        const errors = agent.errors.traceAggregator.errors
+        t.equal(errors.length, 1, 'there should be one error')
+        t.equal(errors[0][2], 'some error', 'got the expected error')
+
+        const metric = agent.metrics.getMetric('Apdex')
+        t.ok(metric.frustrating === 1, 'apdex should be frustrating')
+
+        t.end()
+      })
+    })
+  })
+
+  t.test('collects the actual error object when error handler is used', function (t) {
+    const agent = helper.instrumentMockedAgent()
+
+    const app = require('express')()
+    const server = require('http').createServer(app)
+
+    t.teardown(() => {
+      server.close()
+      helper.unloadAgent(agent)
+    })
+
+    app.get(TEST_PATH, function () {
+      throw new Error('some error')
+    })
+
+    // eslint-disable-next-line no-unused-vars
+    app.use(function (err, rer, res, next) {
+      res.status(400).end()
+    })
+
+    server.listen(0, TEST_HOST, function () {
+      const port = server.address().port
+      helper.makeGetRequest(TEST_URL + port + TEST_PATH, function () {
+        const errors = agent.errors.traceAggregator.errors
+        t.equal(errors.length, 1, 'there should be one error')
+        t.equal(errors[0][2], 'some error', 'got the expected error')
+        t.ok(errors[0][4].stack_trace, 'has stack trace')
+
+        const metric = agent.metrics.getMetric('Apdex')
+        t.ok(metric.frustrating === 1, 'apdex should be frustrating')
+
+        t.end()
+      })
+    })
+  })
+
+  // Some error handlers might sanitize the error object, removing stack and/or message
+  // properties, so that it can be serialized and sent back in the response body.
+  // We use message and stack properties to identify an Error object, so in this case
+  // we want to at least collect the HTTP error based on the status code.
+  t.test('should report errors without message or stack sent to res.send', function (t) {
+    const agent = helper.instrumentMockedAgent()
+
+    const app = require('express')()
+    const server = require('http').createServer(app)
+
+    t.teardown(() => {
+      server.close()
+      helper.unloadAgent(agent)
+    })
+
+    const error = new Error('some error')
+    app.get(TEST_PATH, function () {
+      throw error
+    })
+
+    // eslint-disable-next-line no-unused-vars
+    app.use(function (err, rer, res, next) {
+      delete err.message
+      delete err.stack
+      res.status(400).send(err)
+    })
+
+    server.listen(0, TEST_HOST, function () {
+      const port = server.address().port
+      helper.makeGetRequest(TEST_URL + port + TEST_PATH, function () {
+        const errors = agent.errors.traceAggregator.errors
+        t.equal(errors.length, 1, 'there should be one error')
+        t.equal(errors[0][2], 'HttpError 400', 'got the expected error')
+
+        const metric = agent.metrics.getMetric('Apdex')
+        t.ok(metric.frustrating === 1, 'apdex should be frustrating')
+
+        t.end()
+      })
+    })
+  })
+
+  t.test('should report errors without message or stack sent to next', function (t) {
+    const agent = helper.instrumentMockedAgent()
+
+    const app = require('express')()
+    const server = require('http').createServer(app)
+
+    t.teardown(() => {
+      server.close()
+      helper.unloadAgent(agent)
+    })
+
+    const error = new Error('some error')
+    app.get(TEST_PATH, function () {
+      throw error
+    })
+
+    app.use(function errorHandler(err, rer, res, next) {
+      delete err.message
+      delete err.stack
+      next(err)
+    })
+
+    server.listen(0, TEST_HOST, function () {
+      const port = server.address().port
+      helper.makeGetRequest(TEST_URL + port + TEST_PATH, function () {
+        const errors = agent.errors.traceAggregator.errors
+        t.equal(errors.length, 1, 'there should be one error')
+        t.equal(errors[0][2], 'HttpError 500', 'got the expected error')
+
+        const metric = agent.metrics.getMetric('Apdex')
+        t.ok(metric.frustrating === 1, 'apdex should be frustrating')
+
+        t.end()
+      })
+    })
+  })
+})
+
+test('layer wrapping', function (t) {
+  t.plan(1)
+
+  // Set up the test.
+  const agent = helper.instrumentMockedAgent()
+  const app = require('express')()
+  const server = require('http').createServer(app)
+  t.teardown(() => {
+    server.close()
+    helper.unloadAgent(agent)
+  })
+
+  // Add our route.
+  app.get(TEST_PATH, function (req, res) {
+    res.send('bar')
+  })
+
+  // Proxy the last layer on the stack.
+  const router = app._router || app.router
+  const stack = router.stack
+  stack[stack.length - 1] = makeProxyLayer(stack[stack.length - 1])
+
+  // Make our request.
+  server.listen(0, TEST_HOST, function () {
+    const port = server.address().port
+    helper.makeGetRequest(TEST_URL + port + TEST_PATH, function (err, response, body) {
+      t.equal(body, 'bar', 'should not fail with a proxy layer')
+      t.end()
+    })
+  })
+})
 
 /**
  * Wraps a layer in a proxy with all of the layer's prototype's methods directly

--- a/test/versioned/express/route-iteration.tap.js
+++ b/test/versioned/express/route-iteration.tap.js
@@ -35,7 +35,7 @@ test('new relic should not break route iteration', function (t) {
   router.use(childA)
   router.use(childB)
 
-  t.deepEqual(findAllRoutes(router, ''), ['/get', ['/test'], ['/hello']])
+  t.same(findAllRoutes(router, ''), ['/get', ['/test'], ['/hello']])
 })
 
 function findAllRoutes(router, path) {

--- a/test/versioned/express/transaction-naming.tap.js
+++ b/test/versioned/express/transaction-naming.tap.js
@@ -5,598 +5,593 @@
 
 'use strict'
 
-const helper = require('../../lib/agent_helper')
 const http = require('http')
 const test = require('tap').test
 const semver = require('semver')
 const { version: pkgVersion } = require('express/package')
+const { makeRequest, setup } = require('./utils')
 
-let express
-let agent
-let app
+test('transaction name with single route', function (t) {
+  setup(t)
+  const { app } = t.context
 
-runTests({
-  express_segments: false
-})
-
-runTests({
-  express_segments: true
-})
-
-function runTests(flags) {
-  test('transaction name with single route', function (t) {
-    setup(t)
-
-    app.get('/path1', function (req, res) {
-      res.end()
-    })
-
-    runTest(t, '/path1', '/path1')
+  app.get('/path1', function (req, res) {
+    res.end()
   })
 
-  test('transaction name with no matched routes', function (t) {
-    setup(t)
+  runTest(t, '/path1', '/path1')
+})
 
-    app.get('/path1', function (req, res) {
+test('transaction name with no matched routes', function (t) {
+  setup(t)
+  const { agent, app, isExpress5 } = t.context
+
+  app.get('/path1', function (req, res) {
+    res.end()
+  })
+
+  const endpoint = '/asdf'
+
+  const txPrefix = isExpress5 ? 'WebTransaction/Nodejs' : 'WebTransaction/Expressjs'
+  agent.on('transactionFinished', function (transaction) {
+    t.equal(transaction.name, `${txPrefix}/GET/(not found)`, 'transaction has expected name')
+    t.end()
+  })
+  const server = app.listen(function () {
+    makeRequest(this, endpoint)
+  })
+  t.teardown(() => {
+    server.close()
+  })
+})
+
+test('transaction name with route that has multiple handlers', function (t) {
+  setup(t)
+  const { app } = t.context
+
+  app.get(
+    '/path1',
+    function (req, res, next) {
+      next()
+    },
+    function (req, res) {
       res.end()
-    })
+    }
+  )
 
-    const endpoint = '/asdf'
+  runTest(t, '/path1', '/path1')
+})
 
-    agent.on('transactionFinished', function (transaction) {
-      t.equal(
-        transaction.name,
-        'WebTransaction/Expressjs/GET/(not found)',
-        'transaction has expected name'
-      )
-      t.end()
-    })
-    const server = app.listen(function () {
-      makeRequest(this, endpoint)
-    })
+test('transaction name with router middleware', function (t) {
+  setup(t)
+  const { app, express } = t.context
+
+  const router = new express.Router()
+  router.get('/path1', function (req, res) {
+    res.end()
+  })
+
+  app.use(router)
+
+  runTest(t, '/path1', '/path1')
+})
+
+test('transaction name with middleware function', function (t) {
+  setup(t)
+  const { app } = t.context
+
+  app.use('/path1', function (req, res, next) {
+    next()
+  })
+
+  app.get('/path1', function (req, res) {
+    res.end()
+  })
+
+  runTest(t, '/path1', '/path1')
+})
+
+test('transaction name with shared middleware function', function (t) {
+  setup(t)
+  const { app } = t.context
+
+  app.use(['/path1', '/path2'], function (req, res, next) {
+    next()
+  })
+
+  app.get('/path1', function (req, res) {
+    res.end()
+  })
+
+  runTest(t, '/path1', '/path1')
+})
+
+test('transaction name when ending in shared middleware', function (t) {
+  setup(t)
+  const { app } = t.context
+
+  app.use(['/path1', '/path2'], function (req, res) {
+    res.end()
+  })
+
+  runTest(t, '/path1', '/path1,/path2')
+})
+
+test('transaction name with subapp middleware', function (t) {
+  setup(t)
+  const { app, express } = t.context
+
+  const subapp = express()
+
+  subapp.get('/path1', function middleware(req, res) {
+    res.end()
+  })
+
+  app.use(subapp)
+
+  runTest(t, '/path1', '/path1')
+})
+
+test('transaction name with subrouter', function (t) {
+  setup(t)
+  const { app, express } = t.context
+
+  const router = new express.Router()
+
+  router.get('/path1', function (req, res) {
+    res.end()
+  })
+
+  app.use('/api', router)
+
+  runTest(t, '/api/path1', '/api/path1')
+})
+
+test('multiple route handlers with the same name do not duplicate transaction name', function (t) {
+  setup(t)
+  const { app } = t.context
+
+  app.get('/path1', function (req, res, next) {
+    next()
+  })
+
+  app.get('/path1', function (req, res) {
+    res.end()
+  })
+
+  runTest(t, '/path1', '/path1')
+})
+
+test('responding from middleware', function (t) {
+  setup(t)
+  const { app } = t.context
+
+  app.use('/test', function (req, res, next) {
+    res.send('ok')
+    next()
+  })
+
+  runTest(t, '/test')
+})
+
+test('responding from middleware with parameter', function (t) {
+  setup(t)
+  const { app } = t.context
+
+  app.use('/test', function (req, res, next) {
+    res.send('ok')
+    next()
+  })
+
+  runTest(t, '/test/param', '/test')
+})
+
+test('with error', function (t) {
+  setup(t)
+  const { app } = t.context
+
+  app.get('/path1', function (req, res, next) {
+    next(new Error('some error'))
+  })
+
+  app.use(function (err, req, res) {
+    return res.status(500).end()
+  })
+
+  runTest(t, '/path1', '/path1')
+})
+
+test('with error and path-specific error handler', function (t) {
+  setup(t)
+  const { app } = t.context
+
+  app.get('/path1', function () {
+    throw new Error('some error')
+  })
+
+  app.use('/path1', function(err, req, res, next) { // eslint-disable-line
+    res.status(500).end()
+  })
+
+  runTest(t, '/path1', '/path1')
+})
+
+test('when router error is handled outside of the router', function (t) {
+  setup(t)
+  const { app, express } = t.context
+
+  const router = new express.Router()
+
+  router.get('/path1', function (req, res, next) {
+    next(new Error('some error'))
+  })
+
+  app.use('/router1', router)
+
+  // eslint-disable-next-line no-unused-vars
+  app.use(function (err, req, res, next) {
+    return res.status(500).end()
+  })
+
+  runTest(t, '/router1/path1', '/router1/path1')
+})
+
+test('when using a route variable', function (t) {
+  setup(t)
+  const { app } = t.context
+
+  app.get('/:foo/:bar', function (req, res) {
+    res.end()
+  })
+
+  runTest(t, '/foo/bar', '/:foo/:bar')
+})
+
+test('when using a string pattern in path', function (t) {
+  setup(t)
+  const { app, isExpress5 } = t.context
+
+  const path = isExpress5 ? /ab?cd/ : '/ab?cd'
+
+  app.get(path, function (req, res) {
+    res.end()
+  })
+
+  runTest(t, '/abcd', path)
+})
+
+test('when using a regular expression in path', function (t) {
+  setup(t)
+  const { app } = t.context
+
+  app.get(/a/, function (req, res) {
+    res.end()
+  })
+
+  runTest(t, '/abcd', '/a/')
+})
+
+test('when using router with a route variable', function (t) {
+  setup(t)
+  const { app, express } = t.context
+
+  const router = express.Router() // eslint-disable-line new-cap
+
+  router.get('/:var2/path1', function (req, res) {
+    res.end()
+  })
+
+  app.use('/:var1', router)
+
+  runTest(t, '/foo/bar/path1', '/:var1/:var2/path1')
+})
+
+test('when mounting a subapp using a variable', function (t) {
+  setup(t)
+  const { app, express } = t.context
+
+  const subapp = express()
+  subapp.get('/:var2/path1', function (req, res) {
+    res.end()
+  })
+
+  app.use('/:var1', subapp)
+
+  runTest(t, '/foo/bar/path1', '/:var1/:var2/path1')
+})
+
+test('using two routers', function (t) {
+  setup(t)
+  const { app, express } = t.context
+
+  const router1 = express.Router() // eslint-disable-line new-cap
+  const router2 = express.Router() // eslint-disable-line new-cap
+
+  app.use('/:router1', router1)
+  router1.use('/:router2', router2)
+
+  router2.get('/path1', function (req, res) {
+    res.end()
+  })
+
+  runTest(t, '/router1/router2/path1', '/:router1/:router2/path1')
+})
+
+test('transactions running in parallel should be recorded correctly', function (t) {
+  setup(t)
+  const { app, express } = t.context
+  const router1 = express.Router() // eslint-disable-line new-cap
+  const router2 = express.Router() // eslint-disable-line new-cap
+
+  app.use('/:router1', router1)
+  router1.use('/:router2', router2)
+
+  router2.get('/path1', function (req, res) {
+    setTimeout(function () {
+      res.end()
+    }, 0)
+  })
+
+  const numTests = 4
+  const runner = makeMultiRunner(t, '/router1/router2/path1', '/:router1/:router2/path1', numTests)
+  app.listen(function () {
     t.teardown(() => {
-      server.close()
+      this.close()
     })
+    for (let i = 0; i < numTests; i++) {
+      runner(this)
+    }
+  })
+})
+
+test('names transaction when request is aborted', function (t) {
+  t.plan(4)
+  setup(t)
+  const { agent, app } = t.context
+
+  let request = null
+
+  app.get('/test', function (req, res, next) {
+    t.comment('middleware')
+    t.ok(agent.getTransaction(), 'transaction exists')
+
+    // generate error after client has aborted
+    request.abort()
+    setTimeout(function () {
+      t.comment('timed out')
+      t.ok(agent.getTransaction() == null, 'transaction has already ended')
+      next(new Error('some error'))
+    }, 100)
   })
 
-  test('transaction name with route that has multiple handlers', function (t) {
-    setup(t)
+  // eslint-disable-next-line no-unused-vars
+  app.use(function (error, req, res, next) {
+    t.comment('errorware')
+    t.ok(agent.getTransaction() == null, 'no active transaction when responding')
+    res.end()
+  })
 
-    app.get(
-      '/path1',
-      function (req, res, next) {
-        next()
+  const server = app.listen(function () {
+    t.comment('making request')
+    const port = this.address().port
+    request = http.request(
+      {
+        hostname: 'localhost',
+        port: port,
+        path: '/test'
       },
-      function (req, res) {
-        res.end()
-      }
+      function () {}
     )
+    request.end()
 
-    runTest(t, '/path1', '/path1')
-  })
-
-  test('transaction name with router middleware', function (t) {
-    setup(t)
-
-    const router = new express.Router()
-    router.get('/path1', function (req, res) {
-      res.end()
+    // add error handler, otherwise aborting will cause an exception
+    request.on('error', function (err) {
+      t.comment('request errored: ' + err)
     })
-
-    app.use(router)
-
-    runTest(t, '/path1', '/path1')
-  })
-
-  test('transaction name with middleware function', function (t) {
-    setup(t)
-
-    app.use('/path1', function (req, res, next) {
-      next()
-    })
-
-    app.get('/path1', function (req, res) {
-      res.end()
-    })
-
-    runTest(t, '/path1', '/path1')
-  })
-
-  test('transaction name with shared middleware function', function (t) {
-    setup(t)
-
-    app.use(['/path1', '/path2'], function (req, res, next) {
-      next()
-    })
-
-    app.get('/path1', function (req, res) {
-      res.end()
-    })
-
-    runTest(t, '/path1', '/path1')
-  })
-
-  test('transaction name when ending in shared middleware', function (t) {
-    setup(t)
-
-    app.use(['/path1', '/path2'], function (req, res) {
-      res.end()
-    })
-
-    runTest(t, '/path1', '/path1,/path2')
-  })
-
-  test('transaction name with subapp middleware', function (t) {
-    setup(t)
-
-    const subapp = express()
-
-    subapp.get('/path1', function middleware(req, res) {
-      res.end()
-    })
-
-    app.use(subapp)
-
-    runTest(t, '/path1', '/path1')
-  })
-
-  test('transaction name with subrouter', function (t) {
-    setup(t)
-
-    const router = new express.Router()
-
-    router.get('/path1', function (req, res) {
-      res.end()
-    })
-
-    app.use('/api', router)
-
-    runTest(t, '/api/path1', '/api/path1')
-  })
-
-  test('multiple route handlers with the same name do not duplicate transaction name', function (t) {
-    setup(t)
-
-    app.get('/path1', function (req, res, next) {
-      next()
-    })
-
-    app.get('/path1', function (req, res) {
-      res.end()
-    })
-
-    runTest(t, '/path1', '/path1')
-  })
-
-  test('responding from middleware', function (t) {
-    setup(t)
-
-    app.use('/test', function (req, res, next) {
-      res.send('ok')
-      next()
-    })
-
-    runTest(t, '/test')
-  })
-
-  test('responding from middleware with parameter', function (t) {
-    setup(t)
-
-    app.use('/test', function (req, res, next) {
-      res.send('ok')
-      next()
-    })
-
-    runTest(t, '/test/param', '/test')
-  })
-
-  test('with error', function (t) {
-    setup(t)
-
-    app.get('/path1', function (req, res, next) {
-      next(new Error('some error'))
-    })
-
-    app.use(function (err, req, res) {
-      return res.status(500).end()
-    })
-
-    runTest(t, '/path1', '/path1')
-  })
-
-  test('with error and path-specific error handler', function (t) {
-    setup(t)
-
-    app.get('/path1', function () {
-      throw new Error('some error')
-    })
-
-    app.use('/path1', function(err, req, res, next) { // eslint-disable-line
-      res.status(500).end()
-    })
-
-    runTest(t, '/path1', '/path1')
-  })
-
-  test('when router error is handled outside of the router', function (t) {
-    setup(t)
-
-    const router = new express.Router()
-
-    router.get('/path1', function (req, res, next) {
-      next(new Error('some error'))
-    })
-
-    app.use('/router1', router)
-
-    // eslint-disable-next-line no-unused-vars
-    app.use(function (err, req, res, next) {
-      return res.status(500).end()
-    })
-
-    runTest(t, '/router1/path1', '/router1/path1')
-  })
-
-  test('when using a route variable', function (t) {
-    setup(t)
-
-    app.get('/:foo/:bar', function (req, res) {
-      res.end()
-    })
-
-    runTest(t, '/foo/bar', '/:foo/:bar')
-  })
-
-  test('when using a string pattern in path', function (t) {
-    setup(t)
-
-    app.get('/ab?cd', function (req, res) {
-      res.end()
-    })
-
-    runTest(t, '/abcd', '/ab?cd')
-  })
-
-  test('when using a regular expression in path', function (t) {
-    setup(t)
-
-    app.get(/a/, function (req, res) {
-      res.end()
-    })
-
-    runTest(t, '/abcd', '/a/')
-  })
-
-  test('when using router with a route variable', function (t) {
-    setup(t)
-
-    const router = express.Router() // eslint-disable-line new-cap
-
-    router.get('/:var2/path1', function (req, res) {
-      res.end()
-    })
-
-    app.use('/:var1', router)
-
-    runTest(t, '/foo/bar/path1', '/:var1/:var2/path1')
-  })
-
-  test('when mounting a subapp using a variable', function (t) {
-    setup(t)
-
-    const subapp = express()
-    subapp.get('/:var2/path1', function (req, res) {
-      res.end()
-    })
-
-    app.use('/:var1', subapp)
-
-    runTest(t, '/foo/bar/path1', '/:var1/:var2/path1')
-  })
-
-  test('using two routers', function (t) {
-    setup(t)
-
-    const router1 = express.Router() // eslint-disable-line new-cap
-    const router2 = express.Router() // eslint-disable-line new-cap
-
-    app.use('/:router1', router1)
-    router1.use('/:router2', router2)
-
-    router2.get('/path1', function (req, res) {
-      res.end()
-    })
-
-    runTest(t, '/router1/router2/path1', '/:router1/:router2/path1')
-  })
-
-  test('transactions running in parallel should be recorded correctly', function (t) {
-    setup(t)
-    const router1 = express.Router() // eslint-disable-line new-cap
-    const router2 = express.Router() // eslint-disable-line new-cap
-
-    app.use('/:router1', router1)
-    router1.use('/:router2', router2)
-
-    router2.get('/path1', function (req, res) {
-      setTimeout(function () {
-        res.end()
-      }, 0)
-    })
-
-    const numTests = 4
-    const runner = makeMultiRunner(
-      t,
-      '/router1/router2/path1',
-      '/:router1/:router2/path1',
-      numTests
-    )
-    app.listen(function () {
-      t.teardown(() => {
-        this.close()
-      })
-      for (let i = 0; i < numTests; i++) {
-        runner(this)
-      }
+    request.on('abort', function () {
+      t.comment('request aborted')
     })
   })
 
-  test('names transaction when request is aborted', function (t) {
-    t.plan(4)
-    setup(t)
-
-    let request = null
-
-    app.get('/test', function (req, res, next) {
-      t.comment('middleware')
-      t.ok(agent.getTransaction(), 'transaction exists')
-
-      // generate error after client has aborted
-      request.abort()
-      setTimeout(function () {
-        t.comment('timed out')
-        t.ok(agent.getTransaction() == null, 'transaction has already ended')
-        next(new Error('some error'))
-      }, 100)
-    })
-
-    // eslint-disable-next-line no-unused-vars
-    app.use(function (error, req, res, next) {
-      t.comment('errorware')
-      t.ok(agent.getTransaction() == null, 'no active transaction when responding')
-      res.end()
-    })
-
-    const server = app.listen(function () {
-      t.comment('making request')
-      const port = this.address().port
-      request = http.request(
-        {
-          hostname: 'localhost',
-          port: port,
-          path: '/test'
-        },
-        function () {}
-      )
-      request.end()
-
-      // add error handler, otherwise aborting will cause an exception
-      request.on('error', function (err) {
-        t.comment('request errored: ' + err)
-      })
-      request.on('abort', function () {
-        t.comment('request aborted')
-      })
-    })
-
-    agent.on('transactionFinished', function (tx) {
-      t.equal(tx.name, 'WebTransaction/Expressjs/GET//test')
-    })
-
-    t.teardown(() => {
-      server.close()
-    })
+  agent.on('transactionFinished', function (tx) {
+    t.equal(tx.name, 'WebTransaction/Expressjs/GET//test')
   })
 
-  test('Express transaction names are unaffected by errorware', function (t) {
-    t.plan(1)
-    setup(t)
+  t.teardown(() => {
+    server.close()
+  })
+})
 
-    agent.on('transactionFinished', function (tx) {
-      const expected = 'WebTransaction/Expressjs/GET//test'
-      t.equal(tx.trace.root.children[0].name, expected)
-    })
+test('Express transaction names are unaffected by errorware', function (t) {
+  t.plan(1)
+  setup(t)
+  const { agent, app } = t.context
 
-    app.use('/test', function () {
-      throw new Error('endpoint error')
-    })
-
-    // eslint-disable-next-line no-unused-vars
-    app.use('/test', function (err, req, res, next) {
-      res.send(err.message)
-    })
-
-    const server = app.listen(function () {
-      http.request({ port: this.address().port, path: '/test' }).end()
-    })
-
-    t.teardown(function () {
-      server.close()
-    })
+  agent.on('transactionFinished', function (tx) {
+    const expected = 'WebTransaction/Expressjs/GET//test'
+    t.equal(tx.trace.root.children[0].name, expected)
   })
 
-  test('when next is called after transaction state loss', function (t) {
-    // Uninstrumented work queue. This must be set up before the agent is loaded
-    // so that no transaction state is maintained.
-    const tasks = []
-    const interval = setInterval(function () {
-      if (tasks.length) {
-        tasks.pop()()
-      }
-    }, 10)
-
-    setup(t)
-    t.plan(3)
-
-    let transactionsFinished = 0
-    const transactionNames = [
-      'WebTransaction/Expressjs/GET//bar',
-      'WebTransaction/Expressjs/GET//foo'
-    ]
-    agent.on('transactionFinished', function (tx) {
-      t.equal(
-        tx.name,
-        transactionNames[transactionsFinished++],
-        'should have expected name ' + transactionsFinished
-      )
-    })
-
-    app.use('/foo', function (req, res, next) {
-      setTimeout(function () {
-        tasks.push(next)
-      }, 5)
-    })
-
-    app.get('/foo', function (req, res) {
-      setTimeout(function () {
-        res.send('foo done\n')
-      }, 500)
-    })
-
-    app.get('/bar', function (req, res) {
-      res.send('bar done\n')
-    })
-
-    const server = app.listen(function () {
-      const port = this.address().port
-
-      // Send first request to `/foo` which is slow and uses the work queue.
-      http.get({ port: port, path: '/foo' }, function (res) {
-        res.resume()
-        res.on('end', function () {
-          t.equal(transactionsFinished, 2, 'should have two transactions done')
-          t.end()
-        })
-      })
-
-      // Send the second request after a short wait `/bar` which is fast and
-      // does not use the work queue.
-      setTimeout(function () {
-        http.get({ port: port, path: '/bar' }, function (res) {
-          res.resume()
-        })
-      }, 100)
-    })
-    t.teardown(function () {
-      server.close()
-      clearInterval(interval)
-    })
+  app.use('/test', function () {
+    throw new Error('endpoint error')
   })
 
-  // express did not add array based middleware registration
-  // without path until 4.9.2
-  // https://github.com/expressjs/express/blob/master/History.md#492--2014-09-17
-  if (semver.satisfies(pkgVersion, '>=4.9.2')) {
-    test('transaction name with array of middleware with unspecified mount path', (t) => {
-      setup(t)
+  // eslint-disable-next-line no-unused-vars
+  app.use('/test', function (err, req, res, next) {
+    res.send(err.message)
+  })
 
-      function mid1(req, res, next) {
-        t.pass('mid1 is executed')
-        next()
-      }
+  const server = app.listen(function () {
+    http.request({ port: this.address().port, path: '/test' }).end()
+  })
 
-      function mid2(req, res, next) {
-        t.pass('mid2 is executed')
-        next()
-      }
+  t.teardown(function () {
+    server.close()
+  })
+})
 
-      app.use([mid1, mid2])
-
-      app.get('/path1', (req, res) => {
-        res.end()
-      })
-
-      runTest(t, '/path1', '/path1')
-    })
-
-    test('transaction name when ending in array of unmounted middleware', (t) => {
-      setup(t)
-
-      function mid1(req, res, next) {
-        t.pass('mid1 is executed')
-        next()
-      }
-
-      function mid2(req, res) {
-        t.pass('mid2 is executed')
-        res.end()
-      }
-
-      app.use([mid1, mid2])
-
-      app.use(mid1)
-
-      runTest(t, '/path1', '/')
-    })
-  }
-
-  function setup(t) {
-    agent = helper.instrumentMockedAgent(flags)
-
-    express = require('express')
-    app = express()
-    t.teardown(() => {
-      helper.unloadAgent(agent)
-    })
-  }
-
-  function makeMultiRunner(t, endpoint, expectedName, numTests) {
-    let done = 0
-    const seen = new Set()
-    if (!expectedName) {
-      expectedName = endpoint
+test('when next is called after transaction state loss', function (t) {
+  // Uninstrumented work queue. This must be set up before the agent is loaded
+  // so that no transaction state is maintained.
+  const tasks = []
+  const interval = setInterval(function () {
+    if (tasks.length) {
+      tasks.pop()()
     }
-    agent.on('transactionFinished', function (transaction) {
-      t.notOk(seen.has(transaction), 'should never see the finishing transaction twice')
-      seen.add(transaction)
-      t.equal(
-        transaction.name,
-        'WebTransaction/Expressjs/GET/' + expectedName,
-        'transaction has expected name'
-      )
-      transaction.end()
-      if (++done === numTests) {
-        done = 0
+  }, 10)
+
+  setup(t)
+  const { agent, app } = t.context
+  t.plan(3)
+
+  let transactionsFinished = 0
+  const transactionNames = [
+    'WebTransaction/Expressjs/GET//bar',
+    'WebTransaction/Expressjs/GET//foo'
+  ]
+  agent.on('transactionFinished', function (tx) {
+    t.equal(
+      tx.name,
+      transactionNames[transactionsFinished++],
+      'should have expected name ' + transactionsFinished
+    )
+  })
+
+  app.use('/foo', function (req, res, next) {
+    setTimeout(function () {
+      tasks.push(next)
+    }, 5)
+  })
+
+  app.get('/foo', function (req, res) {
+    setTimeout(function () {
+      res.send('foo done\n')
+    }, 500)
+  })
+
+  app.get('/bar', function (req, res) {
+    res.send('bar done\n')
+  })
+
+  const server = app.listen(function () {
+    const port = this.address().port
+
+    // Send first request to `/foo` which is slow and uses the work queue.
+    http.get({ port: port, path: '/foo' }, function (res) {
+      res.resume()
+      res.on('end', function () {
+        t.equal(transactionsFinished, 2, 'should have two transactions done')
         t.end()
-      }
+      })
     })
-    return function runMany(server) {
-      makeRequest(server, endpoint)
-    }
-  }
 
-  function runTest(t, endpoint, expectedName) {
-    if (!expectedName) {
-      expectedName = endpoint
+    // Send the second request after a short wait `/bar` which is fast and
+    // does not use the work queue.
+    setTimeout(function () {
+      http.get({ port: port, path: '/bar' }, function (res) {
+        res.resume()
+      })
+    }, 100)
+  })
+  t.teardown(function () {
+    server.close()
+    clearInterval(interval)
+  })
+})
+
+// express did not add array based middleware registration
+// without path until 4.9.2
+// https://github.com/expressjs/express/blob/master/History.md#492--2014-09-17
+// TODO: run on express beta 5
+if (semver.satisfies(pkgVersion, '>=4.9.2')) {
+  test('transaction name with array of middleware with unspecified mount path', (t) => {
+    setup(t)
+    const { app } = t.context
+
+    function mid1(req, res, next) {
+      t.pass('mid1 is executed')
+      next()
     }
-    agent.on('transactionFinished', function (transaction) {
-      t.equal(
-        transaction.name,
-        'WebTransaction/Expressjs/GET/' + expectedName,
-        'transaction has expected name'
-      )
+
+    function mid2(req, res, next) {
+      t.pass('mid2 is executed')
+      next()
+    }
+
+    app.use([mid1, mid2])
+
+    app.get('/path1', (req, res) => {
+      res.end()
+    })
+
+    runTest(t, '/path1', '/path1')
+  })
+
+  test('transaction name when ending in array of unmounted middleware', (t) => {
+    setup(t)
+    const { app } = t.context
+
+    function mid1(req, res, next) {
+      t.pass('mid1 is executed')
+      next()
+    }
+
+    function mid2(req, res) {
+      t.pass('mid2 is executed')
+      res.end()
+    }
+
+    app.use([mid1, mid2])
+
+    app.use(mid1)
+
+    runTest(t, '/path1', '/')
+  })
+}
+
+function makeMultiRunner(t, endpoint, expectedName, numTests) {
+  const { agent } = t.context
+  let done = 0
+  const seen = new Set()
+  if (!expectedName) {
+    expectedName = endpoint
+  }
+  agent.on('transactionFinished', function (transaction) {
+    t.notOk(seen.has(transaction), 'should never see the finishing transaction twice')
+    seen.add(transaction)
+    t.equal(
+      transaction.name,
+      'WebTransaction/Expressjs/GET/' + expectedName,
+      'transaction has expected name'
+    )
+    transaction.end()
+    if (++done === numTests) {
+      done = 0
       t.end()
-    })
-    const server = app.listen(function () {
-      makeRequest(this, endpoint)
-    })
-    t.teardown(() => {
-      server.close()
-    })
+    }
+  })
+  return function runMany(server) {
+    makeRequest(server, endpoint)
   }
+}
 
-  function makeRequest(server, path, callback) {
-    const port = server.address().port
-    http.request({ port: port, path: path }, callback).end()
+function runTest(t, endpoint, expectedName) {
+  const { app, agent } = t.context
+  if (!expectedName) {
+    expectedName = endpoint
   }
+  agent.on('transactionFinished', function (transaction) {
+    t.equal(
+      transaction.name,
+      'WebTransaction/Expressjs/GET/' + expectedName,
+      'transaction has expected name'
+    )
+    t.end()
+  })
+  const server = app.listen(function () {
+    makeRequest(this, endpoint)
+  })
+  t.teardown(() => {
+    server.close()
+  })
 }

--- a/test/versioned/express/utils.js
+++ b/test/versioned/express/utils.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const http = require('http')
+const helper = require('../../lib/agent_helper')
+const semver = require('semver')
+
+function isExpress5() {
+  const { version } = require('express/package')
+  // TODO: change to 5.0.0 when officially released
+  return semver.gte(version, '5.0.0-beta.3')
+}
+
+function makeRequest(server, path, callback) {
+  const port = server.address().port
+  http.request({ port: port, path: path }, callback).end()
+}
+
+function setup(t, config = {}) {
+  t.context.agent = helper.instrumentMockedAgent(config)
+  t.context.isExpress5 = isExpress5()
+
+  t.context.express = require('express')
+  t.context.app = t.context.express()
+  t.teardown(() => {
+    helper.unloadAgent(t.context.agent)
+  })
+}
+
+module.exports = {
+  isExpress5,
+  makeRequest,
+  setup
+}

--- a/test/versioned/koa/package.json
+++ b/test/versioned/koa/package.json
@@ -53,7 +53,7 @@
           "samples": 5
         },
         "@koa/router": {
-          "versions": ">=11.0.2",
+          "versions": ">=11.0.2 <13.0.0",
           "samples": 5
         }
       },


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This originally started as a research spike to see what broke. It turns out not much so I just PRd support for express 5 beta.  We will not officially support it because it hasn't been released as generally available.  We will keep tabs on any upcoming beta releases and remove the test stanzas when 5.0.0 is out.  I will make sure when this lands to include a secondary changelog item to state this is not officially supported just yet.

Most of the changes are around how child applications are mounted.  In v4 they used to be mounted as applications, now they are just mixed in.  You can see a difference here:

 * [express 4](https://github.com/expressjs/express/blob/2177f67f5439494f7a29a8d04f744cc20fb9f201/lib/application.js#L221) - it would create a lazyrouter which registered query, and expressInit which would pre-define handlers
 * [express 5](https://github.com/expressjs/express/blob/ecf762ff383c2cefa4e49b4a7e2d7af23a255d5d/lib/application.js#L219) - it now doesn't do this and instead just sets on the default [app configuration](https://github.com/expressjs/express/blob/ecf762ff383c2cefa4e49b4a7e2d7af23a255d5d/lib/application.js#L92)

Also, the routing has changed a little because it migrated to use `router@2.0.0-beta`.  I had to update some definitions and assertions to handle this.  Lastly, express 4 used to bind the query and expressInit middleware as part of the mounted application, this is still done but not as first class middleware so I had to loosen some assertions.  

Lastly, I added tests for async handlers and how they are handled if they reject.  

## How to Test

```sh
npm run versioned:internal express
npm run versioned:internal express-esm
```

## Related Issues
Closes #2385 