### PR TITLE
Fix inline require causes performance issues

### DIFF
--- a/lib/util/code-level-metrics.js
+++ b/lib/util/code-level-metrics.js
@@ -8,6 +8,7 @@ const logger = require('../logger').child({ component: 'code-level-metrics' })
 const { isValidLength } = require('./byte-limit')
 const symbols = require('../symbols')
 const clmUtils = module.exports
+const { funcInfo } = require('@contrast/fn-inspect')
 
 /**
  * Attaches a flag on function indicating that
@@ -52,7 +53,6 @@ clmUtils.addCLMAttributes = function addCLMAttributes(fn, segment) {
   }
 
   try {
-    const { funcInfo } = require('@contrast/fn-inspect')
     const { lineNumber, method, file: filePath, column } = funcInfo(fn)
     const fnName = setFunctionName(method)
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Please provide a brief description of the changes introduced in this pull request.
What problem does it solve? What is the context of this change?

The combination of code-level-metrics require('@contrast/fn-inspect') with @newrelic/ritm being hooked into requires causes a cascading load issue for nodejs.

## How to Test

Please describe how you have tested these changes. Have you run the code against an example application?
What steps did you take to ensure that the changes are working correctly?

For reference, our express server with newrelic was taking 10 seconds to handle 500 requests.  After this change, the same 500 requests takes about half a second.  Should be able to be tested with a similar configuration.

## Related Issues

Please include any related issues or pull requests in this section, using the format `Closes #<issue number>` or `Fixes #<issue number>` if applicable.

Creating this to capture the issue and fix for the newrelic team, we have patched it locally so that we do not run across this issue anymore.