### PR TITLE
test: Updated tests that relied on `tspl` by awating the `plan.completed` instead of calling `end` to avoid flaky tests

### DIFF
--- a/test/unit/serverless/api-gateway-v2.test.js
+++ b/test/unit/serverless/api-gateway-v2.test.js
@@ -64,7 +64,7 @@ test('should pick up the arn', async (t) => {
   assert.equal(agent.collector.metadata.arn, functionContext.invokedFunctionArn)
 })
 
-test('should create a web transaction', (t, end) => {
+test('should create a web transaction', async (t) => {
   const plan = tspl(t, { plan: 8 })
   const { agent, lambda, event, functionContext, responseBody } = t.nr
   agent.on('transactionFinished', verifyAttributes)
@@ -90,21 +90,16 @@ test('should create a web transaction', (t, end) => {
     plan.equal(agentAttributes['request.uri'], '/my/path')
     plan.equal(spanAttributes['request.method'], 'POST')
     plan.equal(spanAttributes['request.uri'], '/my/path')
-
-    end()
   }
+  await plan.completed
 })
 
-test('should set w3c tracecontext on transaction if present on request header', (t, end) => {
+test('should set w3c tracecontext on transaction if present on request header', async (t) => {
   const plan = tspl(t, { plan: 2 })
 
   const expectedTraceId = '4bf92f3577b34da6a3ce929d0e0e4736'
   const traceparent = `00-${expectedTraceId}-00f067aa0ba902b7-00`
   const { agent, lambda, event, functionContext, responseBody } = t.nr
-  agent.on('transactionFinished', () => {
-    end()
-  })
-
   agent.config.distributed_tracing.enabled = true
   event.headers.traceparent = traceparent
 
@@ -124,15 +119,13 @@ test('should set w3c tracecontext on transaction if present on request header', 
   })
 
   wrappedHandler(event, functionContext, () => {})
+  await plan.completed
 })
 
-test('should add w3c tracecontext to transaction if not present on request header', (t, end) => {
+test('should add w3c tracecontext to transaction if not present on request header', async (t) => {
   const plan = tspl(t, { plan: 2 })
 
   const { agent, lambda, event, functionContext, responseBody } = t.nr
-  agent.on('transactionFinished', () => {
-    end()
-  })
 
   agent.config.account_id = 'AccountId1'
   agent.config.primary_application_id = 'AppId1'
@@ -152,9 +145,10 @@ test('should add w3c tracecontext to transaction if not present on request heade
   })
 
   wrappedHandler(event, functionContext, () => {})
+  await plan.completed
 })
 
-test('should capture request parameters', (t, end) => {
+test('should capture request parameters', async (t) => {
   const plan = tspl(t, { plan: 5 })
 
   const { agent, lambda, event, functionContext, responseBody } = t.nr
@@ -182,12 +176,11 @@ test('should capture request parameters', (t, end) => {
     plan.equal(spanAttributes['request.parameters.team'], 'node agent')
 
     plan.equal(agentAttributes['request.parameters.parameter1'], 'value1,value2')
-
-    end()
   }
+  await plan.completed
 })
 
-test('should capture request headers', (t, end) => {
+test('should capture request headers', async (t) => {
   const plan = tspl(t, { plan: 2 })
 
   const { agent, lambda, event, functionContext, responseBody } = t.nr
@@ -203,9 +196,8 @@ test('should capture request headers', (t, end) => {
 
     plan.equal(attrs['request.headers.accept'], 'application/json')
     plan.equal(attrs['request.headers.header2'], 'value1,value2')
-
-    end()
   }
+  await plan.completed
 })
 
 test('should not crash when headers are non-existent', (t) => {

--- a/test/unit/serverless/aws-lambda.test.js
+++ b/test/unit/serverless/aws-lambda.test.js
@@ -1397,7 +1397,7 @@ test('AwsLambda.patchLambdaHandler', async (t) => {
     }
   )
 
-  await t.test('should record error event when error is thrown', (t, end) => {
+  await t.test('should record error event when error is thrown', async (t) => {
     const plan = tspl(t, { plan: 8 })
     const { agent, awsLambda, error, stubEvent, stubContext, stubCallback } = t.nr
 
@@ -1427,8 +1427,8 @@ test('AwsLambda.patchLambdaHandler', async (t) => {
       if (error.name !== 'SyntaxError') {
         throw error
       }
-      end()
     }
+    await plan.completed
   })
 
   await t.test('should not end transactions twice', (t, end) => {

--- a/test/unit/shim/message-shim.test.js
+++ b/test/unit/shim/message-shim.test.js
@@ -370,7 +370,7 @@ test('MessageShim', async function (t) {
       })
     })
 
-    await t.test('should insert distributed trace headers in all messages', function (t, end) {
+    await t.test('should insert distributed trace headers in all messages', async function (t) {
       const plan = tspl(t, { plan: 1 })
       const { agent, shim, wrappable } = t.nr
       const messages = [{}, { headers: { foo: 'foo' } }, {}]
@@ -418,13 +418,13 @@ test('MessageShim', async function (t) {
           }
         ])
         plan.equal(called, 1)
-        end()
       })
 
       helper.runInTransaction(agent, (tx) => {
         wrappable.sendMessages()
         tx.end()
       })
+      await plan.completed
     })
 
     await t.test('should create message broker metrics', function (t, end) {
@@ -1241,7 +1241,7 @@ test('MessageShim', async function (t) {
       })
     })
 
-    await t.test('should wrap object key of consumer', function (t, end) {
+    await t.test('should wrap object key of consumer', async function (t) {
       const plan = tspl(t, { plan: 4 })
       const { shim } = t.nr
       const message = { foo: 'bar' }
@@ -1267,10 +1267,10 @@ test('MessageShim', async function (t) {
           const segment = shim.getSegment()
           plan.equal(segment.name, 'OtherTransaction/Message/RabbitMQ/Exchange/Named/exchange.foo')
           plan.equal(msg, message)
-          end()
         }
       }
       wrapped(handler)
+      await plan.completed
     })
   })
 })

--- a/test/versioned/express/bare-router.test.js
+++ b/test/versioned/express/bare-router.test.js
@@ -16,7 +16,7 @@ test.beforeEach(async (ctx) => {
 
 test.afterEach(teardown)
 
-test('Express router introspection', function (t, end) {
+test('Express router introspection', async function (t) {
   const { agent, app, port } = t.nr
   const plan = tsplan(t, { plan: 11 })
 
@@ -53,6 +53,6 @@ test('Express router introspection', function (t, end) {
   helper.makeGetRequest(url, { json: true }, function (error, res, body) {
     plan.equal(res.statusCode, 200, 'nothing exploded')
     plan.deepEqual(body, { status: 'ok' }, 'got expected response')
-    end()
   })
+  await plan.completed
 })

--- a/test/versioned/express/errors.test.js
+++ b/test/versioned/express/errors.test.js
@@ -185,7 +185,7 @@ test('Error handling tests', async (t) => {
     })
   })
 
-  await t.test('does not error when request is aborted', function (t, end) {
+  await t.test('does not error when request is aborted', async function (t) {
     const plan = tsplan(t, { plan: 4 })
     const { app, agent, port } = t.nr
     let request = null
@@ -205,7 +205,6 @@ test('Error handling tests', async (t) => {
     app.use(function (error, req, res, next) {
       plan.equal(agent.getTransaction(), null, 'no active transaction when responding')
       res.end()
-      end()
     })
 
     request = http.request(
@@ -222,6 +221,7 @@ test('Error handling tests', async (t) => {
     request.on('error', function (err) {
       plan.equal(err.code, 'ECONNRESET')
     })
+    await plan.completed
   })
 })
 

--- a/test/versioned/express/express-enrouten.test.js
+++ b/test/versioned/express/express-enrouten.test.js
@@ -20,7 +20,7 @@ test.beforeEach(async (ctx) => {
 
 test.afterEach(teardown)
 
-test('Express + express-enrouten compatibility test', { skip: isExpress5() }, function (t, end) {
+test('Express + express-enrouten compatibility test', { skip: isExpress5() }, async function (t) {
   const { app, port } = t.nr
   const plan = tsplan(t, { plan: 2 })
 
@@ -35,6 +35,6 @@ test('Express + express-enrouten compatibility test', { skip: isExpress5() }, fu
 
   helper.makeGetRequest('http://localhost:' + port + '/foo', function (error, res) {
     plan.equal(res.statusCode, 200, 'Second Route loaded')
-    end()
   })
+  await plan.completed
 })

--- a/test/versioned/express/ignoring.test.js
+++ b/test/versioned/express/ignoring.test.js
@@ -17,7 +17,7 @@ test.beforeEach(async (ctx) => {
 
 test.afterEach(teardown)
 
-test('ignoring an Express route', function (t, end) {
+test('ignoring an Express route', async function (t) {
   const { agent, app, port } = t.nr
   const plan = tsplan(t, { plan: 7 })
 
@@ -57,6 +57,6 @@ test('ignoring an Express route', function (t, end) {
   helper.makeGetRequest(url, function (error, res, body) {
     plan.equal(res.statusCode, 400, 'got expected error')
     plan.deepEqual(body, { status: 'pollpollpoll' }, 'got expected response')
-    end()
   })
+  await plan.completed
 })

--- a/test/versioned/express/issue171.test.js
+++ b/test/versioned/express/issue171.test.js
@@ -16,7 +16,7 @@ test.beforeEach(async (ctx) => {
 
 test.afterEach(teardown)
 
-test("adding 'handle' middleware", function (t, end) {
+test("adding 'handle' middleware", async function (t) {
   const { app, port } = t.nr
   const plan = tsplan(t, { plan: 2 })
 
@@ -40,7 +40,7 @@ test("adding 'handle' middleware", function (t, end) {
       res.pipe(process.stderr)
 
       plan.equal(res.statusCode, 500)
-      end()
     })
     .end()
+  await plan.completed
 })

--- a/test/versioned/express/route-iteration.test.js
+++ b/test/versioned/express/route-iteration.test.js
@@ -8,7 +8,7 @@ const tsplan = require('@matteo.collina/tspl')
 const test = require('node:test')
 const helper = require('../../lib/agent_helper')
 
-test('new relic should not break route iteration', function (t) {
+test('new relic should not break route iteration', async function (t) {
   const plan = tsplan(t, { plan: 1 })
   const agent = helper.instrumentMockedAgent()
   const express = require('express')
@@ -36,6 +36,7 @@ test('new relic should not break route iteration', function (t) {
   router.use(childB)
 
   plan.deepEqual(findAllRoutes(router, ''), ['/get', ['/test'], ['/hello']])
+  plan.end()
 })
 
 function findAllRoutes(router, path) {

--- a/test/versioned/express/route-param.test.js
+++ b/test/versioned/express/route-param.test.js
@@ -17,7 +17,7 @@ test('Express route param', async function (t) {
 
   t.afterEach(teardown)
 
-  await t.test('pass-through param', function (t, end) {
+  await t.test('pass-through param', async function (t) {
     const { agent, port } = t.nr
     const plan = tsplan(t, { plan: 4 })
 
@@ -33,11 +33,11 @@ test('Express route param', async function (t) {
       plan.ok(!err, 'should not have errored')
       plan.equal(body.action, 'foo', 'should pass through correct parameter value')
       plan.equal(body.name, 'action', 'should pass through correct parameter name')
-      end()
     })
+    await plan.completed
   })
 
-  await t.test('respond from param', function (t, end) {
+  await t.test('respond from param', async function (t) {
     const { agent, port } = t.nr
     const plan = tsplan(t, { plan: 3 })
 
@@ -52,11 +52,11 @@ test('Express route param', async function (t) {
     testRequest(port, 'deny', function (err, body) {
       plan.ok(!err, 'should not have errored')
       plan.equal(body, 'denied', 'should have responded from within paramware')
-      end()
     })
+    await plan.completed
   })
 
-  await t.test('in-active transaction in param handler', function (t, end) {
+  await t.test('in-active transaction in param handler', async function (t) {
     const { agent, port } = t.nr
     const plan = tsplan(t, { plan: 4 })
 
@@ -72,8 +72,8 @@ test('Express route param', async function (t) {
       plan.ok(!err, 'should not have errored')
       plan.equal(body.action, 'preempt', 'should pass through correct parameter value')
       plan.equal(body.name, 'action', 'should pass through correct parameter name')
-      end()
     })
+    await plan.completed
   })
 })
 

--- a/test/versioned/express/router-params.test.js
+++ b/test/versioned/express/router-params.test.js
@@ -21,7 +21,7 @@ test.beforeEach(async (ctx) => {
 
 test.afterEach(teardown)
 
-test('Express router introspection', function (t, end) {
+test('Express router introspection', async function (t) {
   const { agent, app, express, port } = t.nr
   const plan = tsplan(t, { plan: 14 })
 
@@ -64,6 +64,6 @@ test('Express router introspection', function (t, end) {
     plan.ok(!error, 'should not have errored')
     plan.equal(res.statusCode, 200, 'should have ok status')
     plan.deepEqual(body, { status: 'ok' }, 'should have expected response')
-    end()
   })
+  await plan.completed
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We had a flaky express versioned test when migrating to `tspl`. It had concurrent http requests and it was assuming the last request would end last.
This PR updates all instances of `tspl` and adds `await plan.completed` to ensure the plan has been fulfilled before ending.
