### PR TITLE
feat: Added segment synthesis for db client otel spans to db trace

### DIFF
--- a/lib/db/query-parsers/elasticsearch.js
+++ b/lib/db/query-parsers/elasticsearch.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const logger = require('../../logger').child({ component: 'elasticsearch_query_parser' })
+const { isNotEmpty } = require('../../util/objects')
+
+/**
+ * Parses the parameters sent to elasticsearch for collection,
+ * method, and query
+ *
+ * @param {object} params Query object received by the datashim.
+ * Required properties: path {string}, method {string}.
+ * Optional properties: querystring {string}, body {object}, and
+ * bulkBody {object}
+ * @returns {object} consisting of collection {string}, operation {string},
+ * and query {string}
+ */
+function queryParser(params) {
+  params = JSON.parse(params)
+  const { collection, operation } = parsePath(params.path, params.method)
+
+  // the substance of the query may be in querystring or in body.
+  let queryParam = {}
+  if (isNotEmpty(params.querystring)) {
+    queryParam = params.querystring
+  }
+  // let body or bulkBody override querystring, as some requests have both
+  if (isNotEmpty(params.body)) {
+    queryParam = params.body
+  } else if (Array.isArray(params.bulkBody) && params.bulkBody.length) {
+    queryParam = params.bulkBody
+  }
+  // The helper interface provides a simpler API:
+
+  const query = JSON.stringify(queryParam)
+
+  return {
+    collection,
+    operation,
+    query
+  }
+}
+
+/**
+ * Convenience function for parsing the params.path sent to the queryParser
+ * for normalized collection and operation
+ *
+ * @param {string} pathString params.path supplied to the query parser
+ * @param {string} method http method called by @elastic/elasticsearch
+ * @returns {object} consisting of collection {string} and operation {string}
+ */
+function parsePath(pathString, method) {
+  let collection
+  let operation
+  const defaultCollection = 'any'
+  const actions = {
+    GET: 'get',
+    PUT: 'create',
+    POST: 'create',
+    DELETE: 'delete',
+    HEAD: 'exists'
+  }
+  const suffix = actions[method]
+
+  try {
+    const path = pathString.split('/')
+    if (method === 'PUT' && path.length === 2) {
+      collection = path?.[1] || defaultCollection
+      operation = `index.create`
+      return { collection, operation }
+    }
+    path.forEach((segment, idx) => {
+      const prev = idx - 1
+      let opname
+      if (segment === '_search') {
+        collection = path?.[prev] || defaultCollection
+        operation = `search`
+      } else if (segment[0] === '_') {
+        opname = segment.substring(1)
+        collection = path?.[prev] || defaultCollection
+        operation = `${opname}.${suffix}`
+      }
+    })
+    if (!operation && !collection) {
+      // likely creating an index--no underscore segments
+      collection = path?.[1] || defaultCollection
+      operation = `index.${suffix}`
+    }
+  } catch (e) {
+    logger.warn('Failed to parse path for operation and collection. Using defaults')
+    logger.warn(e)
+    collection = defaultCollection
+    operation = 'unknown'
+  }
+
+  return { collection, operation }
+}
+
+module.exports = { queryParser, parsePath }

--- a/lib/db/query-parsers/mongodb.js
+++ b/lib/db/query-parsers/mongodb.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/**
+ * parser used to grab the collection and operation
+ * from a running query
+ *
+ * @param {object} operation mongodb operation
+ * @returns {object} { operation, collection } parsed operation and collection
+ */
+function queryParser(operation) {
+  let collection = this.collectionName || 'unknown'
+
+  // cursor methods have collection on namespace.collection
+  if (this?.namespace?.collection) {
+    collection = this.namespace.collection
+    // (un)ordered bulk operations have collection on different key
+  } else if (this?.s?.collection?.collectionName) {
+    collection = this.s.collection.collectionName
+  }
+
+  return { operation, collection }
+}
+
+module.exports = queryParser

