### PR TITLE
test: Removed transitive deps from versioned tests as they will auto-install if required as peer deps

### DIFF
--- a/test/versioned/aws-sdk-v2/package.json
+++ b/test/versioned/aws-sdk-v2/package.json
@@ -44,10 +44,6 @@
         "node": ">=18.0"
       },
       "dependencies": {
-        "aws-sdk": {
-          "versions": ">=2.463.0",
-          "samples": 10
-        },
         "amazon-dax-client": ">=1.2.5"
       },
       "files": [

--- a/test/versioned/aws-sdk-v3/package.json
+++ b/test/versioned/aws-sdk-v3/package.json
@@ -9,7 +9,7 @@
     {"name": "@aws-sdk/client-dynamodb", "minAgentVersion": "8.7.1"},
     {"name": "@aws-sdk/lib-dynamodb", "minAgentVersion": "8.7.1"},
     {"name": "@aws-sdk/smithy-client", "minAgentVersion": "8.7.1"},
-    {"name": "@smithy/smithy-client", "minAgentVersion": "11.0.0"},
+    {"name": "@smithy/smithy-client", "minSupported": "3.47.0", "minAgentVersion": "11.0.0"},
     {"name": "@aws-sdk/client-bedrock-runtime", "minAgentVersion": "11.13.0"}
   ],
   "version": "0.0.0",
@@ -149,10 +149,6 @@
         "@aws-sdk/client-sns": {
           "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
           "samples": 10
-        },
-        "@aws-sdk/smithy-client": {
-          "versions": ">=3.47.0 <3.370.0",
-          "samples": 1
         }
       },
       "files": [
@@ -192,8 +188,6 @@
         "node": ">=18.0"
       },
       "dependencies": {
-        "@aws-sdk/util-dynamodb": "latest",
-        "@aws-sdk/client-dynamodb": "latest",
         "@aws-sdk/lib-dynamodb": {
           "versions": ">3.377.0 ",
           "samples": 10
@@ -208,11 +202,7 @@
         "node": ">=18.0"
       },
       "dependencies": {
-        "@aws-sdk/client-bedrock-runtime": "^3.474.0",
-        "@smithy/smithy-client": {
-          "versions": ">=2.0.0",
-          "samples": 1
-        }
+        "@aws-sdk/client-bedrock-runtime": ">=3.474.0"
       },
       "files": [
         "bedrock-chat-completions.tap.js",

--- a/test/versioned/grpc/package.json
+++ b/test/versioned/grpc/package.json
@@ -9,25 +9,7 @@
         "node": ">=18"
       },
       "dependencies": {
-        "@grpc/grpc-js": ">=1.4.0 <1.8.0"
-      },
-      "files": [
-        "client-unary.tap.js",
-        "client-streaming.tap.js",
-        "client-server-streaming.tap.js",
-        "client-bidi-streaming.tap.js",
-        "server-unary.tap.js",
-        "server-client-streaming.tap.js",
-        "server-streaming.tap.js",
-        "server-bidi-streaming.tap.js"
-      ]
-    },
-    {
-      "engines": {
-        "node": ">=18"
-      },
-      "dependencies": {
-        "@grpc/grpc-js": ">=1.8.0"
+        "@grpc/grpc-js": ">=1.4.0"
       },
       "files": [
         "client-unary.tap.js",

--- a/test/versioned/langchain/package.json
+++ b/test/versioned/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langchain-tests",
-  "targets": [{"name":"@langchain/core","minAgentVersion":"11.13.0"}],
+  "targets": [{"name":"@langchain/core","minSupported": "0.1.17", "minAgentVersion":"11.13.0"}],
   "version": "0.0.0",
   "private": true,
   "engines": {
@@ -11,9 +11,9 @@
       "engines": {
         "node": ">=18"
       },
+      "comment": "This is implicitly testing `@langchain/core` as it's a peer dep",
       "dependencies": {
-        "@langchain/core": ">=0.1.17",
-        "@langchain/openai": "0.0.34"
+        "@langchain/openai": ">=0.0.34"
       },
       "files": [
         "tools.tap.js",
@@ -25,16 +25,13 @@
       "engines": {
         "node": ">=18"
       },
+      "comment": "Using latest of `@langchain/openai` only as it is being used to seed embeddings, nothing to test that hasn't been done in the above stanza",
       "dependencies": {
-        "@langchain/core": ">=0.1.17",
-        "@langchain/openai": "0.0.34",
-        "@langchain/community": "0.2.2",
+        "@langchain/openai": "latest",
+        "@langchain/community": ">=0.2.2",
         "@elastic/elasticsearch": "8.13.1"
       },
       "files": [
-        "tools.tap.js",
-        "runnables.tap.js",
-        "runnables-streaming.tap.js",
         "vectorstore.tap.js"
       ]
     }

--- a/test/versioned/nextjs/package.json
+++ b/test/versioned/nextjs/package.json
@@ -9,9 +9,7 @@
         "node": ">=18"
       },
       "dependencies": {
-        "next": ">=13.4.19",
-        "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "next": ">=13.4.19"
       },
       "files": [
         "app-dir.tap.js"
@@ -22,9 +20,7 @@
         "node": ">=18"
       },
       "dependencies": {
-        "next": ">=14.0.0",
-        "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "next": ">=14.0.0"
       },
       "files": [
         "attributes.tap.js",

--- a/test/versioned/prisma/package.json
+++ b/test/versioned/prisma/package.json
@@ -12,8 +12,7 @@
         "node": ">=18"
       },
       "dependencies": {
-        "@prisma/client": ">=5.0.0 <5.9.0 || >=5.9.1",
-        "prisma": "latest"
+        "@prisma/client": ">=5.0.0 <5.9.0 || >=5.9.1"
       },
       "files": [
         "prisma.tap.js"


### PR DESCRIPTION


<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We ran into a problem with langchain, and have hit this over the years with other libraries where the versioned tests matrix has conflicts between the transitive dep and package under test. This PR removes all transitive deps, could not remove `pg-native` as it wasn't a peer dep until later.  In versioned tests where it relies on implicitly testing instrumentation I have added `minSupported` to the targets stanza so our nr-versions go util can still mark the package as supported

## Related Issues

Closes #2579 