### PR TITLE
test: Updated koa-router to tests to handle bug fixes from 13.0.1

### DIFF
--- a/test/versioned/koa/package.json
+++ b/test/versioned/koa/package.json
@@ -34,7 +34,7 @@
           "samples": 5
         },
         "koa-router": {
-          "versions": ">=11.0.2 && <13.0.0",
+          "versions": ">=11.0.2",
           "samples": 5
         }
       },
@@ -53,7 +53,7 @@
           "samples": 5
         },
         "@koa/router": {
-          "versions": ">=11.0.2 && <13.0.0",
+          "versions": ">=11.0.2",
           "samples": 5
         }
       },


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

koa router had two fixes: https://github.com/koajs/router/pull/189 and https://github.com/koajs/router/pull/183 which broke our versioned tests.  This PR handles the nuance from 13.0.1+

## How to Test

```sh
npm run versioned:internal koa
```

## Related Issues

I know a fix was made in #2576 but there was still one failing test, this fixes both.
