### PR TITLE
fix: Updated `shim.createSegment` and `shim.handleMqTracingHeaders` to be backwards compatible with the changes to context manager

### DIFF
--- a/lib/shim/message-shim/subscribe-consume.js
+++ b/lib/shim/message-shim/subscribe-consume.js
@@ -213,7 +213,7 @@ function createConsumerWrapper({ shim, spec, consumer }) {
       }
     }
     if (msgDesc.headers) {
-      shim.handleMqTracingHeaders(msgDesc.headers, tx.baseSegment, tx, shim._transportType)
+      shim.handleMqTracingHeaders(msgDesc.headers, tx.baseSegment, shim._transportType, tx)
     }
 
     shim.logger.trace('Started message transaction %s named %s', tx.id, txName)

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -1315,6 +1315,7 @@ function createSegment(name, recorder, parent) {
   }
 
   const transaction = this.tracer.getTransaction()
+  parent = parent || this.getActiveSegment()
   const spec = new specs.SegmentSpec(opts)
   return _rawCreateSegment({ shim: this, spec, parent, transaction })
 }

--- a/lib/shim/transaction-shim.js
+++ b/lib/shim/transaction-shim.js
@@ -184,7 +184,7 @@ function setTransactionName(name) {
 /**
  * Retrieves whatever CAT headers may be in the given headers.
  *
- * - `handleMqTracingHeaders(headers [, segment [, transportType]])`
+ * - `handleMqTracingHeaders(headers [, segment ] [, transportType], [, transaction])`
  *
  * @memberof TransactionShim.prototype
  *
@@ -195,11 +195,11 @@ function setTransactionName(name) {
  * @param {TraceSegment} [segment]
  *  The trace segment to associate the header data with. If no segment is
  *  provided then the currently active segment is used.
- * @param {Transaction} transaction active transaction
  * @param {string} [transportType]
  *  The transport type that brought the headers. Usually `HTTP` or `HTTPS`.
+ * @param {Transaction} transaction active transaction
  */
-function handleMqTracingHeaders(headers, segment, transaction, transportType) {
+function handleMqTracingHeaders(headers, segment, transportType, transaction) {
   // TODO: replace functionality when CAT fully removed.
 
   if (!headers) {
@@ -216,6 +216,7 @@ function handleMqTracingHeaders(headers, segment, transaction, transportType) {
 
   // Check that we're in an active transaction.
   const currentSegment = segment || this.getSegment()
+  transaction = transaction || this.tracer.getTransaction()
   if (!currentSegment || !transaction.isActive()) {
     this.logger.trace('Not processing headers for CAT or DT, not in an active transaction.')
     return

--- a/test/unit/shim/shim.test.js
+++ b/test/unit/shim/shim.test.js
@@ -2117,7 +2117,7 @@ test('Shim', async function (t) {
       helper.runInTransaction(agent, function (tx) {
         const args = [wrappable.getActiveSegment]
         const segment = wrappable.getActiveSegment()
-        const parent = shim.createSegment({ name: 'test segment', parent: segment })
+        const parent = shim.createSegment('test-segment')
         shim.bindCallbackSegment({}, args, shim.LAST, parent)
         const cbSegment = args[0]()
 

--- a/test/unit/shim/transaction-shim.test.js
+++ b/test/unit/shim/transaction-shim.test.js
@@ -441,7 +441,7 @@ test('TransactionShim', async function (t) {
         assert.ok(!segment.catTransaction)
         assert.ok(!segment.getAttributes().transaction_guid)
 
-        shim.handleMqTracingHeaders(headers, segment, tx)
+        shim.handleMqTracingHeaders(headers, segment, null, tx)
 
         assert.ok(!tx.incomingCatId)
         assert.ok(!tx.referringTransactionGuid)
@@ -465,7 +465,7 @@ test('TransactionShim', async function (t) {
         assert.ok(!segment.catTransaction)
         assert.ok(!segment.getAttributes().transaction_guid)
 
-        shim.handleMqTracingHeaders(headers, segment, tx)
+        shim.handleMqTracingHeaders(headers, segment, null, tx)
 
         assert.ok(!tx.incomingCatId)
         assert.ok(!tx.referringTransactionGuid)
@@ -488,7 +488,7 @@ test('TransactionShim', async function (t) {
         assert.ok(!segment.getAttributes().transaction_guid)
 
         assert.doesNotThrow(function () {
-          shim.handleMqTracingHeaders(null, segment, tx)
+          shim.handleMqTracingHeaders(null, segment, null, tx)
         })
 
         assert.ok(!tx.incomingCatId)
@@ -516,7 +516,7 @@ test('TransactionShim', async function (t) {
 
           helper.runInTransaction(agent, shim.BG, function (tx2) {
             assert.notEqual(tx2, tx)
-            shim.handleMqTracingHeaders(headers, segment, tx)
+            shim.handleMqTracingHeaders(headers, segment, null, tx)
           })
 
           assert.equal(tx.incomingCatId, '9876#id')
@@ -541,7 +541,7 @@ test('TransactionShim', async function (t) {
           assert.ok(!tx.tripId)
           assert.ok(!tx.referringPathHash)
 
-          shim.handleMqTracingHeaders(headers, null, tx)
+          shim.handleMqTracingHeaders(headers)
 
           assert.equal(tx.incomingCatId, '9876#id')
           assert.equal(tx.referringTransactionGuid, 'trans id')
@@ -568,7 +568,7 @@ test('TransactionShim', async function (t) {
 
           helper.runInTransaction(agent, shim.BG, function (tx2) {
             assert.notEqual(tx2, tx)
-            shim.handleMqTracingHeaders(headers, segment, tx)
+            shim.handleMqTracingHeaders(headers, segment, null, tx)
           })
 
           assert.equal(tx.incomingCatId, '9876#id')
@@ -592,7 +592,7 @@ test('TransactionShim', async function (t) {
         helper.runInTransaction(agent, function (tx) {
           const headers = { traceparent, tracestate }
           const segment = shim.getSegment()
-          shim.handleMqTracingHeaders(headers, segment, tx)
+          shim.handleMqTracingHeaders(headers, segment)
 
           const outboundHeaders = {}
           tx.insertDistributedTraceHeaders(outboundHeaders)
@@ -615,7 +615,7 @@ test('TransactionShim', async function (t) {
         helper.runInTransaction(agent, function (tx) {
           const headers = { traceparent }
           const segment = shim.getSegment()
-          shim.handleMqTracingHeaders(headers, segment, tx)
+          shim.handleMqTracingHeaders(headers, segment, null, tx)
 
           const outboundHeaders = {}
           tx.insertDistributedTraceHeaders(outboundHeaders)
@@ -638,7 +638,7 @@ test('TransactionShim', async function (t) {
         helper.runInTransaction(agent, function (tx) {
           const headers = { traceparent, tracestate }
           const segment = shim.getSegment()
-          shim.handleMqTracingHeaders(headers, segment, tx)
+          shim.handleMqTracingHeaders(headers, segment, null, tx)
 
           const outboundHeaders = {}
           tx.insertDistributedTraceHeaders(outboundHeaders)
@@ -660,7 +660,7 @@ test('TransactionShim', async function (t) {
       helper.runInTransaction(agent, function (tx) {
         const headers = { traceparent, tracestate }
         const segment = shim.getSegment()
-        shim.handleMqTracingHeaders(headers, segment, tx)
+        shim.handleMqTracingHeaders(headers, segment, null, tx)
 
         const outboundHeaders = {}
         tx.insertDistributedTraceHeaders(outboundHeaders)
@@ -687,7 +687,7 @@ test('TransactionShim', async function (t) {
 
           helper.runInTransaction(agent, shim.BG, function (tx2) {
             assert.notEqual(tx2, tx)
-            shim.handleMqTracingHeaders(headers, segment, tx2)
+            shim.handleMqTracingHeaders(headers, segment, null, tx2)
           })
 
           assert.equal(segment.catId, '6789#app')
@@ -712,7 +712,7 @@ test('TransactionShim', async function (t) {
           assert.ok(!segment.catTransaction)
           assert.ok(!segment.getAttributes().transaction_guid)
 
-          shim.handleMqTracingHeaders(headers, null, tx)
+          shim.handleMqTracingHeaders(headers, null, null, tx)
 
           assert.equal(segment.catId, '6789#app')
           assert.equal(segment.catTransaction, 'app data transaction name')
@@ -738,7 +738,7 @@ test('TransactionShim', async function (t) {
 
           helper.runInTransaction(agent, shim.BG, function (tx2) {
             assert.notEqual(tx2, tx)
-            shim.handleMqTracingHeaders(headers, segment, tx2)
+            shim.handleMqTracingHeaders(headers, segment, null, tx2)
           })
 
           assert.equal(segment.catId, '6789#app')
@@ -764,7 +764,7 @@ test('TransactionShim', async function (t) {
           assert.ok(!segment.catTransaction)
           assert.ok(!segment.getAttributes().transaction_guid)
 
-          shim.handleMqTracingHeaders(headers, null, tx)
+          shim.handleMqTracingHeaders(headers, null, null, tx)
 
           assert.ok(!segment.catId)
           assert.ok(!segment.catTransaction)


### PR DESCRIPTION
…o be backwards compatible with the changes to context manager

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

I did some analysis on the big changes to context manager: #2646, #2689, #2717 and found 2 places where we altered behavior to "public" methods.  I put public in quotes because aside from our api we do document and expose our shim.  These two changes were in the shim where the signatures varied and I updated the code to restore behavior:

`shim.createSegment` - before this PR required you to pass in `parent` to represent the parent segment, I updated this to pull from context manager and get the active segment like before.

`shim.handleMqTracingHeaders` - before this PR it required you to now pass in the transaction. I updated this to get the current transaction if not set and move this to the last arg to not break people's usage.(This is in shim but for some reason it's not in our [API docs](https://newrelic.github.io/node-newrelic/TransactionShim.html)

