### PR TITLE
test: Removed `t.diagnostic` from tests

### DIFF
--- a/test/integration/distributed-tracing/trace-context-cross-agent.test.js
+++ b/test/integration/distributed-tracing/trace-context-cross-agent.test.js
@@ -326,14 +326,6 @@ async function runTestCase(testCase, parentTest) {
   })
 
   await parentTest.test('trace context: ' + testCase.test_name, (t, end) => {
-    if (testCase.comment && testCase.comment.length > 0) {
-      const comment = Array.isArray(testCase.comment)
-        ? testCase.comment.join('\n')
-        : testCase.comment
-
-      t.diagnostic(comment)
-    }
-
     const agent = helper.instrumentMockedAgent({})
     agent.recordSupportability = recordSupportability
     agent.config.trusted_account_key = testCase.trusted_account_key

--- a/test/integration/uninstrumented/package.json
+++ b/test/integration/uninstrumented/package.json
@@ -24,5 +24,8 @@
     "restify": "*",
     "superagent": "*",
     "when": "*"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/test/integration/uninstrumented/uninstrumented.test.js
+++ b/test/integration/uninstrumented/uninstrumented.test.js
@@ -60,7 +60,7 @@ test('all instrumented modules should be detected when uninstrumented', (t, end)
         require(module)
         loaded.push(module)
       } catch {
-        t.diagnostic('failed to load ' + module)
+        // silently fail
       }
     }
   })

--- a/test/lib/temp-override-uncaught.js
+++ b/test/lib/temp-override-uncaught.js
@@ -34,9 +34,7 @@ const oldListeners = {
  */
 function tempOverrideUncaught({ t, handler, type = EXCEPTION }) {
   if (!handler) {
-    handler = function uncaughtTestHandler() {
-      t.diagnostic('uncaught handler not defined')
-    }
+    handler = function uncaughtTestHandler() {}
   }
 
   oldListeners[type] = process.listeners(type)

--- a/test/lib/temp-remove-listeners.js
+++ b/test/lib/temp-remove-listeners.js
@@ -19,7 +19,6 @@
  */
 module.exports = function tempRemoveListeners({ t, emitter, event }) {
   if (!emitter) {
-    t.diagnostic(`Not removing ${event} listeners, emitter does not exist`)
     return
   }
 

--- a/test/unit/collector/facts.test.js
+++ b/test/unit/collector/facts.test.js
@@ -730,7 +730,6 @@ test('display_host facts', async (t) => {
   await t.test('should be ipv6 when ipv_preference === 6', (t, end) => {
     const { agent, facts } = t.nr
     if (!agent.config.getIPAddresses().ipv6) {
-      t.diagnostic('this machine does not have an ipv6 address, skipping')
       end()
     }
 
@@ -753,7 +752,6 @@ test('display_host facts', async (t) => {
   await t.test('returns no ipv4, hostname should be ipv6 if possible', (t, end) => {
     const { agent, facts } = t.nr
     if (!agent.config.getIPAddresses().ipv6) {
-      t.diagnostic('this machine does not have an ipv6 address, skipping')
       end()
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

`t.diagnostic` output gets added to every PR, this is unncessary noise and is not helpful to our test runs.
