### PR TITLE
fix: Updated undici instrumentation to fix crash with trying to calculate exclusive duration on a segment that no longer exists

### DIFF
--- a/documentation/feature-flags.md
+++ b/documentation/feature-flags.md
@@ -20,12 +20,6 @@ Any prerelease flags can be enabled or disabled in your agent config by adding a
 * Environment Variable: `NEW_RELIC_FEATURE_FLAG_REVERSE_NAMING_RULES`
 * Description: Naming rules are in forward order by default.  
 
-#### undici_async_tracking
-* Enabled by default: `true`
-* Configuration: `{ feature_flag: { undici_async_tracking: true|false }}`
-* Environment Variable: `NEW_RELIC_FEATURE_FLAG_UNDICI_ASYNC_TRACKING`
-* Description: If you have multiple undici requests being made in parallel, you may find some state issues if requests to an app are made with keep-alive. If so, *disabling* this flag will avoid these state issues, though at the cost of some broken segment nesting.
-
 #### unresolved_promise_cleanup
 * Enabled by default: `true`
 * Configuration: `{ feature_flag: { unresolved_promise_cleanup: true|false }}`

--- a/lib/feature_flags.js
+++ b/lib/feature_flags.js
@@ -13,7 +13,6 @@ exports.prerelease = {
 
   promise_segments: false,
   reverse_naming_rules: false,
-  undici_async_tracking: true,
   unresolved_promise_cleanup: true,
   kafkajs_instrumentation: false
 }
@@ -36,6 +35,7 @@ exports.released = [
   'await_support',
   'certificate_bundle',
   'async_local_context',
+  'undici_async_tracking',
   'undici_instrumentation',
   'aws_bedrock_instrumentation',
   'langchain_instrumentation'

--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -11,8 +11,6 @@ const logger = require('../logger').child({ component: 'undici' })
 const NAMES = require('../metrics/names')
 const symbols = require('../symbols')
 // eslint-disable-next-line n/no-unsupported-features/node-builtins
-const { executionAsyncResource } = require('async_hooks')
-// eslint-disable-next-line n/no-unsupported-features/node-builtins
 const diagnosticsChannel = require('diagnostics_channel')
 const synthetics = require('../synthetics')
 const urltils = require('../util/urltils')
@@ -47,42 +45,6 @@ module.exports.unsubscribe = function unsubscribe() {
       channel.unsubscribe(hook)
     }
   })
