### PR TITLE
test: Fixed flakey `when` versioned test

### DIFF
--- a/test/versioned/when/when.test.js
+++ b/test/versioned/when/when.test.js
@@ -681,8 +681,9 @@ test('Promise#timeout', async (t) => {
       .catch((error) => {
         const end = Date.now()
         plan.equal(error.message, `${name} timeout message`, `${name} should have correct message`)
-        plan.ok(end - start > 48, `${name} should wait close to the correct time`)
-        plan.ok(end - start < 75, `${name} should wait close to the correct time`)
+        const time = end - start
+        plan.ok(time > 48, `${name} should wait close to the correct time, actual wait ${time}`)
+        plan.ok(time < 100, `${name} should wait close to the correct time, actual wait ${time}`)
       })
   }
 

--- a/test/versioned/when/when.test.js
+++ b/test/versioned/when/when.test.js
@@ -948,7 +948,7 @@ async function testThrowOutsideTransaction({ plan, agent, testFunc }) {
           plan.equal(agent.getTransaction(), undefined, `${name} has no transaction`)
         },
         function rejected(error) {
-          plan.oko(!error, `${name} should not result in error`)
+          plan.ok(!error, `${name} should not result in error`)
         }
       )
     isAsync = true

--- a/test/versioned/when/when.test.js
+++ b/test/versioned/when/when.test.js
@@ -949,7 +949,7 @@ async function testThrowOutsideTransaction({ plan, agent, testFunc }) {
           plan.equal(agent.getTransaction(), undefined, `${name} has no transaction`)
         },
         function rejected(error) {
-          plan.ifError(error, `${name} should not result in error`)
+          plan.oko(!error, `${name} should not result in error`)
         }
       )
     isAsync = true
@@ -980,7 +980,7 @@ async function testInsideTransaction({ plan, agent, testFunc }) {
             plan.equal(agent.getTransaction(), tx, `${name} has the right transaction`)
           },
           function rejected(error) {
-            plan.ifError(error, `${name} should not result in error`)
+            plan.ok(!error, `${name} should not result in error`)
           }
         )
       isAsync = true

--- a/test/versioned/when/when.test.js
+++ b/test/versioned/when/when.test.js
@@ -669,7 +669,7 @@ test('Promise#delay', async (t) => {
 })
 
 test('Promise#timeout', async (t) => {
-  const plan = tspl(t, { plan: 12 })
+  const plan = tspl(t, { plan: 10 })
   const { agent, when } = setupTest(t)
   const { Promise } = when
   const testFunc = (name) => {
@@ -683,7 +683,6 @@ test('Promise#timeout', async (t) => {
         plan.equal(error.message, `${name} timeout message`, `${name} should have correct message`)
         const time = end - start
         plan.ok(time > 48, `${name} should wait close to the correct time, actual wait ${time}`)
-        plan.ok(time < 100, `${name} should wait close to the correct time, actual wait ${time}`)
       })
   }
 

--- a/test/versioned/when/when.test.js
+++ b/test/versioned/when/when.test.js
@@ -948,7 +948,7 @@ async function testThrowOutsideTransaction({ plan, agent, testFunc }) {
           plan.equal(agent.getTransaction(), undefined, `${name} has no transaction`)
         },
         function rejected(error) {
-          assert.ifError(error, `${name} should not result in error`)
+          plan.ifError(error, `${name} should not result in error`)
         }
       )
     isAsync = true


### PR DESCRIPTION
## Details
This test is failing because it was asserting i took longer than the timeout but less than the delay. I have found in CI sometimes it's taking longer than the delay however, if it'd resolve the delay the test would fail so I'm removing the assertion to assert it takes less than the delay

## Related Links
Closes #2826 