### PR TITLE
ci: Added delay to site extension publishing to wait for NPM

### DIFF
--- a/.github/workflows/azure-site-extension.yml
+++ b/.github/workflows/azure-site-extension.yml
@@ -50,10 +50,13 @@ jobs:
         if: ${{ env.NPM_AGENT_VERSION != env.AGENT_VERSION }}
         run: |
           $count = 0
+          $seconds = 30
           while($count -lt 10) {
-            Start-Sleep -s 120
+            $seconds = ($seconds * $count)
+            echo "Sleeping $seconds ($count)"
+            Start-Sleep -s $seconds
             $npmversion = npm view newrelic version
-            echo "Checking npm ($count): $npmversion"
+            echo "Checking npm version ($count): $npmversion"
             $test = [Version]$npmversion -match [Version]${{ env.AGENT_VERSION }}
             if ([Version]$npmversion -match [Version]${{ env.AGENT_VERSION }}) {
               break;

--- a/.github/workflows/azure-site-extension.yml
+++ b/.github/workflows/azure-site-extension.yml
@@ -36,10 +36,39 @@ jobs:
           node-version: ${{ matrix.node-version }}
           architecture: ${{ matrix.arch }}
 
-      - name: Find agent version
+      - name: Get local agent version 
+        run: |
+          $env:local_agent_version = node -p "require('./package.json').version"
+          echo "AGENT_VERSION=$env:local_agent_version" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Find agent version at npm 
         run: |
           $env:npm_agent_version = npm view newrelic version 
-          echo "AGENT_VERSION=$env:npm_agent_version" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "NPM_AGENT_VERSION=$env:npm_agent_version" | Out-File -FilePath $env:GITHUB_ENV -Append
+          
+      - name: Check NPM availability
+        if: ${{ env.NPM_AGENT_VERSION != env.AGENT_VERSION }}
+        run: |
+          $count = 0
+          while($count -lt 10) {
+            Start-Sleep -s 120
+            $npmversion = npm view newrelic version
+            echo "Checking npm ($count): $npmversion"
+            $test = [Version]$npmversion -match [Version]${{ env.AGENT_VERSION }}
+            if ([Version]$npmversion -match [Version]${{ env.AGENT_VERSION }}) {
+              break;
+            }
+            $count++
+          }
+          $env:npm_agent_version = npm view newrelic version 
+          echo "Done with delayed check. Published version: $env:npm_agent_version Local version: ${{env.AGENT_VERSION}}"
+          echo "NPM_AGENT_VERSION=$env:npm_agent_version" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Has the new agent been published?
+        if: ${{ env.NPM_AGENT_VERSION != env.AGENT_VERSION }}
+        run: |
+          echo "Published agent version (${{env.NPM_AGENT_VERSION }}) is behind local agent version (${{env.AGENT_VERSION}}); exiting."
+          exit 1;
 
       - name: Set package filename
         run: |


### PR DESCRIPTION
Our GitHub workflow to publish the Azure site extension was executing before NPM made the new agent available. This change adds a test for local-vs-remote versions, and checks periodically before either resolving or exiting. 

Much of this happens in Powershell, so I've tested extensively on a fork. 

Closes #2615 
Closes NR-317297