-}
-
-/**
- * Retrieves the current segment(parent in our context) and transaction from executionAsyncResource
- * or from context manager then adds to the executionAsyncResource for future
- * undici requests within same async context.
- *
- * It was found that when running concurrent undici requests
- * within a transaction that the parent segment would get out of sync
- * depending on the async context of the transaction.  By using
- * `async_hooks.executionResource` it is more reliable.
- *
- * Note: However, if you have concurrent undici requests in a transaction
- * and the request to the transaction is using a keep alive there is a chance the
- * executionAsyncResource may be incorrect because of shared connections.  To revert to a more
- * naive tracking of parent set `config.feature_flag.undici_async_tracking: false` and
- * it will just get the segment and transaction from the context manager.
- *
- * @param {Shim} shim instance of shim
- * @returns {TraceSegment} parent segment
- */
-function getParentContext(shim) {
-  const { config } = shim.agent
-  if (config.feature_flag.undici_async_tracking) {
-    const resource = executionAsyncResource()
-
-    if (!resource[symbols.parentSegment]) {
-      const parent = shim.getSegment()
-      resource[symbols.parentSegment] = parent
-      const tx = shim.tracer.getTransaction()
-      resource[symbols.transaction] = tx
-    }
-    return { segment: resource[symbols.parentSegment], transaction: resource[symbols.transaction] }
-  }
-
-  return shim.tracer.getContext()
 }
 
 /**
@@ -160,7 +122,7 @@ function createExternalSegment({ shim, request, segment }) {
  */
 function requestCreateHook(shim, { request }) {
   const { config } = shim.agent
-  const { transaction, segment } = getParentContext(shim)
+  const { transaction, segment } = shim.tracer.getContext()
   request[symbols.parentSegment] = segment
   request[symbols.transaction] = transaction
   if (!(segment || transaction) || segment?.opaque) {
@@ -221,9 +183,8 @@ function requestHeadersHook(shim, { request, response }) {
 }
 
 /**
- * Gets the active and parent from given ctx(request, client connector)
- * and ends active and restores parent to active.  If an error exists
- * it will add the error to the transaction
+ * Gets the active segment, parent segment and transaction from given ctx(request, client connector)
+ * and ends segment and sets the previous parent segment as the active segment.  If an error exists it will add the error to the transaction
  *
  * @param {Shim} shim instance of shim
  * @param {object} params object from undici hook
@@ -236,14 +197,14 @@ function endAndRestoreSegment(shim, { request, error }) {
   const tx = request[symbols.transaction]
   if (activeSegment) {
     activeSegment.end()
+  }
 
-    if (error) {
-      handleError(shim, tx, error)
-    }
+  if (error && tx) {
+    handleError(shim, tx, error)
+  }
 
-    if (parentSegment) {
-      shim.setActiveSegment(parentSegment)
-    }
+  if (parentSegment) {
+    shim.setActiveSegment(parentSegment)
   }
 }
 

--- a/test/integration/instrumentation/fetch.test.js
+++ b/test/integration/instrumentation/fetch.test.js
@@ -144,11 +144,55 @@ test('fetch', async function (t) {
       const [{ status }, { status: status2 }] = await Promise.all([req1, req2])
       assert.equal(status, 200)
       assert.equal(status2, 200)
-      assertSegments(tx.trace, tx.trace.root, [`External/${HOST}/post`, `External/${HOST}/put`], {
+      const postName = `External/${HOST}/post`
+      const putName = `External/${HOST}/put`
+      const postSegment = metrics.findSegment(tx.trace, tx.trace.root, postName)
+      assert.equal(postSegment.parentId, tx.trace.root.id)
+      const putSegment = metrics.findSegment(tx.trace, tx.trace.root, putName)
+      // parent of put is the post segment because it is still the active one
+      // not ideal, but our instrumentation does not play nice with diagnostic_channel
+      // we're setting the active segment in the `undici:request:create` and restoring
+      // the parent segment in the request end
+      assert.equal(putSegment.parentId, postSegment.id)
+      assertSegments(tx.trace, tx.trace.root, [postSegment, putSegment], {
         exact: false
       })
       tx.end()
     })
+  })
+
+  await t.test('concurrent requests in diff transaction', async () => {
+    const tx1 = helper.runInTransaction(agent, async (tx) => {
+      const { status } = await fetch(`${REQUEST_URL}/post`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application.json'
+        },
+        body: Buffer.from('{"key":"value"}')
+      })
+      assert.equal(status, 200)
+      const postName = `External/${HOST}/post`
+      const postSegment = metrics.findSegment(tx.trace, tx.trace.root, postName)
+      assert.equal(postSegment.parentId, tx.trace.root.id)
+      tx.end()
+    })
+
+    const tx2 = helper.runInTransaction(agent, async(tx) => {
+      const { status } = await fetch(`${REQUEST_URL}/put`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application.json'
+        },
+        body: Buffer.from('{"key":"value"}')
+      })
+      assert.equal(status, 200)
+      const putName = `External/${HOST}/put`
+      const putSegment = metrics.findSegment(tx.trace, tx.trace.root, putName)
+      assert.equal(putSegment.parentId, tx.trace.root.id)
+      tx.end()
+    })
+
+    await Promise.all([tx1, tx2])
   })
 
   await t.test('invalid host', async () => {


### PR DESCRIPTION
## Description

[v12.11.0](https://github.com/newrelic/node-newrelic/releases/tag/v12.11.0) refactored our context manager and separated child segments from the current segment and stored them on the trace. Undici instrumentation had a bug when relying on the `undici_async_tracking` that took advantage of async_hooks `executionAsyncResource`.  It was keeping a reference to transaction and parent segment that existed from a previous request. I suspect this has to do with the keepAlive logic in undici where it'd return the same async id for different requests.  

When the trace for the new undici segment was being finalized it tried to calculate the exclusive time of the undici segment and it crashed with:

```sh
TypeError: Cannot destructure property 'children' of 'node' as it is null.
    at ExclusiveCalculator.process (/opt/application/node_modules/newrelic/lib/transaction/trace/exclusive-time-calculator.js:22:13)
    at TraceSegment.getExclusiveDurationInMillis (/opt/application/node_modules/newrelic/lib/transaction/trace/segment.js:248:16)
    at externalRecorder (/opt/application/node_modules/newrelic/lib/metrics/recorders/http_external.js:13:31)
    at Transaction.record (/opt/application/node_modules/newrelic/lib/transaction/index.js:680:23)
    at Transaction.end (/opt/application/node_modules/newrelic/lib/transaction/index.js:212:10)
    at ServerResponse.instrumentedFinish (/opt/application/node_modules/newrelic/lib/instrumentation/core/http.js:207:15)
    at Object.onceWrapper (node:events:638:28)
    at ServerResponse.emit (node:events:536:35)
    at AsyncLocalStorage.run (node:internal/async_local_storage/async_hooks:91:14)
    at AsyncLocalContextManager.runInContext (/opt/application/node_modules/newrelic/lib/context-manager/async-local-context-manager.js:58:38)
```

That was because its transaction and parent segments were from a previous request.  The introduction of the `undici_async_tracking` was an attempt to fix an issue where if you had concurrent undici requests within a transaction the 2nd request's parent was the first and not the parent of both requests.  This causes a slight inaccuracy in the parent/child relationship in a trace and transaction trace.  There's no good way to fix this because undici relies on diagnostic channel and its behavior isn't the same as our traditional monkey patching instrumentation.  

I also add more assertions to existing tests around concurrent requests with a note stating that the parentId of the 2nd undici segment is the first request for a reason.  Lastly, I added a test that reproduces the issue that this is fixing where two concurrent transactions are occurring and this is where the state confliation was existing in the old instrumentation.  

Lastly, I "released" the feature flag for `undici_async_tracking` as there is no longer code wired up to support it.

## Related Issues

Closes #2881 