### PR TITLE
test: Updated `match` to fail if you pass in an object that lacks the expected keys

### DIFF
--- a/test/lib/custom-assertions/match.js
+++ b/test/lib/custom-assertions/match.js
@@ -60,6 +60,8 @@ module.exports = function match(actual, expected, { assert = require('node:asser
       } else {
         assert.equal(actual[key], expected[key])
       }
+    } else {
+      assert.fail(`Missing ${key} in ${JSON.stringify(actual)}`)
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

@mrickard found that he was passing in an object that lacked the keys he was asserting. It wasn't failing, this PR fixes that.
