### PR TITLE
feat: Added `labels.enabled` and `labels.exclude` to config defaults

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1185,6 +1185,22 @@ defaultConfig.definition = () => ({
       max_samples_stored: {
         formatter: int,
         default: 10000
+      },
+      labels: {
+        /**
+         * If `true`, the agent attaches labels to log records.
+         */
+        enabled: {
+          formatter: boolean,
+          default: false
+        },
+        /**
+         * A case-insensitive array containing the labels to exclude from log records.
+         */
+        exclude: {
+          formatter: array,
+          default: null
+        }
       }
     },
     metrics: {

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1199,7 +1199,7 @@ defaultConfig.definition = () => ({
          */
         exclude: {
           formatter: array,
-          default: null
+          default: []
         }
       }
     },

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -212,7 +212,7 @@ test('with default properties', async (t) => {
         max_samples_stored: 10000,
         labels: {
           enabled: false,
-          exclude: null
+          exclude: []
         }
       },
       metrics: {
@@ -229,7 +229,7 @@ test('with default properties', async (t) => {
   })
 
   await t.test('should default exclude application logging forwarding label to null', () => {
-    assert.equal(configuration.application_logging.forwarding.labels.exclude, null)
+    assert.deepStrictEqual(configuration.application_logging.forwarding.labels.exclude, [])
   })
 
   await t.test('should default `code_level_metrics.enabled` to true', () => {

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -209,7 +209,11 @@ test('with default properties', async (t) => {
       enabled: true,
       forwarding: {
         enabled: true,
-        max_samples_stored: 10000
+        max_samples_stored: 10000,
+        labels: {
+          enabled: false,
+          exclude: null
+        }
       },
       metrics: {
         enabled: true
@@ -218,6 +222,14 @@ test('with default properties', async (t) => {
         enabled: false
       }
     })
+  })
+
+  await t.test('should default application logging forwarding labels to false', () => {
+    assert.equal(configuration.application_logging.forwarding.labels.enabled, false)
+  })
+
+  await t.test('should default exclude application logging forwarding label to null', () => {
+    assert.equal(configuration.application_logging.forwarding.labels.exclude, null)
   })
 
   await t.test('should default `code_level_metrics.enabled` to true', () => {

--- a/test/unit/config/config-env.test.js
+++ b/test/unit/config/config-env.test.js
@@ -633,14 +633,20 @@ test('when overriding configuration values via environment variables', async (t)
       NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED: 'true',
       NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED: '12345',
       NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED: 'false',
-      NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED: 'true'
+      NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED: 'true',
+      NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_ENABLED: 'true',
+      NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE: 'one, two, three'
     }
     idempotentEnv(config, function (tc) {
       assert.deepStrictEqual(tc.application_logging, {
         enabled: true,
         forwarding: {
           enabled: true,
-          max_samples_stored: 12345
+          max_samples_stored: 12345,
+          labels: {
+            enabled: true,
+            exclude: ['one', 'two', 'three']
+          }
         },
         metrics: {
           enabled: false
@@ -652,6 +658,42 @@ test('when overriding configuration values via environment variables', async (t)
       end()
     })
   })
+
+  await t.test(
+    'should accept a comman delimited list with spaces for application logging forwarding exclusion list',
+    (t, end) => {
+      const config = {
+        NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE: 'one, two, three'
+      }
+
+      idempotentEnv(config, function (tc) {
+        assert.deepStrictEqual(tc.application_logging.forwarding.labels.exclude, [
+          'one',
+          'two',
+          'three'
+        ])
+        end()
+      })
+    }
+  )
+
+  await t.test(
+    'should accept a comman delimited list without spaces for application logging forwarding exclusion list',
+    (t, end) => {
+      const config = {
+        NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE: 'one,two,three'
+      }
+
+      idempotentEnv(config, function (tc) {
+        assert.deepStrictEqual(tc.application_logging.forwarding.labels.exclude, [
+          'one',
+          'two',
+          'three'
+        ])
+        end()
+      })
+    }
+  )
 
   await t.test('should pick up ignore_server_configuration', (t, end) => {
     idempotentEnv({ NEW_RELIC_IGNORE_SERVER_SIDE_CONFIG: 'true' }, function (tc) {

--- a/test/unit/config/config-env.test.js
+++ b/test/unit/config/config-env.test.js
@@ -660,7 +660,7 @@ test('when overriding configuration values via environment variables', async (t)
   })
 
   await t.test(
-    'should accept a comman delimited list with spaces for application logging forwarding exclusion list',
+    'should accept a comma delimited list with spaces for application logging forwarding exclusion list',
     (t, end) => {
       const config = {
         NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE: 'one, two, three'
@@ -678,7 +678,7 @@ test('when overriding configuration values via environment variables', async (t)
   )
 
   await t.test(
-    'should accept a comman delimited list without spaces for application logging forwarding exclusion list',
+    'should accept a comma delimited list without spaces for application logging forwarding exclusion list',
     (t, end) => {
       const config = {
         NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE: 'one,two,three'


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Updated default configs to accept `application_logging.forwarding.labels.enabled` and `application_logging.forwarding.labels.exclude` to support adding labels to log records. 

Docs website will be updated with these configs in #2716 

## How to Test

Added and updated unit tests

## Related Issues

Closes #2713 
Relates to #2716 