### PR TITLE
fix: Nuget pack generates packagName.semver and not packageName-semver

### DIFF
--- a/.github/workflows/azure-site-extension.yml
+++ b/.github/workflows/azure-site-extension.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Set package filename
         run: |
-          echo "PACKAGE_FILENAME=NewRelic.Azure.WebSites.Extension.NodeAgent-${{env.AGENT_VERSION}}" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "PACKAGE_FILENAME=NewRelic.Azure.WebSites.Extension.NodeAgent.${{env.AGENT_VERSION}}" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Verify environment vars # because we can't access GH env vars until the next step
         run: |


### PR DESCRIPTION
## Description

Site extension publishing was tested on a fork; the filename structure there successfully used a `.` before the semver value in the expected filename. The previous workflow specified a hyphen before the semver value, which does not match the file generated by `nuget pack`.

## How to Test

GHA workflows can only be run after merge to main, though arguably this could be tested in a fork.

This fix is a subtask of NR-300597