### PR TITLE
test: Updated fastify versioned tests to work with `fastify@5.0.0`

### DIFF
--- a/test/versioned/fastify/add-hook.tap.js
+++ b/test/versioned/fastify/add-hook.tap.js
@@ -108,7 +108,7 @@ tap.test('fastify hook instrumentation', (t) => {
       t.assertSegments(transaction.trace.root, expectedSegments)
     })
 
-    await fastify.listen(0)
+    await fastify.listen({ port: 0 })
     const address = fastify.server.address()
     const result = await common.makeRequest(address, '/add-hook')
     t.same(result, { hello: 'world' })
@@ -164,7 +164,7 @@ tap.test('fastify hook instrumentation', (t) => {
       t.assertSegments(transaction.trace.root, expectedSegments)
     })
 
-    await fastify.listen(0)
+    await fastify.listen({ port: 0 })
     const address = fastify.server.address()
     const result = await common.makeRequest(address, '/error')
     t.ok(ok)

--- a/test/versioned/fastify/code-level-metrics-hooks.tap.js
+++ b/test/versioned/fastify/code-level-metrics-hooks.tap.js
@@ -73,7 +73,7 @@ tap.test('Fastify CLM Hook Based', (test) => {
         })
       })
 
-      await fastify.listen(0)
+      await fastify.listen({ port: 0 })
       const address = fastify.server.address()
       const result = await common.makeRequest(address, '/add-hook')
 

--- a/test/versioned/fastify/code-level-metrics-middleware.tap.js
+++ b/test/versioned/fastify/code-level-metrics-middleware.tap.js
@@ -103,7 +103,7 @@ tap.test('Fastify CLM Middleware Based', (test) => {
         assertSegments(t, transaction.trace.root.children[0], isCLMEnabled)
       })
 
-      await fastify.listen(0)
+      await fastify.listen({ port: 0 })
       const address = fastify.server.address()
       const result = await common.makeRequest(address, uri)
 

--- a/test/versioned/fastify/errors.tap.js
+++ b/test/versioned/fastify/errors.tap.js
@@ -31,7 +31,7 @@ tap.test('Test Errors', async (test) => {
     next(err)
   })
 
-  await fastify.listen(0)
+  await fastify.listen({ port: 0 })
   const address = fastify.server.address()
   const res = await makeRequest(address, '/404-via-reply')
   test.equal(res.statusCode, 404)

--- a/test/versioned/fastify/naming-common.js
+++ b/test/versioned/fastify/naming-common.js
@@ -39,7 +39,7 @@ module.exports = function createTests(t, getExpectedSegments) {
         t.assertSegments(transaction.trace.root, expectedSegments)
       })
 
-      await fastify.listen(0)
+      await fastify.listen({ port: 0 })
       const address = fastify.server.address()
       const result = await makeRequest(address, uri)
       t.equal(result.called, uri, `${uri} url did not error`)

--- a/test/versioned/fastify/new-state-tracking.tap.js
+++ b/test/versioned/fastify/new-state-tracking.tap.js
@@ -37,7 +37,7 @@ tap.test('fastify with new state tracking', (t) => {
       return { hello: 'world' }
     })
 
-    await fastify.listen(0)
+    await fastify.listen({ port: 0 })
 
     const address = fastify.server.address()
 
@@ -65,7 +65,7 @@ tap.test('fastify with new state tracking', (t) => {
       })
     }
 
-    await fastify.listen(0)
+    await fastify.listen({ port: 0 })
 
     const address = fastify.server.address()
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Doing `fastify.listen(0)` no longer works in `fastify@5`. This PR updates all references of `.listen` to pass in an object of `{ port: 0 }`

## How to Test

```sh
npm run versioned:internal:major fastify
```
