### PR TITLE
chore: Reduce koa-router version to enable CI

### DIFF
--- a/test/versioned/koa/package.json
+++ b/test/versioned/koa/package.json
@@ -34,7 +34,7 @@
           "samples": 5
         },
         "koa-router": {
-          "versions": ">=11.0.2",
+          "versions": ">=11.0.2 && <13.0.0",
           "samples": 5
         }
       },
@@ -53,7 +53,7 @@
           "samples": 5
         },
         "@koa/router": {
-          "versions": ">=11.0.2",
+          "versions": ">=11.0.2 && <13.0.0",
           "samples": 5
         }
       },


### PR DESCRIPTION
This is to get CI working for the weekend.