### PR TITLE
feat: Added segment synthesizer and provided ability to convert http client otel spans to external http trace segments

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -18,6 +18,7 @@ code, the source code can be found at [https://github.com/newrelic/node-newrelic
 * [@grpc/proto-loader](#grpcproto-loader)
 * [@newrelic/security-agent](#newrelicsecurity-agent)
 * [@opentelemetry/api](#opentelemetryapi)
+* [@opentelemetry/semantic-conventions](#opentelemetrysemantic-conventions)
 * [@tyriar/fibonacci-heap](#tyriarfibonacci-heap)
 * [concat-stream](#concat-stream)
 * [https-proxy-agent](#https-proxy-agent)
@@ -765,6 +766,215 @@ This product includes source derived from [@opentelemetry/api](https://github.co
 
 ```
 
+### @opentelemetry/semantic-conventions
+
+This product includes source derived from [@opentelemetry/semantic-conventions](https://github.com/open-telemetry/opentelemetry-js) ([v1.27.0](https://github.com/open-telemetry/opentelemetry-js/tree/v1.27.0)), distributed under the [Apache-2.0 License](https://github.com/open-telemetry/opentelemetry-js/blob/v1.27.0/LICENSE):
+
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+```
+
 ### @tyriar/fibonacci-heap
 
 This product includes source derived from [@tyriar/fibonacci-heap](https://github.com/gwtw/ts-fibonacci-heap) ([v2.0.9](https://github.com/gwtw/ts-fibonacci-heap/tree/v2.0.9)), distributed under the [MIT License](https://github.com/gwtw/ts-fibonacci-heap/blob/v2.0.9/LICENSE):
@@ -827,7 +1037,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ### https-proxy-agent
 
-This product includes source derived from [https-proxy-agent](https://github.com/TooTallNate/proxy-agents) ([v7.0.5](https://github.com/TooTallNate/proxy-agents/tree/v7.0.5)), distributed under the [MIT License](https://github.com/TooTallNate/proxy-agents/blob/v7.0.5/LICENSE):
+This product includes source derived from [https-proxy-agent](https://github.com/TooTallNate/proxy-agents) ([v7.0.4](https://github.com/TooTallNate/proxy-agents/tree/v7.0.4)), distributed under the [MIT License](https://github.com/TooTallNate/proxy-agents/blob/v7.0.4/LICENSE):
 
 ```
 (The MIT License)
@@ -1230,7 +1440,7 @@ SOFTWARE.
 
 ### semver
 
-This product includes source derived from [semver](https://github.com/npm/node-semver) ([v7.6.3](https://github.com/npm/node-semver/tree/v7.6.3)), distributed under the [ISC License](https://github.com/npm/node-semver/blob/v7.6.3/LICENSE):
+This product includes source derived from [semver](https://github.com/npm/node-semver) ([v7.6.2](https://github.com/npm/node-semver/tree/v7.6.2)), distributed under the [ISC License](https://github.com/npm/node-semver/blob/v7.6.2/LICENSE):
 
 ```
 The ISC License
@@ -1253,7 +1463,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ### winston-transport
 
-This product includes source derived from [winston-transport](https://github.com/winstonjs/winston-transport) ([v4.8.0](https://github.com/winstonjs/winston-transport/tree/v4.8.0)), distributed under the [MIT License](https://github.com/winstonjs/winston-transport/blob/v4.8.0/LICENSE):
+This product includes source derived from [winston-transport](https://github.com/winstonjs/winston-transport) ([v4.7.0](https://github.com/winstonjs/winston-transport/tree/v4.7.0)), distributed under the [MIT License](https://github.com/winstonjs/winston-transport/blob/v4.7.0/LICENSE):
 
 ```
 The MIT License (MIT)
@@ -1286,7 +1496,7 @@ SOFTWARE.
 
 ### @aws-sdk/client-s3
 
-This product includes source derived from [@aws-sdk/client-s3](https://github.com/aws/aws-sdk-js-v3) ([v3.676.0](https://github.com/aws/aws-sdk-js-v3/tree/v3.676.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.676.0/LICENSE):
+This product includes source derived from [@aws-sdk/client-s3](https://github.com/aws/aws-sdk-js-v3) ([v3.600.0](https://github.com/aws/aws-sdk-js-v3/tree/v3.600.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.600.0/LICENSE):
 
 ```
                                 Apache License
@@ -1495,7 +1705,7 @@ This product includes source derived from [@aws-sdk/client-s3](https://github.co
 
 ### @aws-sdk/s3-request-presigner
 
-This product includes source derived from [@aws-sdk/s3-request-presigner](https://github.com/aws/aws-sdk-js-v3) ([v3.676.0](https://github.com/aws/aws-sdk-js-v3/tree/v3.676.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.676.0/LICENSE):
+This product includes source derived from [@aws-sdk/s3-request-presigner](https://github.com/aws/aws-sdk-js-v3) ([v3.600.0](https://github.com/aws/aws-sdk-js-v3/tree/v3.600.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.600.0/LICENSE):
 
 ```
                                 Apache License
@@ -1704,7 +1914,7 @@ This product includes source derived from [@aws-sdk/s3-request-presigner](https:
 
 ### @koa/router
 
-This product includes source derived from [@koa/router](https://github.com/koajs/router) ([v12.0.2](https://github.com/koajs/router/tree/v12.0.2)), distributed under the [MIT License](https://github.com/koajs/router/blob/v12.0.2/LICENSE):
+This product includes source derived from [@koa/router](https://github.com/koajs/router) ([v12.0.1](https://github.com/koajs/router/tree/v12.0.1)), distributed under the [MIT License](https://github.com/koajs/router/blob/v12.0.1/LICENSE):
 
 ```
 The MIT License (MIT)
@@ -2627,7 +2837,7 @@ This product includes source derived from [@opentelemetry/sdk-trace-base](https:
 
 ### @slack/bolt
 
-This product includes source derived from [@slack/bolt](https://github.com/slackapi/bolt) ([v3.22.0](https://github.com/slackapi/bolt/tree/v3.22.0)), distributed under the [MIT License](https://github.com/slackapi/bolt/blob/v3.22.0/LICENSE):
+This product includes source derived from [@slack/bolt](https://github.com/slackapi/bolt) ([v3.19.0](https://github.com/slackapi/bolt/tree/v3.19.0)), distributed under the [MIT License](https://github.com/slackapi/bolt/blob/v3.19.0/LICENSE):
 
 ```
 The MIT License (MIT)
@@ -3104,7 +3314,7 @@ SOFTWARE.
 
 ### async
 
-This product includes source derived from [async](https://github.com/caolan/async) ([v3.2.6](https://github.com/caolan/async/tree/v3.2.6)), distributed under the [MIT License](https://github.com/caolan/async/blob/v3.2.6/LICENSE):
+This product includes source derived from [async](https://github.com/caolan/async) ([v3.2.5](https://github.com/caolan/async/tree/v3.2.5)), distributed under the [MIT License](https://github.com/caolan/async/blob/v3.2.5/LICENSE):
 
 ```
 Copyright (c) 2010-2018 Caolan McMahon
@@ -3131,7 +3341,7 @@ THE SOFTWARE.
 
 ### aws-sdk
 
-This product includes source derived from [aws-sdk](https://github.com/aws/aws-sdk-js) ([v2.1691.0](https://github.com/aws/aws-sdk-js/tree/v2.1691.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js/blob/v2.1691.0/LICENSE.txt):
+This product includes source derived from [aws-sdk](https://github.com/aws/aws-sdk-js) ([v2.1648.0](https://github.com/aws/aws-sdk-js/tree/v2.1648.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js/blob/v2.1648.0/LICENSE.txt):
 
 ```
 
@@ -3559,7 +3769,7 @@ THE SOFTWARE.
 
 ### eslint-plugin-jsdoc
 
-This product includes source derived from [eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc) ([v48.11.0](https://github.com/gajus/eslint-plugin-jsdoc/tree/v48.11.0)), distributed under the [BSD-3-Clause License](https://github.com/gajus/eslint-plugin-jsdoc/blob/v48.11.0/LICENSE):
+This product includes source derived from [eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc) ([v48.4.0](https://github.com/gajus/eslint-plugin-jsdoc/tree/v48.4.0)), distributed under the [BSD-3-Clause License](https://github.com/gajus/eslint-plugin-jsdoc/blob/v48.4.0/LICENSE):
 
 ```
 Copyright (c) 2018, Gajus Kuizinas (http://gajus.com/)
@@ -3764,7 +3974,7 @@ Library.
 
 ### eslint
 
-This product includes source derived from [eslint](https://github.com/eslint/eslint) ([v8.57.1](https://github.com/eslint/eslint/tree/v8.57.1)), distributed under the [MIT License](https://github.com/eslint/eslint/blob/v8.57.1/LICENSE):
+This product includes source derived from [eslint](https://github.com/eslint/eslint) ([v8.57.0](https://github.com/eslint/eslint/tree/v8.57.0)), distributed under the [MIT License](https://github.com/eslint/eslint/blob/v8.57.0/LICENSE):
 
 ```
 Copyright OpenJS Foundation and other contributors, <www.openjsf.org>
@@ -3791,7 +4001,7 @@ THE SOFTWARE.
 
 ### express
 
-This product includes source derived from [express](https://github.com/expressjs/express) ([v4.21.1](https://github.com/expressjs/express/tree/v4.21.1)), distributed under the [MIT License](https://github.com/expressjs/express/blob/v4.21.1/LICENSE):
+This product includes source derived from [express](https://github.com/expressjs/express) ([v4.19.2](https://github.com/expressjs/express/tree/v4.19.2)), distributed under the [MIT License](https://github.com/expressjs/express/blob/v4.19.2/LICENSE):
 
 ```
 (The MIT License)
@@ -3927,7 +4137,7 @@ SOFTWARE.
 
 ### jsdoc
 
-This product includes source derived from [jsdoc](https://github.com/jsdoc/jsdoc) ([v4.0.4](https://github.com/jsdoc/jsdoc/tree/v4.0.4)), distributed under the [Apache-2.0 License](https://github.com/jsdoc/jsdoc/blob/v4.0.4/LICENSE.md):
+This product includes source derived from [jsdoc](https://github.com/jsdoc/jsdoc) ([v4.0.3](https://github.com/jsdoc/jsdoc/tree/v4.0.3)), distributed under the [Apache-2.0 License](https://github.com/jsdoc/jsdoc/blob/v4.0.3/LICENSE.md):
 
 ```
 # License

--- a/lib/otel/rules.js
+++ b/lib/otel/rules.js
@@ -49,6 +49,7 @@ class Rule {
   #name
   #spanKinds
   #requiredAttributes
+  #type
   #mappings
 
   /**
@@ -63,6 +64,7 @@ class Rule {
     }
 
     this.#name = input.name
+    this.#type = input.type
     this.#spanKinds = input.matcher.required_span_kinds?.map((v) => v.toLowerCase()) ?? []
     this.#requiredAttributes = input.matcher.required_attribute_keys ?? []
     this.#mappings = input.target.attribute_mappings ?? []
@@ -70,6 +72,10 @@ class Rule {
 
   get name() {
     return this.#name
+  }
+
+  get type() {
+    return this.#type
   }
 
   get isServerRule() {

--- a/lib/otel/rules.json
+++ b/lib/otel/rules.json
@@ -229,6 +229,7 @@
   },
   {
     "name": "OtelDbClientRedis1_24",
+    "type": "db",
     "matcher": {
       "required_span_kinds": [
         "client"
@@ -267,6 +268,7 @@
   },
   {
     "name": "OtelDbClient1_24",
+    "type": "db",
     "matcher": {
       "required_span_kinds": [
         "client"
@@ -302,6 +304,7 @@
   },
   {
     "name": "OtelHttpClient1_23",
+    "type": "external",
     "matcher": {
       "required_metric_names": [
         "http.client.request.duration"
@@ -338,6 +341,7 @@
   },
   {
     "name": "OtelHttpClient1_20",
+    "type": "external",
     "matcher": {
       "required_metric_names": [
         "http.client.duration"
@@ -410,6 +414,7 @@
   },
   {
     "name": "FallbackClient",
+    "type": "external",
     "matcher": {
       "required_metric_names": [
         "rpc.client.duration",

--- a/lib/otel/segment-synthesis.js
+++ b/lib/otel/segment-synthesis.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const { RulesEngine } = require('./rules')
+const defaultLogger = require('../logger').child({ component: 'segment-synthesizer' })
+const NAMES = require('../metrics/names')
+const { SEMATTRS_HTTP_HOST } = require('@opentelemetry/semantic-conventions')
+
+class SegmentSynthesizer {
+  constructor(agent, { logger = defaultLogger } = {}) {
+    this.agent = agent
+    this.logger = logger
+    this.engine = new RulesEngine()
+  }
+
+  synthesize(otelSpan) {
+    const rule = this.engine.test(otelSpan)
+    if (!rule?.type) {
+      this.logger.debug(
+        'Cannot match a rule to span name: %s, kind %s',
+        otelSpan?.name,
+        otelSpan?.kind
+      )
+      return
+    }
+
+    if (rule?.type === 'external') {
+      return this.createExternalSegment(otelSpan)
+    }
+    this.logger.debug('Found type: %s, no synthesize rule currently built', rule.type)
+  }
+
+  // TODO: should we move these to somewhere else and use in the places
+  // where external segments are created in our agent
+  createExternalSegment(otelSpan) {
+    const context = this.agent.tracer.getContext()
+    const host = otelSpan.attributes[SEMATTRS_HTTP_HOST] || 'Unknown'
+    const name = NAMES.EXTERNAL.PREFIX + host
+    return this.agent.tracer.createSegment({
+      name,
+      parent: context.segment,
+      transaction: context.transaction
+    })
+  }
+}
+
+module.exports = SegmentSynthesizer

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "@grpc/proto-loader": "^0.7.5",
     "@newrelic/security-agent": "^2.0.0",
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/semantic-conventions": "^1.27.0",
     "@tyriar/fibonacci-heap": "^2.0.7",
     "concat-stream": "^2.0.0",
     "https-proxy-agent": "^7.0.1",

--- a/test/unit/lib/otel/segment-synthesizer.test.js
+++ b/test/unit/lib/otel/segment-synthesizer.test.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const test = require('node:test')
+const assert = require('node:assert')
+
+const helper = require('../../../lib/agent_helper')
+const { ROOT_CONTEXT, SpanKind, TraceFlags } = require('@opentelemetry/api')
+const { BasicTracerProvider, Span } = require('@opentelemetry/sdk-trace-base')
+const SegmentSynthesizer = require('../../../../lib/otel/segment-synthesis')
+const {
+  SEMATTRS_DB_SYSTEM,
+  SEMATTRS_HTTP_HOST,
+  SEMATTRS_HTTP_METHOD
+} = require('@opentelemetry/semantic-conventions')
+const createMockLogger = require('../../mocks/logger')
+
+test.beforeEach((ctx) => {
+  const loggerMock = createMockLogger()
+  const agent = helper.loadMockedAgent()
+  const synthesizer = new SegmentSynthesizer(agent, { logger: loggerMock })
+  const tracer = new BasicTracerProvider().getTracer('default')
+  const parentId = '5c1c63257de34c67'
+  ctx.nr = {
+    agent,
+    loggerMock,
+    parentId,
+    synthesizer,
+    tracer
+  }
+})
+
+test.afterEach((ctx) => {
+  helper.unloadAgent(ctx.nr.agent)
+})
+
+test('should create http external segment from otel http client span', (t, end) => {
+  const { agent, synthesizer, parentId, tracer } = t.nr
+  helper.runInTransaction(agent, (tx) => {
+    const spanContext = {
+      traceId: tx.trace.id,
+      spanId: tx.trace.root.id,
+      traceFlags: TraceFlags.SAMPLED
+    }
+    const span = new Span(tracer, ROOT_CONTEXT, 'test-span', spanContext, SpanKind.CLIENT, parentId)
+    span.setAttribute(SEMATTRS_HTTP_METHOD, 'GET')
+    span.setAttribute(SEMATTRS_HTTP_HOST, 'newrelic.com')
+    const segment = synthesizer.synthesize(span)
+    assert.equal(segment.name, 'External/newrelic.com')
+    assert.equal(segment.parentId, tx.trace.root.id)
+    tx.end()
+    end()
+  })
+})
+
+test('should log warning if a rule does have a synthesis for the given type', (t, end) => {
+  const { agent, synthesizer, loggerMock, parentId, tracer } = t.nr
+
+  helper.runInTransaction(agent, (tx) => {
+    const spanContext = {
+      traceId: tx.trace.id,
+      spanId: tx.trace.root.id,
+      traceFlags: TraceFlags.SAMPLED
+    }
+    const span = new Span(tracer, ROOT_CONTEXT, 'test-span', spanContext, SpanKind.CLIENT, parentId)
+    span.setAttribute(SEMATTRS_DB_SYSTEM, 'postgres')
+    const segment = synthesizer.synthesize(span)
+    assert.ok(!segment)
+    assert.deepEqual(loggerMock.debug.args[0], [
+      'Found type: %s, no synthesize rule currently built',
+      'db'
+    ])
+    tx.end()
+    end()
+  })
+})
+
+test('should log warning span does not match a rule', (t, end) => {
+  const { agent, synthesizer, loggerMock, parentId, tracer } = t.nr
+
+  helper.runInTransaction(agent, (tx) => {
+    const spanContext = {
+      traceId: tx.trace.id,
+      spanId: tx.trace.root.id,
+      traceFlags: TraceFlags.SAMPLED
+    }
+
+    const span = new Span(tracer, ROOT_CONTEXT, 'test-span', spanContext, 'bogus', parentId)
+    const segment = synthesizer.synthesize(span)
+    assert.ok(!segment)
+    assert.deepEqual(loggerMock.debug.args[0], [
+      'Cannot match a rule to span name: %s, kind %s',
+      'test-span',
+      'bogus'
+    ])
+    tx.end()
+    end()
+  })
+})

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Tue Oct 29 2024 09:36:52 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Fri Nov 15 2024 11:33:43 GMT-0500 (Eastern Standard Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -92,6 +92,18 @@
       "licenseTextSource": "file",
       "publisher": "OpenTelemetry Authors"
     },
+    "@opentelemetry/semantic-conventions@1.27.0": {
+      "name": "@opentelemetry/semantic-conventions",
+      "version": "1.27.0",
+      "range": "^1.27.0",
+      "licenses": "Apache-2.0",
+      "repoUrl": "https://github.com/open-telemetry/opentelemetry-js",
+      "versionedRepoUrl": "https://github.com/open-telemetry/opentelemetry-js/tree/v1.27.0",
+      "licenseFile": "node_modules/@opentelemetry/semantic-conventions/LICENSE",
+      "licenseUrl": "https://github.com/open-telemetry/opentelemetry-js/blob/v1.27.0/LICENSE",
+      "licenseTextSource": "file",
+      "publisher": "OpenTelemetry Authors"
+    },
     "@tyriar/fibonacci-heap@2.0.9": {
       "name": "@tyriar/fibonacci-heap",
       "version": "2.0.9",
@@ -118,15 +130,15 @@
       "publisher": "Max Ogden",
       "email": "max@maxogden.com"
     },
-    "https-proxy-agent@7.0.5": {
+    "https-proxy-agent@7.0.4": {
       "name": "https-proxy-agent",
-      "version": "7.0.5",
+      "version": "7.0.4",
       "range": "^7.0.1",
       "licenses": "MIT",
       "repoUrl": "https://github.com/TooTallNate/proxy-agents",
-      "versionedRepoUrl": "https://github.com/TooTallNate/proxy-agents/tree/v7.0.5",
+      "versionedRepoUrl": "https://github.com/TooTallNate/proxy-agents/tree/v7.0.4",
       "licenseFile": "node_modules/https-proxy-agent/LICENSE",
-      "licenseUrl": "https://github.com/TooTallNate/proxy-agents/blob/v7.0.5/LICENSE",
+      "licenseUrl": "https://github.com/TooTallNate/proxy-agents/blob/v7.0.4/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Nathan Rajlich",
       "email": "nathan@tootallnate.net",
@@ -211,68 +223,68 @@
       "email": "w@tson.dk",
       "url": "https://twitter.com/wa7son"
     },
-    "semver@7.6.3": {
+    "semver@7.6.2": {
       "name": "semver",
-      "version": "7.6.3",
+      "version": "7.6.2",
       "range": "^7.5.2",
       "licenses": "ISC",
       "repoUrl": "https://github.com/npm/node-semver",
-      "versionedRepoUrl": "https://github.com/npm/node-semver/tree/v7.6.3",
+      "versionedRepoUrl": "https://github.com/npm/node-semver/tree/v7.6.2",
       "licenseFile": "node_modules/semver/LICENSE",
-      "licenseUrl": "https://github.com/npm/node-semver/blob/v7.6.3/LICENSE",
+      "licenseUrl": "https://github.com/npm/node-semver/blob/v7.6.2/LICENSE",
       "licenseTextSource": "file",
       "publisher": "GitHub Inc."
     },
-    "winston-transport@4.8.0": {
+    "winston-transport@4.7.0": {
       "name": "winston-transport",
-      "version": "4.8.0",
+      "version": "4.7.0",
       "range": "^4.5.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/winstonjs/winston-transport",
-      "versionedRepoUrl": "https://github.com/winstonjs/winston-transport/tree/v4.8.0",
+      "versionedRepoUrl": "https://github.com/winstonjs/winston-transport/tree/v4.7.0",
       "licenseFile": "node_modules/winston-transport/LICENSE",
-      "licenseUrl": "https://github.com/winstonjs/winston-transport/blob/v4.8.0/LICENSE",
+      "licenseUrl": "https://github.com/winstonjs/winston-transport/blob/v4.7.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Charlie Robbins",
       "email": "charlie.robbins@gmail.com"
     }
   },
   "devDependencies": {
-    "@aws-sdk/client-s3@3.676.0": {
+    "@aws-sdk/client-s3@3.600.0": {
       "name": "@aws-sdk/client-s3",
-      "version": "3.676.0",
+      "version": "3.600.0",
       "range": "^3.556.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/aws/aws-sdk-js-v3",
-      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.676.0",
+      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.600.0",
       "licenseFile": "node_modules/@aws-sdk/client-s3/LICENSE",
-      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.676.0/LICENSE",
+      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.600.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "AWS SDK for JavaScript Team",
       "url": "https://aws.amazon.com/javascript/"
     },
-    "@aws-sdk/s3-request-presigner@3.676.0": {
+    "@aws-sdk/s3-request-presigner@3.600.0": {
       "name": "@aws-sdk/s3-request-presigner",
-      "version": "3.676.0",
+      "version": "3.600.0",
       "range": "^3.556.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/aws/aws-sdk-js-v3",
-      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.676.0",
+      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.600.0",
       "licenseFile": "node_modules/@aws-sdk/s3-request-presigner/LICENSE",
-      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.676.0/LICENSE",
+      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.600.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "AWS SDK for JavaScript Team",
       "url": "https://aws.amazon.com/javascript/"
     },
-    "@koa/router@12.0.2": {
+    "@koa/router@12.0.1": {
       "name": "@koa/router",
-      "version": "12.0.2",
+      "version": "12.0.1",
       "range": "^12.0.1",
       "licenses": "MIT",
       "repoUrl": "https://github.com/koajs/router",
-      "versionedRepoUrl": "https://github.com/koajs/router/tree/v12.0.2",
+      "versionedRepoUrl": "https://github.com/koajs/router/tree/v12.0.1",
       "licenseFile": "node_modules/@koa/router/LICENSE",
-      "licenseUrl": "https://github.com/koajs/router/blob/v12.0.2/LICENSE",
+      "licenseUrl": "https://github.com/koajs/router/blob/v12.0.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Alex Mingoia",
       "email": "talk@alexmingoia.com"
@@ -351,15 +363,15 @@
       "licenseTextSource": "file",
       "publisher": "OpenTelemetry Authors"
     },
-    "@slack/bolt@3.22.0": {
+    "@slack/bolt@3.19.0": {
       "name": "@slack/bolt",
-      "version": "3.22.0",
+      "version": "3.19.0",
       "range": "^3.7.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/slackapi/bolt",
-      "versionedRepoUrl": "https://github.com/slackapi/bolt/tree/v3.22.0",
+      "versionedRepoUrl": "https://github.com/slackapi/bolt/tree/v3.19.0",
       "licenseFile": "node_modules/@slack/bolt/LICENSE",
-      "licenseUrl": "https://github.com/slackapi/bolt/blob/v3.22.0/LICENSE",
+      "licenseUrl": "https://github.com/slackapi/bolt/blob/v3.19.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Slack Technologies, LLC"
     },
@@ -401,27 +413,27 @@
       "licenseTextSource": "file",
       "publisher": "Evgeny Poberezkin"
     },
-    "async@3.2.6": {
+    "async@3.2.5": {
       "name": "async",
-      "version": "3.2.6",
+      "version": "3.2.5",
       "range": "^3.2.4",
       "licenses": "MIT",
       "repoUrl": "https://github.com/caolan/async",
-      "versionedRepoUrl": "https://github.com/caolan/async/tree/v3.2.6",
+      "versionedRepoUrl": "https://github.com/caolan/async/tree/v3.2.5",
       "licenseFile": "node_modules/async/LICENSE",
-      "licenseUrl": "https://github.com/caolan/async/blob/v3.2.6/LICENSE",
+      "licenseUrl": "https://github.com/caolan/async/blob/v3.2.5/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Caolan McMahon"
     },
-    "aws-sdk@2.1691.0": {
+    "aws-sdk@2.1648.0": {
       "name": "aws-sdk",
-      "version": "2.1691.0",
+      "version": "2.1648.0",
       "range": "^2.1604.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/aws/aws-sdk-js",
-      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js/tree/v2.1691.0",
+      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js/tree/v2.1648.0",
       "licenseFile": "node_modules/aws-sdk/LICENSE.txt",
-      "licenseUrl": "https://github.com/aws/aws-sdk-js/blob/v2.1691.0/LICENSE.txt",
+      "licenseUrl": "https://github.com/aws/aws-sdk-js/blob/v2.1648.0/LICENSE.txt",
       "licenseTextSource": "file",
       "publisher": "Amazon Web Services",
       "url": "https://aws.amazon.com/"
@@ -530,15 +542,15 @@
       "publisher": "Michael Radionov",
       "url": "https://github.com/mradionov"
     },
-    "eslint-plugin-jsdoc@48.11.0": {
+    "eslint-plugin-jsdoc@48.4.0": {
       "name": "eslint-plugin-jsdoc",
-      "version": "48.11.0",
+      "version": "48.4.0",
       "range": "^48.0.5",
       "licenses": "BSD-3-Clause",
       "repoUrl": "https://github.com/gajus/eslint-plugin-jsdoc",
-      "versionedRepoUrl": "https://github.com/gajus/eslint-plugin-jsdoc/tree/v48.11.0",
+      "versionedRepoUrl": "https://github.com/gajus/eslint-plugin-jsdoc/tree/v48.4.0",
       "licenseFile": "node_modules/eslint-plugin-jsdoc/LICENSE",
-      "licenseUrl": "https://github.com/gajus/eslint-plugin-jsdoc/blob/v48.11.0/LICENSE",
+      "licenseUrl": "https://github.com/gajus/eslint-plugin-jsdoc/blob/v48.4.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Gajus Kuizinas",
       "email": "gajus@gajus.com",
@@ -555,28 +567,28 @@
       "licenseUrl": "https://github.com/SonarSource/eslint-plugin-sonarjs/blob/v0.18.0/LICENSE",
       "licenseTextSource": "file"
     },
-    "eslint@8.57.1": {
+    "eslint@8.57.0": {
       "name": "eslint",
-      "version": "8.57.1",
+      "version": "8.57.0",
       "range": "^8.24.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/eslint/eslint",
-      "versionedRepoUrl": "https://github.com/eslint/eslint/tree/v8.57.1",
+      "versionedRepoUrl": "https://github.com/eslint/eslint/tree/v8.57.0",
       "licenseFile": "node_modules/eslint/LICENSE",
-      "licenseUrl": "https://github.com/eslint/eslint/blob/v8.57.1/LICENSE",
+      "licenseUrl": "https://github.com/eslint/eslint/blob/v8.57.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Nicholas C. Zakas",
       "email": "nicholas+npm@nczconsulting.com"
     },
-    "express@4.21.1": {
+    "express@4.19.2": {
       "name": "express",
-      "version": "4.21.1",
+      "version": "4.19.2",
       "range": "*",
       "licenses": "MIT",
       "repoUrl": "https://github.com/expressjs/express",
-      "versionedRepoUrl": "https://github.com/expressjs/express/tree/v4.21.1",
+      "versionedRepoUrl": "https://github.com/expressjs/express/tree/v4.19.2",
       "licenseFile": "node_modules/express/LICENSE",
-      "licenseUrl": "https://github.com/expressjs/express/blob/v4.21.1/LICENSE",
+      "licenseUrl": "https://github.com/expressjs/express/blob/v4.19.2/LICENSE",
       "licenseTextSource": "file",
       "publisher": "TJ Holowaychuk",
       "email": "tj@vision-media.ca"
@@ -633,15 +645,15 @@
       "publisher": "Typicode",
       "email": "typicode@gmail.com"
     },
-    "jsdoc@4.0.4": {
+    "jsdoc@4.0.3": {
       "name": "jsdoc",
-      "version": "4.0.4",
+      "version": "4.0.3",
       "range": "^4.0.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/jsdoc/jsdoc",
-      "versionedRepoUrl": "https://github.com/jsdoc/jsdoc/tree/v4.0.4",
+      "versionedRepoUrl": "https://github.com/jsdoc/jsdoc/tree/v4.0.3",
       "licenseFile": "node_modules/jsdoc/LICENSE.md",
-      "licenseUrl": "https://github.com/jsdoc/jsdoc/blob/v4.0.4/LICENSE.md",
+      "licenseUrl": "https://github.com/jsdoc/jsdoc/blob/v4.0.3/LICENSE.md",
       "licenseTextSource": "file",
       "publisher": "Michael Mathews",
       "email": "micmath@gmail.com"


### PR DESCRIPTION
## Description

This PR adds new keys to the rules.json(for now) to identity which type of segment should be created.  I didn't enumerate all the types just yet.  The intention is this will be called on the `onEnterSpan` section of the otel tracer.  Maybe we bind the relevant timeslice metric recorder but for now that's for a different story(#2654)

## Related Issues
Closes #2648 