### PR TITLE
fix: update `mysql2` promise version instrumentation

### DIFF
--- a/lib/instrumentation/mysql/mysql.js
+++ b/lib/instrumentation/mysql/mysql.js
@@ -54,8 +54,8 @@ function promiseInitialize(shim, mysql2) {
   )
 
   shim.wrap(mysql2, 'createPool', function wrapPromiseCreatePool(shim, createPool) {
-    return async function wrappedPromiseCreatePool() {
-      const promisePool = await createPool.apply(this, arguments)
+    return function wrappedPromiseCreatePool() {
+      const promisePool = createPool.apply(this, arguments)
       wrapCreatePool(shim, createPool, 'createPool', promisePool.pool)
       return promisePool
     }
@@ -65,8 +65,8 @@ function promiseInitialize(shim, mysql2) {
     mysql2,
     'createPoolCluster',
     function wrapPromiseCreatePoolCluster(shim, createPoolCluster) {
-      return async function wrappedPromiseCreatePoolCluster() {
-        const promisePoolCluster = await createPoolCluster.apply(this, arguments)
+      return function wrappedPromiseCreatePoolCluster() {
+        const promisePoolCluster = createPoolCluster.apply(this, arguments)
         wrapCreatePoolCluster(
           shim,
           createPoolCluster,

--- a/test/versioned/mysql2/promises.test.js
+++ b/test/versioned/mysql2/promises.test.js
@@ -6,12 +6,24 @@
 'use strict'
 
 const setup = require('../mysql/setup')
+const fs = require('fs')
+const semver = require('semver')
 const test = require('node:test')
 const assert = require('node:assert')
 const helper = require('../../lib/agent_helper')
 const params = require('../../lib/params')
 const urltils = require('../../../lib/util/urltils')
 const { DATABASE, USER, TABLE } = require('./constants')
+
+// exports are defined in newer versions so must read file directly
+let pkgVersion
+try {
+  ;({ version: pkgVersion } = require('mysql2/package'))
+} catch {
+  ;({ version: pkgVersion } = JSON.parse(
+    fs.readFileSync(`${__dirname}/node_modules/mysql2/package.json`)
+  ))
+}
 
 test('mysql2 promises', { timeout: 30000 }, async (t) => {
   t.beforeEach(async (ctx) => {
@@ -116,6 +128,194 @@ test('mysql2 promises', { timeout: 30000 }, async (t) => {
     checkQueries(agent)
   })
 })
+
+test('mysql2 promises pool', async function (t) {
+  t.beforeEach(async function (ctx) {
+    await setup(USER, DATABASE, TABLE, require('mysql2'))
+    const agent = helper.instrumentMockedAgent()
+    const mysql = require('mysql2/promise')
+    const pool = mysql.createPool({
+      user: USER,
+      database: DATABASE,
+      host: params.mysql_host,
+      port: params.mysql_port
+    })
+    ctx.nr = {
+      agent,
+      mysql,
+      pool
+    }
+  })
+
+  t.afterEach(async function (ctx) {
+    const { pool, agent } = ctx.nr
+    helper.unloadAgent(agent)
+    await pool.end()
+  })
+
+  await t.test('pool.query', async function (t) {
+    const { agent, pool } = t.nr
+    await helper.runInTransaction(agent, async (tx) => {
+      await pool.query('SELECT 1 + 1 AS solution')
+      const activeTx = agent.getTransaction()
+      assert.equal(tx.name, activeTx.name)
+      tx.end()
+    })
+  })
+
+  await t.test('pool.query with values', async function (t) {
+    const { agent, pool } = t.nr
+    await helper.runInTransaction(agent, async (tx) => {
+      await pool.query('SELECT ? + ? AS solution', [1, 1])
+      const activeTx = agent.getTransaction()
+      assert.equal(tx.name, activeTx.name)
+      tx.end()
+    })
+  })
+
+  await t.test('pool.getConnection -> connection.query', async function (t) {
+    const { agent, pool } = t.nr
+    await helper.runInTransaction(agent, async (tx) => {
+      const connection = await pool.getConnection()
+      t.after(function () {
+        connection.release()
+      })
+
+      await connection.query('SELECT 1 + 1 AS solution')
+      const activeTx = agent.getTransaction()
+      assert.equal(tx.name, activeTx.name)
+      tx.end()
+    })
+  })
+
+  await t.test('pool.getConnection -> connection.query with values', async function (t) {
+    const { agent, pool } = t.nr
+    await helper.runInTransaction(agent, async (tx) => {
+      const connection = await pool.getConnection()
+      t.after(function () {
+        connection.release()
+      })
+
+      await connection.query('SELECT ? + ? AS solution', [1, 1])
+      const activeTx = agent.getTransaction()
+      assert.equal(tx.name, activeTx.name)
+      tx.end()
+    })
+  })
+})
+
+// not added until 2.3.0
+// https://github.com/sidorares/node-mysql2/blob/05e9e153a3c8530c957140b59a654a999e7c3c6e/Changelog.md?plain=1#L2
+if (semver.satisfies(pkgVersion, '>=2.3.0')) {
+  test('mysql2 promises poolCluster', async function (t) {
+    t.beforeEach(async function (ctx) {
+      await setup(USER, DATABASE, TABLE, require('mysql2'))
+      const agent = helper.instrumentMockedAgent()
+      const mysql = require('mysql2/promise')
+      const poolCluster = mysql.createPoolCluster()
+
+      const config = {
+        user: USER,
+        database: DATABASE,
+        host: params.mysql_host,
+        port: params.mysql_port
+      }
+
+      poolCluster.add(config) // anonymous group
+      poolCluster.add('MASTER', config)
+      poolCluster.add('REPLICA', config)
+      ctx.nr = {
+        agent,
+        mysql,
+        poolCluster
+      }
+    })
+
+    t.afterEach(async function (ctx) {
+      const { agent, poolCluster } = ctx.nr
+      helper.unloadAgent(agent)
+      await poolCluster.end()
+    })
+
+    await t.test('get any connection', async function (t) {
+      const { agent, poolCluster } = t.nr
+      const connection = await poolCluster.getConnection()
+      await helper.runInTransaction(agent, async (tx) => {
+        await connection.query('SELECT ? + ? AS solution', [1, 1])
+        const activeTx = agent.getTransaction()
+        assert.equal(tx.name, activeTx.name)
+        tx.end()
+        connection.release()
+      })
+    })
+
+    await t.test('get MASTER connection', async function (t) {
+      const { agent, poolCluster } = t.nr
+      const connection = await poolCluster.getConnection('MASTER')
+      await helper.runInTransaction(agent, async (tx) => {
+        await connection.query('SELECT ? + ? AS solution', [1, 1])
+        const activeTx = agent.getTransaction()
+        assert.equal(tx.name, activeTx.name)
+        tx.end()
+        connection.release()
+      })
+    })
+
+    await t.test('get glob', async function (t) {
+      const { agent, poolCluster } = t.nr
+      const connection = await poolCluster.getConnection('REPLICA*', 'ORDER')
+      await helper.runInTransaction(agent, async (tx) => {
+        await connection.query('SELECT ? + ? AS solution', [1, 1])
+        const activeTx = agent.getTransaction()
+        assert.equal(tx.name, activeTx.name)
+        tx.end()
+        connection.release()
+      })
+    })
+
+    // does not work until mysql2 bug is fixed
+    // https://github.com/sidorares/node-mysql2/issues/3091
+    if (!semver.satisfies(pkgVersion, '>=3.11.1 <3.12.0')) {
+      await t.test('get star', async function (t) {
+        const { agent, poolCluster } = t.nr
+        const connection = await poolCluster.of('*').getConnection()
+        await helper.runInTransaction(agent, async (tx) => {
+          await connection.query('SELECT ? + ? AS solution', [1, 1])
+          const activeTx = agent.getTransaction()
+          assert.equal(tx.name, activeTx.name)
+          tx.end()
+          connection.release()
+        })
+      })
+
+      await t.test('get wildcard', async function (t) {
+        const { agent, poolCluster } = t.nr
+        const pool = poolCluster.of('REPLICA*', 'RANDOM')
+        const connection = await pool.getConnection()
+        await helper.runInTransaction(agent, async (tx) => {
+          await connection.query('SELECT ? + ? AS solution', [1, 1])
+          const activeTx = agent.getTransaction()
+          assert.equal(tx.name, activeTx.name)
+          tx.end()
+          connection.release()
+        })
+      })
+    }
+
+    await t.test('poolCluster query', async function (t) {
+      const { agent, poolCluster } = t.nr
+      const masterPool = poolCluster.of('MASTER', 'RANDOM')
+      const replicaPool = poolCluster.of('REPLICA', 'RANDOM')
+      await helper.runInTransaction(agent, async (tx) => {
+        await replicaPool.query('SELECT ? + ? AS solution', [1, 1])
+        await masterPool.query('SELECT ? + ? AS solution', [1, 1])
+        const activeTx = agent.getTransaction()
+        assert.equal(tx.name, activeTx.name)
+        tx.end()
+      })
+    })
+  })
+}
 
 function checkQueries(agent) {
   const querySamples = agent.queries.samples


### PR DESCRIPTION
Update `createPool` and `createPoolCluster` to not return a `Promise`

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Updated `mysql2` promise version of `createPool` and `createPoolCluster` to not return a `Promise`, following the `mysql2` source code.

## How to Test

`npm run versioned:internal mysql2`

Additionally, I have patched the `newrelic` package locally to test in my project and confirmed that the changes fixed `mysql2` instrumentation.

## Related Issues

Closes #2822.