### PR TITLE
chore: Restricted mysql2 version to get CI working

### DIFF
--- a/test/versioned/mysql2/package.json
+++ b/test/versioned/mysql2/package.json
@@ -9,7 +9,7 @@
         "node": ">=18"
       },
       "dependencies": {
-        "mysql2": ">=2.0.0",
+        "mysql2": ">=2.0.0 <=3.11.4",
         "generic-pool": ">=2.4 <2.5 || latest"
       },
       "files": [


### PR DESCRIPTION
A temporary patch to get our CI working while we investigate why `mysql2@3.11.5` is causing our `mysql2` promise instrumentation to fail.