### PR TITLE
fix: Updated `mysql2` instrumentation to work with 3.11.5+

### DIFF
--- a/lib/instrumentation/mysql/mysql.js
+++ b/lib/instrumentation/mysql/mysql.js
@@ -11,63 +11,116 @@ const symbols = require('../../symbols')
 const { QuerySpec } = require('../../shim/specs')
 const DatastoreParameters = require('../../shim/specs/params/datastore')
 
+/**
+ * Used to instrument `mysql` and `mysql2` packages
+ * the `mysql2/promise` instrumentation is below in `promiseInitialize`
+ *
+ * @param {Shim} shim instance of shim
+ * @param {object} mysql package to instrument
+ */
 function callbackInitialize(shim, mysql) {
   shim.setDatastore(shim.MYSQL)
   shim[symbols.wrappedPoolConnection] = false
 
   shim.wrapReturn(mysql, 'createConnection', wrapCreateConnection)
-  function wrapCreateConnection(shim, fn, fnName, connection) {
-    if (shim[symbols.unwrapConnection]) {
-      return
-    }
-    shim.logger.debug('Wrapping Connection#query')
-    if (wrapQueryable(shim, connection, false)) {
-      const connProto = Object.getPrototypeOf(connection)
-      connProto[symbols.storeDatabase] = true
-      shim[symbols.unwrapConnection] = true
-    }
-  }
-
   shim.wrapReturn(mysql, 'createPool', wrapCreatePool)
-  function wrapCreatePool(shim, fn, fnName, pool) {
-    if (shim[symbols.unwrapPool]) {
-      return
-    }
-    shim.logger.debug('Wrapping Pool#query and Pool#getConnection')
-    if (wrapQueryable(shim, pool, true) && wrapGetConnection(shim, pool)) {
-      shim[symbols.unwrapPool] = true
-    }
-  }
-
   shim.wrapReturn(mysql, 'createPoolCluster', wrapCreatePoolCluster)
-  function wrapCreatePoolCluster(shim, fn, fnName, poolCluster) {
-    if (shim[symbols.createPoolCluster]) {
-      return
-    }
-    shim.logger.debug('Wrapping PoolCluster#of')
-    const proto = Object.getPrototypeOf(poolCluster)
-    shim.wrapReturn(proto, 'of', wrapPoolClusterOf)
-    function wrapPoolClusterOf(shim, of, _n, poolNamespace) {
-      if (poolNamespace[symbols.clusterOf]) {
-        return
-      }
+}
 
-      if (wrapGetConnection(shim, poolNamespace) && wrapQueryable(shim, poolNamespace, false)) {
-        poolNamespace[symbols.clusterOf] = true
+/**
+ * Used to instrument `mysql2/promise`
+ *
+ * @param {Shim} shim instance of shim
+ * @param {object} mysql2 package to instrument
+ */
+function promiseInitialize(shim, mysql2) {
+  shim.setDatastore(shim.MYSQL)
+  shim[symbols.wrappedPoolConnection] = false
+  shim.wrap(
+    mysql2,
+    'createConnection',
+    function wrapPromiseCreateConnection(shim, createConnection) {
+      return async function wrappedPromiseCreateConnection() {
+        const promiseConnection = await createConnection.apply(this, arguments)
+        wrapCreateConnection(
+          shim,
+          createConnection,
+          'createConnection',
+          promiseConnection.connection
+        )
+        return promiseConnection
       }
     }
+  )
 
-    shim.logger.debug('Wrapping PoolCluster#getConnection')
-    if (wrapGetConnection(shim, poolCluster)) {
-      shim[symbols.createPoolCluster] = true
+  shim.wrap(mysql2, 'createPool', function wrapPromiseCreatePool(shim, createPool) {
+    return async function wrappedPromiseCreatePool() {
+      const promisePool = await createPool.apply(this, arguments)
+      wrapCreatePool(shim, createPool, 'createPool', promisePool.pool)
+      return promisePool
     }
+  })
+
+  shim.wrap(
+    mysql2,
+    'createPoolCluster',
+    function wrapPromiseCreatePoolCluster(shim, createPoolCluster) {
+      return async function wrappedPromiseCreatePoolCluster() {
+        const promisePoolCluster = await createPoolCluster.apply(this, arguments)
+        wrapCreatePoolCluster(
+          shim,
+          createPoolCluster,
+          'createPoolCluster',
+          promisePoolCluster.poolCluster
+        )
+        return promisePoolCluster
+      }
+    }
+  )
+}
+
+function wrapCreateConnection(shim, fn, fnName, connection) {
+  if (shim[symbols.unwrapConnection]) {
+    return
+  }
+  shim.logger.debug('Wrapping Connection#query')
+  if (wrapQueryable(shim, connection, false)) {
+    const connProto = Object.getPrototypeOf(connection)
+    connProto[symbols.storeDatabase] = true
+    shim[symbols.unwrapConnection] = true
   }
 }
 
-function promiseInitialize(shim) {
-  const callbackAPI = shim.require('./index')
-  if (callbackAPI && !shim.isWrapped(callbackAPI.createConnection)) {
-    callbackInitialize(shim, callbackAPI)
+function wrapCreatePool(shim, fn, fnName, pool) {
+  if (shim[symbols.unwrapPool]) {
+    return
+  }
+  shim.logger.debug('Wrapping Pool#query and Pool#getConnection')
+  if (wrapQueryable(shim, pool, true) && wrapGetConnection(shim, pool)) {
+    shim[symbols.unwrapPool] = true
+  }
+}
+
+function wrapCreatePoolCluster(shim, fn, fnName, poolCluster) {
+  if (shim[symbols.createPoolCluster]) {
+    return
+  }
+  shim.logger.debug('Wrapping PoolCluster#of')
+  const proto = Object.getPrototypeOf(poolCluster)
+  shim.wrapReturn(proto, 'of', wrapPoolClusterOf)
+  function wrapPoolClusterOf(shim, of, _n, poolNamespace) {
+    if (poolNamespace[symbols.clusterOf]) {
+      return
+    }
+
+    if (wrapGetConnection(shim, poolNamespace) && wrapQueryable(shim, poolNamespace, false)) {
+      poolNamespace[symbols.clusterOf] = true
+    }
+  }
+
+  shim.logger.debug('Wrapping PoolCluster#getConnection')
+  if (wrapGetConnection(shim, poolCluster)) {
+    shim[symbols.createPoolCluster] = true
   }
 }
 

--- a/test/versioned/mysql/basic.js
+++ b/test/versioned/mysql/basic.js
@@ -21,7 +21,14 @@ module.exports = function ({ lib, factory, poolFactory, constants }) {
   test('Basic run through mysql functionality', { timeout: 30 * 1000 }, async function (t) {
     t.beforeEach(async function (ctx) {
       const poolLogger = logger.child({ component: 'pool' })
-      const agent = helper.instrumentMockedAgent()
+      const agent = helper.instrumentMockedAgent({
+        slow_sql: { enabled: true },
+        transaction_tracer: {
+          recod_sql: 'raw',
+          explain_threshold: 0,
+          enabled: true
+        }
+      })
       const mysql = factory()
       const genericPool = poolFactory()
       const pool = setup.pool(USER, DATABASE, mysql, genericPool, poolLogger)

--- a/test/versioned/mysql/newrelic.js
+++ b/test/versioned/mysql/newrelic.js
@@ -18,13 +18,5 @@ exports.config = {
     detect_azure: false,
     detect_gcp: false,
     detect_docker: false
-  },
-  slow_sql: {
-    enabled: true
-  },
-  transaction_tracer: {
-    record_sql: 'raw',
-    explain_threshold: 0,
-    enabled: true
   }
 }

--- a/test/versioned/mysql2/newrelic.js
+++ b/test/versioned/mysql2/newrelic.js
@@ -18,13 +18,5 @@ exports.config = {
     detect_azure: false,
     detect_gcp: false,
     detect_docker: false
-  },
-  slow_sql: {
-    enabled: true
-  },
-  transaction_tracer: {
-    record_sql: 'raw',
-    explain_threshold: 0,
-    enabled: true
   }
 }

--- a/test/versioned/mysql2/package.json
+++ b/test/versioned/mysql2/package.json
@@ -9,7 +9,7 @@
         "node": ">=18"
       },
       "dependencies": {
-        "mysql2": ">=2.0.0 <=3.11.4",
+        "mysql2": ">=2.0.0",
         "generic-pool": ">=2.4 <2.5 || latest"
       },
       "files": [

--- a/test/versioned/mysql2/promises.test.js
+++ b/test/versioned/mysql2/promises.test.js
@@ -16,7 +16,14 @@ const { DATABASE, USER, TABLE } = require('./constants')
 test('mysql2 promises', { timeout: 30000 }, async (t) => {
   t.beforeEach(async (ctx) => {
     await setup(USER, DATABASE, TABLE, require('mysql2'))
-    const agent = helper.instrumentMockedAgent()
+    const agent = helper.instrumentMockedAgent({
+      slow_sql: { enabled: true },
+      transaction_tracer: {
+        recod_sql: 'raw',
+        explain_threshold: 0,
+        enabled: true
+      }
+    })
 
     const mysql = require('mysql2/promise')
 


### PR DESCRIPTION
## Description

Turns out we were relying on the fact that the `msyql2/index.js` was a circular reference for the `mysql2/promises` interface.  This was updated in https://github.com/sidorares/node-mysql2/pull/3081/files.  I also noticed that the versioned tests were configuring the sql tracing in the config file and at times wasn't sticking. So I moved those to be explicit in the tests that need that configuration.

## How to Test

```sh
npm run versioned:internal mysql2
npm run versioned:internal mysql
```

## Related Issues
Closes #2810 