### PR TITLE
chore: Document emitted events

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -58,6 +58,94 @@ const INITIAL_HARVEST_DELAY_MS = 1000
 const DEFAULT_HARVEST_INTERVAL_MS = 60000
 
 /**
+ * Indicates that the agent has finished connecting. It is preceded by
+ * {@link Agent#event:connecting}.
+ *
+ * @event Agent#connected
+ */
+
+/**
+ * Indicates that the agent is in the connecting state. That is, it is
+ * communicating with the New Relic data collector and performing requisite
+ * operations before the agent is ready to collect and send data.
+ *
+ * @event Agent#connecting
+ */
+
+/**
+ * Indicates that the agent has terminated, or lost, its connection to the
+ * New Relic data collector.
+ *
+ * @event Agent#disconnected
+ */
+
+/**
+ * Indicates that the agent has encountered, or generated, some error that
+ * prevents it from operating correctly. The agent state will be set to
+ * "errored."
+ *
+ * @event Agent#errored
+ */
+
+/**
+ * Indicates that the synchronous harvest cycle has completed. This will be
+ * prefaced by the {@link Agent#event:harvestStarted} event. It is only fired
+ * in a serverless context.
+ *
+ * @event Agent#harvestFinished
+ */
+
+/**
+ * Indicates that a synchronous harvest cycle (collecting data from the various
+ * aggregators and sending said data to the New Relic data collector) has
+ * started. This is only fired in a serverless context.
+ *
+ * @event Agent#harvestStarted
+ */
+
+/**
+ * Indicates that the agent state has entered the "started" state. That is,
+ * the agent has finished bootstrapping and is collecting and sending data.
+ *
+ * @event Agent#started
+ */
+
+/**
+ * Indicates that the agent is starting. This is typically the first event
+ * emitted by the agent.
+ *
+ * @event Agent#starting
+ */
+
+/**
+ * Indicates that the agent state has changed to the "stopped" state. That is,
+ * the agent is no longer collecting or sending data.
+ *
+ * @event Agent#stopped
+ */
+
+/**
+ * Indicates that the agent is entering its shutdown process.
+ *
+ * @event Agent#stopping
+ */
+
+/**
+ * Indicates that the transaction has begun recording data.
+ *
+ * @event Agent#transactionStarted
+ * @param {Transaction} currentTransaction
+ */
+
+/**
+ * Indicates that the transaction has stopped recording data and has been
+ * closed.
+ *
+ * @event Agent#transactionFinished
+ * @param {Transaction} currentTransaction
+ */
+
+/**
  * There's a lot of stuff in this constructor, due to Agent acting as the
  * orchestrator for New Relic within instrumented applications.
  *
@@ -101,7 +189,7 @@ function Agent(config) {
     this.harvester
   )
 
-  this.metrics.on('starting metric_data data send.', this._beforeMetricDataSend.bind(this))
+  this.metrics.on('starting_data_send-metric_data', this._beforeMetricDataSend.bind(this))
 
   this.spanEventAggregator = createSpanEventAggregator(config, this)
 
@@ -226,6 +314,12 @@ util.inherits(Agent, EventEmitter)
  *
  * @param {Function} callback Continuation and error handler.
  * @returns {void}
+ *
+ * @fires Agent#errored When configuration is not sufficient for operations or
+ * cannot establish a connection to the data collector.
+ * @fires Agent#starting
+ * @fires Agent#stopped When configuration indicates that the agent should be
+ * disabled.
  */
 Agent.prototype.start = function start(callback) {
   if (!callback) {
@@ -306,6 +400,8 @@ Agent.prototype.startStreaming = function startStreaming() {
  *
  * @param {boolean} shouldImmediatelyHarvest Whether we should immediately schedule a harvest, or wait a cycle
  * @param {Function} callback callback function that executes after harvest completes (now if immediate, otherwise later)
+ *
+ * @fires Agent#started
  */
 Agent.prototype.onConnect = function onConnect(shouldImmediatelyHarvest, callback) {
   this.harvester.update(this.config)
@@ -368,6 +464,11 @@ Agent.prototype._serverlessModeStart = function _serverlessModeStart(callback) {
  * current instrumentation and patch to the module loader.
  *
  * @param {Function} callback callback function to invoke after agent stop
+ *
+ * @fires Agent#errored When disconnecting from the data collector has resulted
+ * in some error.
+ * @fires Agent#stopped
+ * @fires Agent#stopping
  */
 Agent.prototype.stop = function stop(callback) {
   if (!callback) {
@@ -432,9 +533,13 @@ Agent.prototype._resetCustomEvents = function resetCustomEvents() {
 }
 
 /**
- * This method invokes a harvest synchronously.
+ * This method invokes a harvest synchronously, i.e. sends all data to the
+ * New Relic collector in a blocking fashion.
  *
- * NOTE: this doesn't currently work outside of serverless mode.
+ * NOTE: this doesn't currently work outside serverless mode.
+ *
+ * @fires Agent#harvestStarted
+ * @fires Agent#harvestFinished
  */
 Agent.prototype.harvestSync = function harvestSync() {
   logger.trace('Peparing to harvest.')
@@ -518,6 +623,15 @@ Agent.prototype.reconfigure = function reconfigure(configuration) {
  * creation of Transactions.
  *
  * @param {string} newState The new state of the agent.
+ *
+ * @fires Agent#connected
+ * @fires Agent#connecting
+ * @fires Agent#disconnected
+ * @fires Agent#errored
+ * @fires Agent#started
+ * @fires Agent#starting
+ * @fires Agent#stopped
+ * @fires Agent#stopping
  */
 Agent.prototype.setState = function setState(newState) {
   if (!STATES.hasOwnProperty(newState)) {

--- a/lib/aggregators/base-aggregator.js
+++ b/lib/aggregators/base-aggregator.js
@@ -8,6 +8,152 @@
 const EventEmitter = require('events').EventEmitter
 const logger = require('../logger').child({ component: 'base_aggregator' })
 
+/**
+ * Triggered when the aggregator has finished sending data to the
+ * `analytic_event_data` collector endpoint.
+ *
+ * @event Aggregator#finished_data_send-analytic_event_data
+ */
+
+/**
+ * Triggered when an aggregator is sending data to the `analytic_event_data`
+ * collector endpoint.
+ *
+ * @event Aggregator#starting_data_send-analytic_event_data
+ */
+
+/**
+ * Triggered when the aggregator has finished sending data to the
+ * `custom_event_data` collector endpoint.
+ *
+ * @event Aggregator#finished_data_send-custom_event_data
+ */
+
+/**
+ * Triggered when an aggregator is sending data to the `custom_event_data`
+ * collector endpoint.
+ *
+ * @event Aggregator#starting_data_send-custom_event_data
+ */
+
+/**
+ * Triggered when the aggregator has finished sending data to the
+ * `error_data` collector endpoint.
+ *
+ * @event Aggregator#finished_data_send-error_data
+ */
+
+/**
+ * Triggered when an aggregator is sending data to the `error_data`
+ * collector endpoint.
+ *
+ * @event Aggregator#starting_data_send-error_data
+ */
+
+/**
+ * Triggered when the aggregator has finished sending data to the
+ * `error_event_data` collector endpoint.
+ *
+ * @event Aggregator#finished_data_send-error_event_data
+ */
+
+/**
+ * Triggered when an aggregator is sending data to the `error_event_data`
+ * collector endpoint.
+ *
+ * @event Aggregator#starting_data_send-error_event_data
+ */
+
+/**
+ * Triggered when the aggregator has finished sending data to the
+ * `log_event_data` collector endpoint.
+ *
+ * @event Aggregator#finished_data_send-log_event_data
+ */
+
+/**
+ * Triggered when an aggregator is sending data to the `log_event_data`
+ * collector endpoint.
+ *
+ * @event Aggregator#starting_data_send-log_event_data
+ */
+
+/**
+ * Triggered when the aggregator has finished sending data to the
+ * `metric_data` collector endpoint.
+ *
+ * @event Aggregator#finished_data_send-metric_data
+ */
+
+/**
+ * Triggered when an aggregator is sending data to the `metric_data`
+ * collector endpoint.
+ *
+ * @event Aggregator#starting_data_send-metric_data
+ */
+
+/**
+ * Triggered when the aggregator has finished sending data to the
+ * `span_event_data` collector endpoint.
+ *
+ * @event Aggregator#finished_data_send-span_event_data
+ */
+
+/**
+ * Triggered when an aggregator is sending data to the `span_event_data`
+ * collector endpoint.
+ *
+ * @event Aggregator#starting_data_send-span_event_data
+ */
+
+/**
+ * Triggered when the aggregator has finished sending data to the
+ * `sql_trace_data` collector endpoint.
+ *
+ * @event Aggregator#finished_data_send-sql_trace_data
+ */
+
+/**
+ * Triggered when an aggregator is sending data to the `sql_trace_data`
+ * collector endpoint.
+ *
+ * @event Aggregator#starting_data_send-sql_trace_data
+ */
+
+/**
+ * Triggered when the aggregator has finished sending data to the
+ * `transaction_sample_data` collector endpoint.
+ *
+ * @event Aggregator#finished_data_send-transaction_sample_data
+ */
+
+/**
+ * Triggered when an aggregator is sending data to the `transaction_sample_data`
+ * collector endpoint.
+ *
+ * @event Aggregator#starting_data_send-transaction_sample_data
+ */
+
+/**
+ * Baseline data aggregator that is used to ship data to the New Relic
+ * data collector. Specific data aggregators, e.g. an errors aggregator,
+ * extend this base object.
+ *
+ * Aggregators fire of several events. The events are named according to the
+ * pattern `<finished|starting>_data_send-<endpoint_name>`. As an example,
+ * if the aggregator is collecting data to send to the `error_event_data`
+ * endpoint, there will be two events:
+ *
+ * + `starting_data_send-error_event_data`
+ * + `finished_data_send-error_event_data`
+ *
+ * For a list of possible endpoints, see
+ * {@link https://source.datanerd.us/agents/agent-specs/tree/main/endpoints/protocol-version-17}.
+ *
+ * Note: effort has been made to document the events for every endpoint this
+ * agent interacts with, but due to the dynamic nature of the event names we
+ * may have missed some.
+ */
 class Aggregator extends EventEmitter {
   constructor(opts, collector, harvester) {
     super()
@@ -23,6 +169,16 @@ class Aggregator extends EventEmitter {
         return true
       }
     this.enabled = this.isEnabled(opts.config)
+
+    /**
+     * The name of the collector endpoint that the
+     * aggregator will communicate with.
+     *
+     * @see https://source.datanerd.us/agents/agent-specs/tree/main/endpoints/protocol-version-17
+     *
+     * @type {string}
+     * @memberof Aggregator
+     */
     this.method = opts.method
     this.collector = collector
     this.sendTimer = null
@@ -90,7 +246,7 @@ class Aggregator extends EventEmitter {
   _runSend(data, payload) {
     if (!payload) {
       this._afterSend(false)
-      this.emit(`finished ${this.method} data send.`)
+      this.emit(`finished_data_send-${this.method}`)
       return
     }
 
@@ -102,13 +258,36 @@ class Aggregator extends EventEmitter {
 
       // TODO: Log?
       this._afterSend(true)
-      this.emit(`finished ${this.method} data send.`)
+      this.emit(`finished_data_send-${this.method}`)
     })
   }
 
+  /**
+   * Serialize all collected data and ship it off to the New Relic data
+   * collector. The target endpoint is defined by {@link Aggregator#method}.
+   *
+   * @fires Aggregator#finished_data_send-analytic_event_data
+   * @fires Aggregator#starting_data_send-analytic_event_data
+   * @fires Aggregator#finished_data_send-custom_event_data
+   * @fires Aggregator#starting_data_send-custom_event_data
+   * @fires Aggregator#finished_data_send-error_data
+   * @fires Aggregator#starting_data_send-error_data
+   * @fires Aggregator#finished_data_send-error_event_data
+   * @fires Aggregator#starting_data_send-error_event_data
+   * @fires Aggregator#finished_data_send-log_event_data
+   * @fires Aggregator#starting_data_send-log_event_data
+   * @fires Aggregator#finished_data_send-metric_data
+   * @fires Aggregator#starting_data_send-metric_data
+   * @fires Aggregator#finished_data_send-span_event_data
+   * @fires Aggregator#starting_data_send-span_event_data
+   * @fires Aggregator#finished_data_send-sql_trace_data
+   * @fires Aggregator#starting_data_send-sql_trace_data
+   * @fires Aggregator#finished_data_send-transaction_sample_data
+   * @fires Aggregator#starting_data_send-transaction_sample_data
+   */
   send() {
     logger.debug(`${this.method} Aggregator data send.`)
-    this.emit(`starting ${this.method} data send.`)
+    this.emit(`starting_data_send-${this.method}`)
 
     const data = this._getMergeData()
     if (this.isAsync) {

--- a/lib/collector/api.js
+++ b/lib/collector/api.js
@@ -150,6 +150,17 @@ CollectorAPI.prototype._updateEndpoints = function _updateEndpoints(endpoint) {
   }
 }
 
+/**
+ * Connect to the data collector.
+ *
+ * @param {function} callback A typical error first callback to be invoked
+ * upon successful or unsuccessful connection. The second parameter will be
+ * an instance of {@link CollectorResponse}.
+ *
+ * @fires Agent#connected By way of the full connection process. This event
+ * is not fired directly in this method.
+ * @fires Agent#connecting
+ */
 CollectorAPI.prototype.connect = function connect(callback) {
   if (!callback) {
     this._throwCallbackError()
@@ -367,6 +378,8 @@ CollectorAPI.prototype._connect = function _connect(env, callback) {
  * @param {Function} callback function to run after processing response
  * @param {Error} error collector response error
  * @param {http.ServerOptions} res collector response
+ *
+ * @fires Agent#connected
  */
 CollectorAPI.prototype._onConnect = function _onConnect(callback, error, res) {
   const agent = this._agent
@@ -451,6 +464,8 @@ CollectorAPI.prototype.shutdown = function shutdown(callback) {
   /**
    * @param {Error} error response error
    * @param {http.ServerResponse} response response from collector
+   *
+   * @fires Agent#disconnected
    */
   function onShutdown(error, response) {
     if (error) {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -70,6 +70,32 @@ function _findConfigFile() {
   return configFileCandidates.find(exists)
 }
 
+/**
+ * Indicates if the agent should be enabled or disabled based upon the
+ * processed configuration.
+ *
+ * @event Config#agent_enabled
+ * @param {boolean} indication
+ */
+
+/**
+ * Indicates that the configuration has changed due to some external factor,
+ * e.g. the configuration from the New Relic server has overridden some
+ * local setting.
+ *
+ * @event Config#change
+ * @param {Config} currentConfig
+ */
+
+/**
+ * Parses and manages the agent configuration.
+ *
+ * @param {object} config Configuration object as read from a `newrelic.js`
+ * file. This is used as the baseline, which is the overridden by environment
+ * variables and feature flags.
+ *
+ * @class
+ */
 function Config(config) {
   EventEmitter.call(this)
 
@@ -194,6 +220,10 @@ Config.prototype.mergeServerConfig = mergeServerConfig
  *
  * @param {object} json The config blob sent by New Relic.
  * @param {boolean} recursion flag indicating coming from server side config
+ *
+ * @fires Config#agent_enabled When there is a conflict between the local
+ * setting of high security mode and what the New Relic server has returned.
+ * @fires Config#change
  */
 Config.prototype.onConnect = function onConnect(json, recursion) {
   json = json || Object.create(null)
@@ -274,6 +304,8 @@ Config.prototype._updateHarvestConfig = function _updateHarvestConfig(serverConf
  *
  * @param {object} params A configuration dictionary.
  * @param {string} key    The particular configuration parameter to set.
+ *
+ * @fires Config#change
  */
 Config.prototype._fromServer = function _fromServer(params, key) {
   /* eslint-disable-next-line sonarjs/max-switch-cases */

--- a/lib/errors/error-collector.js
+++ b/lib/errors/error-collector.js
@@ -35,7 +35,7 @@ class ErrorCollector {
     this.seenObjectsByTransaction = Object.create(null)
     this.seenStringsByTransaction = Object.create(null)
 
-    this.traceAggregator.on('starting error_data data send.', this._onSendErrorTrace.bind(this))
+    this.traceAggregator.on('starting_data_send-error_data', this._onSendErrorTrace.bind(this))
 
     this.errorGroupCallback = null
   }

--- a/lib/harvester.js
+++ b/lib/harvester.js
@@ -37,7 +37,7 @@ module.exports = class Harvester {
       this.aggregators.map((aggregator) => {
         return new Promise((resolve) => {
           if (aggregator.enabled) {
-            aggregator.once(`finished ${aggregator.method} data send.`, function finish() {
+            aggregator.once(`finished_data_send-${aggregator.method}`, function finish() {
               resolve()
             })
 

--- a/lib/metrics/normalizer.js
+++ b/lib/metrics/normalizer.js
@@ -33,6 +33,13 @@ function plain(normalized, path) {
 }
 
 /**
+ * @event MetricNormalizer#appliedRule
+ * @param {object} rule The rule that matched and was applied.
+ * @param {string} normalized The newly updated metric name.
+ * @param {string} last The metric name that matched the rule.
+ */
+
+/**
  * The collector keeps track of rules that should be applied to metric names,
  * and sends these rules to the agent at connection time. These rules can
  * either change the name of the metric or indicate that metrics associated with
@@ -206,6 +213,8 @@ MetricNormalizer.prototype.addSimple = function addSimple(pattern, name) {
  *
  * @param {string} path - The URL path to turn into a name.
  * @returns {NormalizationResults} - The results of normalization.
+ *
+ * @fires MetricNormalizer#appliedRule
  */
 MetricNormalizer.prototype.normalize = function normalize(path) {
   let last = path

--- a/lib/spans/streaming-span-event-aggregator.js
+++ b/lib/spans/streaming-span-event-aggregator.js
@@ -13,8 +13,23 @@ const SEND_WARNING =
   'send() is not currently supported on streaming span event aggregator. ' +
   'This warning will not appear again this agent run.'
 
+/**
+ * Indicates that span streaming has begun.
+ *
+ * @event StreamingSpanEventAggregator#started
+ */
+
+/**
+ * Indicates that span streaming has finished.
+ *
+ * @event StreamingSpanEventAggregator#stopped
+ */
+
 // TODO: this doesn't "aggregate". Perhaps we need a different terminology
 // for the base-class and then this implementation can avoid the misleading language.
+/**
+ * Handles streaming of spans to the New Relic data collector.
+ */
 class StreamingSpanEventAggregator extends Aggregator {
   constructor(opts, agent) {
     const { metrics, collector, harvester } = agent
@@ -31,6 +46,11 @@ class StreamingSpanEventAggregator extends Aggregator {
     this.isStream = true
   }
 
+  /**
+   * Start streaming spans to the collector.
+   *
+   * @fires StreamingSpanEventAggregator#started
+   */
   start() {
     if (this.started) {
       return
@@ -43,6 +63,11 @@ class StreamingSpanEventAggregator extends Aggregator {
     this.emit('started')
   }
 
+  /**
+   * Cease streaming of spans to the collector.
+   *
+   * @fires StreamingSpanEventAggregator#stopped
+   */
   stop() {
     if (!this.started) {
       return
@@ -60,7 +85,7 @@ class StreamingSpanEventAggregator extends Aggregator {
       logger.warnOnce('SEND_WARNING', SEND_WARNING)
     }
 
-    this.emit(`finished ${this.method} data send.`)
+    this.emit(`finished_data_send-${this.method}`)
   }
 
   /**
@@ -76,7 +101,7 @@ class StreamingSpanEventAggregator extends Aggregator {
    * Attempts to add the given segment to the collection.
    *
    * @param {TraceSegment}  segment         - The segment to add.
-   * @param {string}        [parentId=null] - The GUID of the parent span.
+   * @param {string}        [parentId] - The GUID of the parent span.
    * @param isRoot
    * @returns {boolean} True if the segment was added, or false if it was discarded.
    */

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -70,6 +70,8 @@ const MULTIPLE_INSERT_MESSAGE =
  * transaction.
  *
  * @param {object} agent The agent.
+ *
+ * @fires Agent#transactionStarted
  */
 function Transaction(agent) {
   if (!agent) {
@@ -200,6 +202,8 @@ Transaction.prototype.isActive = function isActive() {
  * instances of this transaction annotated onto the call stack.
  *
  * @returns {(Transaction|undefined)} this transaction, or undefined
+ *
+ * @fires Agent#transactionFinished
  */
 Transaction.prototype.end = function end() {
   if (!this.timer.isActive()) {

--- a/lib/transaction/transaction-event-aggregator.js
+++ b/lib/transaction/transaction-event-aggregator.js
@@ -48,7 +48,7 @@ class TransactionEventAggregator extends EventAggregator {
     }
 
     // TODO: log?
-    this.emit(`starting ${this.method} data send.`)
+    this.emit(`starting_data_send-${this.method}`)
 
     logger.debug('Splitting transaction events into multiple payloads')
 
@@ -60,7 +60,7 @@ class TransactionEventAggregator extends EventAggregator {
 
     this._sendMultiple(eventPayloadPairs, () => {
       // TODO: Log?
-      this.emit(`finished ${this.method} data send.`)
+      this.emit(`finished_data_send-${this.method}`)
     })
   }
 

--- a/lib/util/stream-sink.js
+++ b/lib/util/stream-sink.js
@@ -9,6 +9,19 @@ const EventEmitter = require('events').EventEmitter
 const util = require('util')
 
 /**
+ * Triggered when the stream has been terminated.
+ *
+ * @event StreamSink#close
+ */
+
+/**
+ * Triggered when the stream cannot be written to.
+ *
+ * @event StreamSink#error
+ * @param {Error} error The error that has triggered the event.
+ */
+
+/**
  * Pipe a readable stream into this sink that fulfills the Writable Stream
  * contract and the callback will be fired when the stream has been completely
  * read.
@@ -30,6 +43,14 @@ function StreamSink(callback) {
 }
 util.inherits(StreamSink, EventEmitter)
 
+/**
+ * Write data to the stream.
+ *
+ * @param {string} string The data to write.
+ * @returns {boolean}
+ *
+ * @fires StreamSink#error
+ */
 StreamSink.prototype.write = function write(string) {
   if (!this.writable) {
     this.emit('error', new Error('Sink no longer writable!'))
@@ -49,6 +70,11 @@ StreamSink.prototype.end = function end() {
   this.callback(null, this.sink)
 }
 
+/**
+ * Stop the stream and mark it unusable.
+ *
+ * @fires StreamSink#close
+ */
 StreamSink.prototype.destroy = function destroy() {
   this.emit('close')
   this.writable = false

--- a/test/integration/newrelic-harvest-limits.tap.js
+++ b/test/integration/newrelic-harvest-limits.tap.js
@@ -87,7 +87,7 @@ tap.test('Connect calls re-generate harvest limits from original config values',
       serverHarvest.event_harvest_config,
       'config should have been updated from server'
     )
-    agent.metrics.once('finished metric_data data send.', function onMetricsFinished() {
+    agent.metrics.once('finished_data_send-metric_data', function onMetricsFinished() {
       const connectCalls = agent.collector._connect.args
       t.same(
         config.event_harvest_config,

--- a/test/integration/newrelic-response-handling.tap.js
+++ b/test/integration/newrelic-response-handling.tap.js
@@ -226,14 +226,14 @@ function createStatusCodeTest(testCase) {
 
 function whenAllAggregatorsSend(agent) {
   const metricPromise = new Promise((resolve) => {
-    agent.metrics.once('finished metric_data data send.', function onMetricsFinished() {
+    agent.metrics.once('finished_data_send-metric_data', function onMetricsFinished() {
       resolve()
     })
   })
 
   const spanPromise = new Promise((resolve) => {
     agent.spanEventAggregator.once(
-      'finished span_event_data data send.',
+      'finished_data_send-span_event_data',
       function onSpansFinished() {
         resolve()
       }
@@ -242,7 +242,7 @@ function whenAllAggregatorsSend(agent) {
 
   const customEventPromise = new Promise((resolve) => {
     agent.customEventAggregator.once(
-      'finished custom_event_data data send.',
+      'finished_data_send-custom_event_data',
       function onCustomEventsFinished() {
         resolve()
       }
@@ -251,7 +251,7 @@ function whenAllAggregatorsSend(agent) {
 
   const transactionEventPromise = new Promise((resolve) => {
     agent.transactionEventAggregator.once(
-      'finished analytic_event_data data send.',
+      'finished_data_send-analytic_event_data',
       function onTransactionEventsFinished() {
         resolve()
       }
@@ -259,20 +259,20 @@ function whenAllAggregatorsSend(agent) {
   })
 
   const transactionTracePromise = new Promise((resolve) => {
-    agent.traces.once('finished transaction_sample_data data send.', function onTracesFinished() {
+    agent.traces.once('finished_data_send-transaction_sample_data', function onTracesFinished() {
       resolve()
     })
   })
 
   const sqlTracePromise = new Promise((resolve) => {
-    agent.queries.once('finished sql_trace_data data send.', function onSqlTracesFinished() {
+    agent.queries.once('finished_data_send-sql_trace_data', function onSqlTracesFinished() {
       resolve()
     })
   })
 
   const errorTracePromise = new Promise((resolve) => {
     agent.errors.traceAggregator.once(
-      'finished error_data data send.',
+      'finished_data_send-error_data',
       function onErrorTracesFinished() {
         resolve()
       }
@@ -281,7 +281,7 @@ function whenAllAggregatorsSend(agent) {
 
   const errorEventPromise = new Promise((resolve) => {
     agent.errors.eventAggregator.once(
-      'finished error_event_data data send.',
+      'finished_data_send-error_event_data',
       function onErrorEventsFinished() {
         resolve()
       }

--- a/test/unit/aggregators/base-aggregator.test.js
+++ b/test/unit/aggregators/base-aggregator.test.js
@@ -129,7 +129,7 @@ test('send', async (t) => {
     baseAggregator._toPayloadSync = () => null
     baseAggregator.clear = () => {}
 
-    const expectedStartEmit = `starting ${METHOD} data send.`
+    const expectedStartEmit = `starting_data_send-${METHOD}`
     let emitFired = false
     baseAggregator.once(expectedStartEmit, () => {
       emitFired = true
@@ -274,7 +274,7 @@ test('send', async (t) => {
     baseAggregator._getMergeData = () => ['data']
     baseAggregator._toPayloadSync = () => ['data']
 
-    const expectedStartEmit = `finished ${METHOD} data send.`
+    const expectedStartEmit = `finished_data_send-${METHOD}`
     let emitFired = false
     baseAggregator.once(expectedStartEmit, () => {
       emitFired = true

--- a/test/unit/collector/api.test.js
+++ b/test/unit/collector/api.test.js
@@ -68,7 +68,7 @@ test('reportSettings', async (t) => {
     const toFind = log('find me')
 
     let sends = 0
-    agent.logs.on('finished log_event_data data send.', () => {
+    agent.logs.on('finished_data_send-log_event_data', () => {
       sends += 1
       if (sends === 3) {
         const logs = agent.logs.events.toArray()

--- a/test/unit/harvester.test.js
+++ b/test/unit/harvester.test.js
@@ -19,7 +19,7 @@ class FakeAggregator extends EventEmitter {
 
   start() {}
   send() {
-    this.emit(`finished ${this.method} data send.`)
+    this.emit(`finished_data_send-${this.method}`)
   }
 
   stop() {}

--- a/test/unit/trace-aggregator.test.js
+++ b/test/unit/trace-aggregator.test.js
@@ -244,7 +244,7 @@ tap.test('TraceAggregator', function (t) {
       t.notOk(agent.traces.trace, 'trace waiting to be collected')
       createTransaction(agent, `/test-${n % 3}`, 500)
       t.ok(agent.traces.trace, `${n}th trace to collect`)
-      agent.traces.once('finished transaction_sample_data data send.', (err) =>
+      agent.traces.once('finished_data_send-transaction_sample_data', (err) =>
         cb(err, { idx: n, max })
       )
       agent.traces.send()
@@ -289,25 +289,25 @@ tap.test('TraceAggregator', function (t) {
       remaining--
       if (remaining < 1) {
         // 6th harvest: no serialized trace, timings reset
-        agent.traces.once('finished transaction_sample_data data send.', function () {
+        agent.traces.once('finished_data_send-transaction_sample_data', function () {
           t.notOk(aggregator.requestTimes['WebTransaction/Uri/test'])
 
           t.end()
         })
         agent.traces.send()
       } else {
-        agent.traces.once('finished transaction_sample_data data send.', looper)
+        agent.traces.once('finished_data_send-transaction_sample_data', looper)
         agent.traces.send()
       }
     }
 
     aggregator.add(tx)
 
-    agent.traces.once('finished transaction_sample_data data send.', function () {
+    agent.traces.once('finished_data_send-transaction_sample_data', function () {
       t.equal(aggregator.requestTimes['WebTransaction/Uri/test'], 5030)
       aggregator.clear()
 
-      agent.traces.once('finished transaction_sample_data data send.', looper)
+      agent.traces.once('finished_data_send-transaction_sample_data', looper)
       agent.traces.send()
     })
     agent.traces.send()
@@ -401,7 +401,7 @@ tap.test('TraceAggregator with top n support', function (t) {
       } else {
         t.notOk(agent.traces.trace, 'trace 5 collected')
       }
-      agent.traces.once('finished transaction_sample_data data send.', (err) =>
+      agent.traces.once('finished_data_send-transaction_sample_data', (err) =>
         cb(err, { idx: n, max })
       )
       agent.traces.send()

--- a/test/unit/transaction-event-aggregator.test.js
+++ b/test/unit/transaction-event-aggregator.test.js
@@ -90,7 +90,7 @@ tap.test('Transaction Event Aggregator - when data over split threshold', (t) =>
 
   t.test('should emit proper message with method for starting send', (t) => {
     const { eventAggregator } = t.context
-    const expectedStartEmit = `starting ${EXPECTED_METHOD} data send.`
+    const expectedStartEmit = `starting_data_send-${EXPECTED_METHOD}`
 
     eventAggregator.once(expectedStartEmit, t.end)
 
@@ -204,9 +204,9 @@ tap.test('Transaction Event Aggregator - when data over split threshold', (t) =>
 
   t.test('should emit proper message with method for finishing send', (t) => {
     const { eventAggregator, fakeCollectorApi } = t.context
-    const expectedStartEmit = `finished ${EXPECTED_METHOD} data send.`
+    const expectedEndEmit = `finished_data_send-${EXPECTED_METHOD}`
 
-    eventAggregator.once(expectedStartEmit, t.end)
+    eventAggregator.once(expectedEndEmit, t.end)
 
     fakeCollectorApi.send.callsFake((_method, _payload, callback) => {
       callback(null, { retainData: false })


### PR DESCRIPTION
While working on #2548 I needed to understand when some events are firing and learned that we do not have any documentation around events. Ideally, we'd have a document that outlines the common event sequences, but I don't have that picture right now. What this PR includes is jsdoc for almost every event the codebase generates. There is a whole class events in the `Config` namespace that I could not document. These events are emitting events named after configuration keys. There are two problems here:

1. It's not clear what the event names will actually be. As an example, what would be fired if `enabled` from `{ feature_name: { enabled: true } }` is changed to `false`? Would the event name be `enabled`, `feature_name`, or something like `feature_name.enabled`?
2. There's no way to document dynamic event names with jsdoc. At least no way that I can think of that would really clarify anything.

Also, _this PR changes_ the events around data sending. The current event names are like `starting error_data data send.`. This PR changes them to `starting_data_send-error_data`. We can't document event names with spaces, and other non-alphanum characters, in them. Indeed, it was a bit of a challenge to find a separator character to separate the prefix and actual event name that jsdoc would handle correctly.

So, while not everything is fully documented, I think the PR puts us in a better position than before.