### PR TITLE
fix: Updated default config to accept `undefined` as default value

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1042,7 +1042,7 @@ Config.prototype._fromPassed = function _fromPassed(external, internal, arbitrar
 
   Object.keys(external).forEach(function overwrite(key) {
     // if it's not in the defaults, it doesn't exist
-    if (!arbitrary && internal[key] === undefined) {
+    if (!arbitrary && !(key in internal)) {
       return
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Our current configuration doesn't allow an `undefined` value for a 3 layers deep/nested config item. This PR allows that now. 

## How to Test

Run unit tests

## Related Issues

Fixes #2871 