### PR TITLE
feat: Added segment synthesis for otel producer spans

### DIFF
--- a/lib/otel/rules.js
+++ b/lib/otel/rules.js
@@ -45,6 +45,7 @@ const srcJson = require('./rules.json')
 class Rule {
   static OTEL_SPAN_KIND_SERVER = 'server'
   static OTEL_SPAN_KIND_CLIENT = 'client'
+  static OTEL_SPAN_KIND_PRODUCER = 'producer'
 
   #name
   #spanKinds
@@ -82,15 +83,15 @@ class Rule {
   }
 
   get isClientRule() {
-    return this.#spanKinds.includes(Rule.OTEL_SPAN_KIND_CLIENT) || this.isProducer
+    return this.#spanKinds.includes(Rule.OTEL_SPAN_KIND_CLIENT)
   }
 
   get isConsumer() {
     return this.#spanKinds.includes('consumer')
   }
 
-  get isProducer() {
-    return this.#spanKinds.includes('producer')
+  get isProducerRule() {
+    return this.#spanKinds.includes(Rule.OTEL_SPAN_KIND_PRODUCER)
   }
 
   get isServerRule() {
@@ -126,6 +127,7 @@ class RulesEngine {
   #fallbackServerRules = new Map()
   #clientRules = new Map()
   #fallbackClientRules = new Map()
+  #fallbackProducerRules = new Map()
 
   constructor() {
     for (const inputRule of srcJson) {
@@ -136,6 +138,8 @@ class RulesEngine {
           this.#fallbackServerRules.set(rule.name, rule)
         } else if (rule.isClientRule === true) {
           this.#fallbackClientRules.set(rule.name, rule)
+        } else if (rule.isProducerRule === true) {
+          this.#fallbackProducerRules.set(rule.name, rule)
         }
         continue
       }
@@ -178,8 +182,7 @@ class RulesEngine {
         break
       }
 
-      case SpanKind.CLIENT:
-      case SpanKind.PRODUCER: {
+      case SpanKind.CLIENT: {
         for (const rule of this.#clientRules.values()) {
           if (rule.matches(otelSpan) === true) {
             result = rule
@@ -187,6 +190,18 @@ class RulesEngine {
           }
         }
         for (const rule of this.#fallbackClientRules.values()) {
+          if (rule.matches(otelSpan) === true) {
+            result = rule
+            break
+          }
+        }
+        break
+      }
+
+      // there currently are no producer rules, just fallback
+      // if we add new rules they will have to be wired up
+      case SpanKind.PRODUCER: {
+        for (const rule of this.#fallbackProducerRules.values()) {
           if (rule.matches(otelSpan) === true) {
             result = rule
             break

--- a/lib/otel/rules.json
+++ b/lib/otel/rules.json
@@ -455,6 +455,7 @@
   },
   {
     "name": "FallbackProducer",
+    "type": "producer",
     "matcher": {
       "required_span_kinds": [
         "producer"

--- a/lib/otel/segment-synthesis.js
+++ b/lib/otel/segment-synthesis.js
@@ -6,7 +6,12 @@
 'use strict'
 const { RulesEngine } = require('./rules')
 const defaultLogger = require('../logger').child({ component: 'segment-synthesizer' })
-const { createDbSegment, createHttpExternalSegment, createServerSegment } = require('./segments')
+const {
+  createDbSegment,
+  createHttpExternalSegment,
+  createServerSegment,
+  createProducerSegment
+} = require('./segments')
 
 class SegmentSynthesizer {
   constructor(agent, { logger = defaultLogger } = {}) {
@@ -27,10 +32,12 @@ class SegmentSynthesizer {
     }
 
     switch (rule.type) {
-      case 'external':
-        return createHttpExternalSegment(this.agent, otelSpan)
       case 'db':
         return createDbSegment(this.agent, otelSpan)
+      case 'external':
+        return createHttpExternalSegment(this.agent, otelSpan)
+      case 'producer':
+        return createProducerSegment(this.agent, otelSpan)
       case 'server':
         return createServerSegment(this.agent, otelSpan)
       default:

--- a/lib/otel/segments/index.js
+++ b/lib/otel/segments/index.js
@@ -7,9 +7,11 @@
 const createHttpExternalSegment = require('./http-external')
 const createDbSegment = require('./database')
 const createServerSegment = require('./server')
+const createProducerSegment = require('./producer')
 
 module.exports = {
   createDbSegment,
   createHttpExternalSegment,
+  createProducerSegment,
   createServerSegment
 }

--- a/lib/otel/segments/producer.js
+++ b/lib/otel/segments/producer.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const {
+  SEMATTRS_MESSAGING_SYSTEM,
+  SEMATTRS_MESSAGING_DESTINATION,
+  SEMATTRS_MESSAGING_DESTINATION_KIND
+} = require('@opentelemetry/semantic-conventions')
+
+module.exports = function createProducerSegment(agent, otelSpan) {
+  const context = agent.tracer.getContext()
+  const name = setName(otelSpan)
+  const segment = agent.tracer.createSegment({
+    name,
+    parent: context.segment,
+    transaction: context.transaction
+  })
+  return { segment, transaction: context.transaction }
+}
+
+function setName(otelSpan) {
+  const system = otelSpan.attributes[SEMATTRS_MESSAGING_SYSTEM] || 'Unknown'
+  const destKind = otelSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND] || 'Unknown'
+  const destination = otelSpan.attributes[SEMATTRS_MESSAGING_DESTINATION] || 'Unknown'
+  return `MessageBroker/${system}/${destKind}/Produce/Named/${destination}`
+}

--- a/test/unit/lib/otel/fixtures/index.js
+++ b/test/unit/lib/otel/fixtures/index.js
@@ -14,6 +14,7 @@ const {
 const createSpan = require('./span')
 const createHttpClientSpan = require('./http-client')
 const { createRpcServerSpan, createHttpServerSpan, createBaseHttpSpan } = require('./server')
+const { createQueueProducerSpan, createTopicProducerSpan } = require('./producer')
 
 module.exports = {
   createBaseHttpSpan,
@@ -23,7 +24,9 @@ module.exports = {
   createHttpServerSpan,
   createMemcachedDbSpan,
   createMongoDbSpan,
+  createQueueProducerSpan,
   createRedisDbSpan,
   createRpcServerSpan,
-  createSpan
+  createSpan,
+  createTopicProducerSpan
 }

--- a/test/unit/lib/otel/fixtures/producer.js
+++ b/test/unit/lib/otel/fixtures/producer.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const {
+  MessagingDestinationKindValues,
+  SEMATTRS_MESSAGING_SYSTEM,
+  SEMATTRS_MESSAGING_DESTINATION,
+  SEMATTRS_MESSAGING_DESTINATION_KIND
+} = require('@opentelemetry/semantic-conventions')
+const { SpanKind } = require('@opentelemetry/api')
+const createSpan = require('./span')
+
+function createTopicProducerSpan({ parentId, tracer, tx, name = 'test-span' }) {
+  const span = createSpan({ name, kind: SpanKind.PRODUCER, parentId, tracer, tx })
+  span.setAttribute(SEMATTRS_MESSAGING_SYSTEM, 'messaging-lib')
+  span.setAttribute(SEMATTRS_MESSAGING_DESTINATION_KIND, MessagingDestinationKindValues.TOPIC)
+  span.setAttribute(SEMATTRS_MESSAGING_DESTINATION, 'test-topic')
+  return span
+}
+
+function createQueueProducerSpan({ parentId, tracer, tx, name = 'test-span' }) {
+  const span = createSpan({ name, kind: SpanKind.PRODUCER, parentId, tracer, tx })
+  span.setAttribute(SEMATTRS_MESSAGING_SYSTEM, 'messaging-lib')
+  span.setAttribute(SEMATTRS_MESSAGING_DESTINATION_KIND, MessagingDestinationKindValues.QUEUE)
+  span.setAttribute(SEMATTRS_MESSAGING_DESTINATION, 'test-queue')
+  return span
+}
+
+module.exports = {
+  createQueueProducerSpan,
+  createTopicProducerSpan
+}

--- a/test/unit/lib/otel/rules.test.js
+++ b/test/unit/lib/otel/rules.test.js
@@ -57,11 +57,22 @@ test('fallback server rule is met', () => {
 
 test('fallback client rule is met', () => {
   const engine = new RulesEngine()
-  const span = new Span(tracer, ROOT_CONTEXT, 'test-span', spanContext, SpanKind.PRODUCER, parentId)
+  const span = new Span(tracer, ROOT_CONTEXT, 'test-span', spanContext, SpanKind.CLIENT, parentId)
   span.setAttribute('foo.bar', 'baz')
   span.end()
 
   const rule = engine.test(span)
   assert.notEqual(rule, undefined)
   assert.equal(rule.name, 'FallbackClient')
+})
+
+test('fallback producer rule is met', () => {
+  const engine = new RulesEngine()
+  const span = new Span(tracer, ROOT_CONTEXT, 'test-span', spanContext, SpanKind.PRODUCER, parentId)
+  span.setAttribute('foo.bar', 'baz')
+  span.end()
+
+  const rule = engine.test(span)
+  assert.notEqual(rule, undefined)
+  assert.equal(rule.name, 'FallbackProducer')
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

I updated the rules engine to handle producer spans separate from client spans as they are different.  Currently there's only one producer rule which is a fallback rule. I _think_ this is because the messaging spec is most complete and takes a few span attributes to build the name.

## Related Issues
Closes #2650 