### PR TITLE
feat: Added support for region-prefixed Bedrock models

### DIFF
--- a/lib/llm-events/aws-bedrock/bedrock-command.js
+++ b/lib/llm-events/aws-bedrock/bedrock-command.js
@@ -124,11 +124,11 @@ class BedrockCommand {
   }
 
   isClaude() {
-    return this.#modelId.startsWith('anthropic.claude-v')
+    return this.#modelId.startsWith('anthropic.claude-v') || this.#modelId.startsWith('us.anthropic.claude-v') || this.#modelId.startsWith('eu.anthropic.claude-v') || this.#modelId.startsWith('apac.anthropic.claude-v')
   }
 
   isClaude3() {
-    return this.#modelId.startsWith('anthropic.claude-3')
+    return this.#modelId.startsWith('anthropic.claude-3') || this.#modelId.startsWith('us.anthropic.claude-3') || this.#modelId.startsWith('eu.anthropic.claude-3') || this.#modelId.startsWith('apac.anthropic.claude-3')
   }
 
   isCohere() {

--- a/lib/llm-events/aws-bedrock/bedrock-command.js
+++ b/lib/llm-events/aws-bedrock/bedrock-command.js
@@ -124,11 +124,11 @@ class BedrockCommand {
   }
 
   isClaude() {
-    return this.#modelId.startsWith('anthropic.claude-v') || this.#modelId.startsWith('us.anthropic.claude-v') || this.#modelId.startsWith('eu.anthropic.claude-v') || this.#modelId.startsWith('apac.anthropic.claude-v')
+    return this.#modelId.split('.').slice(-2).join('.').startsWith('anthropic.claude-v')
   }
 
   isClaude3() {
-    return this.#modelId.startsWith('anthropic.claude-3') || this.#modelId.startsWith('us.anthropic.claude-3') || this.#modelId.startsWith('eu.anthropic.claude-3') || this.#modelId.startsWith('apac.anthropic.claude-3')
+    return this.#modelId.split('.').slice(-2).join('.').startsWith('anthropic.claude-3')
   }
 
   isCohere() {

--- a/test/lib/aws-server-stubs/ai-server/index.js
+++ b/test/lib/aws-server-stubs/ai-server/index.js
@@ -89,20 +89,44 @@ function handler(req, res) {
       case 'anthropic.claude-v1':
       case 'anthropic.claude-instant-v1':
       case 'anthropic.claude-v2':
-      case 'anthropic.claude-v2:1': {
+      case 'anthropic.claude-v2:1':
+      case 'us.anthropic.claude-v1':
+      case 'us.anthropic.claude-instant-v1':
+      case 'us.anthropic.claude-v2':
+      case 'us.anthropic.claude-v2:1':
+      case 'eu.anthropic.claude-v1':
+      case 'eu.anthropic.claude-instant-v1':
+      case 'eu.anthropic.claude-v2':
+      case 'eu.anthropic.claude-v2:1':
+      case 'apac.anthropic.claude-v1':
+      case 'apac.anthropic.claude-instant-v1':
+      case 'apac.anthropic.claude-v2':
+      case 'apac.anthropic.claude-v2:1':{
         response = responses.claude.get(payload.prompt)
         break
       }
 
       case 'anthropic.claude-3-haiku-20240307-v1:0':
       case 'anthropic.claude-3-opus-20240229-v1:0':
-      case 'anthropic.claude-3-sonnet-20240229-v1:0': {
+      case 'anthropic.claude-3-sonnet-20240229-v1:0':
+      case 'us.anthropic.claude-3-haiku-20240307-v1:0':
+      case 'us.anthropic.claude-3-opus-20240229-v1:0':
+      case 'us.anthropic.claude-3-sonnet-20240229-v1:0':
+      case 'eu.anthropic.claude-3-haiku-20240307-v1:0':
+      case 'eu.anthropic.claude-3-opus-20240229-v1:0':
+      case 'eu.anthropic.claude-3-sonnet-20240229-v1:0':
+      case 'apac.anthropic.claude-3-haiku-20240307-v1:0':
+      case 'apac.anthropic.claude-3-opus-20240229-v1:0':
+      case 'apac.anthropic.claude-3-sonnet-20240229-v1:0': {
         response = responses.claude3.get(payload?.messages?.[0]?.content)
         break
       }
 
       // Chunked claude model
-      case 'anthropic.claude-3-5-sonnet-20240620-v1:0': {
+      case 'anthropic.claude-3-5-sonnet-20240620-v1:0':
+      case 'us.anthropic.claude-3-5-sonnet-20240620-v1:0':
+      case 'eu.anthropic.claude-3-5-sonnet-20240620-v1:0':
+      case 'apac.anthropic.claude-3-5-sonnet-20240620-v1:0':{
         response = responses.claude3.get(payload?.messages?.[0]?.content?.[0].text)
         break
       }


### PR DESCRIPTION
## Added feature to Node agent to match cross-region inference model names in Bedrock

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This PR adds support to the Node agent for matching cross-region inference model names in Bedrock.  Some newer Bedrock models use region-prefixed names (e.g., us.anthropic.claude-xyz) for cross-region inference optimization. The Node agent now correctly identifies and reports these models.

## How to Test

1. Run the Node application with the Node agent configured.
2.  Navigate to the AI Response section in the New Relic dashboard.
3. Verify that the response metadata now includes the full, region-prefixed model name. A screenshot 
demonstrating this is attached.
<img width="1728" alt="Screenshot 2025-02-11 at 2 31 45 PM" src="https://github.com/user-attachments/assets/3a90653c-d7ee-495f-8865-e4ef004b7b35" />
