### PR TITLE
test: Updated tests that used the context manager directly and instead use the tracer to access the segment context

### DIFF
--- a/lib/transaction/tracer/index.js
+++ b/lib/transaction/tracer/index.js
@@ -26,6 +26,7 @@ function Tracer(agent, contextManager) {
 
 Tracer.prototype.getTransaction = getTransaction
 Tracer.prototype.getSegment = getSegment
+Tracer.prototype.setSegment = setSegment
 Tracer.prototype.getSpanContext = getSpanContext
 Tracer.prototype.createSegment = createSegment
 Tracer.prototype.addSegment = addSegment
@@ -55,6 +56,10 @@ function getTransaction() {
 // TODO: Remove/replace external uses to tracer.getSegment()
 function getSegment() {
   return this._contextManager.getContext()
+}
+
+function setSegment(segment) {
+  this._contextManager.setContext(segment)
 }
 
 // TODO: Remove/replace external uses to tracer.getSpanContext()

--- a/test/benchmark/shim/record.bench.js
+++ b/test/benchmark/shim/record.bench.js
@@ -11,7 +11,7 @@ const Shim = require('../../../lib/shim/shim')
 const { RecorderSpec } = require('../../../lib/shim/specs')
 
 const agent = helper.loadMockedAgent()
-const contextManager = helper.getContextManager()
+const tracer = helper.getTracer()
 
 const shim = new Shim(agent, 'test-module', './')
 const suite = benchmark.createBenchmark({ name: 'Shim#record' })
@@ -41,7 +41,7 @@ const wrapped = shim.record(getTest(), 'func', function () {
 suite.add({
   name: 'wrapper - no transaction',
   fn: function () {
-    contextManager.setContext(null)
+    tracer.setSegment(null)
     wrapped.func(noop)
   }
 })
@@ -49,7 +49,7 @@ suite.add({
 suite.add({
   name: 'wrapper - in transaction',
   fn: function () {
-    contextManager.setContext(transaction.trace.root)
+    tracer.setSegment(transaction.trace.root)
     wrapped.func(noop)
   }
 })

--- a/test/benchmark/tracer/bindFunction.bench.js
+++ b/test/benchmark/tracer/bindFunction.bench.js
@@ -10,12 +10,11 @@ const shared = require('./shared')
 
 const s = shared.makeSuite()
 const suite = s.suite
-const tracer = s.agent.tracer
-const contextManager = helper.getContextManager()
+const tracer = helper.getTracer()
 const tx = helper.runInTransaction(s.agent, function (_tx) {
   return _tx
 })
-contextManager.setContext(tx.root)
+tracer.setSegment(tx.root)
 
 preOptBind()
 const bound = tracer.bindFunction(shared.getTest().func, tx.root, true)

--- a/test/benchmark/tracer/segments.bench.js
+++ b/test/benchmark/tracer/segments.bench.js
@@ -10,14 +10,13 @@ const shared = require('./shared')
 
 const s = shared.makeSuite('Tracer segments')
 const suite = s.suite
-const tracer = s.agent.tracer
-const contextManager = helper.getContextManager()
+const tracer = helper.getTracer()
 
 const tx = helper.runInTransaction(s.agent, function (_tx) {
   return _tx
 })
 
-contextManager.setContext(tx.root)
+tracer.setSegment(tx.root)
 
 suite.add({
   name: 'tracer.getSegment',

--- a/test/benchmark/tracer/transaction.bench.js
+++ b/test/benchmark/tracer/transaction.bench.js
@@ -10,14 +10,12 @@ const shared = require('./shared')
 
 const s = shared.makeSuite('Tracer transactions')
 const suite = s.suite
-const tracer = s.agent.tracer
-
-const contextManager = helper.getContextManager()
+const tracer = helper.getTracer()
 const tx = helper.runInTransaction(s.agent, function (_tx) {
   return _tx
 })
 
-contextManager.setContext(tx.root)
+tracer.setSegment(tx.root)
 
 suite.add({
   name: 'tracer.getTransaction',

--- a/test/benchmark/tracer/utilities.bench.js
+++ b/test/benchmark/tracer/utilities.bench.js
@@ -10,14 +10,13 @@ const helper = require('../../lib/agent_helper')
 
 const s = shared.makeSuite('Tracer utilities')
 const suite = s.suite
-const tracer = s.agent.tracer
-const contextManager = helper.getContextManager()
+const tracer = helper.getTracer()
 
 const tx = helper.runInTransaction(s.agent, function (_tx) {
   return _tx
 })
 
-contextManager.setContext(tx.root)
+tracer.setSegment(tx.root)
 
 suite.add({
   name: 'tracer.slice',

--- a/test/benchmark/webframework-shim/recordMiddleware.bench.js
+++ b/test/benchmark/webframework-shim/recordMiddleware.bench.js
@@ -11,7 +11,7 @@ const WebFrameworkShim = require('../../../lib/shim/webframework-shim')
 const symbols = require('../../../lib/symbols')
 
 const agent = helper.loadMockedAgent()
-const contextManager = helper.getContextManager()
+const tracer = helper.getTracer()
 const shim = new WebFrameworkShim(agent, 'test-module', './')
 const { MiddlewareSpec } = require('../../../lib/shim/specs')
 const suite = benchmark.createBenchmark({ name: 'recordMiddleware' })
@@ -59,7 +59,7 @@ function addTests(name, speccer) {
   suite.add({
     name: name + ' - wrapper (no tx)    ',
     fn: function () {
-      contextManager.setContext(null)
+      tracer.setSegment(null)
       middleware(getReqd(), {}, noop)
     }
   })
@@ -67,7 +67,7 @@ function addTests(name, speccer) {
   suite.add({
     name: name + ' - wrapper (tx)       ',
     fn: function () {
-      contextManager.setContext(transaction.trace.root)
+      tracer.setSegment(transaction.trace.root)
       middleware(getReqd(), {}, noop)
     }
   })

--- a/test/integration/core/net.tap.js
+++ b/test/integration/core/net.tap.js
@@ -14,14 +14,14 @@ function id(tx) {
 }
 
 test('createServer', function createServerTest(t) {
-  const { agent, contextManager } = setupAgent(t)
+  const { agent, tracer } = setupAgent(t)
 
   helper.runInTransaction(agent, function transactionWrapper(transaction) {
     const server = net.createServer(handler)
 
     server.listen(4123, function listening() {
       // leave transaction
-      contextManager.setContext(null)
+      tracer.setSegment(null)
       const socket = net.connect({ port: 4123 })
       socket.write('test123')
       socket.end()
@@ -31,7 +31,7 @@ test('createServer', function createServerTest(t) {
       t.equal(id(agent.getTransaction()), id(transaction), 'should maintain tx')
       socket.end('test')
       t.equal(
-        contextManager.getContext().name,
+        tracer.getSegment().name,
         'net.Server.onconnection',
         'child segment should have correct name'
       )
@@ -135,7 +135,7 @@ test('connect', function connectTest(t) {
 })
 
 test('createServer and connect', function createServerTest(t) {
-  const { agent, contextManager } = setupAgent(t)
+  const { agent, tracer } = setupAgent(t)
 
   helper.runInTransaction(agent, function transactionWrapper(transaction) {
     const server = net.createServer(handler)
@@ -150,7 +150,7 @@ test('createServer and connect', function createServerTest(t) {
       t.equal(id(agent.getTransaction()), id(transaction), 'should maintain tx')
       socket.end('test')
       t.equal(
-        contextManager.getContext().name,
+        tracer.getSegment().name,
         'net.Server.onconnection',
         'child segment should have correct name'
       )
@@ -199,7 +199,7 @@ test('createServer and connect', function createServerTest(t) {
 
 function setupAgent(t) {
   const agent = helper.instrumentMockedAgent()
-  const contextManager = helper.getContextManager()
+  const tracer = helper.getTracer()
 
   t.teardown(function tearDown() {
     helper.unloadAgent(agent)
@@ -207,6 +207,6 @@ function setupAgent(t) {
 
   return {
     agent,
-    contextManager
+    tracer
   }
 }

--- a/test/integration/core/timers.tap.js
+++ b/test/integration/core/timers.tap.js
@@ -289,11 +289,10 @@ tap.test('clearTimeout should not ignore parent segment when internal', (t) => {
 
 function setupAgent(t) {
   const agent = helper.instrumentMockedAgent()
-  const contextManager = helper.getContextManager()
 
   t.teardown(function tearDown() {
     helper.unloadAgent(agent)
   })
 
-  return { agent, contextManager }
+  return { agent }
 }

--- a/test/lib/agent_helper.js
+++ b/test/lib/agent_helper.js
@@ -71,7 +71,7 @@ helper.FakeSegment = function FakeSegment(transaction, duration, name = 'FakeSeg
 
 helper.SSL_HOST = 'localhost'
 helper.getAgent = () => _agent
-helper.getContextManager = () => _agent && _agent._contextManager
+helper.getTracer = () => _agent?.tracer
 
 /**
  * Set up an agent that won't try to connect to the collector, but also

--- a/test/unit/api/api-start-background-transaction.test.js
+++ b/test/unit/api/api-start-background-transaction.test.js
@@ -18,7 +18,7 @@ test('Agent API - startBackgroundTransaction', async (t) => {
   t.beforeEach((ctx) => {
     ctx.nr = {}
     const agent = helper.loadMockedAgent()
-    ctx.nr.contextManager = helper.getContextManager()
+    ctx.nr.tracer = helper.getTracer()
     ctx.nr.api = new API(agent)
     ctx.nr.agent = agent
   })
@@ -39,7 +39,7 @@ test('Agent API - startBackgroundTransaction', async (t) => {
   })
 
   await t.test('should add nested transaction as segment to parent transaction', (t, end) => {
-    const { agent, api, contextManager } = t.nr
+    const { agent, api, tracer } = t.nr
     let transaction = null
 
     api.startBackgroundTransaction('test', function () {
@@ -50,7 +50,7 @@ test('Agent API - startBackgroundTransaction', async (t) => {
       assert.equal(transaction.getFullName(), 'OtherTransaction/Nodejs/test')
       assert.ok(transaction.isActive())
 
-      const currentSegment = contextManager.getContext()
+      const currentSegment = tracer.getSegment()
       const nestedSegment = currentSegment.children[0]
       assert.equal(nestedSegment.name, 'Nodejs/nested')
     })
@@ -216,11 +216,11 @@ test('Agent API - startBackgroundTransaction', async (t) => {
       await t.test(
         `should ${enabled ? 'add' : 'not add'} CLM attributes to nested web transactions`,
         (t, end) => {
-          const { agent, api, contextManager } = t.nr
+          const { agent, api, tracer } = t.nr
           agent.config.code_level_metrics.enabled = enabled
           api.startBackgroundTransaction('nested-clm-test', function () {
             nested({ api })
-            const currentSegment = contextManager.getContext()
+            const currentSegment = tracer.getSegment()
             const nestedSegment = currentSegment.children[0]
             assertCLMAttrs({
               segments: [

--- a/test/unit/api/api-start-web-transaction.test.js
+++ b/test/unit/api/api-start-web-transaction.test.js
@@ -17,7 +17,7 @@ test('Agent API - startWebTransaction', async (t) => {
   t.beforeEach((ctx) => {
     ctx.nr = {}
     const agent = helper.loadMockedAgent()
-    ctx.nr.contextManager = helper.getContextManager()
+    ctx.nr.tracer = helper.getTracer()
     ctx.nr.api = new API(agent)
     ctx.nr.agent = agent
   })
@@ -38,7 +38,7 @@ test('Agent API - startWebTransaction', async (t) => {
   })
 
   await t.test('should add nested transaction as segment to parent transaction', (t, end) => {
-    const { agent, api, contextManager } = t.nr
+    const { agent, api, tracer } = t.nr
     let transaction = null
 
     api.startWebTransaction('test', function () {
@@ -48,7 +48,7 @@ test('Agent API - startWebTransaction', async (t) => {
       assert.equal(transaction.getFullName(), 'WebTransaction/Custom//test')
       assert.ok(transaction.isActive())
 
-      const currentSegment = contextManager.getContext()
+      const currentSegment = tracer.getSegment()
       const nestedSegment = currentSegment.children[0]
       assert.equal(nestedSegment.name, 'nested')
     })
@@ -171,11 +171,11 @@ test('Agent API - startWebTransaction', async (t) => {
       await t.test(
         `should ${enabled ? 'add' : 'not add'} CLM attributes to nested web transactions`,
         (t, end) => {
-          const { agent, api, contextManager } = t.nr
+          const { agent, api, tracer } = t.nr
           agent.config.code_level_metrics.enabled = enabled
           api.startWebTransaction('clm-nested-test', function () {
             nested({ api })
-            const currentSegment = contextManager.getContext()
+            const currentSegment = tracer.getSegment()
             const nestedSegment = currentSegment.children[0]
             assertCLMAttrs({
               segments: [

--- a/test/unit/instrumentation/core/promises.test.js
+++ b/test/unit/instrumentation/core/promises.test.js
@@ -148,19 +148,18 @@ function step(n, rejection) {
 }
 
 function name(newName) {
-  const segment = helper.getContextManager().getContext()
+  const tracer = helper.getTracer()
+  const segment = tracer.getSegment()
   segment.name = newName
 }
 
 function checkTrace(t, tx) {
+  const tracer = helper.getTracer()
+  const expectedSegment = tracer.getSegment()
   const segment = tx.trace.root
   assert.equal(segment.name, 'a')
   assert.equal(segment.children.length, 0)
   // verify current segment is same as trace root
-  assert.deepEqual(
-    segment.name,
-    helper.getContextManager().getContext().name,
-    'current segment is same as one in async context manager'
-  )
+  assert.deepEqual(segment.name, expectedSegment.name, 'current segment is same as one in tracer')
   return Promise.resolve()
 }

--- a/test/unit/instrumentation/http/outbound-utils.js
+++ b/test/unit/instrumentation/http/outbound-utils.js
@@ -69,7 +69,7 @@ async function testSignature(testOpts) {
   const testName = names.join(', ')
 
   await t.test(testName, function (t, end) {
-    const { agent, contextManager } = t.nr
+    const { agent, tracer } = t.nr
     // If testing the options overriding the URL argument, set up nock differently
     if (swapHost) {
       nock(`${nodule}://www.google.com`).get(path).reply(200, 'Hello from Google')
@@ -79,7 +79,7 @@ async function testSignature(testOpts) {
 
     // Setup a function to test the response.
     const callbackTester = (res) => {
-      testResult({ res, headers, swapHost, end, host, port, path, contextManager })
+      testResult({ res, headers, swapHost, end, host, port, path, tracer })
     }
 
     // Add callback to the arguments, if used
@@ -101,7 +101,7 @@ async function testSignature(testOpts) {
   })
 }
 
-function testResult({ res, headers, swapHost, end, host, port, path, contextManager }) {
+function testResult({ res, headers, swapHost, end, host, port, path, tracer }) {
   let external = `External/${host}${port}${path}`
   let str = 'Hello from New Relic'
   if (swapHost) {
@@ -109,7 +109,7 @@ function testResult({ res, headers, swapHost, end, host, port, path, contextMana
     str = 'Hello from Google'
   }
 
-  const segment = contextManager.getContext()
+  const segment = tracer.getSegment()
 
   assert.equal(segment.name, external)
   assert.equal(res.statusCode, 200)

--- a/test/versioned/bluebird/methods.test.js
+++ b/test/versioned/bluebird/methods.test.js
@@ -113,19 +113,19 @@ test('new Promise()', async function (t) {
       end,
       count: 3,
       testFunc: function resolveTest({ name, plan }) {
-        const contextManager = helper.getContextManager()
-        const inTx = !!contextManager.getContext()
+        const tracer = helper.getTracer()
+        const inTx = !!tracer.getSegment()
 
         return new Promise(function (resolve) {
           addTask(t.nr, function () {
-            plan.ok(!contextManager.getContext(), name + 'should lose tx')
+            plan.ok(!tracer.getSegment(), name + 'should lose tx')
             resolve('foobar ' + name)
           })
         }).then(function (res) {
           if (inTx) {
-            plan.ok(contextManager.getContext(), name + 'should return tx')
+            plan.ok(tracer.getSegment(), name + 'should return tx')
           } else {
-            plan.ok(!contextManager.getContext(), name + 'should not create tx')
+            plan.ok(!tracer.getSegment(), name + 'should not create tx')
           }
           plan.equal(res, 'foobar ' + name, name + 'should resolve with correct value')
         })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This PR updates all tests to interact with the tracer to get the segment context. This along with #2642 will centralize how we access the context and make it easier for future refactors.
