### PR TITLE
feat: Moved `entity.guid`, `entity.name`, `entity.type`, and `hostname` to `common.attributes` on logs payload instead of in every log message

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -821,6 +821,8 @@ Agent.prototype._listenForConfigChanges = function _listenForConfigChanges() {
  * This method returns an object with the following keys/data:
  * - `trace.id`: The current trace ID
  * - `span.id`: The current span ID
+ *
+ * If `excludeServiceLinks` is false it will also include the following:
  * - `entity.name`: The application name specified in the connect request as
  *   app_name. If multiple application names are specified this will only be
  *   the first name
@@ -830,17 +832,14 @@ Agent.prototype._listenForConfigChanges = function _listenForConfigChanges() {
  *   utilization.full_hostname. If utilization.full_hostname is null or empty,
  *   this will be the hostname specified in the connect request as host.
  *
+ * @param {boolean} excludeServiceLinks flag to indicate if you should include `entity.guid`, `entity.type`, `entity.name` and `hostname` from linking metadata
  * @returns {object} The LinkingMetadata object with the data above
  */
-Agent.prototype.getLinkingMetadata = function getLinkingMetadata() {
+Agent.prototype.getLinkingMetadata = function getLinkingMetadata(excludeServiceLinks = false) {
   const segment = this.tracer.getSegment()
   const config = this.config
 
-  const linkingMetadata = {
-    'entity.name': config.applications()[0],
-    'entity.type': 'SERVICE',
-    'hostname': config.getHostnameSafe()
-  }
+  const linkingMetadata = {}
 
   if (config.distributed_tracing.enabled && segment) {
     linkingMetadata['trace.id'] = segment.transaction.traceId
@@ -852,10 +851,37 @@ Agent.prototype.getLinkingMetadata = function getLinkingMetadata() {
     logger.debug('getLinkingMetadata with no active transaction')
   }
 
+  if (!excludeServiceLinks) {
+    this.getServiceLinkingMetadata(linkingMetadata)
+  }
+
+  return linkingMetadata
+}
+
+/**
+ * This methods returns an object with the following keys/data:
+ * - `entity.name`: The application name specified in the connect request as
+ *   app_name. If multiple application names are specified this will only be
+ *   the first name
+ * - `entity.type`: The string "SERVICE"
+ * - `entity.guid`: The entity ID returned in the connect reply as entity_guid
+ * - `hostname`: The hostname as specified in the connect request as
+ *   utilization.full_hostname. If utilization.full_hostname is null or empty,
+ *   this will be the hostname specified in the connect request as host.
+ *
+ * @param {object} linkingMetadata object to add service linking keys
+ * @returns {object} with service linking metadata
+ */
+Agent.prototype.getServiceLinkingMetadata = function getServiceLinkingMetadata(
+  linkingMetadata = {}
+) {
+  const config = this.config
   if (config.entity_guid) {
     linkingMetadata['entity.guid'] = config.entity_guid
   }
-
+  linkingMetadata['entity.name'] = config.applications()[0]
+  linkingMetadata['entity.type'] = 'SERVICE'
+  linkingMetadata.hostname = config.getHostnameSafe()
   return linkingMetadata
 }
 

--- a/lib/aggregators/log-aggregator.js
+++ b/lib/aggregators/log-aggregator.js
@@ -56,7 +56,13 @@ class LogAggregator extends EventAggregator {
       return
     }
 
-    return [{ logs: formattedLogs }]
+    const commonAttrs = this.agent.getServiceLinkingMetadata()
+    return [
+      {
+        common: { attributes: commonAttrs },
+        logs: formattedLogs
+      }
+    ]
   }
 
   add(logLine) {

--- a/lib/instrumentation/nr-winston-transport.js
+++ b/lib/instrumentation/nr-winston-transport.js
@@ -35,7 +35,7 @@ class NrTransport extends TransportStream {
    * @param {Function} callback callback to invoke once we are done
    */
   log(logLine, callback) {
-    const metadata = this.agent.getLinkingMetadata()
+    const metadata = this.agent.getLinkingMetadata(true)
     const formattedLine = reformatLogLine(logLine, metadata)
     this.agent.logs.add(formattedLine)
     callback()

--- a/lib/instrumentation/pino/pino.js
+++ b/lib/instrumentation/pino/pino.js
@@ -45,7 +45,6 @@ module.exports = function instrument(shim, tools) {
  * @param {object} params.tools exported `pino/lib/tools`
  */
 function wrapAsJson({ shim, tools }) {
-  const symbols = shim.require('./lib/symbols')
   const { agent } = shim
   const { config, metrics } = agent
 
@@ -88,12 +87,10 @@ function wrapAsJson({ shim, tools }) {
       const logLine = asJson.apply(this, args)
 
       if (isLogForwardingEnabled(config, agent)) {
-        const chindings = this[symbols.chindingsSym]
         const formatLogLine = reformatLogLine({
           msg: useMergeObj === true ? args[0].msg : args[1],
           logLine,
           agent,
-          chindings,
           level,
           logger: shim.logger
         })
@@ -114,22 +111,12 @@ function wrapAsJson({ shim, tools }) {
  * @param {object} params.logLine log line
  * @param {string} params.msg message of log line
  * @param {object} params.agent instance of agent
- * @param {string} params.chindings serialized string of all common log line data
  * @param {string} params.level log level
  * @param {object} params.logger instance of agent logger
  * @returns {function} wrapped log formatter function
  */
-function reformatLogLine({ logLine, msg, agent, chindings = '', level, logger }) {
-  const metadata = agent.getLinkingMetadata()
-
-  /**
-   * pino adds this already for us at times
-   * since asJson manually constructs the json string,
-   * it will have hostname twice if we do not delete ours.
-   */
-  if (chindings.includes('hostname')) {
-    delete metadata.hostname
-  }
+function reformatLogLine({ logLine, msg, agent, level, logger }) {
+  const metadata = agent.getLinkingMetadata(true)
 
   const agentMeta = Object.assign({}, { timestamp: Date.now() }, metadata)
   // eslint-disable-next-line eqeqeq

--- a/test/lib/logging-helper.js
+++ b/test/lib/logging-helper.js
@@ -7,28 +7,17 @@
 
 const assert = require('node:assert')
 
-// NOTE: pino adds hostname to log lines which is why we don't check it here
-const CONTEXT_KEYS = [
-  'entity.name',
-  'entity.type',
-  'entity.guid',
-  'trace.id',
-  'span.id',
-  'hostname'
-]
+const CONTEXT_KEYS = ['trace.id', 'span.id']
 
 /**
- * To be registered as a tap assertion
+ * Validates context about a given log line
+ *
+ * @param {object} params to fn
+ * @param {object} params.log log line
+ * @param {string} params.message message in log line
+ * @param {number} params.level log level
  */
-function validateLogLine({ line: logLine, message, level, config }) {
-  assert.equal(
-    logLine['entity.name'],
-    config.applications()[0],
-    'should have entity name that matches app'
-  )
-  assert.equal(logLine['entity.guid'], 'test-guid', 'should have set entity guid')
-  assert.equal(logLine['entity.type'], 'SERVICE', 'should have entity type of SERVICE')
-  assert.equal(logLine.hostname, config.getHostnameSafe(), 'should have proper hostname')
+function validateLogLine({ line: logLine, message, level }) {
   assert.equal(/[0-9]{10}/.test(logLine.timestamp), true, 'should have proper unix timestamp')
   assert.equal(
     logLine.message.includes('NR-LINKING'),
@@ -44,7 +33,26 @@ function validateLogLine({ line: logLine, message, level, config }) {
   }
 }
 
+/**
+ * Validates the common attributes of a given log payload
+ *
+ * @param {object} params to fn
+ * @param {object} params.commonAttrs common attributes on a log batch
+ * @param {object} params.config agent config
+ */
+function validateCommonAttrs({ commonAttrs, config }) {
+  assert.equal(
+    commonAttrs['entity.name'],
+    config.applications()[0],
+    'should have entity name that matches app'
+  )
+  assert.equal(commonAttrs['entity.guid'], 'test-guid', 'should have set entity guid')
+  assert.equal(commonAttrs['entity.type'], 'SERVICE', 'should have entity type of SERVICE')
+  assert.equal(commonAttrs.hostname, config.getHostnameSafe(), 'should have proper hostname')
+}
+
 module.exports = {
   CONTEXT_KEYS,
-  validateLogLine
+  validateLogLine,
+  validateCommonAttrs
 }

--- a/test/versioned/bunyan/helpers.js
+++ b/test/versioned/bunyan/helpers.js
@@ -8,7 +8,7 @@
 const assert = require('node:assert')
 
 const helpers = module.exports
-const { CONTEXT_KEYS, validateLogLine } = require('../../lib/logging-helper')
+const { CONTEXT_KEYS, validateLogLine, validateCommonAttrs } = require('../../lib/logging-helper')
 
 /**
  * Provides a mocked-up writable stream that can be provided to Bunyan for easier testing
@@ -56,9 +56,7 @@ helpers.originalMsgAssertion = function originalMsgAssertion({
   hostname
 }) {
   CONTEXT_KEYS.forEach((key) => {
-    if (key !== 'hostname') {
-      assert.equal(logLine[key], undefined, `should not have ${key}`)
-    }
+    assert.equal(logLine[key], undefined, `should not have ${key}`)
   })
 
   assert.ok(logLine.time, 'should include timestamp')
@@ -103,4 +101,8 @@ helpers.logForwardingMsgAssertion = function logForwardingMsgAssertion(logLine, 
     assert.equal(typeof logLine['trace.id'], 'string', 'msg in trans should have trace id')
     assert.equal(typeof logLine['span.id'], 'string', 'msg in trans should have span id')
   }
+
+  const [payload] = agent.logs._toPayloadSync()
+  const commonAttrs = payload.common.attributes
+  validateCommonAttrs({ commonAttrs, config: agent.config })
 }

--- a/test/versioned/pino/helpers.js
+++ b/test/versioned/pino/helpers.js
@@ -25,9 +25,7 @@ helpers.originalMsgAssertion = function originalMsgAssertion({
   hostname
 }) {
   CONTEXT_KEYS.forEach((key) => {
-    if (key !== 'hostname') {
-      assert.equal(logLine[key], undefined, `should not have ${key}`)
-    }
+    assert.equal(logLine[key], undefined, `should not have ${key}`)
   })
 
   assert.ok(logLine.time, 'should include timestamp')

--- a/test/versioned/pino/pino.test.js
+++ b/test/versioned/pino/pino.test.js
@@ -16,7 +16,7 @@ const helper = require('../../lib/agent_helper')
 const { removeMatchedModules } = require('../../lib/cache-buster')
 const { LOGGING } = require('../../../lib/metrics/names')
 const { originalMsgAssertion } = require('./helpers')
-const { validateLogLine } = require('../../lib/logging-helper')
+const { validateLogLine, validateCommonAttrs } = require('../../lib/logging-helper')
 
 const { version: pinoVersion } = require('pino/package')
 
@@ -131,6 +131,9 @@ test('forwarding', async (t) => {
     })
     assert.equal(agent.logs.getEvents().length, 1, 'should have 1 log in aggregator')
     const formattedLine = agent.logs.getEvents()[0]()
+    const [payload] = agent.logs._toPayloadSync()
+    const commonAttrs = payload.common.attributes
+    validateCommonAttrs({ commonAttrs, config })
     validateLogLine({ line: formattedLine, message, level, config })
   })
 
@@ -150,6 +153,9 @@ test('forwarding', async (t) => {
     // See: https://github.com/pinojs/pino/pull/1779/files
     if (semver.gte(pinoVersion, '8.15.1')) {
       const formattedLine = agent.logs.getEvents()[0]()
+      const [payload] = agent.logs._toPayloadSync()
+      const commonAttrs = payload.common.attributes
+      validateCommonAttrs({ commonAttrs, config })
       validateLogLine({ line: formattedLine, message: testMsg, level, config })
     } else {
       assert.equal(
@@ -180,6 +186,9 @@ test('forwarding', async (t) => {
       level,
       config
     })
+    const [payload] = agent.logs._toPayloadSync()
+    const commonAttrs = payload.common.attributes
+    validateCommonAttrs({ commonAttrs, config })
     assert.equal(formattedLine['error.class'], 'Error', 'should have Error as error.class')
     assert.equal(formattedLine['error.message'], err.message, 'should have proper error.message')
     assert.equal(
@@ -216,6 +225,9 @@ test('forwarding', async (t) => {
 
       const formattedLine = agent.logs.getEvents()[0]()
       validateLogLine({ line: formattedLine, message, level, config })
+      const [payload] = agent.logs._toPayloadSync()
+      const commonAttrs = payload.common.attributes
+      validateCommonAttrs({ commonAttrs, config })
       assert.equal(formattedLine['trace.id'], meta['trace.id'])
       assert.equal(formattedLine['span.id'], meta['span.id'])
 
@@ -292,6 +304,9 @@ test('forwarding', async (t) => {
         )
         assert.equal(formattedLine['span.id'], meta['span.id'], 'should be expected span.id value')
       })
+      const [payload] = agent.logs._toPayloadSync()
+      const commonAttrs = payload.common.attributes
+      validateCommonAttrs({ commonAttrs, config })
 
       end()
     })

--- a/test/versioned/winston/helpers.js
+++ b/test/versioned/winston/helpers.js
@@ -8,7 +8,7 @@
 const assert = require('node:assert')
 const helpers = module.exports
 
-const { CONTEXT_KEYS, validateLogLine } = require('../../lib/logging-helper')
+const { CONTEXT_KEYS, validateLogLine, validateCommonAttrs } = require('../../lib/logging-helper')
 
 /**
  * Stream factory for a test.  Iterates over every message and calls an assertFn.
@@ -165,4 +165,8 @@ helpers.logForwardingMsgAssertion = function logForwardingMsgAssertion(logLine, 
     assert.equal(typeof logLine['trace.id'], 'string', 'msg in trans should have trace id')
     assert.equal(typeof logLine['span.id'], 'string', 'msg in trans should have span id')
   }
+
+  const [payload] = agent.logs._toPayloadSync()
+  const commonAttrs = payload.common.attributes
+  validateCommonAttrs({ commonAttrs, config: agent.config })
 }

--- a/test/versioned/winston/winston.test.js
+++ b/test/versioned/winston/winston.test.js
@@ -381,7 +381,7 @@ test('log forwarding enabled', async (t) => {
     const handleMessages = makeStreamTest((msgs) => {
       const events = agent.logs.getEvents()
       events.forEach((event) => {
-        logForwardingMsgAssertion(t, event, agent)
+        logForwardingMsgAssertion(event, agent)
         assert.equal(
           event.label,
           '123',


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

While helping @svetlanabrennan understand the work to add labels to logs it was discovered the spec suggests we put them in a common.attributes section of the logs array. It also suggested we add the `entity.guid`, `entity.name`, `entity.type` and `hostnmae` as these are static to a given application and reduces the redundancy in the logs payload.  This PR addresses that.


I'd still like to test this with our example applications but the code in here is closer to our specification now.

## Related Issues
Closes #2735
