### PR TITLE
test: Updated tests to use `helper.loadTestAgent` where applicable

### DIFF
--- a/test/lib/agent_helper.js
+++ b/test/lib/agent_helper.js
@@ -250,6 +250,7 @@ helper.unloadAgent = (agent, shimmer = require('../../lib/shimmer')) => {
 
 helper.loadTestAgent = (t, conf, setState = true) => {
   const agent = helper.instrumentMockedAgent(conf, setState)
+
   if (t.after) {
     t.after(() => {
       helper.unloadAgent(agent)

--- a/test/unit/agent/agent.test.js
+++ b/test/unit/agent/agent.test.js
@@ -179,11 +179,7 @@ test('when forcing transaction ignore status', async (t) => {
 })
 
 test('#harvesters.start should start all aggregators', (t) => {
-  const agent = helper.loadMockedAgent(null, false)
-  t.after(() => {
-    helper.unloadAgent(agent)
-  })
-
+  const agent = helper.loadTestAgent(t, null, false)
   agent.harvester.start()
   const aggregators = [
     agent.traces,
@@ -201,11 +197,7 @@ test('#harvesters.start should start all aggregators', (t) => {
 
 test('#harvesters.stop should stop all aggregators', (t) => {
   // Load agent with default 'stopped' state:
-  const agent = helper.loadMockedAgent(null, false)
-  t.after(() => {
-    helper.unloadAgent(agent)
-  })
-
+  const agent = helper.loadTestAgent(t, null, false)
   agent.harvester.start()
   agent.harvester.stop()
 

--- a/test/unit/api/api-obfuscate-sql.test.js
+++ b/test/unit/api/api-obfuscate-sql.test.js
@@ -10,12 +10,8 @@ const API = require('../../../api')
 const helper = require('../../lib/agent_helper')
 
 test('Agent API - obfuscateSql', (t, end) => {
-  const agent = helper.instrumentMockedAgent()
+  const agent = helper.loadTestAgent(t)
   const api = new API(agent)
-
-  t.after(() => {
-    helper.unloadAgent(agent)
-  })
 
   const sql = `select * from foo where a='b' and c=100;`
   const obfuscated = api.obfuscateSql(sql, 'postgres')

--- a/test/unit/collector/api-connect.test.js
+++ b/test/unit/collector/api-connect.test.js
@@ -33,13 +33,9 @@ const baseAgentConfig = {
 }
 
 test('requires a callback', (t) => {
-  const agent = helper.loadMockedAgent(baseAgentConfig)
+  const agent = helper.loadTestAgent(t, baseAgentConfig)
   agent.reconfigure = () => {}
   agent.setState = () => {}
-  t.after(() => {
-    helper.unloadAgent(agent)
-  })
-
   const collectorApi = new CollectorApi(agent)
   assert.throws(
     () => {

--- a/test/unit/collector/facts.test.js
+++ b/test/unit/collector/facts.test.js
@@ -421,11 +421,7 @@ test('utilization facts', async (t) => {
       // We don't collect full hostnames.
       delete expected.full_hostname
 
-      const agent = helper.loadMockedAgent(config)
-      t.after(() => {
-        helper.unloadAgent(agent)
-      })
-
+      const agent = helper.loadTestAgent(t, config)
       if (mockHostname) {
         agent.config.getHostnameSafe = mockHostname
       }
@@ -567,8 +563,7 @@ test('boot id facts', async (t) => {
       }
 
       const expected = testCase.expected_output_json
-      agent = helper.loadMockedAgent(structuredClone(DISABLE_ALL_DETECTIONS))
-      t.after(() => helper.unloadAgent(agent))
+      agent = helper.loadTestAgent(t, structuredClone(DISABLE_ALL_DETECTIONS))
 
       if (mockHostname) {
         agent.config.getHostnameSafe = mockHostname

--- a/test/unit/errors/error-collector.test.js
+++ b/test/unit/errors/error-collector.test.js
@@ -370,13 +370,12 @@ test('Errors', async (t) => {
       // 9. new trace invokes getDisplayHost()
       // 10. getDisplayHost() returns the original cached value because the agent has been reused
       helper.unloadAgent(t.nr.agent)
-      const agent = helper.loadMockedAgent({
+      const agent = helper.loadTestAgent(t, {
         attributes: { enabled: true },
         process_host: {
           display_name: 'test-value'
         }
       })
-      t.after(() => helper.unloadAgent(agent))
 
       const tx = new Transaction(agent)
       tx.url = '/'
@@ -1689,8 +1688,7 @@ test('Errors', async (t) => {
 
     await t.test('not spill over reservoir size', (t) => {
       helper.unloadAgent(t.nr.agent)
-      const agent = helper.loadMockedAgent({ error_collector: { max_event_samples_stored: 10 } })
-      t.after(() => helper.unloadAgent(agent))
+      const agent = helper.loadTestAgent(t, { error_collector: { max_event_samples_stored: 10 } })
 
       for (let i = 0; i < 20; i++) {
         agent.errors.add(null, Error('some error'))
@@ -2016,8 +2014,7 @@ test('Errors', async (t) => {
 
         await t.test('includes http port if the transaction is a web transaction', (t, end) => {
           helper.unloadAgent(t.nr.agent)
-          const agent = helper.instrumentMockedAgent()
-          t.after(() => helper.unloadAgent(agent))
+          const agent = helper.loadTestAgent(t)
 
           const server = http.createServer(function createServerCb(req, res) {
             assert.ok(agent.getTransaction())

--- a/test/unit/instrumentation/core/globals.test.js
+++ b/test/unit/instrumentation/core/globals.test.js
@@ -14,10 +14,7 @@ test('unhandledRejection should not report it if there is another handler', () =
 })
 
 test('should catch early throws with long chains', (t, end) => {
-  const agent = helper.instrumentMockedAgent()
-  t.after(() => {
-    helper.unloadAgent(agent)
-  })
+  const agent = helper.loadTestAgent(t)
   let segment
 
   helper.runInTransaction(agent, function (transaction) {

--- a/test/unit/instrumentation/core/inspector.test.js
+++ b/test/unit/instrumentation/core/inspector.test.js
@@ -11,10 +11,6 @@ const helper = require('../../../lib/agent_helper')
 const inspectorInstrumentation = require('../../../../lib/instrumentation/core/inspector')
 
 test('Inspector instrumentation', async (t) => {
-  const agent = helper.loadMockedAgent()
-  t.after(() => {
-    helper.unloadAgent(agent)
-  })
-
+  const agent = helper.loadTestAgent(t)
   assert.doesNotThrow(inspectorInstrumentation.bind(null, agent, null))
 })

--- a/test/unit/instrumentation/generic-pool.test.js
+++ b/test/unit/instrumentation/generic-pool.test.js
@@ -11,13 +11,9 @@ const helper = require('../../lib/agent_helper')
 const Shim = require('../../../lib/shim/shim.js')
 
 test('agent instrumentation of generic-pool', async function (t) {
-  const agent = helper.loadMockedAgent()
+  const agent = helper.loadTestAgent(t)
   const shim = new Shim(agent, 'generic-pool')
   const initialize = require('../../../lib/instrumentation/generic-pool')
-
-  t.after(function () {
-    helper.unloadAgent(agent)
-  })
 
   await t.test("shouldn't cause bootstrapping to fail", async function (t) {
     await t.test('when passed no module', async function () {

--- a/test/unit/instrumentation/hapi.test.js
+++ b/test/unit/instrumentation/hapi.test.js
@@ -12,12 +12,8 @@ const shims = require('../../../lib/shim')
 
 test('an instrumented Hapi application', async function (t) {
   await t.test("shouldn't cause bootstrapping to fail", async function (t) {
-    const agent = helper.loadMockedAgent()
+    const agent = helper.loadTestAgent(t)
     const initialize = require('../../../lib/instrumentation/@hapi/hapi')
-
-    t.after(function () {
-      helper.unloadAgent(agent)
-    })
 
     await t.test('when passed nothing', async function () {
       assert.doesNotThrow(function () {
@@ -42,7 +38,7 @@ test('an instrumented Hapi application', async function (t) {
   await t.test(
     'when stubbed should set framework to Hapi when a new app is created',
     async function (t) {
-      const agent = helper.instrumentMockedAgent()
+      const agent = helper.loadTestAgent(t)
       agent.environment.clearFramework()
 
       function Server() {}
@@ -54,10 +50,6 @@ test('an instrumented Hapi application', async function (t) {
       const shim = new shims.WebFrameworkShim(agent, 'hapi')
 
       require('../../../lib/instrumentation/@hapi/hapi')(agent, stub, 'hapi', shim)
-
-      t.after(function () {
-        helper.unloadAgent(agent)
-      })
 
       const server = new stub.Server()
       server.start()

--- a/test/unit/instrumentation/http/http.test.js
+++ b/test/unit/instrumentation/http/http.test.js
@@ -931,7 +931,7 @@ test('built-in http module instrumentation', async (t) => {
 
   await t.test('request headers for outbound request', async (t) => {
     await t.test('should preserve headers regardless of format', (t, end) => {
-      const agent = helper.instrumentMockedAgent({
+      const agent = helper.loadTestAgent(t, {
         cross_application_tracer: { enabled: true },
         distributed_tracing: { enabled: false },
         encoding_key: encKey,
@@ -940,9 +940,6 @@ test('built-in http module instrumentation', async (t) => {
 
       const http = require('http')
       let hadExpect = 0
-      t.after(() => {
-        helper.unloadAgent(agent)
-      })
 
       const server = http.createServer(function (req, res) {
         if (req.headers.expect) {

--- a/test/unit/instrumentation/memcached.test.js
+++ b/test/unit/instrumentation/memcached.test.js
@@ -10,12 +10,8 @@ const test = require('node:test')
 const assert = require('node:assert')
 
 test('agent instrumentation of memcached should not cause bootstrapping to fail', async function (t) {
-  const agent = helper.loadMockedAgent()
+  const agent = helper.loadTestAgent(t)
   const initialize = require('../../../lib/instrumentation/memcached')
-
-  t.after(function () {
-    helper.unloadAgent(agent)
-  })
 
   await t.test('when passed no module', async function () {
     assert.doesNotThrow(() => {

--- a/test/unit/shim/shim.test.js
+++ b/test/unit/shim/shim.test.js
@@ -3096,11 +3096,7 @@ test('Shim', async function (t) {
   })
 
   await t.test('shim.specs', (t) => {
-    const agent = helper.loadMockedAgent()
-    t.after(() => {
-      helper.unloadAgent(agent)
-    })
-
+    const agent = helper.loadTestAgent(t)
     const shim = new Shim(agent, 'test-mod')
     assert.ok(shim.specs, 'should assign specs to an instance of shim')
     assert.ok(shim.specs.ClassWrapSpec)
@@ -3120,11 +3116,7 @@ test('Shim', async function (t) {
   })
 
   await t.test('should not use functions in MessageSubscribeSpec if it is not an array', (t) => {
-    const agent = helper.loadMockedAgent()
-    t.after(() => {
-      helper.unloadAgent(agent)
-    })
-
+    const agent = helper.loadTestAgent(t)
     const shim = new Shim(agent, 'test-mod')
     const spec = new shim.specs.MessageSubscribeSpec({
       functions: 'foo-bar'

--- a/test/unit/shimmer.test.js
+++ b/test/unit/shimmer.test.js
@@ -631,11 +631,7 @@ test('shimmer', async function (t) {
 })
 
 test('Should not augment module when no instrumentation hooks provided', async (t) => {
-  const agent = helper.instrumentMockedAgent()
-
-  t.after(() => {
-    helper.unloadAgent(agent)
-  })
+  helper.loadTestAgent(t)
 
   const instrumentationOpts = {
     moduleName: TEST_MODULE_PATH,
@@ -659,19 +655,13 @@ test('Should not augment module when no instrumentation hooks provided', async (
 })
 
 test('Should not crash on empty instrumentation registration', async (t) => {
-  const agent = helper.instrumentMockedAgent()
-  t.after(() => {
-    helper.unloadAgent(agent)
-  })
+  helper.loadTestAgent(t)
 
   assert.doesNotThrow(shimmer.registerInstrumentation)
 })
 
 test('Should not register instrumentation with no name provided', async (t) => {
-  const agent = helper.instrumentMockedAgent()
-  t.after(() => {
-    helper.unloadAgent(agent)
-  })
+  helper.loadTestAgent(t)
 
   shimmer.registerInstrumentation({})
 
@@ -679,10 +669,7 @@ test('Should not register instrumentation with no name provided', async (t) => {
 })
 
 test('Should not register when no hooks provided', async (t) => {
-  const agent = helper.instrumentMockedAgent()
-  t.after(() => {
-    helper.unloadAgent(agent)
-  })
+  helper.loadTestAgent(t)
 
   const moduleName = 'test name'
   shimmer.registerInstrumentation({

--- a/test/unit/transaction/trace/index.test.js
+++ b/test/unit/transaction/trace/index.test.js
@@ -757,14 +757,10 @@ test('when inserting segments', async (t) => {
 test('should set URI to null when request.uri attribute is excluded globally', async (t) => {
   const URL = '/test'
 
-  const agent = helper.loadMockedAgent({
+  const agent = helper.loadTestAgent(t, {
     attributes: {
       exclude: ['request.uri']
     }
-  })
-
-  t.after(() => {
-    helper.unloadAgent(agent)
   })
 
   const transaction = new Transaction(agent)
@@ -784,16 +780,10 @@ test('should set URI to null when request.uri attribute is excluded globally', a
 test('should set URI to null when request.uri attribute is exluded from traces', async (t) => {
   const URL = '/test'
 
-  const agent = helper.loadMockedAgent({
-    transaction_tracer: {
-      attributes: {
-        exclude: ['request.uri']
-      }
+  const agent = helper.loadTestAgent(t, {
+    attributes: {
+      exclude: ['request.uri']
     }
-  })
-
-  t.after(() => {
-    helper.unloadAgent(agent)
   })
 
   const transaction = new Transaction(agent)
@@ -811,11 +801,7 @@ test('should set URI to null when request.uri attribute is exluded from traces',
 })
 
 test('should set URI to /Unknown when URL is not known/set on transaction', async (t) => {
-  const agent = helper.loadMockedAgent()
-
-  t.after(() => {
-    helper.unloadAgent(agent)
-  })
+  const agent = helper.loadTestAgent(t)
 
   const transaction = new Transaction(agent)
   const trace = transaction.trace
@@ -830,7 +816,7 @@ test('should set URI to /Unknown when URL is not known/set on transaction', asyn
 
 test('should obfuscate URI using regex when pattern is set', async (t) => {
   const URL = '/abc/123/def/456/ghi'
-  const agent = helper.loadMockedAgent({
+  const agent = helper.loadTestAgent(t, {
     url_obfuscation: {
       enabled: true,
       regex: {
@@ -839,10 +825,6 @@ test('should obfuscate URI using regex when pattern is set', async (t) => {
         replacement: '/***/'
       }
     }
-  })
-
-  t.after(() => {
-    helper.unloadAgent(agent)
   })
 
   const transaction = new Transaction(agent)

--- a/test/versioned/express/app-use.test.js
+++ b/test/versioned/express/app-use.test.js
@@ -13,12 +13,8 @@ const tsplan = require('@matteo.collina/tspl')
 // This test is no longer applicable in express 5 as mounting a child router does not emit the same
 // mount event
 test('app should be at top of stack when mounted', { skip: isExpress5() }, async function (t) {
-  const agent = helper.instrumentMockedAgent()
+  helper.loadTestAgent(t)
   const express = require('express')
-
-  t.after(() => {
-    helper.unloadAgent(agent)
-  })
 
   const plan = tsplan(t, { plan: 1 })
 

--- a/test/versioned/express/route-iteration.test.js
+++ b/test/versioned/express/route-iteration.test.js
@@ -10,15 +10,11 @@ const helper = require('../../lib/agent_helper')
 
 test('new relic should not break route iteration', async function (t) {
   const plan = tsplan(t, { plan: 1 })
-  const agent = helper.instrumentMockedAgent()
+  helper.loadTestAgent(t)
   const express = require('express')
   const router = new express.Router()
   const childA = new express.Router()
   const childB = new express.Router()
-
-  t.after(() => {
-    helper.unloadAgent(agent)
-  })
 
   router.get('/get', function (req, res) {
     res.end()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

In #2635 there was a question about `helper.loadTestAgent`.  It inits a mock agent and adds an after/teardown to unload the agent. This PR updates all tests that could use that instead of being verbose within the tests.
