### PR TITLE
feat: Added support for Bedrock invoke model user request

### DIFF
--- a/lib/llm-events/aws-bedrock/bedrock-command.js
+++ b/lib/llm-events/aws-bedrock/bedrock-command.js
@@ -85,7 +85,11 @@ class BedrockCommand {
       result = this.#body.prompt
     } else if (this.isClaude3() === true) {
       result = this.#body?.messages?.reduce((acc, curr) => {
-        acc += curr?.content ?? ''
+        if (Object.keys(curr?.content).length) {
+          acc += curr?.content.text ?? ''
+        } else {
+          acc += curr?.content ?? ''
+        }
         return acc
       }, '')
     }

--- a/lib/llm-events/aws-bedrock/bedrock-command.js
+++ b/lib/llm-events/aws-bedrock/bedrock-command.js
@@ -77,7 +77,7 @@ class BedrockCommand {
     } else if (this.isCohereEmbed() === true) {
       result = this.#body.texts.join(' ')
     } else if (
-      (this.isClaude() === true && this.isClaude3() === false) ||
+      this.isClaude() === true ||
       this.isAi21() === true ||
       this.isCohere() === true ||
       this.isLlama() === true

--- a/lib/llm-events/aws-bedrock/bedrock-command.js
+++ b/lib/llm-events/aws-bedrock/bedrock-command.js
@@ -77,7 +77,7 @@ class BedrockCommand {
     } else if (this.isCohereEmbed() === true) {
       result = this.#body.texts.join(' ')
     } else if (
-      this.isClaude() === true ||
+      (this.isClaude() === true && this.isClaude3() === false) ||
       this.isAi21() === true ||
       this.isCohere() === true ||
       this.isLlama() === true
@@ -85,10 +85,10 @@ class BedrockCommand {
       result = this.#body.prompt
     } else if (this.isClaude3() === true) {
       result = this.#body?.messages?.reduce((acc, curr) => {
-        if (Object.keys(curr?.content).length) {
+        if (typeof curr?.content === 'string') {
+          acc += curr?.content
+        } else if (Object.keys(curr?.content).length) {
           acc += curr?.content.text ?? ''
-        } else {
-          acc += curr?.content ?? ''
         }
         return acc
       }, '')

--- a/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
+++ b/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
@@ -24,6 +24,13 @@ const claude = {
   }
 }
 
+const claude35 = {
+  modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+  body: {
+    messages: [{ role: 'user', content: { type: 'text', text: 'who are you' } }]
+  }
+}
+
 const claude3 = {
   modelId: 'anthropic.claude-3-haiku-20240307-v1:0',
   body: {
@@ -182,6 +189,30 @@ test('claude3 complete command works', async (t) => {
   assert.equal(cmd.temperature, payload.body.temperature)
 })
 
+test('claude35 minimal command works', async (t) => {
+  t.nr.updatePayload(structuredClone(claude35))
+  const cmd = new BedrockCommand(t.nr.input)
+  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.maxTokens, undefined)
+  assert.equal(cmd.modelId, claude35.modelId)
+  assert.equal(cmd.modelType, 'completion')
+  assert.equal(cmd.prompt, claude35.body.messages[0].content.text)
+  assert.equal(cmd.temperature, undefined)
+})
+
+test('claude35 complete command works', async (t) => {
+  const payload = structuredClone(claude35)
+  payload.body.max_tokens = 25
+  payload.body.temperature = 0.5
+  t.nr.updatePayload(payload)
+  const cmd = new BedrockCommand(t.nr.input)
+  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.maxTokens, 25)
+  assert.equal(cmd.modelId, payload.modelId)
+  assert.equal(cmd.modelType, 'completion')
+  assert.equal(cmd.prompt, payload.body.messages[0].content.text)
+  assert.equal(cmd.temperature, payload.body.temperature)
+})
 test('cohere minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(cohere))
   const cmd = new BedrockCommand(t.nr.input)

--- a/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
+++ b/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
@@ -189,6 +189,17 @@ test('claude3 complete command works', async (t) => {
   assert.equal(cmd.temperature, payload.body.temperature)
 })
 
+test('claude35 minimal command works with claude 3 api', async (t) => {
+  t.nr.updatePayload(structuredClone(claude3))
+  const cmd = new BedrockCommand(t.nr.input)
+  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.maxTokens, undefined)
+  assert.equal(cmd.modelId, claude3.modelId)
+  assert.equal(cmd.modelType, 'completion')
+  assert.equal(cmd.prompt, claude3.body.messages[0].content)
+  assert.equal(cmd.temperature, undefined)
+})
+
 test('claude35 minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(claude35))
   const cmd = new BedrockCommand(t.nr.input)

--- a/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
+++ b/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
@@ -224,6 +224,7 @@ test('claude35 complete command works', async (t) => {
   assert.equal(cmd.prompt, payload.body.messages[0].content.text)
   assert.equal(cmd.temperature, payload.body.temperature)
 })
+
 test('cohere minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(cohere))
   const cmd = new BedrockCommand(t.nr.input)


### PR DESCRIPTION
<!--

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This Pr will improve the support for using the invoke model with bedrock LLM. the Invoke API expects the body to be of type `{[content: "user or assistant message"]}`.

We will now check for the type of the input if the type is a string we will return the value as is. If the param is an object we will attempt to reduce the object to just the message value.

## How to Test

run test suite. 

## Related Issues

https://new-relic.atlassian.net/browse/NR-326020