### PR TITLE
chore: Fix testing of koa-router

### DIFF
--- a/test/versioned/koa/package.json
+++ b/test/versioned/koa/package.json
@@ -34,7 +34,7 @@
           "samples": 5
         },
         "koa-router": {
-          "versions": ">=11.0.2 && <13.0.0",
+          "versions": ">=11.0.2",
           "samples": 5
         }
       },
@@ -53,7 +53,7 @@
           "samples": 5
         },
         "@koa/router": {
-          "versions": ">=11.0.2 && <13.0.0",
+          "versions": ">=11.0.2",
           "samples": 5
         }
       },


### PR DESCRIPTION
This PR reverts #2573 and implements the changes required to make the tests work again.

1. https://github.com/koajs/router/commit/b5b08baf369c32005839513c6031e2227cd081b0 shows that `/first/(.*)` should become `/first/{*any}`
2. I don't know why the segment names have changed in the other test. I don't understand why the list was the way it was to begin with.