### PR TITLE
feat: IAST configurations for scan scheduling and restrictions

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1318,6 +1318,147 @@ defaultConfig.definition = () => ({
           default: true
         }
       }
+    },
+
+    /**
+     * Unique test identifier when runnning IAST with CI/CD
+     */
+    iast_test_identifier: '',
+
+    /**
+     * IAST scan controllers to get more control over IAST analysis
+     */
+    scan_controllers: {
+      /**
+       * The maximum number of analysis probes or requests
+       * that can be sent to the application in one minute.
+       */
+      iast_scan_request_rate_limit: {
+        formatter: int,
+        default: 3600
+      },
+      /**
+       * The number of application instances for a specific entity where IAST analysis is performed.
+       *  Values are 0 or 1, 0 signifies run on all application instances
+       */
+      scan_instance_count: {
+        formatter: int,
+        default: 0
+      }
+    },
+    /**
+     * Schedule start and stop of IAST scan
+     */
+    scan_schedule: {
+      /**
+       * The delay field specifies the time in minutes
+       * before an IAST scan begins after the application starts
+       */
+      delay: {
+        formatter: int,
+        default: 0
+      },
+      /**
+       * The duration field specifies the length of
+       * time in minutes that the IAST scan will run
+       */
+      duration: {
+        formatter: int,
+        default: 0
+      },
+      /**
+       * The schedule field specifies a cron expression that defines when the IAST scan should run.
+       * By default, schedule is disabled
+       *
+       */
+      schedule: '',
+      /**
+       * Allows IAST to actively collect trace data in the background
+       * and the security agent will use this collected data to perform
+       * an IAST scan at the scheduled time
+       */
+      always_sample_traces: {
+        formatter: boolean,
+        default: false
+      }
+    },
+
+    /**
+     * The exclude from IAST scan setting allows to exclude specific APIs,
+     * vulnerability categories, and parameters from IAST analysis.
+     */
+    exclude_from_iast_scan: {
+      /**
+       * Ignore specific APIs from IAST analysis.
+       * The regex pattern should provide a full match for the URL without the endpoint.
+       */
+      api: {
+        formatter: array,
+        default: []
+      },
+      /**
+       * Ignore specific HTTP request parameters from IAST analysis.
+       */
+      http_request_parameters: {
+        header: {
+          formatter: array,
+          default: []
+        },
+        query: {
+          formatter: array,
+          default: []
+        },
+        body: {
+          formatter: array,
+          default: []
+        }
+      },
+      /**
+       *  Allows users to specify categories of vulnerabilities
+       *  for which IAST analysis will be applied or ignored.
+       */
+      iast_detection_category: {
+        insecure_settings: {
+          formatter: boolean,
+          default: false
+        },
+        invalid_file_access: {
+          formatter: boolean,
+          default: false
+        },
+        sql_injection: {
+          formatter: boolean,
+          default: false
+        },
+        nosql_injection: {
+          formatter: boolean,
+          default: false
+        },
+        ldap_injection: {
+          formatter: boolean,
+          default: false
+        },
+        javascript_injection: {
+          formatter: boolean,
+          default: false
+        },
+        command_injection: {
+          formatter: boolean,
+          default: false
+        },
+        xpath_injection: {
+          formatter: boolean,
+          default: false
+        },
+        ssrf: {
+          formatter: boolean,
+          default: false
+        },
+        rxss: {
+          formatter: boolean,
+          default: false
+        }
+      }
     }
   },
 

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1359,7 +1359,7 @@ defaultConfig.definition = () => ({
         default: 0
       },
       /**
-       * The duration field specifies the length of
+       * The duration field specifies the amount of
        * time in minutes that the IAST scan will run
        */
       duration: {
@@ -1367,7 +1367,7 @@ defaultConfig.definition = () => ({
         default: 0
       },
       /**
-       * The schedule field specifies a cron expression that defines when the IAST scan should run.
+       * The schedule field specifies a unix cron expression that defines when the IAST scan should run.
        * By default, schedule is disabled
        *
        */

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -242,7 +242,7 @@ test('with default properties', async (t) => {
         rxss: { enabled: true },
         deserialization: { enabled: true }
       },
-      iast_test_identifier: 'test_id',
+      iast_test_identifier: '',
       scan_controllers: {
         iast_scan_request_rate_limit: 3600,
         scan_instance_count: 0

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -245,20 +245,20 @@ test('with default properties', async (t) => {
       iast_test_identifier: 'test_id',
       scan_controllers: {
         iast_scan_request_rate_limit: 3600,
-        scan_instance_count: 1
+        scan_instance_count: 0
       },
       scan_schedule: {
         delay: 0,
-        duration: 300,
+        duration: 0,
         schedule: '',
         always_sample_traces: false
       },
       exclude_from_iast_scan: {
-        api: ['foo'],
+        api: [],
         http_request_parameters: {
-          header: ['header1', 'header2'],
-          query: ['q1', 'q2'],
-          body: ['a1']
+          header: [],
+          query: [],
+          body: []
         },
         iast_detection_category: {
           insecure_settings: false,

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -241,6 +241,37 @@ test('with default properties', async (t) => {
         rci: { enabled: true },
         rxss: { enabled: true },
         deserialization: { enabled: true }
+      },
+      iast_test_identifier: 'test_id',
+      scan_controllers: {
+        iast_scan_request_rate_limit: 3600,
+        scan_instance_count: 1
+      },
+      scan_schedule: {
+        delay: 0,
+        duration: 300,
+        schedule: '',
+        always_sample_traces: false
+      },
+      exclude_from_iast_scan: {
+        api: ['foo'],
+        http_request_parameters: {
+          header: ['header1', 'header2'],
+          query: ['q1', 'q2'],
+          body: ['a1']
+        },
+        iast_detection_category: {
+          insecure_settings: false,
+          invalid_file_access: false,
+          sql_injection: false,
+          nosql_injection: false,
+          ldap_injection: false,
+          javascript_injection: false,
+          command_injection: false,
+          xpath_injection: false,
+          ssrf: false,
+          rxss: false
+        }
       }
     })
   })

--- a/test/unit/config/config-env.test.js
+++ b/test/unit/config/config-env.test.js
@@ -737,7 +737,29 @@ test('when overriding configuration values via environment variables', async (t)
         NEW_RELIC_SECURITY_VALIDATOR_SERVICE_URL: 'new-url',
         NEW_RELIC_SECURITY_DETECTION_RCI_ENABLED: false,
         NEW_RELIC_SECURITY_DETECTION_RXSS_ENABLED: false,
-        NEW_RELIC_SECURITY_DETECTION_DESERIALIZATION_ENABLED: false
+        NEW_RELIC_SECURITY_DETECTION_DESERIALIZATION_ENABLED: false,
+        NEW_RELIC_SECURITY_IAST_TEST_IDENTIFIER: 'test_id',
+        NEW_RELIC_SECURITY_SCAN_CONTROLLERS_IAST_SCAN_REQUEST_RATE_LIMIT: 3600,
+        NEW_RELIC_SECURITY_SCAN_CONTROLLERS_SCAN_INSTANCE_COUNT: 1,
+        NEW_RELIC_SECURITY_SCAN_SCHEDULE_DELAY: 0,
+        NEW_RELIC_SECURITY_SCAN_SCHEDULE_DURATION: 300,
+        NEW_RELIC_SECURITY_SCAN_SCHEDULE_SCHEDULE: '',
+        NEW_RELIC_SECURITY_SCAN_SCHEDULE_ALWAYS_SAMPLE_TRACES: false,
+        NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_API: 'foo',
+        NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_HTTP_REQUEST_PARAMETERS_HEADER:
+          'header1, header2',
+        NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_HTTP_REQUEST_PARAMETERS_QUERY: 'q1, q2',
+        NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_HTTP_REQUEST_PARAMETERS_BODY: 'a1',
+        NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_INSECURE_SETTINGS: false,
+        NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_INVALID_FILE_ACCESS: false,
+        NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_SQL_INJECTION: false,
+        NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_NOSQL_INJECTION: false,
+        NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_LDAP_INJECTION: false,
+        NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_JAVASCRIPT_INJECTION: false,
+        NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_COMMAND_INJECTION: false,
+        NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_XPATH_INJECTION: false,
+        NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_SSRF: false,
+        NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_RXSS: false
       }
       idempotentEnv(env, (config) => {
         assert.deepStrictEqual(config.security, {
@@ -749,6 +771,37 @@ test('when overriding configuration values via environment variables', async (t)
             rci: { enabled: false },
             rxss: { enabled: false },
             deserialization: { enabled: false }
+          },
+          iast_test_identifier: 'test_id',
+          scan_controllers: {
+            iast_scan_request_rate_limit: 3600,
+            scan_instance_count: 1
+          },
+          scan_schedule: {
+            delay: 0,
+            duration: 300,
+            schedule: '',
+            always_sample_traces: false
+          },
+          exclude_from_iast_scan: {
+            api: ['foo'],
+            http_request_parameters: {
+              header: ['header1', 'header2'],
+              query: ['q1', 'q2'],
+              body: ['a1']
+            },
+            iast_detection_category: {
+              insecure_settings: false,
+              invalid_file_access: false,
+              sql_injection: false,
+              nosql_injection: false,
+              ldap_injection: false,
+              javascript_injection: false,
+              command_injection: false,
+              xpath_injection: false,
+              ssrf: false,
+              rxss: false
+            }
           }
         })
         end()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
This PR contains config for IAST scan scheduling and restrictions.
You can configure your IAST to handle scan scheduling. These configurations allow you to exclude certain APIs, parameters, and vulnerability categories from IAST analysis. You can also delay IAST scans or schedule them for specific times of the day.
Example config is given below:
`security:
 {
 iast_test_identifier: '1008',
 scan_controllers: {
      iast_scan_request_rate_limit: 3600,
      scan_instance_count: 1
    },
 scan_schedule:
    {
      delay: 0,
      duration: 300,
      schedule: '',
      always_sample_traces: false
    },
 exclude_from_iast_scan: {
      api:[]
      http_request_parameters:
      {
        header: [],
        query: [],
        body: []
      },
      iast_detection_category: {
        insecure_settings: false,
        invalid_file_access: false,
        sql_injection: false,
        nosql_injection: false,
        ldap_injection: false,
        javascript_injection: false,
        command_injection: false,
        xpath_injection: false,
        ssrf: false,
        rxss: false
      }
    }
 }`
Reference:[ IAST-CONFIGURATION](https://docs.newrelic.com/docs/iast/iast-configuration/)

