### PR TITLE
test: Fixed @koa/router tests. path-to-regex differs between @koa/router and koa-router now

### DIFF
--- a/test/versioned/koa/router-common.js
+++ b/test/versioned/koa/router-common.js
@@ -149,7 +149,7 @@ module.exports = (pkg) => {
       t.test('should name and produce segments for matched wildcard path', (t) => {
         const { agent, router, app } = t.context
         let path = '(.*)'
-        if (semver.gte(pkgVersion, '13.0.1')) {
+        if (pkg === 'koa-router' && semver.gte(pkgVersion, '13.0.1')) {
           path = '{*any}'
         }
         router.get(`/:first/${path}`, function firstMiddleware(ctx) {
@@ -347,15 +347,16 @@ module.exports = (pkg) => {
           ctx.body = ' second'
         })
 
-        const segmentTree = semver.gte(pkgVersion, '13.0.1')
-          ? ['Nodejs/Middleware/Koa/terminalMiddleware//:second']
-          : [
-              'Nodejs/Middleware/Koa/secondMiddleware//:first',
-              [
-                'Nodejs/Middleware/Koa/secondMiddleware//:second',
-                ['Nodejs/Middleware/Koa/terminalMiddleware//:second']
+        const segmentTree =
+          pkg === 'koa-router' && semver.gte(pkgVersion, '13.0.1')
+            ? ['Nodejs/Middleware/Koa/terminalMiddleware//:second']
+            : [
+                'Nodejs/Middleware/Koa/secondMiddleware//:first',
+                [
+                  'Nodejs/Middleware/Koa/secondMiddleware//:second',
+                  ['Nodejs/Middleware/Koa/terminalMiddleware//:second']
+                ]
               ]
-            ]
         app.use(router.routes())
         agent.on('transactionFinished', (tx) => {
           t.assertSegments(tx.trace.root, [


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

I described the issue [here](https://github.com/koajs/router/issues/192). This PR fixes this nuance for now until I can get confirmation.
