### PR TITLE
fix: Corrected expected shape of user input in get Prompt()

### DIFF
--- a/lib/llm-events/aws-bedrock/bedrock-command.js
+++ b/lib/llm-events/aws-bedrock/bedrock-command.js
@@ -86,7 +86,7 @@ class BedrockCommand {
     } else if (this.isClaude3() === true) {
       result = this.#body?.messages
         ?.reduce((acc, curr) => {
-          if (curr?.role === 'user') {
+          if (curr?.role !== 'assistant') {
             if (typeof curr?.content === 'string') {
               acc.push(curr?.content)
             } else {

--- a/lib/llm-events/aws-bedrock/bedrock-command.js
+++ b/lib/llm-events/aws-bedrock/bedrock-command.js
@@ -84,18 +84,19 @@ class BedrockCommand {
     ) {
       result = this.#body.prompt
     } else if (this.isClaude3() === true) {
-      result = this.#body?.messages?.reduce((acc, curr) => {
-        if (curr?.role === 'user') {
-          if (typeof curr?.content === 'string') {
-            acc += curr?.content
-          } else {
-            acc += curr?.content.map((msgObj) => msgObj.text)
+      result = this.#body?.messages
+        ?.reduce((acc, curr) => {
+          if (curr?.role === 'user') {
+            if (typeof curr?.content === 'string') {
+              acc.push(curr?.content)
+            } else {
+              const mappedMsgObj = curr?.content.map((msgObj) => msgObj.text)
+              acc.push(mappedMsgObj)
+            }
           }
-        } else {
-          acc += ' '
-        }
-        return acc
-      }, '')
+          return acc
+        }, [])
+        .join(' ')
     }
     return result
   }

--- a/lib/llm-events/aws-bedrock/bedrock-command.js
+++ b/lib/llm-events/aws-bedrock/bedrock-command.js
@@ -87,8 +87,8 @@ class BedrockCommand {
       result = this.#body?.messages?.reduce((acc, curr) => {
         if (typeof curr?.content === 'string') {
           acc += curr?.content
-        } else if (Object.keys(curr?.content).length) {
-          acc += curr?.content.text ?? ''
+        } else if (Array.isArray(curr?.content) && Object.keys(curr?.content[0]).length) {
+          acc += curr?.content[0].text ?? ''
         }
         return acc
       }, '')

--- a/lib/llm-events/aws-bedrock/bedrock-command.js
+++ b/lib/llm-events/aws-bedrock/bedrock-command.js
@@ -85,10 +85,14 @@ class BedrockCommand {
       result = this.#body.prompt
     } else if (this.isClaude3() === true) {
       result = this.#body?.messages?.reduce((acc, curr) => {
-        if (typeof curr?.content === 'string') {
-          return curr?.content
-        } else if (Array.isArray(curr?.content) && Object.keys(curr?.content[0]).length) {
-          return curr?.content[curr?.content.length - 1].text ?? ''
+        if (curr?.role === 'user') {
+          if (typeof curr?.content === 'string') {
+            acc += curr?.content
+          } else {
+            acc += curr?.content.map((msgObj) => msgObj.text)
+          }
+        } else {
+          acc += ' '
         }
         return acc
       }, '')

--- a/lib/llm-events/aws-bedrock/bedrock-command.js
+++ b/lib/llm-events/aws-bedrock/bedrock-command.js
@@ -84,20 +84,19 @@ class BedrockCommand {
     ) {
       result = this.#body.prompt
     } else if (this.isClaude3() === true) {
-      result = this.#body?.messages
-        ?.reduce((acc, curr) => {
-          if (curr?.role !== 'assistant') {
-            return acc
-          }
-          if (typeof curr?.content === 'string') {
-            acc.push(curr?.content)
-          } else {
-            const mappedMsgObj = curr?.content.map((msgObj) => msgObj.text)
-            acc.push(mappedMsgObj)
-          }
-          return acc
-        }, [])
-        .join(' ')
+      const collected = []
+      for (const message of this.#body?.messages) {
+        if (message?.role === 'assistant') {
+          continue
+        }
+        if (typeof message?.content === 'string') {
+          collected.push(message?.content)
+          continue
+        }
+        const mappedMsgObj = message?.content.map((msgContent) => msgContent.text)
+        collected.push(mappedMsgObj)
+      }
+      result = collected.join(' ')
     }
     return result
   }

--- a/lib/llm-events/aws-bedrock/bedrock-command.js
+++ b/lib/llm-events/aws-bedrock/bedrock-command.js
@@ -87,12 +87,13 @@ class BedrockCommand {
       result = this.#body?.messages
         ?.reduce((acc, curr) => {
           if (curr?.role !== 'assistant') {
-            if (typeof curr?.content === 'string') {
-              acc.push(curr?.content)
-            } else {
-              const mappedMsgObj = curr?.content.map((msgObj) => msgObj.text)
-              acc.push(mappedMsgObj)
-            }
+            return acc
+          }
+          if (typeof curr?.content === 'string') {
+            acc.push(curr?.content)
+          } else {
+            const mappedMsgObj = curr?.content.map((msgObj) => msgObj.text)
+            acc.push(mappedMsgObj)
           }
           return acc
         }, [])

--- a/lib/llm-events/aws-bedrock/bedrock-command.js
+++ b/lib/llm-events/aws-bedrock/bedrock-command.js
@@ -86,9 +86,9 @@ class BedrockCommand {
     } else if (this.isClaude3() === true) {
       result = this.#body?.messages?.reduce((acc, curr) => {
         if (typeof curr?.content === 'string') {
-          acc += curr?.content
+          return curr?.content
         } else if (Array.isArray(curr?.content) && Object.keys(curr?.content[0]).length) {
-          acc += curr?.content[0].text ?? ''
+          return curr?.content[curr?.content.length - 1].text ?? ''
         }
         return acc
       }, '')

--- a/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
+++ b/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
@@ -27,7 +27,11 @@ const claude = {
 const claude35 = {
   modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
   body: {
-    messages: [{ role: 'user', content: [{ type: 'text', text: 'who are you' }] }]
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: 'who are' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'researching' }] },
+      { role: 'user', content: [{ type: 'text', text: 'you' }] }
+    ]
   }
 }
 
