### PR TITLE
ci: Added workflow run trigger to Azure site extension publish job

### DIFF
--- a/.github/workflows/azure-site-extension.yml
+++ b/.github/workflows/azure-site-extension.yml
@@ -2,6 +2,10 @@ name: Azure Site Extension
 
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Create Release"]
+    types:
+      - completed
 
 env:
   SPEC_FILE_TEMPLATE: 'NewRelic.Azure.WebSites.Extension.NodeAgent.nuspec'
@@ -9,6 +13,9 @@ env:
 jobs:
   create_extension_bundle:
     runs-on: windows-latest
+    if:
+      (github.event.workflow_run && github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'workflow_dispatch')
 
     strategy:
       matrix:


### PR DESCRIPTION
## Description

This PR adds a trigger to the GitHub Actions workflow that publishes the agent as an Azure Site Extension. If a version of the agent is successfully released to NPM, this workflow will then publish to nuget.

## How to Test

I've tested in this fork with a different workflow as the trigger: https://github.com/mrickard/node-newrelic/actions/runs/10856411190 was triggered by a workflow that optionally succeeded or failed, based on user input: https://github.com/mrickard/node-newrelic/actions/runs/10856407943

## Related Issues

Closes #2559 
Closes NR-311751