### PR TITLE
ci: Optimized the lambda layers and k8s init containers post release workflow

### DIFF
--- a/.github/workflows/release-lambda-init-containers.yml
+++ b/.github/workflows/release-lambda-init-containers.yml
@@ -9,17 +9,13 @@ on:
 jobs:
   release-tags:
     runs-on: ubuntu-latest
+    if:
+      (github.event.workflow_run && github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'workflow_dispatch')
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 'lts/*'
-      - run: npm install
-      - run: |
-          git config user.name ${GITHUB_ACTOR}
-          git config user.email gh-actions-${GITHUB_ACTOR}@github.com
       - id: get_tag
         run: echo "latest_tag=$(cat package.json | jq .version)" >> $GITHUB_OUTPUT
       - name: Create release tags for Lambda and K8s Init Containers


### PR DESCRIPTION
## Description

In #2848 we moved the publishing of github releases of `newrelic-lambda-layers` and `newrelic-agent-init-container` to a post release workflow, instead of a lambda cron that checked if any new releases of agent existed. I overlooked when I first reviewed that it doesn't check if Create Release was a success so I added that logic. I also removed some unnecessary jobs to setup node, install deps and configure git.  The reason is Node.js isn't being used here, we just cat the package.json to get the version and then rely on `gh` to create releases. Also since it auths to `gh` cli with a token we don't have to set up the username/email.
