### PR TITLE
chore: Removed noisy test log

### DIFF
--- a/test/unit/util/obfuscate-sql.test.js
+++ b/test/unit/util/obfuscate-sql.test.js
@@ -10,7 +10,6 @@ const tests = require('../../lib/cross_agent_tests/sql_obfuscation/sql_obfuscati
 const obfuscate = require('../../../lib/util/sql/obfuscate')
 
 function runTest(t, testCase, dialect) {
-  t.diagnostic(dialect)
   const obfuscated = obfuscate(testCase.sql, dialect)
   if (testCase.obfuscated.length === 1) {
     assert.equal(obfuscated, testCase.obfuscated[0])
@@ -19,28 +18,24 @@ function runTest(t, testCase, dialect) {
   }
 }
 
-test('sql obfuscation', async (t) => {
-  await Promise.all(
-    tests.map(async (tc) => {
-      await t.test(tc.name, (t) => {
-        for (let i = 0; i < tc.dialects.length; ++i) {
-          runTest(t, tc, tc.dialects[i])
-        }
-      })
+for (const testCase of tests) {
+  for (const dialect of testCase.dialects) {
+    test(`${dialect}: ${testCase.name}`, (t) => {
+      runTest(t, testCase, dialect)
     })
+  }
+}
+
+test('should handle line endings', () => {
+  const result = obfuscate('select * from foo where --abc\r\nbar=5', 'mysql')
+  assert.equal(result, 'select * from foo where ?\r\nbar=?')
+})
+
+test('should handle large JSON inserts', () => {
+  const JSONData = '{"data": "' + new Array(8400000).fill('a').join('') + '"}'
+  const result = obfuscate(
+    'INSERT INTO "Documents" ("data") VALUES (\'' + JSONData + "')",
+    'postgres'
   )
-
-  await t.test('should handle line endings', () => {
-    const result = obfuscate('select * from foo where --abc\r\nbar=5', 'mysql')
-    assert.equal(result, 'select * from foo where ?\r\nbar=?')
-  })
-
-  await t.test('should handle large JSON inserts', () => {
-    const JSONData = '{"data": "' + new Array(8400000).fill('a').join('') + '"}'
-    const result = obfuscate(
-      'INSERT INTO "Documents" ("data") VALUES (\'' + JSONData + "')",
-      'postgres'
-    )
-    assert.equal(result, 'INSERT INTO "Documents" ("data") VALUES (?)')
-  })
+  assert.equal(result, 'INSERT INTO "Documents" ("data") VALUES (?)')
 })


### PR DESCRIPTION
Refactors the `test/unit/util/obfuscate-sql.test.js` script to generate less noise.