### PR TITLE
chore: Fixed mysql2 tests for new mysql2 version

### DIFF
--- a/test/versioned/mysql2/promises.test.js
+++ b/test/versioned/mysql2/promises.test.js
@@ -275,7 +275,7 @@ if (semver.satisfies(pkgVersion, '>=2.3.0')) {
 
     // does not work until mysql2 bug is fixed
     // https://github.com/sidorares/node-mysql2/issues/3091
-    if (!semver.satisfies(pkgVersion, '>=3.11.1 <3.12.0')) {
+    if (!semver.satisfies(pkgVersion, '>=3.11.1 <3.13.0')) {
       await t.test('get star', async function (t) {
         const { agent, poolCluster } = t.nr
         const connection = await poolCluster.of('*').getConnection()


### PR DESCRIPTION
This PR fixes an issue in our tests that showed up with the release of `mysql2@3.12.0` on 2024-12-23. Basically, that version still exhibits the bug reported in https://github.com/sidorares/node-mysql2/issues/3091. So all we can really do is bump this conditional with each release of `mysql2` until that bug is resolved.