### PR TITLE
chore: Updated lint rule suppression comment

### DIFF
--- a/lib/db/utils.js
+++ b/lib/db/utils.js
@@ -11,9 +11,9 @@ function extractDatabaseChangeFromUse(sql) {
   // The character ranges for this were pulled from
   // http://dev.mysql.com/doc/refman/5.7/en/identifiers.html
 
-  // Suppressing a warning on this regex because it is not obvious what this
-  // regex does, and we don't want to break anything.
-  // eslint-disable-next-line sonarjs/slow-regex, sonarjs/duplicates-in-character-class
-  const match = /^\s*use[^\w`]+([\w$_\u0080-\uFFFF]+|`[^`]+`)[\s;]*$/i.exec(sql)
+  // The lint rule being suppressed here has been evaluated, and it has been
+  // determined that the regular expression is sufficient for our use case.
+  // eslint-disable-next-line sonarjs/slow-regex
+  const match = /^\s*use[^\w`]+([\w$\u0080-\uFFFF]+|`[^`]+`)[\s;]*$/i.exec(sql)
   return (match && match[1]) || null
 }


### PR DESCRIPTION
This PR resolves #2859.

I worked on a couple of different algorithms in an attempt to get around the rule violation, but the regular expression is our best option. The simplest algorithm I was able to devise still used regular expressions, but ended up being slower (despite being easier to follow). I have attached my benchmark below.

<details>
<summary>Benchmark</summary>

```js
'use strict'

const assert = require('node:assert')

const tests = [
  ['use test_db;', 'test_db'],
  ['USE INIT', 'INIT'],
  ['use test_db', 'test_db'],
  ['use test_db;;;;;;', 'test_db'],
  ['            use test_db;', 'test_db'],
  ['use            test_db;', 'test_db'],
  ['use test_db            ;', 'test_db'],
  ['use test_db;            ', 'test_db'],
  ['use `test_db`;', '`test_db`'],
  ['use `☃☃☃☃☃☃`;', '`☃☃☃☃☃☃`'],
  ['use cxvozicjvzocixjv`oasidfjaosdfij`;', null],
  ['use `oasidfjaosdfij`123;', null],
  ['use `oasidfjaosdfij` 123;', null],
  ['use \u0001;', null],
  ['use oasidfjaosdfij 123;', null]
]
const iterations = 10_000

const regexA = process.hrtime.bigint()
for (let i = 0; i < iterations; i += 1) {
  for (const [input, expected] of tests) {
    const found = extractWithRegex(input)
    assert.equal(found, expected)
  }
}
const regexB = process.hrtime.bigint()

const withoutA = process.hrtime.bigint()
for (let i = 0; i < iterations; i += 1) {
  for (const [input, expected] of tests) {
    const found = extractWithoutRegex(input)
    assert.equal(found, expected)
  }
}
const withoutB = process.hrtime.bigint()

console.log('with regex time:', regexB - regexA)
console.log('without regex time:', withoutB - withoutA)
console.log('with < without:', (regexB - regexA) < (withoutB - withoutA))

function extractWithRegex(input) {
  const match = /^\s*use[^\w`]+([\w$_\u0080-\uFFFF]+|`[^`]+`)[\s;]*$/i.exec(input)
  return (match && match[1]) || null
}

function extractWithoutRegex(input) {
  const dbName = input
    .trim()
    .replace(/use\s+/i, '')
    .replace(/;+$/, '')
    .trim()
  if (/^`?[\w$_\u0080-\uFFFF]+`?$/.test(dbName) === true) {
    return dbName
  }
  return null
}
```

</details>