### PR TITLE
ci: Move init container release from lambda to GHA

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -65,3 +65,34 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.NODE_AGENT_GH_TOKEN }}
           GITHUB_USER: ${{ vars.NODE_AGENT_CI_USER_NAME }}
           GITHUB_EMAIL: ${{ vars.NODE_AGENT_CI_USER_EMAIL }}
+
+  release-tags:
+    runs-on: ubuntu-latest
+    if:
+      (github.event.workflow_run && github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'workflow_dispatch')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+      - run: npm install
+      - run: |
+          git config user.name ${GITHUB_ACTOR}
+          git config user.email gh-actions-${GITHUB_ACTOR}@github.com
+      - id: get_tag
+        run: echo "latest_tag=$(cat package.json | jq .version)" >> $GITHUB_OUTPUT
+      - name: Create release tags for Lambda and K8s Init Containers
+        uses: dev-hanz-ops/install-gh-cli-action@c78dbed4be2f8d6133a14a9a597ee12fd4ed5c93 # v3
+        with:
+          gh-cli-version: 2.63.2
+        run: |
+          gh auth login --with-token <<< $GH_RELEASE_TOKEN
+          echo "newrelic/newrelic-lambda-layers - Releasing New Relic Node Agent v${{ steps.get_tag.outputs.latest_tag }}.0 with tag v${{ steps.get_tag.outputs.latest_tag }}.0_nodejs"
+          gh create release "v${{ steps.get_tag.outputs.latest_tag }}.0_nodejs" -t "New Relic Node Agent v${{ steps.get_tag.outputs.latest_tag }}.0" --repo=newrelic/newrelic-lambda-layers
+          echo "newrelic/newrelic-agent-init-container - Releasing New Relic Node Agent v${{ steps.get_tag.outputs.latest_tag }}.0 with tag v${{ steps.get_tag.outputs.latest_tag }}.0_nodejs"
+          gh create release "v${{ steps.get_tag.outputs.latest_tag }}.0_nodejs" -t "New Relic Node Agent v${{ steps.get_tag.outputs.latest_tag }}.0" --repo=newrelic/newrelic-agent-init-container
+        env:
+          GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -65,34 +65,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.NODE_AGENT_GH_TOKEN }}
           GITHUB_USER: ${{ vars.NODE_AGENT_CI_USER_NAME }}
           GITHUB_EMAIL: ${{ vars.NODE_AGENT_CI_USER_EMAIL }}
-
-  release-tags:
-    runs-on: ubuntu-latest
-    if:
-      (github.event.workflow_run && github.event.workflow_run.conclusion == 'success') ||
-      (github.event_name == 'workflow_dispatch')
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 'lts/*'
-      - run: npm install
-      - run: |
-          git config user.name ${GITHUB_ACTOR}
-          git config user.email gh-actions-${GITHUB_ACTOR}@github.com
-      - id: get_tag
-        run: echo "latest_tag=$(cat package.json | jq .version)" >> $GITHUB_OUTPUT
-      - name: Create release tags for Lambda and K8s Init Containers
-        run: |
-          RELEASE_TITLE="New Relic Node Agent v${{ steps.get_tag.outputs.latest_tag }}.0"
-          RELEASE_TAG="v${{ steps.get_tag.outputs.latest_tag }}.0_nodejs"
-          RELEASE_NOTES="Automated release for [Node Agent v${{ steps.get_tag.outputs.latest_tag }}](https://github.com/newrelic/node-newrelic/releases/tag/v${{ steps.get_tag.outputs.latest_tag }})"
-          gh auth login --with-token <<< $GH_RELEASE_TOKEN
-          echo "newrelic/newrelic-lambda-layers - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
-          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-lambda-layers --notes=${RELEASE_NOTES}
-          echo "newrelic/newrelic-agent-init-container - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
-          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-agent-init-container --notes=${RELEASE_NOTES}
-        env:
-          GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -85,14 +85,14 @@ jobs:
       - id: get_tag
         run: echo "latest_tag=$(cat package.json | jq .version)" >> $GITHUB_OUTPUT
       - name: Create release tags for Lambda and K8s Init Containers
-        uses: dev-hanz-ops/install-gh-cli-action@c78dbed4be2f8d6133a14a9a597ee12fd4ed5c93 # v3
-        with:
-          gh-cli-version: 2.63.2
         run: |
+          RELEASE_TITLE="New Relic Node Agent v${{ steps.get_tag.outputs.latest_tag }}.0"
+          RELEASE_TAG="v${{ steps.get_tag.outputs.latest_tag }}.0_nodejs"
+          RELEASE_NOTES="Automated release for [Node Agent v${{ steps.get_tag.outputs.latest_tag }}](https://github.com/newrelic/node-newrelic/releases/tag/v${{ steps.get_tag.outputs.latest_tag }})"
           gh auth login --with-token <<< $GH_RELEASE_TOKEN
