### PR TITLE
chore: Improved unit test speed

### DIFF
--- a/test/lib/fake-cert.js
+++ b/test/lib/fake-cert.js
@@ -32,6 +32,11 @@ const selfCert = require('self-cert')
  */
 module.exports = function fakeCert({ commonName = null } = {}) {
   const cert = selfCert({
+    // We set the certificate bits to 1,024 because we don't need 4,096 bit
+    // certificates for tests. This speeds up certificate generation time by
+    // a significant amount, and thus speeds up tests that rely on these
+    // certificates.
+    bits: 1_024,
     attrs: {
       commonName: commonName,
       stateName: 'Georgia',


### PR DESCRIPTION
This PR resolves #2709. Unit tests, on my system, run in about 1 minute and 28 seconds after this change. I also have a caching implementation, but it only shaves off another 5 seconds. I can push it up if we want those precious seconds.