### PR TITLE
chore: Replaced backtracking regex with new algorithm

### DIFF
--- a/lib/header-attributes.js
+++ b/lib/header-attributes.js
@@ -95,10 +95,10 @@ function _headerToCamelCase(header) {
   const newHeader = header.charAt(0).toLowerCase() + header.slice(1)
 
   // Converts headers in the form 'header-name' to be in the form 'headerName'
-  // eslint-disable-next-line sonarjs/slow-regex
-  return newHeader.replace(/[\W_]+(\w)/g, function capitalize(m, $1) {
-    return $1.toUpperCase()
-  })
+  return newHeader.split(/[\W_]/).map((ele, i) => {
+    if (i === 0) return ele
+    return ele.slice(0, 1).toUpperCase() + ele.slice(1)
+  }).join('')
 }
 
 function _collectHeaders(headers, nameMap, prefix, transaction) {

--- a/test/unit/header-attributes.test.js
+++ b/test/unit/header-attributes.test.js
@@ -77,6 +77,23 @@ test('#collectRequestHeaders', async (t) => {
     })
   })
 
+  await t.test('should replace repeating non-word characters', (t, end) => {
+    const { agent } = t.nr
+    agent.config.allow_all_headers = true
+    const headers = {
+      'foo-bar--baz': 'valid-type'
+    }
+
+    helper.runInTransaction(agent, (transaction) => {
+      headerAttributes.collectRequestHeaders(headers, transaction)
+
+      const attributes = transaction.trace.attributes.get(DESTINATIONS.TRANS_COMMON)
+      assert.equal(attributes['request.headers.fooBarBaz'], 'valid-type')
+      assert.equal(attributes['foo-bar--baz'], undefined)
+      end()
+    })
+  })
+
   await t.test('should lowercase first letter in headers', (t, end) => {
     const { agent } = t.nr
     const headers = {


### PR DESCRIPTION
This PR resolves #2860. If we were to insist of using a simple regular expression to match the characters we want to strip, that regular expression would _always_ include backtracking. This is because we want to replace _all_ occurrences of the offending characters. The only solution I can determine that will satisfy Sonar is to split and rejoin.