### PR TITLE
test: Updated a missing `minSupported` in aws-sdk-v3 versioned tests

### DIFF
--- a/test/versioned/aws-sdk-v3/package.json
+++ b/test/versioned/aws-sdk-v3/package.json
@@ -8,8 +8,8 @@
     {"name": "@aws-sdk/client-sns", "minAgentVersion": "8.7.1"},
     {"name": "@aws-sdk/client-dynamodb", "minAgentVersion": "8.7.1"},
     {"name": "@aws-sdk/lib-dynamodb", "minAgentVersion": "8.7.1"},
-    {"name": "@aws-sdk/smithy-client", "minAgentVersion": "8.7.1"},
-    {"name": "@smithy/smithy-client", "minSupported": "3.47.0", "minAgentVersion": "11.0.0"},
+    {"name": "@aws-sdk/smithy-client", "minSupported": "3.47.0", "minAgentVersion": "8.7.1"},
+    {"name": "@smithy/smithy-client", "minSupported": "2.0.0", "minAgentVersion": "11.0.0"},
     {"name": "@aws-sdk/client-bedrock-runtime", "minAgentVersion": "11.13.0"}
   ],
   "version": "0.0.0",


### PR DESCRIPTION
Missed `minSupported` and messed up `@smithy/smithy-client`