### PR TITLE
fix: Fixed matching for ALB and API Gateway (v1 & v2) events for Lambda

### DIFF
--- a/lib/serverless/api-gateway.js
+++ b/lib/serverless/api-gateway.js
@@ -22,7 +22,7 @@ class LambdaProxyWebRequest {
     }
     this.method = ''
 
-    if (isGatewayV1Event(event) === true) {
+    if (isGatewayV1Event(event) === true || isAlbEvent(event) === true) {
       this.url.path = event.path
       this.method = event.httpMethod
     } else if (isGatewayV2Event(event) === true) {
@@ -54,7 +54,10 @@ class LambdaProxyWebResponse {
  * @returns {Object<string, string>} The normalized query string map
  */
 function normalizeQueryStringParameters(event) {
-  if (!event.multiValueQueryStringParameters) {
+  if (
+    !event.multiValueQueryStringParameters ||
+    Object.keys(event.multiValueQueryStringParameters).length === 0
+  ) {
     return event.queryStringParameters
   }
   return Object.fromEntries(
@@ -107,7 +110,7 @@ function normalizeHeaders(event, lowerCaseKey = false) {
  *                    to create a web transaction.
  */
 function isLambdaProxyEvent(event) {
-  return isGatewayV1Event(event) || isGatewayV2Event(event)
+  return isGatewayV1Event(event) || isGatewayV2Event(event) || isAlbEvent(event)
 }
 
 // See https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
@@ -158,6 +161,25 @@ function isGatewayV2Event(event) {
   const keys = Object.keys(event).sort().join(',')
   return keys === httpApiV2Keys && event?.version === '2.0'
 }
+const albKeys = [
+  'requestContext',
+  'httpMethod',
+  'path',
+  'queryStringParameters',
+  'headers',
+  'body',
+  'isBase64Encoded',
+  'rawHeaders',
+  'multiValueQueryStringParameters',
+  'pathParameters'
+]
+  .sort()
+  .join(',')
+
+function isAlbEvent(event) {
+  const keys = Object.keys(event).sort().join(',')
+  return keys === albKeys && event?.requestContext?.elb !== undefined
+}
 
 /**
  * Determines if Lambda event appears to be a valid Lambda Proxy response.
@@ -176,5 +198,6 @@ module.exports = {
   isLambdaProxyEvent,
   isValidLambdaProxyResponse,
   isGatewayV1Event,
-  isGatewayV2Event
+  isGatewayV2Event,
+  isAlbEvent
 }

--- a/lib/serverless/api-gateway.js
+++ b/lib/serverless/api-gateway.js
@@ -114,14 +114,30 @@ function isLambdaProxyEvent(event) {
 }
 
 /**
- * Iterates over the minimum signature properties of an event triggered by API Gateway
- * to determine the version. V1 and V2 have a lot of overlap, but some signature differences.
+ * Iterates over the minimum signature properties of an event received by this Lambda function
+ * to determine if this request is triggered from a proxy (API Gateway V1, V2, ALB) or some other service.
+ * If API Gateway, we need to determine which version: V1 and V2 have a lot of overlap, but some signature
+ * differences for which we can test.
+ *
+ * The test is designed to look only at signature properties used by each version, and returns true with the first
+ * top-level match. Each test array has only four elements, and each invocation should incur
+ * only five comparisons: one match for its matching type, and four comparisons for the non-matching type.
+ *
+ * API Gateway v2 HTTP: top-level 'rawPath', 'rawQueryString', 'routeKey'. Possibly 'cookies'
+ * API Gateway v1 HTTP: top-level 'httpMethod', 'resource'. Possibly 'multiValueHeaders', 'multiValueQueryStringParameters'
+ * API Gateway v1 REST same as HTTP, but without top-level `version`
+ * ALB: very similar to API Gateway v1, but requestContext contains an elb property
+ *
+ * In tests, this set of required API Gateway v1 properties has consistently been delivered in event payloads.
+ * Similar tests with API Gateway V2 shows that the cookies property is *only* defined if cookies are present.
+ * If `cookies` is present as a top-level property, the event is surely triggered by API Gateway V2. Its absence,
+ * though, is *not* a certain indicator of v1. As such, it's the last property considered in our test.
  *
  * @param {object} targetEvent The event to inspect.
  * @param {Array} searchFor An array of keys unique to this proxy type
  * @returns {boolean} Whether this event has matches for the keys we're checking
  */
-function findProperties(targetEvent, searchFor) {
+function eventHasRequiredKeys(targetEvent, searchFor) {
   const keys = Object.keys(targetEvent)
   for (const el of searchFor) {
     if (keys.indexOf(el) > -1) {
@@ -131,19 +147,8 @@ function findProperties(targetEvent, searchFor) {
   return false
 }
 
-/**
- * We need to determine whether this invocation event was triggered from a proxy: API Gateway V1, V2, ALB, or some other service.
- * API Gateway V1/V2 and ALB events aren't guaranteed always to have the same properties in all cases. There are, however, properties
- * that are vary consistently depending on the service triggering the event.
- *
- * API Gateway v2 HTTP
- * API Gateway v1 HTTP: top-level httpMethod, resource, multiValueHeaders (possibly), multiValueQueryStringParameters (possibly)
- * API Gateway v1 REST same as HTTP, but without version
- * ALB: very similar to API Gateway v1, but requestContext contains an elb property
- */
-
 // See https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
-const uniqueHttpApiV1Keys = [
+const requiredHttpApiV1Keys = [
   'httpMethod',
   'path',
   'resource',
@@ -152,12 +157,11 @@ const uniqueHttpApiV1Keys = [
 ]
 
 // See https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
-
 function isGatewayV1Event(event) {
   if (event?.requestContext?.elb !== undefined) {
     return false
   }
-  const hasKeys = findProperties(event, uniqueHttpApiV1Keys)
+  const hasKeys = eventHasRequiredKeys(event, requiredHttpApiV1Keys)
   if (hasKeys && event?.version === '1.0') {
     return true
   }
@@ -166,13 +170,13 @@ function isGatewayV1Event(event) {
 }
 
 // See https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
-const uniqueHttpApiV2Keys = ['rawPath', 'rawQueryString', 'routeKey', 'cookies']
+const requiredHttpApiV2Keys = ['rawPath', 'rawQueryString', 'routeKey', 'cookies']
 
 function isGatewayV2Event(event) {
   if (event?.requestContext?.elb !== undefined) {
     return false
   }
-  return findProperties(event, uniqueHttpApiV2Keys) && event?.version === '2.0'
+  return eventHasRequiredKeys(event, requiredHttpApiV2Keys) && event?.version === '2.0'
 }
 
 /**
@@ -182,8 +186,9 @@ function isGatewayV2Event(event) {
  * and https://docs.aws.amazon.com/lambda/latest/dg/services-alb.html
  *
  * If we check for that property, we can accept variation in other properties.
+ * @param {object} event The event property supplied to the Lambda handler
+ * @returns {boolean} Whether or not the event was triggered by ALB
  */
-
 function isAlbEvent(event) {
   return event?.requestContext?.elb !== undefined
 }

--- a/lib/serverless/api-gateway.js
+++ b/lib/serverless/api-gateway.js
@@ -113,72 +113,79 @@ function isLambdaProxyEvent(event) {
   return isGatewayV1Event(event) || isGatewayV2Event(event) || isAlbEvent(event)
 }
 
+/**
+ * Iterates over the minimum signature properties of an event triggered by API Gateway
+ * to determine the version. V1 and V2 have a lot of overlap, but some signature differences.
+ *
+ * @param {object} targetEvent The event to inspect.
+ * @param {Array} searchFor An array of keys unique to this proxy type
+ * @returns {boolean} Whether this event has matches for the keys we're checking
+ */
+function findProperties(targetEvent, searchFor) {
+  const keys = Object.keys(targetEvent)
+  for (const el of searchFor) {
+    if (keys.indexOf(el) > -1) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * We need to determine whether this invocation event was triggered from a proxy: API Gateway V1, V2, ALB, or some other service.
+ * API Gateway V1/V2 and ALB events aren't guaranteed always to have the same properties in all cases. There are, however, properties
+ * that are vary consistently depending on the service triggering the event.
+ *
+ * API Gateway v2 HTTP
+ * API Gateway v1 HTTP: top-level httpMethod, resource, multiValueHeaders (possibly), multiValueQueryStringParameters (possibly)
+ * API Gateway v1 REST same as HTTP, but without version
+ * ALB: very similar to API Gateway v1, but requestContext contains an elb property
+ */
+
 // See https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
-const restApiV1Keys = [
-  'body',
-  'headers',
+const uniqueHttpApiV1Keys = [
   'httpMethod',
-  'isBase64Encoded',
-  'multiValueHeaders',
-  'multiValueQueryStringParameters',
   'path',
-  'pathParameters',
-  'queryStringParameters',
-  'requestContext',
   'resource',
-  'stageVariables'
-].join(',')
+  'multiValueHeaders',
+  'multiValueQueryStringParameters'
+]
 
 // See https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
-const httpApiV1Keys = [...restApiV1Keys.split(','), 'version'].join(',')
 
 function isGatewayV1Event(event) {
-  const keys = Object.keys(event).sort().join(',')
-  if (keys === httpApiV1Keys && event?.version === '1.0') {
+  if (event?.requestContext?.elb !== undefined) {
+    return false
+  }
+  const hasKeys = findProperties(event, uniqueHttpApiV1Keys)
+  if (hasKeys && event?.version === '1.0') {
     return true
   }
-
-  return keys === restApiV1Keys
+  // Rest API doesn't have version, but we can check on the key matching:
+  return hasKeys
 }
 
 // See https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
-const httpApiV2Keys = [
-  'body',
-  'cookies',
-  'headers',
-  'isBase64Encoded',
-  'pathParameters',
-  'queryStringParameters',
-  'rawPath',
-  'rawQueryString',
-  'requestContext',
-  'routeKey',
-  'stageVariables',
-  'version'
-].join(',')
+const uniqueHttpApiV2Keys = ['rawPath', 'rawQueryString', 'routeKey', 'cookies']
 
 function isGatewayV2Event(event) {
-  const keys = Object.keys(event).sort().join(',')
-  return keys === httpApiV2Keys && event?.version === '2.0'
+  if (event?.requestContext?.elb !== undefined) {
+    return false
+  }
+  return findProperties(event, uniqueHttpApiV2Keys) && event?.version === '2.0'
 }
-const albKeys = [
-  'requestContext',
-  'httpMethod',
-  'path',
-  'queryStringParameters',
-  'headers',
-  'body',
-  'isBase64Encoded',
-  'rawHeaders',
-  'multiValueQueryStringParameters',
-  'pathParameters'
-]
-  .sort()
-  .join(',')
+
+/**
+ * ALB can act as a proxy for Lambda. Properties have commonalities with API GateWay v1, though ALB-triggered events
+ * consistently carry an ARN at requestContext.elb. See
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#receive-event-from-load-balancer
+ * and https://docs.aws.amazon.com/lambda/latest/dg/services-alb.html
+ *
+ * If we check for that property, we can accept variation in other properties.
+ */
 
 function isAlbEvent(event) {
-  const keys = Object.keys(event).sort().join(',')
-  return keys === albKeys && event?.requestContext?.elb !== undefined
+  return event?.requestContext?.elb !== undefined
 }
 
 /**

--- a/test/unit/serverless/alb-event.test.js
+++ b/test/unit/serverless/alb-event.test.js
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert')
+const os = require('node:os')
+
+const { tspl } = require('@matteo.collina/tspl')
+const helper = require('../../lib/agent_helper')
+const AwsLambda = require('../../../lib/serverless/aws-lambda')
+
+const { DESTINATIONS: ATTR_DEST } = require('../../../lib/config/attribute-filter')
+const { albEvent: albEvent } = require('./fixtures')
+
+test.beforeEach((ctx) => {
+  // This env var suppresses console output we don't need to inspect.
+  process.env.NEWRELIC_PIPE_PATH = os.devNull
+
+  ctx.nr = {}
+  ctx.nr.agent = helper.loadMockedAgent({
+    allow_all_headers: true,
+    serverless_mode: {
+      enabled: true
+    }
+  })
+
+  ctx.nr.lambda = new AwsLambda(ctx.nr.agent)
+  ctx.nr.lambda._resetModuleState()
+
+  ctx.nr.event = structuredClone(albEvent)
+  ctx.nr.functionContext = {
+    done() {},
+    succeed() {},
+    fail() {},
+    functionName: 'testFunction',
+    functionVersion: 'testVersion',
+    invokedFunctionArn: 'arn:test:function',
+    memoryLimitInMB: '128',
+    awsRequestId: 'testId'
+  }
+  ctx.nr.responseBody = {
+    isBase64Encoded: false,
+    statusCode: 200,
+    headers: { responseHeader: 'headerValue' },
+    body: 'worked'
+  }
+
+  ctx.nr.agent.setState('started')
+})
+
+test.afterEach((ctx) => {
+  helper.unloadAgent(ctx.nr.agent)
+})
+
+test('should pick up the arn', async (t) => {
+  const { agent, lambda, event, functionContext } = t.nr
+  assert.equal(agent.collector.metadata.arn, null)
+  lambda.patchLambdaHandler(() => {})(event, functionContext, () => {})
+  assert.equal(agent.collector.metadata.arn, functionContext.invokedFunctionArn)
+})
+
+test('should create a web transaction', async (t) => {
+  const plan = tspl(t, { plan: 8 })
+  const { agent, lambda, event, functionContext, responseBody } = t.nr
+  agent.on('transactionFinished', verifyAttributes)
+
+  const wrappedHandler = lambda.patchLambdaHandler((event, context, callback) => {
+    const tx = agent.tracer.getTransaction()
+    plan.ok(tx)
+    plan.equal(tx.type, 'web')
+    plan.equal(tx.getFullName(), 'WebTransaction/Function/testFunction')
+    plan.equal(tx.isActive(), true)
+
+    callback(null, responseBody)
+  })
+
+  wrappedHandler(event, functionContext, () => {})
+
+  function verifyAttributes(tx) {
+    const agentAttributes = tx.trace.attributes.get(ATTR_DEST.TRANS_EVENT)
+    const segment = tx.baseSegment
+    const spanAttributes = segment.attributes.get(ATTR_DEST.SPAN_EVENT)
+
+    plan.equal(agentAttributes['request.method'], 'POST')
+    plan.equal(agentAttributes['request.uri'], '/elbCategory/elbEndpoint')
+    plan.equal(spanAttributes['request.method'], 'POST')
+    plan.equal(spanAttributes['request.uri'], '/elbCategory/elbEndpoint')
+  }
+  await plan.completed
+})
+
+test('should set w3c tracecontext on transaction if present on request header', async (t) => {
+  const plan = tspl(t, { plan: 2 })
+
+  const expectedTraceId = '4bf92f3577b34da6a3ce929d0e0e4736'
+  const traceparent = `00-${expectedTraceId}-00f067aa0ba902b7-00`
+  const { agent, lambda, event, functionContext, responseBody } = t.nr
+  agent.config.distributed_tracing.enabled = true
+  event.headers.traceparent = traceparent
+
+  const wrappedHandler = lambda.patchLambdaHandler((event, context, callback) => {
+    const tx = agent.tracer.getTransaction()
+
+    const headers = {}
+    tx.insertDistributedTraceHeaders(headers)
+
+    const traceParentFields = headers.traceparent.split('-')
+    const [version, traceId] = traceParentFields
+
+    plan.equal(version, '00')
+    plan.equal(traceId, expectedTraceId)
+
+    callback(null, responseBody)
+  })
+
+  wrappedHandler(event, functionContext, () => {})
+  await plan.completed
+})
+
+test('should add w3c tracecontext to transaction if not present on request header', async (t) => {
+  const plan = tspl(t, { plan: 2 })
+
+  const { agent, lambda, event, functionContext, responseBody } = t.nr
+
+  agent.config.account_id = 'AccountId1'
+  agent.config.primary_application_id = 'AppId1'
+  agent.config.trusted_account_key = 33
+  agent.config.distributed_tracing.enabled = true
+
+  const wrappedHandler = lambda.patchLambdaHandler((event, context, callback) => {
+    const tx = agent.tracer.getTransaction()
+
+    const headers = {}
+    tx.insertDistributedTraceHeaders(headers)
+
+    plan.match(headers.traceparent, /00-[a-f0-9]{32}-[a-f0-9]{16}-\d{2}/)
+    plan.match(headers.tracestate, /33@nr=.+AccountId1-AppId1.+/)
+
+    callback(null, responseBody)
+  })
+
+  wrappedHandler(event, functionContext, () => {})
+  await plan.completed
+})
+
+test('should capture request parameters', async (t) => {
+  const plan = tspl(t, { plan: 5 })
+
+  const { agent, lambda, event, functionContext, responseBody } = t.nr
+  agent.on('transactionFinished', verifyAttributes)
+
+  agent.config.attributes.enabled = true
+  agent.config.attributes.include = ['request.parameters.*']
+  agent.config.span_events.attributes.include = ['request.parameters.*']
+  agent.config.emit('attributes.include')
+  agent.config.emit('span_events.attributes.include')
+
+  const wrappedHandler = lambda.patchLambdaHandler((event, context, callback) => {
+    callback(null, responseBody)
+  })
+
+  wrappedHandler(event, functionContext, () => {})
+
+  function verifyAttributes(tx) {
+    const agentAttributes = tx.trace.attributes.get(ATTR_DEST.TRANS_EVENT)
+    plan.equal(agentAttributes['request.parameters.name'], 'me')
+    plan.equal(agentAttributes['request.parameters.team'], 'node agent')
+
+    const spanAttributes = tx.baseSegment.attributes.get(ATTR_DEST.SPAN_EVENT)
+    plan.equal(spanAttributes['request.parameters.name'], 'me')
+    plan.equal(spanAttributes['request.parameters.team'], 'node agent')
+
+    plan.equal(agentAttributes['request.parameters.parameter1'], 'value1,value2')
+  }
+  await plan.completed
+})
+
+test('should capture request headers', async (t) => {
+  const plan = tspl(t, { plan: 8 })
+
+  const { agent, lambda, event, functionContext, responseBody } = t.nr
+  agent.on('transactionFinished', verifyAttributes)
+
+  const wrappedHandler = lambda.patchLambdaHandler((event, context, callback) => {
+    callback(null, responseBody)
+  })
+  wrappedHandler(event, functionContext, () => {})
+
+  function verifyAttributes(tx) {
+    const attrs = tx.trace.attributes.get(ATTR_DEST.TRANS_EVENT)
+    plan.equal(attrs['http.statusCode'], 200)
+    plan.equal(attrs['request.headers.accept'], 'application/json;v=4')
+    plan.equal(attrs['request.headers.contentLength'], '35')
+    plan.equal(attrs['request.headers.contentType'], 'application/json')
+    plan.equal(attrs['request.headers.host'], 'examplehost.example.com')
+    plan.equal(attrs['request.method'], 'POST')
+    plan.equal(attrs['request.uri'], '/elbCategory/elbEndpoint')
+    plan.equal(attrs['request.headers.header2'], 'value1,value2')
+  }
+  await plan.completed
+})
+
+test('should not crash when headers are non-existent', (t) => {
+  const { lambda, event, functionContext, responseBody } = t.nr
+  delete event.headers
+
+  const wrappedHandler = lambda.patchLambdaHandler((event, context, callback) => {
+    callback(null, responseBody)
+  })
+
+  assert.doesNotThrow(() => {
+    wrappedHandler(event, functionContext, () => {})
+  })
+})

--- a/test/unit/serverless/fixtures.js
+++ b/test/unit/serverless/fixtures.js
@@ -215,6 +215,56 @@ const httpApiGatewayV2Event = {
   }
 }
 
+const secondApiGatewayV2Event = {
+  version: '2.0',
+  routeKey: 'ANY /',
+  rawPath: '/dev/',
+  rawQueryString: '',
+  headers: {
+    'accept':
+      'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+    'accept-encoding': 'gzip, deflate, br, zstd',
+    'accept-language': 'en-US,en;q=0.9',
+    'content-length': '0',
+    'host': 'zzz1234567890.execute-api.us-east-2.amazonaws.com',
+    'priority': 'u=0, i',
+    'sec-ch-ua': '"Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"',
+    'sec-ch-ua-mobile': '?0',
+    'sec-ch-ua-platform': '"macOS"',
+    'sec-fetch-dest': 'document',
+    'sec-fetch-mode': 'navigate',
+    'sec-fetch-site': 'cross-site',
+    'sec-fetch-user': '?1',
+    'upgrade-insecure-requests': '1',
+    'user-agent':
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+    'x-amzn-trace-id': 'Root=1-abcdef01-01234567890abcdef0123456',
+    'x-forwarded-for': '11.11.11.148',
+    'x-forwarded-port': '443',
+    'x-forwarded-proto': 'https'
+  },
+  requestContext: {
+    accountId: '466768951184',
+    apiId: 'zzz1234567890',
+    domainName: 'zzz1234567890.execute-api.us-east-2.amazonaws.com',
+    domainPrefix: 'zzz1234567890',
+    http: {
+      method: 'GET',
+      path: '/dev/',
+      protocol: 'HTTP/1.1',
+      sourceIp: '11.11.11.148',
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+    },
+    requestId: 'ABCDEF0123456=',
+    routeKey: 'ANY /',
+    stage: 'dev',
+    time: '26/Nov/2024:19:14:00 +0000',
+    timeEpoch: 1732648440329
+  },
+  isBase64Encoded: false
+}
+
 const albEvent = {
   requestContext: {
     elb: {
@@ -292,6 +342,7 @@ module.exports = {
   restApiGatewayV1Event,
   httpApiGatewayV1Event,
   httpApiGatewayV2Event,
+  secondApiGatewayV2Event,
   albEvent,
   lambaV1InvocationEvent
 }

--- a/test/unit/serverless/fixtures.js
+++ b/test/unit/serverless/fixtures.js
@@ -215,6 +215,50 @@ const httpApiGatewayV2Event = {
   }
 }
 
+const albEvent = {
+  requestContext: {
+    elb: {
+      targetGroupArn:
+        'arn:aws:elasticloadbalancing:us-west-2:1234567890:path/directory/otherDirectory'
+    }
+  },
+  httpMethod: 'POST',
+  path: '/elbCategory/elbEndpoint',
+  queryStringParameters: {
+    parameter1: 'value1,value2',
+    parameter2: 'value',
+    name: 'me',
+    team: 'node agent'
+  },
+  headers: {
+    'accept': 'application/json;v=4',
+    'content-length': '35',
+    'content-type': 'application/json',
+    'header2': 'value1,value2',
+    'host': 'examplehost.example.com',
+    'x-amzn-trace-id': 'Root=1-1234567890',
+    'x-forwarded-for': '10.10.10.10',
+    'x-forwarded-port': '443',
+    'x-forwarded-proto': 'https',
+    'x-message-id': 'albtest'
+  },
+  body: '{"exampleProperty": "exampleValue"}',
+  isBase64Encoded: false,
+  rawHeaders: {
+    'accept': 'application/json;v=4',
+    'content-length': '35',
+    'content-type': 'application/json',
+    'host': 'examplehost.example.com',
+    'x-amzn-trace-id': 'Root=1-1234567890',
+    'x-forwarded-for': '10.10.10.10',
+    'x-forwarded-port': '443',
+    'x-forwarded-proto': 'https',
+    'x-message-id': 'albtest'
+  },
+  multiValueQueryStringParameters: {},
+  pathParameters: {}
+}
+
 // Event used when one Lambda directly invokes another Lambda.
 // https://docs.aws.amazon.com/lambda/latest/dg/invocation-async-retain-records.html#invocation-async-destinations
 const lambaV1InvocationEvent = {
@@ -248,5 +292,6 @@ module.exports = {
   restApiGatewayV1Event,
   httpApiGatewayV1Event,
   httpApiGatewayV2Event,
+  albEvent,
   lambaV1InvocationEvent
 }

--- a/test/unit/serverless/fixtures.js
+++ b/test/unit/serverless/fixtures.js
@@ -215,7 +215,7 @@ const httpApiGatewayV2Event = {
   }
 }
 
-const secondApiGatewayV2Event = {
+const httpApiGatewayV2EventAlt = {
   version: '2.0',
   routeKey: 'ANY /',
   rawPath: '/dev/',
@@ -342,7 +342,7 @@ module.exports = {
   restApiGatewayV1Event,
   httpApiGatewayV1Event,
   httpApiGatewayV2Event,
-  secondApiGatewayV2Event,
+  httpApiGatewayV2EventAlt,
   albEvent,
   lambaV1InvocationEvent
 }

--- a/test/unit/serverless/utils.test.js
+++ b/test/unit/serverless/utils.test.js
@@ -18,7 +18,7 @@ const {
   restApiGatewayV1Event,
   httpApiGatewayV1Event,
   httpApiGatewayV2Event,
-  secondApiGatewayV2Event,
+  httpApiGatewayV2EventAlt,
   lambaV1InvocationEvent,
   albEvent
 } = require('./fixtures')
@@ -27,7 +27,7 @@ test('isGatewayV1Event', () => {
   assert.equal(isGatewayV1Event(restApiGatewayV1Event), true)
   assert.equal(isGatewayV1Event(httpApiGatewayV1Event), true)
   assert.equal(isGatewayV1Event(httpApiGatewayV2Event), false)
-  assert.equal(isGatewayV1Event(secondApiGatewayV2Event), false)
+  assert.equal(isGatewayV1Event(httpApiGatewayV2EventAlt), false)
   assert.equal(isGatewayV1Event(lambaV1InvocationEvent), false)
   assert.equal(isGatewayV1Event(albEvent), false)
 })
@@ -36,7 +36,7 @@ test('isGatewayV2Event', () => {
   assert.equal(isGatewayV2Event(restApiGatewayV1Event), false)
   assert.equal(isGatewayV2Event(httpApiGatewayV1Event), false)
   assert.equal(isGatewayV2Event(httpApiGatewayV2Event), true)
-  assert.equal(isGatewayV2Event(secondApiGatewayV2Event), true)
+  assert.equal(isGatewayV2Event(httpApiGatewayV2EventAlt), true)
   assert.equal(isGatewayV2Event(lambaV1InvocationEvent), false)
   assert.equal(isGatewayV2Event(albEvent), false)
 })
@@ -45,7 +45,7 @@ test('isAlbEvent', () => {
   assert.equal(isAlbEvent(restApiGatewayV1Event), false)
   assert.equal(isAlbEvent(httpApiGatewayV1Event), false)
   assert.equal(isAlbEvent(httpApiGatewayV2Event), false)
-  assert.equal(isAlbEvent(secondApiGatewayV2Event), false)
+  assert.equal(isAlbEvent(httpApiGatewayV2EventAlt), false)
   assert.equal(isAlbEvent(lambaV1InvocationEvent), false)
   assert.equal(isAlbEvent(albEvent), true)
 })

--- a/test/unit/serverless/utils.test.js
+++ b/test/unit/serverless/utils.test.js
@@ -8,24 +8,44 @@
 const test = require('node:test')
 const assert = require('node:assert')
 
-const { isGatewayV1Event, isGatewayV2Event } = require('../../../lib/serverless/api-gateway')
+const {
+  isGatewayV1Event,
+  isGatewayV2Event,
+  isAlbEvent
+} = require('../../../lib/serverless/api-gateway')
+
 const {
   restApiGatewayV1Event,
   httpApiGatewayV1Event,
   httpApiGatewayV2Event,
-  lambaV1InvocationEvent
+  secondApiGatewayV2Event,
+  lambaV1InvocationEvent,
+  albEvent
 } = require('./fixtures')
 
 test('isGatewayV1Event', () => {
   assert.equal(isGatewayV1Event(restApiGatewayV1Event), true)
   assert.equal(isGatewayV1Event(httpApiGatewayV1Event), true)
   assert.equal(isGatewayV1Event(httpApiGatewayV2Event), false)
+  assert.equal(isGatewayV1Event(secondApiGatewayV2Event), false)
   assert.equal(isGatewayV1Event(lambaV1InvocationEvent), false)
+  assert.equal(isGatewayV1Event(albEvent), false)
 })
 
 test('isGatewayV2Event', () => {
   assert.equal(isGatewayV2Event(restApiGatewayV1Event), false)
   assert.equal(isGatewayV2Event(httpApiGatewayV1Event), false)
   assert.equal(isGatewayV2Event(httpApiGatewayV2Event), true)
+  assert.equal(isGatewayV2Event(secondApiGatewayV2Event), true)
   assert.equal(isGatewayV2Event(lambaV1InvocationEvent), false)
+  assert.equal(isGatewayV2Event(albEvent), false)
+})
+
+test('isAlbEvent', () => {
+  assert.equal(isAlbEvent(restApiGatewayV1Event), false)
+  assert.equal(isAlbEvent(httpApiGatewayV1Event), false)
+  assert.equal(isAlbEvent(httpApiGatewayV2Event), false)
+  assert.equal(isAlbEvent(secondApiGatewayV2Event), false)
+  assert.equal(isAlbEvent(lambaV1InvocationEvent), false)
+  assert.equal(isAlbEvent(albEvent), true)
 })


### PR DESCRIPTION
## Description
Filtering of API Gateway v1 vs v2 did not allow for Lambda functions triggered by ALB/ELB. Prior to our most recent change to that filtering, ALB events were traced without explicit filtering. This adds explicit checking for an ALB event type, and allows ALB-triggered web requests to be treated as web transactions. 

## How to Test
This adds a unit test at `test/unit/serverless/alb-event.test.js` checking for the expected request properties. Existing tests at `test/unit/serverless/api-gateway-v2.test.js`, `test/unit/serverless/aws-lambda.test.js`, and `test/unit/serverless/utils.test.js` also test the new comparison method.

## Related Issues

Closes NR-341636
Closes #2779 
Closes NR-342521
Closes #2753 
Closes NR-341279