### PR TITLE
fix: Added defensive code in shim to prevent crashing when checking parent segment

### DIFF
--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -677,7 +677,7 @@ function recordWrapper({ shim, fn, name, recordNamer }) {
       return fnApply.call(fn, this, args)
     }
 
-    // middleweare recorders pass in parent segment
+    // middleware recorders pass in parent segment
     // we need to destructure this as it is not needed past this function
     // and will overwhelm trace level loggers with logging the entire spec
     const { parent: specParent, ...segDesc } = spec
@@ -686,7 +686,7 @@ function recordWrapper({ shim, fn, name, recordNamer }) {
     const transaction = context.transaction
     const parent = transaction?.isActive() && specParent ? specParent : context.segment
 
-    if (!transaction?.isActive()) {
+    if (!transaction?.isActive() || !parent) {
       shim.logger.debug('Not recording function %s, not in a transaction.', name)
       return fnApply.call(fn, this, arguments)
     }

--- a/test/unit/shim/shim.test.js
+++ b/test/unit/shim/shim.test.js
@@ -1627,6 +1627,20 @@ test('Shim', async function (t) {
       })
     })
 
+    await t.test('should not create a segment', function (t, end) {
+      const { agent, shim, wrappable } = t.nr
+      shim.record(wrappable, 'getActiveSegment', function () {
+        return new RecorderSpec({ name: 'test segment' })
+      })
+
+      helper.runInTransaction(agent, function (tx) {
+        shim.setActiveSegment(null)
+        const segment = wrappable.getActiveSegment()
+        assert.equal(segment, null)
+        end()
+      })
+    })
+
     await t.test('should execute the wrapped function', function (t, end) {
       const { agent, shim } = t.nr
       let executed = false

--- a/test/unit/shim/shim.test.js
+++ b/test/unit/shim/shim.test.js
@@ -1609,7 +1609,7 @@ test('Shim', async function (t) {
     })
   })
 
-  await t.test('#record wrapper when called with an inactive transaction', async function (t) {
+  await t.test('#record wrapper should not create a new segment when called with an inactive transaction', async function (t) {
     t.beforeEach(beforeEach)
     t.afterEach(afterEach)
     await t.test('should not create a segment', function (t, end) {
@@ -1627,7 +1627,7 @@ test('Shim', async function (t) {
       })
     })
 
-    await t.test('should not create a segment', function (t, end) {
+    await t.test('#record wrapper should not create a new segment when there is no current active segment', function (t, end) {
       const { agent, shim, wrappable } = t.nr
       shim.record(wrappable, 'getActiveSegment', function () {
         return new RecorderSpec({ name: 'test segment' })
@@ -1637,6 +1637,8 @@ test('Shim', async function (t) {
         shim.setActiveSegment(null)
         const segment = wrappable.getActiveSegment()
         assert.equal(segment, null)
+        tx.end()
+        assert.equal(tx.isActive(), false)
         end()
       })
     })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This PR adds some defensive code in shim `recordWrapper`. Before the segment refactor, this check was:

```js
    // See if we're in an active transaction.
    let parent
    if (segDesc.parent) {
      // We only want to continue recording in a transaction if the
      // transaction is active.
      parent = segDesc.parent.transaction.isActive() ? segDesc.parent : null
    } else {
      parent = shim.getActiveSegment()
    }

    if (!parent) {
      shim.logger.debug('Not recording function %s, not in a transaction.', name)
      return fnApply.call(fn, this, arguments)
    }
```

Afterwards, it only checked if the transaction was active, assuming there was always a segment.  
```js
    // middleware recorders pass in parent segment
    // we need to destructure this as it is not needed past this function
    // and will overwhelm trace level loggers with logging the entire spec
    const { parent: specParent, ...segDesc } = spec

    const context = shim.tracer.getContext()
    const transaction = context.transaction
    const parent = transaction?.isActive() && specParent ? specParent : context.segment

    if (!transaction?.isActive()) {
      shim.logger.debug('Not recording function %s, not in a transaction.', name)
      return fnApply.call(fn, this, arguments)
    }
```

A customer reported in #2894, that there was a crash. Looking at the stack and the winston code it appears to be in a state where the transaction is active but there is no active segment.  I tried to recreate with a winston versioned test but could not get it setup properly.  The new unit test demonstrates the crash before my fix:

before fix:

```sh
✖ should not create a segment (0.75475ms)
  TypeError: Cannot read properties of null (reading 'opaque')
      at Object.wrapper [as getActiveSegment] (/Users/revans/code/pull-requests/node-newrelic/lib/shim/shim.js:703:14)
      at /Users/revans/code/pull-requests/node-newrelic/test/unit/shim/shim.test.js:1638:35
      at /Users/revans/code/pull-requests/node-newrelic/test/lib/agent_helper.js:289:12
      at AsyncLocalStorage.run (node:internal/async_local_storage/async_hooks:91:14)
      at AsyncLocalContextManager.runInContext (/Users/revans/code/pull-requests/node-newrelic/lib/context-manager/async-local-context-manager.js:58:38)
      at wrapped (/Users/revans/code/pull-requests/node-newrelic/lib/transaction/tracer/index.js:250:37)
      at wrapTransactionInvocation (/Users/revans/code/pull-requests/node-newrelic/lib/transaction/tracer/index.js:222:50)
      at helper.runInTransaction (/Users/revans/code/pull-requests/node-newrelic/test/lib/agent_helper.js:290:5)
      at TestContext.<anonymous> (/Users/revans/code/pull-requests/node-newrelic/test/unit/shim/shim.test.js:1636:14)
      at Test.runInAsyncScope (node:async_hooks:211:14)
```

after fix, no crash/test failure.


## Related Issues
Closes #2894
