### PR TITLE
feat: Added entity linking attributes to aws-sdk v3 Lambda segments

### DIFF
--- a/lib/instrumentation/aws-sdk/v3/lambda.js
+++ b/lib/instrumentation/aws-sdk/v3/lambda.js
@@ -4,11 +4,10 @@
  */
 
 'use strict'
-// const { OperationSpec } = require('../../../shim/specs')
 const InstrumentationDescriptor = require('../../../instrumentation-descriptor')
 
 /**
- * Wraps the deserialize middleware step to add the
+ * Defines a deserialize middleware to add the
  * cloud.resource_id segment attributes for the AWS command
  *
  * @param {Shim} shim

--- a/lib/instrumentation/aws-sdk/v3/lambda.js
+++ b/lib/instrumentation/aws-sdk/v3/lambda.js
@@ -18,11 +18,12 @@ const InstrumentationDescriptor = require('../../../instrumentation-descriptor')
  */
 function resourceIdMiddleware(shim, config, next) {
   return async function wrappedResourceIdMiddleware(args) {
-    let region
+    let result
     try {
-      region = await config.region()
-      const segment = shim.getSegment()
-
+      const region = await config.region()
+      result = await next(args)
+      const { response } = result
+      const segment = shim.getSegment(response.body.req)
       // We can't derive account ID, so we have to consume it from config
       const accountId = shim.agent.config.cloud.aws.account_id
       const functionName = args?.input?.FunctionName // have to get function from params
@@ -35,9 +36,9 @@ function resourceIdMiddleware(shim, config, next) {
       }
     } catch (err) {
       shim.logger.debug(err, 'Failed to add AWS cloud resource id to segment')
+    } finally {
+      return result
     }
-
-    return next(args)
   }
 }
 
