### PR TITLE
test: Removed `t.diagnostic` as they are better suited as code comments

### DIFF
--- a/test/unit/collector/facts.test.js
+++ b/test/unit/collector/facts.test.js
@@ -731,7 +731,7 @@ test('display_host facts', async (t) => {
     const { agent, facts } = t.nr
     if (!agent.config.getIPAddresses().ipv6) {
       t.diagnostic('this machine does not have an ipv6 address, skipping')
-      return end()
+      end()
     }
 
     agent.config.process_host.ipv_preference = '6'
@@ -754,7 +754,7 @@ test('display_host facts', async (t) => {
     const { agent, facts } = t.nr
     if (!agent.config.getIPAddresses().ipv6) {
       t.diagnostic('this machine does not have an ipv6 address, skipping')
-      return end()
+      end()
     }
 
     const mockedNI = {

--- a/test/unit/spans/batch-span-streamer.test.js
+++ b/test/unit/spans/batch-span-streamer.test.js
@@ -198,7 +198,7 @@ test('BatchSpanStreamer', async (t) => {
 
   await t.test('should send in appropriate batch sizes', (t) => {
     const { fakeConnection, spanStreamer } = t.nr
-    t.diagnostic('this will simulate n full batches and the last batch being 1/3 full')
+    // this will simulate n full batches and the last batch being 1/3 full
     const SPANS = 10000
     const BATCH = 750
     const metrics = spanStreamer._metrics

--- a/test/unit/util/code-level-metrics.test.js
+++ b/test/unit/util/code-level-metrics.test.js
@@ -104,9 +104,7 @@ test('CLM Meta', async (t) => {
   await t.test('should not add CLM attrs when filePath is null', (t) => {
     const { segmentStub } = t.nr
     function fn() {}
-    t.diagnostic(
-      'This is testing Express router.route which binds a function thus breaking any function metadata'
-    )
+    // This is testing Express router.route which binds a function thus breaking any function metadata
     const boundFn = fn.bind(null)
     boundFn[symbols.clm] = true
     addCLMAttributes(boundFn, segmentStub)

--- a/test/versioned/grpc/server-client-streaming.test.js
+++ b/test/versioned/grpc/server-client-streaming.test.js
@@ -86,11 +86,9 @@ test('should add DT headers when `distributed_tracing` is enabled', async (t) =>
     tx.end()
   })
 
-  payload.forEach(({ name }) => {
-    // TODO: gotta instrument and test event listeners on client streaming
-    // t.test(`adding '${name}' should create a server trace segment`)
-    t.diagnostic(`adding '${name}' should create a server trace segment`)
-  })
+  // TODO: gotta instrument and test event listeners on client streaming
+  // payload.forEach(({ name }) => {})
+
   assertDistributedTracing({ clientTransaction, serverTransaction })
 })
 

--- a/test/versioned/mongodb-esm/db.test.mjs
+++ b/test/versioned/mongodb-esm/db.test.mjs
@@ -51,7 +51,7 @@ test('addUser, authenticate, removeUser', async (t) => {
       if (typeof db.authenticate === 'function') {
         db.authenticate(username, password, authed)
       } else {
-        t.diagnostic('skipping authentication test, not supported on db')
+        // skipping authentication test, not supported on db
         db.removeUser(username, removedNoAuth)
       }
     }
@@ -476,7 +476,7 @@ function verifyMongoSegments({ t, tx, expectedSegments }) {
     // datastore instance attributes.
     if (/^Datastore\/.*?\/MongoDB/.test(current.name) === true) {
       if (isBadSegment(current) === true) {
-        t.diagnostic(`skipping attributes check for ${current.name}`)
+        // skipping attributes check for ${current.name}
         continue
       }
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
I noticed this while looking at the output in CI.  These diagnostic comments aren't very helpful and just moving to code comments
