### PR TITLE
Nr-326020 Found bug - solution - fixes shape of user prompt 

### DIFF
--- a/lib/llm-events/aws-bedrock/bedrock-command.js
+++ b/lib/llm-events/aws-bedrock/bedrock-command.js
@@ -85,7 +85,11 @@ class BedrockCommand {
       result = this.#body.prompt
     } else if (this.isClaude3() === true) {
       result = this.#body?.messages?.reduce((acc, curr) => {
-        acc += curr?.content ?? ''
+        if (Object.keys(curr?.content).length) {
+          acc += curr?.content.text ?? ''
+        } else {
+          acc += curr?.content ?? ''
+        }
         return acc
       }, '')
     }

--- a/lib/llm-events/aws-bedrock/bedrock-command.js
+++ b/lib/llm-events/aws-bedrock/bedrock-command.js
@@ -77,7 +77,7 @@ class BedrockCommand {
     } else if (this.isCohereEmbed() === true) {
       result = this.#body.texts.join(' ')
     } else if (
-      (this.isClaude() === true && this.isClaude3() === false) ||
+      this.isClaude() === true ||
       this.isAi21() === true ||
       this.isCohere() === true ||
       this.isLlama() === true

--- a/lib/llm-events/aws-bedrock/bedrock-command.js
+++ b/lib/llm-events/aws-bedrock/bedrock-command.js
@@ -77,7 +77,7 @@ class BedrockCommand {
     } else if (this.isCohereEmbed() === true) {
       result = this.#body.texts.join(' ')
     } else if (
-      this.isClaude() === true ||
+      (this.isClaude() === true && this.isClaude3() === false) ||
       this.isAi21() === true ||
       this.isCohere() === true ||
       this.isLlama() === true
@@ -85,10 +85,10 @@ class BedrockCommand {
       result = this.#body.prompt
     } else if (this.isClaude3() === true) {
       result = this.#body?.messages?.reduce((acc, curr) => {
-        if (Object.keys(curr?.content).length) {
+        if (typeof curr?.content === 'string') {
+          acc += curr?.content
+        } else if (Object.keys(curr?.content).length) {
           acc += curr?.content.text ?? ''
-        } else {
-          acc += curr?.content ?? ''
         }
         return acc
       }, '')

--- a/lib/llm-events/aws-bedrock/bedrock-command.js
+++ b/lib/llm-events/aws-bedrock/bedrock-command.js
@@ -87,8 +87,8 @@ class BedrockCommand {
       result = this.#body?.messages?.reduce((acc, curr) => {
         if (typeof curr?.content === 'string') {
           acc += curr?.content
-        } else if (Object.keys(curr?.content).length) {
-          acc += curr?.content.text ?? ''
+        } else if (curr?.content.length > 0) {
+          acc += curr?.content[0].text ?? ''
         }
         return acc
       }, '')

--- a/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
+++ b/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
@@ -27,7 +27,7 @@ const claude = {
 const claude35 = {
   modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
   body: {
-    messages: [{ role: 'user', content: { type: 'text', text: 'who are you' } }]
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'who are you' }] }]
   }
 }
 

--- a/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
+++ b/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
@@ -24,6 +24,13 @@ const claude = {
   }
 }
 
+const claude35 = {
+  modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+  body: {
+    messages: [{ role: 'user', content: { type: 'text', text: 'who are you' } }]
+  }
+}
+
 const claude3 = {
   modelId: 'anthropic.claude-3-haiku-20240307-v1:0',
   body: {
@@ -182,6 +189,30 @@ test('claude3 complete command works', async (t) => {
   assert.equal(cmd.temperature, payload.body.temperature)
 })
 
+test('claude35 minimal command works', async (t) => {
+  t.nr.updatePayload(structuredClone(claude35))
+  const cmd = new BedrockCommand(t.nr.input)
+  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.maxTokens, undefined)
+  assert.equal(cmd.modelId, claude35.modelId)
+  assert.equal(cmd.modelType, 'completion')
+  assert.equal(cmd.prompt, claude35.body.messages[0].content.text)
+  assert.equal(cmd.temperature, undefined)
+})
+
+test('claude35 complete command works', async (t) => {
+  const payload = structuredClone(claude35)
+  payload.body.max_tokens = 25
+  payload.body.temperature = 0.5
+  t.nr.updatePayload(payload)
+  const cmd = new BedrockCommand(t.nr.input)
+  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.maxTokens, 25)
+  assert.equal(cmd.modelId, payload.modelId)
+  assert.equal(cmd.modelType, 'completion')
+  assert.equal(cmd.prompt, payload.body.messages[0].content.text)
+  assert.equal(cmd.temperature, payload.body.temperature)
+})
 test('cohere minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(cohere))
   const cmd = new BedrockCommand(t.nr.input)

--- a/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
+++ b/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
@@ -189,6 +189,17 @@ test('claude3 complete command works', async (t) => {
   assert.equal(cmd.temperature, payload.body.temperature)
 })
 
+test('claude35 minimal command works with claude 3 api', async (t) => {
+  t.nr.updatePayload(structuredClone(claude3))
+  const cmd = new BedrockCommand(t.nr.input)
+  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.maxTokens, undefined)
+  assert.equal(cmd.modelId, claude3.modelId)
+  assert.equal(cmd.modelType, 'completion')
+  assert.equal(cmd.prompt, claude3.body.messages[0].content)
+  assert.equal(cmd.temperature, undefined)
+})
+
 test('claude35 minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(claude35))
   const cmd = new BedrockCommand(t.nr.input)

--- a/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
+++ b/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
@@ -224,6 +224,7 @@ test('claude35 complete command works', async (t) => {
   assert.equal(cmd.prompt, payload.body.messages[0].content.text)
   assert.equal(cmd.temperature, payload.body.temperature)
 })
+
 test('cohere minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(cohere))
   const cmd = new BedrockCommand(t.nr.input)


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

The shape of the users prompt message was incorrect for claude 3.5 
```
 // Prepare the payload for the model.
  const payload = {
    anthropic_version: "bedrock-2023-05-31",
    max_tokens: 1000,
    messages: [
      {
        role: "user",
        content: [{ type: "text", text: prompt }],
      },
    ],
  };
```
https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/javascript_bedrock-runtime_code_examples.html#anthropic_claude


## How to Test

run unit test suite.


## Related Issues

