### PR TITLE
test: Updated how we handle the koa-router nuance of wildcard routes

### DIFF
--- a/test/versioned/koa/package.json
+++ b/test/versioned/koa/package.json
@@ -81,5 +81,7 @@
       ]
     }
   ],
-  "dependencies": {}
+  "engines": {
+    "node": ">=18"
+  }
 }

--- a/test/versioned/koa/router-common.js
+++ b/test/versioned/koa/router-common.js
@@ -4,6 +4,27 @@
  */
 
 'use strict'
+const fs = require('fs')
+
+/**
+ * koa-router and @koa/router updated how they defined wildcard routing
+ * It used to be native and then relied on `path-to-regexp`. If `path-to-regexp`
+ * is present get the version. For post 8 it relies on different syntax to define
+ * routes. If it is not present assume the pre 8 behavior of `path-to-regexp`
+ * is the same. Also cannot use require because `path-to-regexp` defines exports
+ * and package.json is not a defined export.
+ */
+function getPathToRegexpVersion() {
+  let pathToRegexVersion
+  try {
+    ;({ version: pathToRegexVersion } = JSON.parse(
+      fs.readFileSync(`${__dirname}/node_modules/path-to-regexp/package.json`)
+    ))
+  } catch {
+    pathToRegexVersion = '6.0.0'
+  }
+  return pathToRegexVersion
+}
 
 module.exports = (pkg) => {
   const tap = require('tap')
@@ -15,6 +36,7 @@ module.exports = (pkg) => {
   tap.test(`${pkg} instrumentation`, (t) => {
     const { version: pkgVersion } = require(`${pkg}/package.json`)
     const paramMiddlewareName = 'Nodejs/Middleware/Koa/middleware//:first'
+    const pathToRegexVersion = getPathToRegexpVersion()
 
     /**
      * Helper to decide how to name nested route segments
@@ -149,7 +171,7 @@ module.exports = (pkg) => {
       t.test('should name and produce segments for matched wildcard path', (t) => {
         const { agent, router, app } = t.context
         let path = '(.*)'
-        if (pkg === 'koa-router' && semver.gte(pkgVersion, '13.0.1')) {
+        if (semver.gte(pathToRegexVersion, '8.0.0')) {
           path = '{*any}'
         }
         router.get(`/:first/${path}`, function firstMiddleware(ctx) {
@@ -347,16 +369,15 @@ module.exports = (pkg) => {
           ctx.body = ' second'
         })
 
-        const segmentTree =
-          pkg === 'koa-router' && semver.gte(pkgVersion, '13.0.1')
-            ? ['Nodejs/Middleware/Koa/terminalMiddleware//:second']
-            : [
-                'Nodejs/Middleware/Koa/secondMiddleware//:first',
-                [
-                  'Nodejs/Middleware/Koa/secondMiddleware//:second',
-                  ['Nodejs/Middleware/Koa/terminalMiddleware//:second']
-                ]
+        const segmentTree = semver.gte(pathToRegexVersion, '8.0.0')
+          ? ['Nodejs/Middleware/Koa/terminalMiddleware//:second']
+          : [
+              'Nodejs/Middleware/Koa/secondMiddleware//:first',
+              [
+                'Nodejs/Middleware/Koa/secondMiddleware//:second',
+                ['Nodejs/Middleware/Koa/terminalMiddleware//:second']
               ]
+            ]
         app.use(router.routes())
         agent.on('transactionFinished', (tx) => {
           t.assertSegments(tx.trace.root, [


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

 Both `koa-rotuer` and `@koa/router` 13.0.1 use `path-to-regexp@8` but `@koa/router` released 13.1.0 and downgraded `path-to-regexp@6`. This PR updates how we determined how to defined wildcard routes by keying off the version of `path-to-regexp` when present. If it is not present assume the legacy behavior.


## How to test


```sh
npm run versioned:internal koa
```


```sh
===============================================================
 ✓ koa (100) 3m
===============================================================
Versions executed

Folder: koa
	 * koa(5): 2.0.1, 2.4.1, 2.8.2, 2.12.1, 2.15.3
	 * koa-router(3): 11.0.2, 12.0.1, 13.0.1
	 * @koa/router(4): 11.0.2, 12.0.2, 13.0.1, 13.1.0
	 * koa-route(4): 3.0.0, 3.1.0, 3.2.0, 4.0.1
===============================================================
PASS
```

I suspect they remedy this version mismatch of `path-to-regexp` between 13.0.1 and 13.1.0. I filed an issue [here](https://github.com/koajs/router/issues/192)

