### PR TITLE
fix: Fixed matching for Lambda events containing resource but which aren't API Gateway

### DIFF
--- a/lib/serverless/api-gateway.js
+++ b/lib/serverless/api-gateway.js
@@ -173,7 +173,7 @@ function isGatewayV1Event(event) {
 const requiredHttpApiV2Keys = ['rawPath', 'rawQueryString', 'routeKey', 'cookies']
 
 function isGatewayV2Event(event) {
-  if (event?.requestContext?.elb !== undefined) {
+  if (event?.requestContext?.elb !== undefined || event?.version === undefined) {
     return false
   }
   return eventHasRequiredKeys(event, requiredHttpApiV2Keys) && event?.version === '2.0'

--- a/lib/serverless/api-gateway.js
+++ b/lib/serverless/api-gateway.js
@@ -158,7 +158,7 @@ const requiredHttpApiV1Keys = [
 
 // See https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
 function isGatewayV1Event(event) {
-  if (event?.requestContext?.elb !== undefined) {
+  if (event?.requestContext?.elb !== undefined || event?.version === undefined) {
     return false
   }
   const hasKeys = eventHasRequiredKeys(event, requiredHttpApiV1Keys)

--- a/lib/serverless/api-gateway.js
+++ b/lib/serverless/api-gateway.js
@@ -158,7 +158,7 @@ const requiredHttpApiV1Keys = [
 
 // See https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
 function isGatewayV1Event(event) {
-  if (event?.requestContext?.elb !== undefined || event?.version === undefined) {
+  if (event?.requestContext === undefined || event?.requestContext?.elb !== undefined) {
     return false
   }
   const hasKeys = eventHasRequiredKeys(event, requiredHttpApiV1Keys)
@@ -173,7 +173,7 @@ function isGatewayV1Event(event) {
 const requiredHttpApiV2Keys = ['rawPath', 'rawQueryString', 'routeKey', 'cookies']
 
 function isGatewayV2Event(event) {
-  if (event?.requestContext?.elb !== undefined || event?.version === undefined) {
+  if (event?.requestContext === undefined || event?.requestContext?.elb !== undefined) {
     return false
   }
   return eventHasRequiredKeys(event, requiredHttpApiV2Keys) && event?.version === '2.0'

--- a/test/unit/serverless/aws-lambda.test.js
+++ b/test/unit/serverless/aws-lambda.test.js
@@ -108,44 +108,47 @@ test('AwsLambda.patchLambdaHandler', async (t) => {
       body: 'worked'
     }
 
-    await t.test('should not create web transaction', (t, end) => {
-      const { agent, awsLambda, stubContext, stubCallback } = t.nr
-      agent.on('transactionFinished', confirmAgentAttribute)
+    await t.test(
+      'should not create web transaction for custom direct invocation payload',
+      (t, end) => {
+        const { agent, awsLambda, stubContext, stubCallback } = t.nr
+        agent.on('transactionFinished', confirmAgentAttribute)
 
-      const nonApiGatewayProxyEvent = {
-        resource : {
-          some: 'key',
-        },
-        action: 'someAction',
+        const nonApiGatewayProxyEvent = {
+          resource: {
+            some: 'key'
+          },
+          action: 'someAction'
+        }
+
+        const wrappedHandler = awsLambda.patchLambdaHandler((event, context, callback) => {
+          const transaction = agent.tracer.getTransaction()
+
+          assert.ok(transaction)
+          assert.equal(transaction.type, 'bg')
+          assert.equal(transaction.getFullName(), expectedBgTransactionName)
+          assert.equal(transaction.isActive(), true)
+
+          callback(null, validResponse)
+        })
+
+        wrappedHandler(nonApiGatewayProxyEvent, stubContext, stubCallback)
+
+        function confirmAgentAttribute(transaction) {
+          const agentAttributes = transaction.trace.attributes.get(ATTR_DEST.TRANS_EVENT)
+          const segment = transaction.baseSegment
+          const spanAttributes = segment.attributes.get(ATTR_DEST.SPAN_EVENT)
+
+          assert.equal(agentAttributes['request.method'], undefined)
+          assert.equal(agentAttributes['request.uri'], undefined)
+
+          assert.equal(spanAttributes['request.method'], undefined)
+          assert.equal(spanAttributes['request.uri'], undefined)
+
+          end()
+        }
       }
-
-      const wrappedHandler = awsLambda.patchLambdaHandler((event, context, callback) => {
-        const transaction = agent.tracer.getTransaction()
-
-        assert.ok(transaction)
-        assert.equal(transaction.type, 'bg')
-        assert.equal(transaction.getFullName(), expectedBgTransactionName)
-        assert.equal(transaction.isActive(), true)
-
-        callback(null, validResponse)
-      })
-
-      wrappedHandler(nonApiGatewayProxyEvent, stubContext, stubCallback)
-
-      function confirmAgentAttribute(transaction) {
-        const agentAttributes = transaction.trace.attributes.get(ATTR_DEST.TRANS_EVENT)
-        const segment = transaction.baseSegment
-        const spanAttributes = segment.attributes.get(ATTR_DEST.SPAN_EVENT)
-
-        assert.equal(agentAttributes['request.method'], undefined)
-        assert.equal(agentAttributes['request.uri'], undefined)
-
-        assert.equal(spanAttributes['request.method'], undefined)
-        assert.equal(spanAttributes['request.uri'], undefined)
-
-        end()
-      }
-    })
+    )
 
     await t.test('should create web transaction', (t, end) => {
       const { agent, awsLambda, stubContext, stubCallback } = t.nr

--- a/test/unit/serverless/aws-lambda.test.js
+++ b/test/unit/serverless/aws-lambda.test.js
@@ -108,6 +108,45 @@ test('AwsLambda.patchLambdaHandler', async (t) => {
       body: 'worked'
     }
 
+    await t.test('should not create web transaction', (t, end) => {
+      const { agent, awsLambda, stubContext, stubCallback } = t.nr
+      agent.on('transactionFinished', confirmAgentAttribute)
+
+      const nonApiGatewayProxyEvent = {
+        resource : {
+          some: 'key',
+        },
+        action: 'someAction',
+      }
+
+      const wrappedHandler = awsLambda.patchLambdaHandler((event, context, callback) => {
+        const transaction = agent.tracer.getTransaction()
+
+        assert.ok(transaction)
+        assert.equal(transaction.type, 'bg')
+        assert.equal(transaction.getFullName(), expectedBgTransactionName)
+        assert.equal(transaction.isActive(), true)
+
+        callback(null, validResponse)
+      })
+
+      wrappedHandler(nonApiGatewayProxyEvent, stubContext, stubCallback)
+
+      function confirmAgentAttribute(transaction) {
+        const agentAttributes = transaction.trace.attributes.get(ATTR_DEST.TRANS_EVENT)
+        const segment = transaction.baseSegment
+        const spanAttributes = segment.attributes.get(ATTR_DEST.SPAN_EVENT)
+
+        assert.equal(agentAttributes['request.method'], undefined)
+        assert.equal(agentAttributes['request.uri'], undefined)
+
+        assert.equal(spanAttributes['request.method'], undefined)
+        assert.equal(spanAttributes['request.uri'], undefined)
+
+        end()
+      }
+    })
+
     await t.test('should create web transaction', (t, end) => {
       const { agent, awsLambda, stubContext, stubCallback } = t.nr
       agent.on('transactionFinished', confirmAgentAttribute)

--- a/test/unit/serverless/fixtures.js
+++ b/test/unit/serverless/fixtures.js
@@ -338,11 +338,20 @@ const lambaV1InvocationEvent = {
   }
 }
 
+// Event which contains `resource` key and should not be a web event.
+const lambdaEvent = {
+  someKey: 'someValue',
+  resource: {
+    otherKey: 'otherValue'
+  }
+}
+
 module.exports = {
   restApiGatewayV1Event,
   httpApiGatewayV1Event,
   httpApiGatewayV2Event,
   httpApiGatewayV2EventAlt,
   albEvent,
-  lambaV1InvocationEvent
+  lambaV1InvocationEvent,
+  lambdaEvent
 }

--- a/test/unit/serverless/utils.test.js
+++ b/test/unit/serverless/utils.test.js
@@ -20,7 +20,8 @@ const {
   httpApiGatewayV2Event,
   httpApiGatewayV2EventAlt,
   lambaV1InvocationEvent,
-  albEvent
+  albEvent,
+  lambdaEvent
 } = require('./fixtures')
 
 test('isGatewayV1Event', () => {
@@ -30,6 +31,7 @@ test('isGatewayV1Event', () => {
   assert.equal(isGatewayV1Event(httpApiGatewayV2EventAlt), false)
   assert.equal(isGatewayV1Event(lambaV1InvocationEvent), false)
   assert.equal(isGatewayV1Event(albEvent), false)
+  assert.equal(isGatewayV1Event(lambdaEvent), false)
 })
 
 test('isGatewayV2Event', () => {
@@ -39,6 +41,7 @@ test('isGatewayV2Event', () => {
   assert.equal(isGatewayV2Event(httpApiGatewayV2EventAlt), true)
   assert.equal(isGatewayV2Event(lambaV1InvocationEvent), false)
   assert.equal(isGatewayV2Event(albEvent), false)
+  assert.equal(isGatewayV2Event(lambdaEvent), false)
 })
 
 test('isAlbEvent', () => {
@@ -48,4 +51,5 @@ test('isAlbEvent', () => {
   assert.equal(isAlbEvent(httpApiGatewayV2EventAlt), false)
   assert.equal(isAlbEvent(lambaV1InvocationEvent), false)
   assert.equal(isAlbEvent(albEvent), true)
+  assert.equal(isAlbEvent(lambdaEvent), true)
 })

--- a/test/unit/serverless/utils.test.js
+++ b/test/unit/serverless/utils.test.js
@@ -51,5 +51,5 @@ test('isAlbEvent', () => {
   assert.equal(isAlbEvent(httpApiGatewayV2EventAlt), false)
   assert.equal(isAlbEvent(lambaV1InvocationEvent), false)
   assert.equal(isAlbEvent(albEvent), true)
-  assert.equal(isAlbEvent(lambdaEvent), true)
+  assert.equal(isAlbEvent(lambdaEvent), false)
 })


### PR DESCRIPTION
Fixes #2824 