--- a/lib/instrumentation/@elastic/elasticsearch.js
+++ b/lib/instrumentation/@elastic/elasticsearch.js
@@ -7,8 +7,7 @@
 
 const { QuerySpec } = require('../../shim/specs')
 const semver = require('semver')
-const logger = require('../../logger').child({ component: 'ElasticSearch' })
-const { isNotEmpty } = require('../../util/objects')
+const { queryParser } = require('../../db/query-parsers/elasticsearch')
 
 /**
  * Instruments the `@elastic/elasticsearch` module. This function is
@@ -47,98 +46,6 @@ module.exports = function initialize(_agent, elastic, _moduleName, shim) {
 }
 
 /**
- * Parses the parameters sent to elasticsearch for collection,
- * method, and query
- *
- * @param {object} params Query object received by the datashim.
- * Required properties: path {string}, method {string}.
- * Optional properties: querystring {string}, body {object}, and
- * bulkBody {object}
- * @returns {object} consisting of collection {string}, operation {string},
- * and query {string}
- */
-function queryParser(params) {
-  params = JSON.parse(params)
-  const { collection, operation } = parsePath(params.path, params.method)
-
-  // the substance of the query may be in querystring or in body.
-  let queryParam = {}
-  if (isNotEmpty(params.querystring)) {
-    queryParam = params.querystring
-  }
-  // let body or bulkBody override querystring, as some requests have both
-  if (isNotEmpty(params.body)) {
-    queryParam = params.body
-  } else if (Array.isArray(params.bulkBody) && params.bulkBody.length) {
-    queryParam = params.bulkBody
-  }
-  // The helper interface provides a simpler API:
-
-  const query = JSON.stringify(queryParam)
-
-  return {
-    collection,
-    operation,
-    query
-  }
-}
-
-/**
- * Convenience function for parsing the params.path sent to the queryParser
- * for normalized collection and operation
- *
- * @param {string} pathString params.path supplied to the query parser
- * @param {string} method http method called by @elastic/elasticsearch
- * @returns {object} consisting of collection {string} and operation {string}
- */
-function parsePath(pathString, method) {
-  let collection
-  let operation
-  const defaultCollection = 'any'
-  const actions = {
-    GET: 'get',
-    PUT: 'create',
-    POST: 'create',
-    DELETE: 'delete',
-    HEAD: 'exists'
-  }
-  const suffix = actions[method]
-
-  try {
-    const path = pathString.split('/')
-    if (method === 'PUT' && path.length === 2) {
-      collection = path?.[1] || defaultCollection
-      operation = `index.create`
-      return { collection, operation }
-    }
-    path.forEach((segment, idx) => {
-      const prev = idx - 1
-      let opname
-      if (segment === '_search') {
-        collection = path?.[prev] || defaultCollection
-        operation = `search`
-      } else if (segment[0] === '_') {
-        opname = segment.substring(1)
-        collection = path?.[prev] || defaultCollection
-        operation = `${opname}.${suffix}`
-      }
-    })
-    if (!operation && !collection) {
-      // likely creating an index--no underscore segments
-      collection = path?.[1] || defaultCollection
-      operation = `index.${suffix}`
-    }
-  } catch (e) {
-    logger.warn('Failed to parse path for operation and collection. Using defaults')
-    logger.warn(e)
-    collection = defaultCollection
-    operation = 'unknown'
-  }
-
-  return { collection, operation }
-}
-
-/**
  * Convenience function for deriving connection information from
  * elasticsearch
  *
@@ -152,6 +59,4 @@ function getConnection(shim) {
   return shim.captureInstanceAttributes(host[0], port)
 }
 
-module.exports.queryParser = queryParser
-module.exports.parsePath = parsePath
 module.exports.getConnection = getConnection

--- a/lib/instrumentation/mongodb/v4-mongo.js
+++ b/lib/instrumentation/mongodb/v4-mongo.js
@@ -13,27 +13,7 @@ const {
   instrumentDb,
   parseAddress
 } = require('./common')
-
-/**
- * parser used to grab the collection and operation
- * from a running query
- *
- * @param {object} operation mongodb operation
- * @returns {object} { operation, collection } parsed operation and collection
- */
-function queryParser(operation) {
-  let collection = this.collectionName || 'unknown'
-
-  // cursor methods have collection on namespace.collection
-  if (this?.namespace?.collection) {
-    collection = this.namespace.collection
-    // (un)ordered bulk operations have collection on different key
-  } else if (this?.s?.collection?.collectionName) {
-    collection = this.s.collection.collectionName
-  }
-
-  return { operation, collection }
-}
+const queryParser = require('../../db/query-parsers/mongodb')
 
 /**
  * `commandStarted` handler used to

--- a/lib/otel/rules.json
+++ b/lib/otel/rules.json
@@ -1,6 +1,7 @@
 [
   {
     "name": "OtelHttpServer1_23",
+    "type": "server",
     "matcher": {
       "required_metric_names": [
         "http.server.request.duration"
@@ -41,6 +42,7 @@
   },
   {
     "name": "OtelHttpServer1_20",
+    "type": "server",
     "matcher": {
       "required_metric_names": [
         "http.server.duration"
@@ -81,6 +83,7 @@
   },
   {
     "name": "OtelRpcServer1_20",
+    "type": "server",
     "matcher": {
       "required_metric_names": [
         "rpc.server.duration"
@@ -121,6 +124,7 @@
   },
   {
     "name": "FallbackServer",
+    "type": "server",
     "matcher": {
       "required_metric_names": [
         "rpc.server.duration",

--- a/lib/otel/segment-synthesis.js
+++ b/lib/otel/segment-synthesis.js
@@ -7,7 +7,16 @@
 const { RulesEngine } = require('./rules')
 const defaultLogger = require('../logger').child({ component: 'segment-synthesizer' })
 const NAMES = require('../metrics/names')
-const { SEMATTRS_HTTP_HOST } = require('@opentelemetry/semantic-conventions')
+const {
+  SEMATTRS_HTTP_HOST,
+  SEMATTRS_DB_MONGODB_COLLECTION,
+  SEMATTRS_DB_SYSTEM,
+  SEMATTRS_DB_SQL_TABLE,
+  SEMATTRS_DB_OPERATION,
+  SEMATTRS_DB_STATEMENT,
+  DbSystemValues
+} = require('@opentelemetry/semantic-conventions')
+const parseSql = require('../db/query-parsers/sql')
 
 class SegmentSynthesizer {
   constructor(agent, { logger = defaultLogger } = {}) {
@@ -27,10 +36,13 @@ class SegmentSynthesizer {
       return
     }
 
-    if (rule?.type === 'external') {
+    if (rule.type === 'external') {
       return this.createExternalSegment(otelSpan)
+    } else if (rule.type === 'db') {
+      return this.createDatabaseSegment(otelSpan)
     }
-    this.logger.debug('Found type: %s, no synthesize rule currently built', rule.type)
+
+    this.logger.debug('Found type: %s, no synthesis rule currently built', rule.type)
   }
 
   // TODO: should we move these to somewhere else and use in the places
@@ -39,6 +51,54 @@ class SegmentSynthesizer {
     const context = this.agent.tracer.getContext()
     const host = otelSpan.attributes[SEMATTRS_HTTP_HOST] || 'Unknown'
     const name = NAMES.EXTERNAL.PREFIX + host
+    return this.agent.tracer.createSegment({
+      name,
+      parent: context.segment,
+      transaction: context.transaction
+    })
+  }
+
+  parseStatement(otelSpan, system) {
+    let table = otelSpan.attributes[SEMATTRS_DB_SQL_TABLE]
+    let operation = otelSpan.attributes[SEMATTRS_DB_OPERATION]
+    const statement = otelSpan.attributes[SEMATTRS_DB_STATEMENT]
+    if (statement && !(table || operation)) {
+      const parsed = parseSql({ sql: statement })
+      if (parsed.operation && !operation) {
+        operation = parsed.operation
+      }
+
+      if (parsed.collection && !table) {
+        table = parsed.collection
+      }
+    }
+    if (system === DbSystemValues.MONGODB) {
+      table = otelSpan.attributes[SEMATTRS_DB_MONGODB_COLLECTION]
+    }
+
+    if (system === DbSystemValues.REDIS && statement) {
+      ;[operation] = statement.split(' ')
+    }
+
+    table = table || 'Unknown'
+    operation = operation || 'Unknown'
+
+    return { operation, table }
+  }
+
+  // TODO: This probably has some holes
+  // I did analysis and tried to apply the best logic
+  // to extract table/operation
+  createDatabaseSegment(otelSpan) {
+    const context = this.agent.tracer.getContext()
+    const system = otelSpan.attributes[SEMATTRS_DB_SYSTEM]
+    const { operation, table } = this.parseStatement(otelSpan, system)
+
+    let name = `Datastore/statement/${system}/${table}/${operation}`
+    // All segment name shapes are same except redis/memcached
+    if (system === DbSystemValues.REDIS || system === DbSystemValues.MEMCACHED) {
+      name = `Datastore/operation/${system}/${operation}`
+    }
     return this.agent.tracer.createSegment({
       name,
       parent: context.segment,

--- a/test/unit/db/query-parsers/elasticsearch.test.js
+++ b/test/unit/db/query-parsers/elasticsearch.test.js
@@ -7,7 +7,7 @@
 
 const test = require('node:test')
 const assert = require('node:assert')
-const { parsePath, queryParser } = require('../../../lib/instrumentation/@elastic/elasticsearch')
+const { parsePath, queryParser } = require('../../../../lib/db/query-parsers/elasticsearch')
 const methods = [
   { name: 'GET', expected: 'get' },
   { name: 'PUT', expected: 'create' },

--- a/test/unit/lib/otel/fixtures/db-sql.js
+++ b/test/unit/lib/otel/fixtures/db-sql.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const {
+  SEMATTRS_DB_SYSTEM,
+  SEMATTRS_DB_SQL_TABLE,
+  SEMATTRS_DB_OPERATION,
+  SEMATTRS_DB_STATEMENT,
+  DbSystemValues,
+  SEMATTRS_DB_MONGODB_COLLECTION
+} = require('@opentelemetry/semantic-conventions')
+const { SpanKind } = require('@opentelemetry/api')
+const createSpan = require('./span')
+
+function createDbClientSpan({ parentId, tracer, tx, name = 'test-span' }) {
+  const span = createSpan({ name, kind: SpanKind.CLIENT, parentId, tracer, tx })
+  span.setAttribute(SEMATTRS_DB_SYSTEM, 'custom-db')
+  span.setAttribute(SEMATTRS_DB_SQL_TABLE, 'test-table')
+  span.setAttribute(SEMATTRS_DB_OPERATION, 'select')
+  return span
+}
+
+function createDbStatementSpan({ parentId, tracer, tx, name = 'test-span' }) {
+  const span = createSpan({ name, kind: SpanKind.CLIENT, parentId, tracer, tx })
+  span.setAttribute(SEMATTRS_DB_SYSTEM, 'custom-db')
+  span.setAttribute(SEMATTRS_DB_STATEMENT, 'select * from test-table')
+  return span
+}
+
+function createMemcachedDbSpan({ parentId, tracer, tx, name = 'test-span' }) {
+  const span = createSpan({ name, kind: SpanKind.CLIENT, parentId, tracer, tx })
+  span.setAttribute(SEMATTRS_DB_SYSTEM, DbSystemValues.MEMCACHED)
+  span.setAttribute(SEMATTRS_DB_OPERATION, 'set')
+  return span
+}
+
+function createMongoDbSpan({ parentId, tracer, tx, name = 'test-span' }) {
+  const span = createSpan({ name, kind: SpanKind.CLIENT, parentId, tracer, tx })
+  span.setAttribute(SEMATTRS_DB_SYSTEM, DbSystemValues.MONGODB)
+  span.setAttribute(SEMATTRS_DB_OPERATION, 'insert')
+  span.setAttribute(SEMATTRS_DB_MONGODB_COLLECTION, 'test-collection')
+  return span
+}
+
+function createRedisDbSpan({ parentId, tracer, tx, name = 'test-span' }) {
+  const span = createSpan({ name, kind: SpanKind.CLIENT, parentId, tracer, tx })
+  span.setAttribute(SEMATTRS_DB_SYSTEM, DbSystemValues.REDIS)
+  span.setAttribute(SEMATTRS_DB_STATEMENT, 'hset hash random random')
+  return span
+}
+
+module.exports = {
+  createDbClientSpan,
+  createDbStatementSpan,
+  createMemcachedDbSpan,
+  createMongoDbSpan,
+  createRedisDbSpan
+}

--- a/test/unit/lib/otel/fixtures/http-client.js
+++ b/test/unit/lib/otel/fixtures/http-client.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const { SEMATTRS_HTTP_HOST, SEMATTRS_HTTP_METHOD } = require('@opentelemetry/semantic-conventions')
+const { SpanKind } = require('@opentelemetry/api')
+const createSpan = require('./span')
+
+module.exports = function createHttpClientSpan({ parentId, tracer, tx }) {
+  const span = createSpan({ name: 'test-span', kind: SpanKind.CLIENT, parentId, tracer, tx })
+  span.setAttribute(SEMATTRS_HTTP_METHOD, 'GET')
+  span.setAttribute(SEMATTRS_HTTP_HOST, 'newrelic.com')
+  return span
+}

--- a/test/unit/lib/otel/fixtures/index.js
+++ b/test/unit/lib/otel/fixtures/index.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const {
+  createDbClientSpan,
+  createDbStatementSpan,
+  createMemcachedDbSpan,
+  createMongoDbSpan,
+  createRedisDbSpan
+} = require('./db-sql')
+const createSpan = require('./span')
+const createHttpClientSpan = require('./http-client')
+
+module.exports = {
+  createDbClientSpan,
+  createDbStatementSpan,
+  createHttpClientSpan,
+  createMemcachedDbSpan,
+  createMongoDbSpan,
+  createRedisDbSpan,
+  createSpan
+}

--- a/test/unit/lib/otel/fixtures/span.js
+++ b/test/unit/lib/otel/fixtures/span.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const { ROOT_CONTEXT, TraceFlags } = require('@opentelemetry/api')
+const { Span } = require('@opentelemetry/sdk-trace-base')
+
+module.exports = function createSpan({ parentId, tracer, tx, kind, name }) {
+  const spanContext = {
+    traceId: tx.trace.id,
+    spanId: tx.trace.root.id,
+    traceFlags: TraceFlags.SAMPLED
+  }
+  return new Span(tracer, ROOT_CONTEXT, name, spanContext, kind, parentId)
+}


### PR DESCRIPTION
## Description
The transformation rules key off of client as span kind and db.system to do its matching.  However some of the required attributes for naming do not exist in Node.js opentelemetry instrumetation. Most `db.sql.table`. For traditional sql database libs we must parse the SQL to extract the operation and table. I also cross referenced our instrumentation to determine how we name segments for databases:

Segment naming for all dbs:
* mysql/mysql2 - `Datastore/statement/MySQL/<table>/<operation>`
* pg - `Datastore/statement/Postgres/<table>/<operation>`
* redis - `Datastore/operation/Redis/<operation>`
* mongodb - `Datastore/statement/MongoDB/<collection` or `Datastore/operation/MongoDB/<operation>`
* elasticsearch - `Datastore/statement/ElasticSearch/<index>/<operation>` or `Datastore/operation/ElasticSearch/<operation>`
* prisma - out of scope
* cassandra - `Datastore/statement/Cassandra/<keyspace>.<table>/<operation>` or `Datastore/operation/Cassandra/<operation>`
* ioredis - same as redis
* memcached - `Datastore/operation/Memcache/<operation>`

The only difference here will be mongodb/elasticsearch as all will be prefixed with `Datastore/statement`

## How to Test

```sh
node test/until/lib/otel/segment-synthesizer.test.js
```

## Related Issues
Closes #2647