### PR TITLE
Override agentMeta.message only if msg is set

### DIFF
--- a/lib/instrumentation/pino/pino.js
+++ b/lib/instrumentation/pino/pino.js
@@ -131,8 +131,10 @@ function reformatLogLine({ logLine, msg, agent, chindings = '', level, logger })
     delete metadata.hostname
   }
 
-  const agentMeta = Object.assign({}, { timestamp: Date.now(), message: msg }, metadata)
-
+  const agentMeta = Object.assign({}, { timestamp: Date.now() }, metadata)
+  if (msg) {
+    Object.assign(agentMeta, { message: msg });
+  }
   /**
    * A function that gets executed in `_toPayloadSync` of log aggregator.
    * This will parse the serialized log line and then add the relevant NR


### PR DESCRIPTION

## Description

This fixes https://github.com/newrelic/node-newrelic/issues/2595
It avoids to override message parameter in pino log if msg parameter is not set


## How to Test

Run steps from  https://github.com/newrelic/node-newrelic/issues/2595 ticket

## Related Issues

#2595 2595