### PR TITLE
feat: Added ARN and provider to Lambda segments

### DIFF
--- a/lib/serverless/aws-lambda.js
+++ b/lib/serverless/aws-lambda.js
@@ -249,7 +249,9 @@ class AwsLambda {
   _getAwsAgentAttributes(event, context) {
     const attributes = {
       'aws.lambda.arn': context.invokedFunctionArn,
-      'aws.requestId': context.awsRequestId
+      'aws.requestId': context.awsRequestId,
+      'cloud.resource_id': context.invokedFunctionArn,
+      'cloud.platform': 'aws_lambda'
     }
 
     const eventSourceInfo = this._detectEventType(event)

--- a/test/unit/serverless/aws-lambda.test.js
+++ b/test/unit/serverless/aws-lambda.test.js
@@ -25,6 +25,8 @@ const LAMBDA_ARN = 'aws.lambda.arn'
 const COLDSTART = 'aws.lambda.coldStart'
 const EVENTSOURCE_ARN = 'aws.lambda.eventSource.arn'
 const EVENTSOURCE_TYPE = 'aws.lambda.eventSource.eventType'
+const PLATFORM = 'cloud.platform'
+const RESOURCE_ID = 'cloud.resource_id'
 
 function getMetrics(agent) {
   return agent.metrics._metrics
@@ -62,7 +64,8 @@ test('AwsLambda.patchLambdaHandler', async (t) => {
       functionVersion: 'TestVersion',
       invokedFunctionArn: 'arn:test:function',
       memoryLimitInMB: '128',
-      awsRequestId: 'testid'
+      awsRequestId: 'testid',
+      platform: 'aws_lambda'
     }
     ctx.nr.stubCallback = () => {}
 
@@ -624,7 +627,8 @@ test('AwsLambda.patchLambdaHandler', async (t) => {
       assert.equal(txTrace[REQ_ID], stubContext.awsRequestId)
       assert.equal(txTrace[LAMBDA_ARN], stubContext.invokedFunctionArn)
       assert.equal(txTrace[COLDSTART], true)
-
+      assert.equal(txTrace[PLATFORM], stubContext.platform)
+      assert.equal(txTrace[RESOURCE_ID], stubContext.invokedFunctionArn)
       end()
     }
 


### PR DESCRIPTION
## Description

Entity linking for Lambda functions requires standardized attributes being added to transaction trace segments: `cloud.resource_id` and `cloud.provider`. This PR adds them.

## How to Test

@svetlanabrennan added assertions to the `aws-lambda` unit test; running serverless unit tests shows that these are present. 

## Related Issues

Closes #2586 
Closes NR-314346