@@ -207,7 +211,7 @@ test('claude35 minimal command works', async (t) => {
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, claude35.modelId)
   assert.equal(cmd.modelType, 'completion')
-  assert.equal(cmd.prompt, claude35.body.messages[0].content[0].text)
+  assert.equal(cmd.prompt, 'who are you')
   assert.equal(cmd.temperature, undefined)
 })
 
@@ -221,7 +225,7 @@ test('claude35 complete command works', async (t) => {
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
   assert.equal(cmd.modelType, 'completion')
-  assert.equal(cmd.prompt, payload.body.messages[0].content[0].text)
+  assert.equal(cmd.prompt, 'who are you')
   assert.equal(cmd.temperature, payload.body.temperature)
 })
 

--- a/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
+++ b/test/unit/llm-events/aws-bedrock/bedrock-command.test.js
@@ -27,7 +27,7 @@ const claude = {
 const claude35 = {
   modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
   body: {
-    messages: [{ role: 'user', content: { type: 'text', text: 'who are you' } }]
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'who are you' }] }]
   }
 }
 
@@ -207,7 +207,7 @@ test('claude35 minimal command works', async (t) => {
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, claude35.modelId)
   assert.equal(cmd.modelType, 'completion')
-  assert.equal(cmd.prompt, claude35.body.messages[0].content.text)
+  assert.equal(cmd.prompt, claude35.body.messages[0].content[0].text)
   assert.equal(cmd.temperature, undefined)
 })
 
@@ -221,7 +221,7 @@ test('claude35 complete command works', async (t) => {
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
   assert.equal(cmd.modelType, 'completion')
-  assert.equal(cmd.prompt, payload.body.messages[0].content.text)
+  assert.equal(cmd.prompt, payload.body.messages[0].content[0].text)
   assert.equal(cmd.temperature, payload.body.temperature)
 })
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

The shape of the users prompt message was incorrect for claude 3.5 
```
 // Prepare the payload for the model.
  const payload = {
    anthropic_version: "bedrock-2023-05-31",
    max_tokens: 1000,
    messages: [
      {
        role: "user",
        content: [{ type: "text", text: prompt }],
      },
    ],
  };
```
https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/javascript_bedrock-runtime_code_examples.html#anthropic_claude


## How to Test

run unit test suite.


## Related Issues

