### PR TITLE
docs: Fixed links to next.js apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ If you are having trouble getting the `newrelic` package to instrument Next.js, 
 ### Next.js example projects
 The following example applications show how to load the `newrelic` instrumentation, inject browser agent, and handle errors:
 
- * [Pages Router example](https://github.com/newrelic/newrelic-node-examples/tree/58f760e828c45d90391bda3f66764d4420ba4990/nextjs-legacy)
- * [App Router example](https://github.com/newrelic/newrelic-node-examples/tree/58f760e828c45d90391bda3f66764d4420ba4990/nextjs-app-router)
+ * [Pages Router example](https://github.com/newrelic/newrelic-node-examples/tree/9415503f3bd78fa5d87a7214596d51c946199474/nextjs/nextjs-legacy)
+ * [App Router example](https://github.com/newrelic/newrelic-node-examples/tree/9415503f3bd78fa5d87a7214596d51c946199474/nextjs/nextjs-app-router)
 
 ### Custom Next.js servers
 

--- a/documentation/nextjs/faqs/browser-agent.md
+++ b/documentation/nextjs/faqs/browser-agent.md
@@ -8,5 +8,5 @@ A: It depends on if you are using the Pages or App Router for Next.js.
 ## Inject Browser Agent 
 The following links demonstrates how to inject the browser agent.
 
- * [Pages Router](https://github.com/newrelic/newrelic-node-examples/blob/e118117470ae9f9038c60d8a171a6f0d440f6291/nextjs-legacy/pages/_document.jsx)
- * [App Router](https://github.com/newrelic/newrelic-node-examples/blob/58f760e828c45d90391bda3f66764d4420ba4990/nextjs-app-router/app/layout.js)
+ * [Pages Router](https://github.com/newrelic/newrelic-node-examples/blob/9415503f3bd78fa5d87a7214596d51c946199474/nextjs/nextjs-legacy/pages/_document.jsx)
+ * [App Router](https://github.com/newrelic/newrelic-node-examples/blob/9415503f3bd78fa5d87a7214596d51c946199474/nextjs/nextjs-app-router/app/layout.js)

--- a/documentation/nextjs/faqs/error-handling.md
+++ b/documentation/nextjs/faqs/error-handling.md
@@ -8,6 +8,6 @@ A: The Node.js agent has an API to log errors `newrelic.noticeError`. Next.js ha
 
 The error page varies between [Pages Router](https://nextjs.org/docs/pages/building-your-application/routing/custom-error) and [App Router](https://nextjs.org/docs/app/building-your-application/routing/error-handling) Next.js projects.
 
-* [Pages Router](https://github.com/newrelic/newrelic-node-examples/blob/e118117470ae9f9038c60d8a171a6f0d440f6291/nextjs-legacy/pages/_error.jsx) error handling example.
+* [Pages Router](https://github.com/newrelic/newrelic-node-examples/blob/9415503f3bd78fa5d87a7214596d51c946199474/nextjs/nextjs-legacy/pages/_error.jsx) error handling example.
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
In #2807 it was brought to our attention that the Next.js apps linked in docs were permalinks to old versions that still referred to `@newrelic/next`. This PR updates those permalinks to point to the latest examples.