@@ -46,7 +47,7 @@ const lambdaMiddlewareConfig = {
   type: InstrumentationDescriptor.TYPE_GENERIC,
   config: {
     name: 'NewRelicGetResourceId',
-    step: 'finalizeRequest',
+    step: 'deserialize',
     priority: 'low',
     override: true
   }

--- a/lib/instrumentation/aws-sdk/v3/lambda.js
+++ b/lib/instrumentation/aws-sdk/v3/lambda.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+// const { OperationSpec } = require('../../../shim/specs')
+const InstrumentationDescriptor = require('../../../instrumentation-descriptor')
+
+/**
+ * Wraps the deserialize middleware step to add the
+ * cloud.resource_id segment attributes for the AWS command
+ *
+ * @param {Shim} shim
+ * @param {Object} config AWS command configuration
+ * @param {function} next next function in middleware chain
+ * @returns {function}
+ */
+function resourceIdMiddleware(shim, config, next) {
+  return async function wrappedResourceIdMiddleware(args) {
+    let region
+    try {
+      region = await config.region()
+      const segment = shim.getSegment()
+
+      // We can't derive account ID, so we have to consume it from config
+      const accountId = shim.agent.config.cloud.aws.account_id
+      const functionName = args?.input?.FunctionName // have to get function from params
+      if (accountId && functionName) {
+        segment.addAttribute(
+          'cloud.resource_id',
+          `arn:aws:lambda:${region}:${accountId}:function:${functionName}`
+        )
+        segment.addAttribute('cloud.platform', `aws_lambda`)
+      }
+    } catch (err) {
+      shim.logger.debug(err, 'Failed to add AWS cloud resource id to segment')
+    }
+
+    return next(args)
+  }
+}
+
+const lambdaMiddlewareConfig = {
+  middleware: resourceIdMiddleware,
+  type: InstrumentationDescriptor.TYPE_GENERIC,
+  config: {
+    name: 'NewRelicGetResourceId',
+    step: 'finalizeRequest',
+    priority: 'low',
+    override: true
+  }
+}
+
+module.exports = {
+  lambdaMiddlewareConfig
+}

--- a/lib/instrumentation/aws-sdk/v3/lambda.js
+++ b/lib/instrumentation/aws-sdk/v3/lambda.js
@@ -10,10 +10,10 @@ const InstrumentationDescriptor = require('../../../instrumentation-descriptor')
  * Defines a deserialize middleware to add the
  * cloud.resource_id segment attributes for the AWS command
  *
- * @param {Shim} shim
+ * @param {Shim} shim New Relic agent shim
  * @param {Object} config AWS command configuration
  * @param {function} next next function in middleware chain
- * @returns {function}
+ * @returns {function} wrapped version of middleware function
  */
 function resourceIdMiddleware(shim, config, next) {
   return async function wrappedResourceIdMiddleware(args) {

--- a/lib/instrumentation/aws-sdk/v3/smithy-client.js
+++ b/lib/instrumentation/aws-sdk/v3/smithy-client.js
@@ -9,12 +9,14 @@ const { middlewareConfig } = require('./common')
 const { snsMiddlewareConfig } = require('./sns')
 const { sqsMiddlewareConfig } = require('./sqs')
 const { dynamoMiddlewareConfig } = require('./dynamodb')
+const { lambdaMiddlewareConfig } = require('./lambda')
 const { bedrockMiddlewareConfig } = require('./bedrock')
 const MIDDLEWARE = Symbol('nrMiddleware')
 
 const middlewareByClient = {
   Client: middlewareConfig,
   BedrockRuntime: [...middlewareConfig, bedrockMiddlewareConfig],
+  Lambda: [...middlewareConfig, lambdaMiddlewareConfig],
   SNS: [...middlewareConfig, snsMiddlewareConfig],
   SQS: [...middlewareConfig, sqsMiddlewareConfig],
   DynamoDB: [...middlewareConfig, ...dynamoMiddlewareConfig],

--- a/lib/serverless/aws-lambda.js
+++ b/lib/serverless/aws-lambda.js
@@ -249,9 +249,7 @@ class AwsLambda {
   _getAwsAgentAttributes(event, context) {
     const attributes = {
       'aws.lambda.arn': context.invokedFunctionArn,
-      'aws.requestId': context.awsRequestId,
-      'cloud.resource_id': context.invokedFunctionArn,
-      'cloud.platform': 'aws_lambda'
+      'aws.requestId': context.awsRequestId
     }
 
     const eventSourceInfo = this._detectEventType(event)

--- a/test/unit/serverless/aws-lambda.test.js
+++ b/test/unit/serverless/aws-lambda.test.js
@@ -25,8 +25,6 @@ const LAMBDA_ARN = 'aws.lambda.arn'
 const COLDSTART = 'aws.lambda.coldStart'
 const EVENTSOURCE_ARN = 'aws.lambda.eventSource.arn'
 const EVENTSOURCE_TYPE = 'aws.lambda.eventSource.eventType'
-const PLATFORM = 'cloud.platform'
-const RESOURCE_ID = 'cloud.resource_id'
 
 function getMetrics(agent) {
   return agent.metrics._metrics
@@ -64,8 +62,7 @@ test('AwsLambda.patchLambdaHandler', async (t) => {
       functionVersion: 'TestVersion',
       invokedFunctionArn: 'arn:test:function',
       memoryLimitInMB: '128',
-      awsRequestId: 'testid',
-      platform: 'aws_lambda'
+      awsRequestId: 'testid'
     }
     ctx.nr.stubCallback = () => {}
 
@@ -669,8 +666,6 @@ test('AwsLambda.patchLambdaHandler', async (t) => {
       assert.equal(txTrace[REQ_ID], stubContext.awsRequestId)
       assert.equal(txTrace[LAMBDA_ARN], stubContext.invokedFunctionArn)
       assert.equal(txTrace[COLDSTART], true)
-      assert.equal(txTrace[PLATFORM], stubContext.platform)
-      assert.equal(txTrace[RESOURCE_ID], stubContext.invokedFunctionArn)
       end()
     }
 

--- a/test/versioned/aws-sdk-v3/lambda.test.js
+++ b/test/versioned/aws-sdk-v3/lambda.test.js
@@ -35,7 +35,7 @@ function checkEntityLinkingSegments({ operations, tx, end }) {
       'aws.operation': operations[0],
       'aws.requestId': String,
       'aws.region': 'us-east-1',
-      'aws.service': 'lambda',
+      'aws.service': String,
       'cloud.resource_id': `arn:aws:lambda:${attrs['aws.region']}:${accountId}:function:${testFunctionName}`,
       'cloud.platform': `aws_lambda`
     })
@@ -72,7 +72,7 @@ function checkNonLinkableSegments({ operations, tx, end }) {
       'aws.operation': operations[0],
       'aws.requestId': String,
       'aws.region': 'us-east-1',
-      'aws.service': 'lambda'
+      'aws.service': String
     })
   })
   end()

--- a/test/versioned/aws-sdk-v3/lambda.test.js
+++ b/test/versioned/aws-sdk-v3/lambda.test.js
@@ -18,7 +18,7 @@ const {
 const { createEmptyResponseServer, FAKE_CREDENTIALS } = require('../../lib/aws-server-stubs')
 const { match } = require('../../lib/custom-assertions')
 
-function checkEntityLinkingSegments({ service, operations, tx, end }) {
+function checkEntityLinkingSegments({ operations, tx, end }) {
   const root = tx.trace.root
 
   const segments = checkAWSAttributes(root, EXTERN_PATTERN)
@@ -35,7 +35,7 @@ function checkEntityLinkingSegments({ service, operations, tx, end }) {
       'aws.operation': operations[0],
       'aws.requestId': String,
       'aws.region': 'us-east-1',
-      'aws.service': String(service).toLowerCase(),
+      'aws.service': 'lambda',
       'cloud.resource_id': `arn:aws:lambda:${attrs['aws.region']}:${accountId}:function:${testFunctionName}`,
       'cloud.platform': `aws_lambda`
     })
@@ -43,7 +43,7 @@ function checkEntityLinkingSegments({ service, operations, tx, end }) {
   end()
 }
 
-function checkNonLinkableSegments({ service, operations, tx, end }) {
+function checkNonLinkableSegments({ operations, tx, end }) {
   // When no account ID or ARN is available, make sure not to set cloud resource id or platform
   const root = tx.trace.root
 
@@ -72,7 +72,7 @@ function checkNonLinkableSegments({ service, operations, tx, end }) {
       'aws.operation': operations[0],
       'aws.requestId': String,
       'aws.region': 'us-east-1',
-      'aws.service': String(service).toLowerCase()
+      'aws.service': 'lambda'
     })
   })
   end()
@@ -134,7 +134,6 @@ test('LambdaClient', async (t) => {
       await service.send(cmd)
       tx.end()
       setImmediate(checkEntityLinkingSegments, {
-        service: 'Lambda',
         operations: ['InvokeCommand'],
         tx,
         end
@@ -153,7 +152,6 @@ test('LambdaClient', async (t) => {
       await service.send(cmd)
       tx.end()
       setImmediate(checkNonLinkableSegments, {
-        service: 'Lambda',
         operations: ['InvokeCommand'],
         tx,
         end

--- a/test/versioned/aws-sdk-v3/lambda.test.js
+++ b/test/versioned/aws-sdk-v3/lambda.test.js
@@ -35,7 +35,7 @@ function checkEntityLinkingSegments({ service, operations, tx, end }) {
       'aws.operation': operations[0],
       'aws.requestId': String,
       'aws.region': 'us-east-1',
-      'aws.service': service.toLowerCase(),
+      'aws.service': String(service).toLowerCase(),
       'cloud.resource_id': `arn:aws:lambda:${attrs['aws.region']}:${accountId}:function:${testFunctionName}`,
       'cloud.platform': `aws_lambda`
     })
@@ -72,7 +72,7 @@ function checkNonLinkableSegments({ service, operations, tx, end }) {
       'aws.operation': operations[0],
       'aws.requestId': String,
       'aws.region': 'us-east-1',
-      'aws.service': service.toLowerCase()
+      'aws.service': String(service).toLowerCase()
     })
   })
   end()


### PR DESCRIPTION
## Description
External Lambda functions invoked by a Node application result in external segments. In order for the entity to be linked, external segments need two additional attributes: `cloud.resource_id` and `cloud.platform`. This PR adds middleware at `instrumentation/aws-sdk/v3/lambda.js` (via `instrumentation/aws-sdk/v3/smithy-client.js`) to add these attributes. This middleware adds the attributes only if the agent's config includes an AWS account ID defined as `cloud.aws.account_id`. The account ID referenced here should be the same as the AWS account ID hosting Lambda functions that will be invoked by the instrumented Node application. 

## How to Test

There are two new tests in `test/versioned/aws-sdk-v3/lambda.test.js`: one to test for these new attributes when `cloud.aws.account_id` is set on the agent config, and one to test for their absence when `cloud.aws.account_id` is not set.

## Related Issues
Closes #2829 
Closes NR-348168