### PR TITLE
chore: Disable express@5 in versioned tests

### DIFF
--- a/test/versioned/express-esm/package.json
+++ b/test/versioned/express-esm/package.json
@@ -11,7 +11,7 @@
       },
       "dependencies": {
         "express": {
-          "versions": ">=4.6.0",
+          "versions": ">=4.6.0 && <5.0.0",
           "samples": 5
         }
       },

--- a/test/versioned/express/package.json
+++ b/test/versioned/express/package.json
@@ -15,7 +15,7 @@
       },
       "dependencies": {
         "express": {
-          "versions": ">=4.6.0",
+          "versions": ">=4.6.0 && <5.0.0",
           "samples": 5
         },
         "express-enrouten": "1.1",


### PR DESCRIPTION
`express@5` was released on 2024-09-09. It has some incompatibility with the security agent tests. This PR disables it for the time being.

https://github.com/newrelic/node-newrelic/actions/runs/10789319338/job/29922071924

+ [x] https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/321 is required first.