### PR TITLE
test: Fixed two assertions to work against older versions of `openai`

### DIFF
--- a/test/versioned/openai/chat-completions.test.js
+++ b/test/versioned/openai/chat-completions.test.js
@@ -360,10 +360,11 @@ if (semver.gte(pkgVersion, '4.12.2')) {
       const events = agent.customEventAggregator.events.toArray()
       assert.equal(events.length, 0)
       // we will still record the external segment but not the chat completion
-      assertSegments(tx.trace.root, [
-        'timers.setTimeout',
-        `External/${host}:${port}/chat/completions`
-      ])
+      assertSegments(
+        tx.trace.root,
+        ['timers.setTimeout', `External/${host}:${port}/chat/completions`],
+        { exact: false }
+      )
 
       tx.end()
       end()

--- a/test/versioned/openai/embeddings.test.js
+++ b/test/versioned/openai/embeddings.test.js
@@ -146,7 +146,7 @@ test('embedding invalid payload errors should be tracked', (t, end) => {
       },
       customAttributes: {
         'http.statusCode': 403,
-        'error.message': '403 You are not allowed to generate embeddings from this model',
+        'error.message': /You are not allowed to generate embeddings from this model/,
         'error.code': null,
         'error.param': null,
         'completion_id': undefined,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

When #2723 was merged the build was failing for older versions of `openai`. This PR fixes those two issues.

## How to Test

```sh
npm run versioned:internal openai
```
