### PR TITLE
test: Updated the mininum version of pg-native in pg-esm tests to align with the pg tests

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -646,7 +646,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ### import-in-the-middle
 
-This product includes source derived from [import-in-the-middle](https://github.com/nodejs/import-in-the-middle) ([v1.11.0](https://github.com/nodejs/import-in-the-middle/tree/v1.11.0)), distributed under the [Apache-2.0 License](https://github.com/nodejs/import-in-the-middle/blob/v1.11.0/LICENSE):
+This product includes source derived from [import-in-the-middle](https://github.com/nodejs/import-in-the-middle) ([v1.11.1](https://github.com/nodejs/import-in-the-middle/tree/v1.11.1)), distributed under the [Apache-2.0 License](https://github.com/nodejs/import-in-the-middle/blob/v1.11.1/LICENSE):
 
 ```
                                  Apache License
@@ -1076,7 +1076,7 @@ SOFTWARE.
 
 ### @aws-sdk/client-s3
 
-This product includes source derived from [@aws-sdk/client-s3](https://github.com/aws/aws-sdk-js-v3) ([v3.654.0](https://github.com/aws/aws-sdk-js-v3/tree/v3.654.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.654.0/LICENSE):
+This product includes source derived from [@aws-sdk/client-s3](https://github.com/aws/aws-sdk-js-v3) ([v3.658.1](https://github.com/aws/aws-sdk-js-v3/tree/v3.658.1)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.658.1/LICENSE):
 
 ```
                                 Apache License
@@ -1285,7 +1285,7 @@ This product includes source derived from [@aws-sdk/client-s3](https://github.co
 
 ### @aws-sdk/s3-request-presigner
 
-This product includes source derived from [@aws-sdk/s3-request-presigner](https://github.com/aws/aws-sdk-js-v3) ([v3.654.0](https://github.com/aws/aws-sdk-js-v3/tree/v3.654.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.654.0/LICENSE):
+This product includes source derived from [@aws-sdk/s3-request-presigner](https://github.com/aws/aws-sdk-js-v3) ([v3.658.1](https://github.com/aws/aws-sdk-js-v3/tree/v3.658.1)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.658.1/LICENSE):
 
 ```
                                 Apache License

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "@tyriar/fibonacci-heap": "^2.0.7",
     "concat-stream": "^2.0.0",
     "https-proxy-agent": "^7.0.1",
-    "import-in-the-middle": "^1.6.0",
+    "import-in-the-middle": "1.11.0",
     "json-bigint": "^1.0.0",
     "json-stringify-safe": "^5.0.0",
     "module-details-from-path": "^1.0.3",

--- a/test/versioned/pg-esm/package.json
+++ b/test/versioned/pg-esm/package.json
@@ -10,21 +10,7 @@
         "node": ">=18"
       },
       "dependencies": {
-        "pg": ">=8.2.0 <8.8.0",
-        "pg-native": ">=2.0.0"
-      },
-      "files": [
-        "force-native.tap.mjs",
-        "native.tap.mjs",
-        "pg.tap.mjs"
-      ]
-    },
-    {
-      "engines": {
-        "node": ">=18"
-      },
-      "dependencies": {
-        "pg": ">=8.8.0",
+        "pg": ">=8.2.0",
         "pg-native": ">=3.0.0"
       },
       "files": [

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Fri Sep 20 2024 16:37:31 GMT+0530 (India Standard Time)",
+  "lastUpdated": "Fri Sep 27 2024 11:07:28 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -120,15 +120,15 @@
       "email": "nathan@tootallnate.net",
       "url": "http://n8.io/"
     },
-    "import-in-the-middle@1.11.0": {
+    "import-in-the-middle@1.11.1": {
       "name": "import-in-the-middle",
-      "version": "1.11.0",
-      "range": "^1.6.0",
+      "version": "1.11.1",
+      "range": "1.11.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/nodejs/import-in-the-middle",
-      "versionedRepoUrl": "https://github.com/nodejs/import-in-the-middle/tree/v1.11.0",
+      "versionedRepoUrl": "https://github.com/nodejs/import-in-the-middle/tree/v1.11.1",
       "licenseFile": "node_modules/import-in-the-middle/LICENSE",
-      "licenseUrl": "https://github.com/nodejs/import-in-the-middle/blob/v1.11.0/LICENSE",
+      "licenseUrl": "https://github.com/nodejs/import-in-the-middle/blob/v1.11.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Bryan English",
       "email": "bryan.english@datadoghq.com"
@@ -226,28 +226,28 @@
     }
   },
   "devDependencies": {
-    "@aws-sdk/client-s3@3.654.0": {
+    "@aws-sdk/client-s3@3.658.1": {
       "name": "@aws-sdk/client-s3",
-      "version": "3.654.0",
+      "version": "3.658.1",
       "range": "^3.556.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/aws/aws-sdk-js-v3",
-      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.654.0",
+      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.658.1",
       "licenseFile": "node_modules/@aws-sdk/client-s3/LICENSE",
-      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.654.0/LICENSE",
+      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.658.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "AWS SDK for JavaScript Team",
       "url": "https://aws.amazon.com/javascript/"
     },
-    "@aws-sdk/s3-request-presigner@3.654.0": {
+    "@aws-sdk/s3-request-presigner@3.658.1": {
       "name": "@aws-sdk/s3-request-presigner",
-      "version": "3.654.0",
+      "version": "3.658.1",
       "range": "^3.556.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/aws/aws-sdk-js-v3",
-      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.654.0",
+      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.658.1",
       "licenseFile": "node_modules/@aws-sdk/s3-request-presigner/LICENSE",
-      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.654.0/LICENSE",
+      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.658.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "AWS SDK for JavaScript Team",
       "url": "https://aws.amazon.com/javascript/"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We had some failures in CI with the IAST agent.  I noticed we have a discrepancy between the versions of `pg-native` we test in `pg` vs `pg-esm`. 

