### PR TITLE
fix: Updated koa instrumentation to properly get the matched route name and to handle changes in `@koa/router@13.0.0`

### DIFF
--- a/lib/instrumentation/koa/instrumentation.js
+++ b/lib/instrumentation/koa/instrumentation.js
@@ -115,10 +115,8 @@ function wrapMatchedRoute(shim, context) {
   Object.defineProperty(context, '_matchedRoute', {
     get: () => context[symbols.koaMatchedRoute],
     set: (val) => {
-      const match = getLayerForTransactionName(context)
-
       // match should never be undefined given _matchedRoute was set
-      if (match) {
+      if (val) {
         const currentSegment = shim.getActiveSegment()
 
         // Segment/Transaction may be null, see:
@@ -131,7 +129,7 @@ function wrapMatchedRoute(shim, context) {
             transaction.nameState.popPath()
           }
 
-          transaction.nameState.appendPath(match.path)
+          transaction.nameState.appendPath(val)
           transaction.nameState.markPath()
         }
       }
@@ -167,22 +165,6 @@ function wrapResponseStatus(shim, context) {
       return statusDescriptor.set.call(this, val)
     }
   })
-}
-
-function getLayerForTransactionName(context) {
-  // Context.matched might be null
-  // See https://github.com/newrelic/node-newrelic-koa/pull/29
-  if (!context.matched) {
-    return null
-  }
-  for (let i = context.matched.length - 1; i >= 0; i--) {
-    const layer = context.matched[i]
-    if (layer.opts.end) {
-      return layer
-    }
-  }
-
-  return null
 }
 
 function getInheritedPropertyDescriptor(obj, property) {

--- a/test/versioned/koa/package.json
+++ b/test/versioned/koa/package.json
@@ -53,7 +53,7 @@
           "samples": 5
         },
         "@koa/router": {
-          "versions": ">=11.0.2 <13.0.0",
+          "versions": ">=11.0.2",
           "samples": 5
         }
       },


### PR DESCRIPTION
…

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This PR removes skipping `@koa/router@13.0.0`+.  There were too big changes:
 * allowedMethods middleware is no longer a named function so I updated the tests to handle this
 * Fixed instrumentation to properly name segments/transactions for nested routers.  Turns out we had a test that defined both `:/wildcard`, and `/specific`, in this case it should match the wildcard which it does but our segment/transaction naming was using the `/specific` which was incorrect.

## How to Test
```sh
npm run versioned:internal koa
```

## Related Issues
Closes #2477 