### PR TITLE
fix: Ensure Readme displays for Azure site extension

### DIFF
--- a/cloud-tooling/README.md
+++ b/cloud-tooling/README.md
@@ -5,5 +5,5 @@ This repository contains various cloud based tools for the New Relic Node Agent 
 ## Getting Started
 Please refer to the README of any of the cloud based tools:
 
-- [Azure Site Extensions](./azure-site-extension/README.md)
+- [Azure Site Extensions](./azure-site-extension/Content/README.md)
 

--- a/cloud-tooling/azure-site-extension/NewRelic.Azure.WebSites.Extension.NodeAgent.nuspec
+++ b/cloud-tooling/azure-site-extension/NewRelic.Azure.WebSites.Extension.NodeAgent.nuspec
@@ -9,7 +9,7 @@
     <projectUrl>https://github.com/newrelic/node-newrelic</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>This extension adds the New Relic Node Agent to your Azure WebSite.</description>
-    <readme>Content\README.md</readme>
+    <readme>content\README.md</readme>
     <iconUrl>https://newrelic.com/static-assets/images/icons/avatar-newrelic.png</iconUrl>
 	<icon>images\icon.png</icon>
     <copyright>New Relic, Inc., 2024</copyright>

--- a/cloud-tooling/azure-site-extension/NewRelic.Azure.WebSites.Extension.NodeAgent.nuspec
+++ b/cloud-tooling/azure-site-extension/NewRelic.Azure.WebSites.Extension.NodeAgent.nuspec
@@ -9,6 +9,7 @@
     <projectUrl>https://github.com/newrelic/node-newrelic</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>This extension adds the New Relic Node Agent to your Azure WebSite.</description>
+    <readme>Content\README.md</readme>
     <iconUrl>https://newrelic.com/static-assets/images/icons/avatar-newrelic.png</iconUrl>
 	<icon>images\icon.png</icon>
     <copyright>New Relic, Inc., 2024</copyright>


### PR DESCRIPTION
## Description
The new Azure site extension contains an informative README.md which was not displaying on the nuget.org site. This PR adds a tag to the .nuspec file, allowing display. 

## How to Test

I've tested this with a renamed site extension from my fork, and can provide the link. 

## Related Issues

Closes #2558
Closes NR-311749