### PR TITLE
fix: Fixed transaction-shim to properly create new transactions when the existing transaction is not active

### DIFF
--- a/lib/shim/transaction-shim.js
+++ b/lib/shim/transaction-shim.js
@@ -372,12 +372,13 @@ function _makeNestedTransWrapper(shim, func, name, spec) {
     }
 
     let context = shim.tracer.getContext()
+    let transaction = shim.tracer.getTransaction()
 
     // Only create a new transaction if we either do not have a current
     // transaction _or_ the current transaction is not of the type we want.
-    if (!context?.transaction || spec.type !== context?.transaction?.type) {
+    if (!transaction || spec.type !== transaction?.type) {
       shim.logger.trace('Creating new nested %s transaction for %s', spec.type, name)
-      const transaction = new Transaction(shim.agent)
+      transaction = new Transaction(shim.agent)
       transaction.type = spec.type
       context = context.enterTransaction(transaction)
     }
@@ -405,10 +406,11 @@ function _makeNestedTransWrapper(shim, func, name, spec) {
  */
 function _makeTransWrapper(shim, func, name, spec) {
   return function transactionWrapper() {
-    // Don't nest transactions, reuse existing ones!
     let context = shim.tracer.getContext()
-    const existingTransaction = context.transaction
+    // Don't nest transactions, reuse existing ones!
+    const existingTransaction = shim.tracer.getTransaction()
     if (!shim.agent.canCollectData() || existingTransaction) {
+      shim.logger.trace('Transaction %s exists, not creating new transaction %s for %s', existingTransaction?.id, spec.type, name)
       return func.apply(this, arguments)
     }
 


### PR DESCRIPTION

## Description

It seems like warm starts of lambdas leak async context in Node.js A regression was introduced [here](https://github.com/newrelic/node-newrelic/pull/2646/files#diff-094eb25e618908bce01ee4101c497f24988ddfc48bd7200371c2b6bc67a31b21L406). Previously before wrapping a call in a transaction it checked for an active transaction, this changed and only checked for a transaction, not that it was active. For some reason during warm invocations of lambda, the Node.js async context(which we just leverage AsyncLocalStorage) is leaking across runs.  

## How to Test

I added some unit tests around transaction-shim. Also we manually tested with a patched layer in lambda and there were 8 requests made and all 8 had telemetry.

## Related Issues

Closes #2910 