-          echo "newrelic/newrelic-lambda-layers - Releasing New Relic Node Agent v${{ steps.get_tag.outputs.latest_tag }}.0 with tag v${{ steps.get_tag.outputs.latest_tag }}.0_nodejs"
-          gh create release "v${{ steps.get_tag.outputs.latest_tag }}.0_nodejs" -t "New Relic Node Agent v${{ steps.get_tag.outputs.latest_tag }}.0" --repo=newrelic/newrelic-lambda-layers
-          echo "newrelic/newrelic-agent-init-container - Releasing New Relic Node Agent v${{ steps.get_tag.outputs.latest_tag }}.0 with tag v${{ steps.get_tag.outputs.latest_tag }}.0_nodejs"
-          gh create release "v${{ steps.get_tag.outputs.latest_tag }}.0_nodejs" -t "New Relic Node Agent v${{ steps.get_tag.outputs.latest_tag }}.0" --repo=newrelic/newrelic-agent-init-container
+          echo "newrelic/newrelic-lambda-layers - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
+          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-lambda-layers --notes=${RELEASE_NOTES}
+          echo "newrelic/newrelic-agent-init-container - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
+          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-agent-init-container --notes=${RELEASE_NOTES}
         env:
           GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}

--- a/.github/workflows/release-lambda-init-containers.yml
+++ b/.github/workflows/release-lambda-init-containers.yml
@@ -28,9 +28,9 @@ jobs:
           RELEASE_TAG="v${{ steps.get_tag.outputs.latest_tag }}.0_nodejs"
           RELEASE_NOTES="Automated release for [Node Agent v${{ steps.get_tag.outputs.latest_tag }}](https://github.com/newrelic/node-newrelic/releases/tag/v${{ steps.get_tag.outputs.latest_tag }})"
           gh auth login --with-token <<< $GH_RELEASE_TOKEN
-          echo "newrelic/newrelic-lambda-layers - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
-          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-lambda-layers --notes=${RELEASE_NOTES}
-          echo "newrelic/newrelic-agent-init-container - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
-          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-agent-init-container --notes=${RELEASE_NOTES}
+          echo "newrelic/newrelic-lambda-layers - Releasing \"${RELEASE_TITLE}\" with tag ${RELEASE_TAG}"
+          gh release create "${RELEASE_TAG}" --title="${RELEASE_TITLE}" --repo=newrelic/newrelic-lambda-layers --notes="${RELEASE_NOTES}"
+          echo "newrelic/newrelic-agent-init-container - Releasing \"${RELEASE_TITLE}\" with tag ${RELEASE_TAG}"
+          gh release create "${RELEASE_TAG}" --title="${RELEASE_TITLE}" --repo=newrelic/newrelic-agent-init-container --notes="${RELEASE_NOTES}"
         env:
           GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}

--- a/.github/workflows/release-lambda-init-containers.yml
+++ b/.github/workflows/release-lambda-init-containers.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   release-tags:
     runs-on: ubuntu-latest
-    if:
-      (github.event.workflow_run && github.event.workflow_run.conclusion == 'success')
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-lambda-init-containers.yml
+++ b/.github/workflows/release-lambda-init-containers.yml
@@ -1,0 +1,38 @@
+name: Agent Release Lambda Layers and K8s Init Containers
+
+on:
+  workflow_run:
+    workflows: ["Create Release"]
+    types:
+      - completed
+
+jobs:
+  release-tags:
+    runs-on: ubuntu-latest
+    if:
+      (github.event.workflow_run && github.event.workflow_run.conclusion == 'success')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+      - run: npm install
+      - run: |
+          git config user.name ${GITHUB_ACTOR}
+          git config user.email gh-actions-${GITHUB_ACTOR}@github.com
+      - id: get_tag
+        run: echo "latest_tag=$(cat package.json | jq .version)" >> $GITHUB_OUTPUT
+      - name: Create release tags for Lambda and K8s Init Containers
+        run: |
+          RELEASE_TITLE="New Relic Node Agent v${{ steps.get_tag.outputs.latest_tag }}.0"
+          RELEASE_TAG="v${{ steps.get_tag.outputs.latest_tag }}.0_nodejs"
+          RELEASE_NOTES="Automated release for [Node Agent v${{ steps.get_tag.outputs.latest_tag }}](https://github.com/newrelic/node-newrelic/releases/tag/v${{ steps.get_tag.outputs.latest_tag }})"
+          gh auth login --with-token <<< $GH_RELEASE_TOKEN
+          echo "newrelic/newrelic-lambda-layers - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
+          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-lambda-layers --notes=${RELEASE_NOTES}
+          echo "newrelic/newrelic-agent-init-container - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
+          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-agent-init-container --notes=${RELEASE_NOTES}
+        env:
+          GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}


### PR DESCRIPTION
## Description
We are getting rid of the internal [auto-layer-releases repo](https://source.datanerd.us/aws-lambda/auto-layer-releases/blob/master/app.py) and moving creating of the release tags into each agent's GHA deploy flow.