### PR TITLE
feat: Propagate agent root context when opentelemetry `ROOT_CONTEXT` is passed in to trace propagator. Added logic to handle properly naming and ending transactions for server spans.

### DIFF
--- a/lib/otel/constants.js
+++ b/lib/otel/constants.js
@@ -69,6 +69,11 @@ module.exports = {
   ATTR_FULL_URL: 'url.full',
 
   /**
+   * The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request.
+   */
+  ATTR_GRPC_STATUS_CODE: 'rpc.grpc.status_code',
+
+  /**
    * Value of the HTTP `host` header.
    *
    * {@link ATTR_HTTP_REQUEST_METHOD} is newer and should be used instead.
@@ -100,6 +105,20 @@ module.exports = {
    * @example https://example.com/foo?bar=baz
    */
   ATTR_HTTP_URL: 'http.url',
+
+  /**
+   * The http response status code
+   *
+   * @example 200
+   */
+  ATTR_HTTP_STATUS_CODE: 'http.response.status_code',
+
+  /**
+   * The http response status text
+   *
+   * @example OK
+   */
+  ATTR_HTTP_STATUS_TEXT: 'http.status_text',
 
   /**
    * The message destination name.
@@ -174,6 +193,15 @@ module.exports = {
    * @example /tmp/my.sock
    */
   ATTR_SERVER_ADDRESS: 'server.address',
+  ATTR_NET_HOST_NAME: 'net.host.name',
+
+  /**
+   * Poort of the local HTTP server that received the request.
+   *
+   * @example 80
+   */
+  ATTR_SERVER_PORT: 'server.port',
+  ATTR_NET_HOST_PORT: 'net.host.port',
 
   /**
    * Logical name of the local service being instrumented.

--- a/lib/otel/segments/server.js
+++ b/lib/otel/segments/server.js
@@ -9,12 +9,12 @@ const Transaction = require('../../transaction')
 const httpRecorder = require('../../metrics/recorders/http')
 const urltils = require('../../util/urltils')
 const url = require('node:url')
+const { NODEJS, ACTION_DELIMITER } = require('../../metrics/names')
 
 const DESTINATION = Transaction.DESTINATIONS.TRANS_COMMON
 const {
   ATTR_HTTP_METHOD,
   ATTR_HTTP_REQUEST_METHOD,
-  ATTR_HTTP_ROUTE,
   ATTR_HTTP_URL,
   ATTR_RPC_METHOD,
   ATTR_RPC_SERVICE,
@@ -24,15 +24,15 @@ const {
 module.exports = function createServerSegment(agent, otelSpan) {
   const transaction = new Transaction(agent)
   transaction.type = 'web'
+  transaction.nameState.setPrefix(NODEJS.PREFIX)
+  transaction.nameState.setPrefix(ACTION_DELIMITER)
   const rpcSystem = otelSpan.attributes[ATTR_RPC_SYSTEM]
   const httpMethod = otelSpan.attributes[ATTR_HTTP_METHOD] ?? otelSpan.attributes[ATTR_HTTP_REQUEST_METHOD]
   let segment
   if (rpcSystem) {
     segment = rpcSegment({ agent, otelSpan, transaction, rpcSystem })
-  } else if (httpMethod) {
-    segment = httpSegment({ agent, otelSpan, transaction, httpMethod })
   } else {
-    segment = genericHttpSegment({ agent, transaction })
+    segment = httpSegment({ agent, otelSpan, transaction, httpMethod })
   }
   transaction.baseSegment = segment
   return { segment, transaction }
@@ -41,11 +41,12 @@ module.exports = function createServerSegment(agent, otelSpan) {
 function rpcSegment({ agent, otelSpan, transaction, rpcSystem }) {
   const rpcService = otelSpan.attributes[ATTR_RPC_SERVICE] || 'Unknown'
   const rpcMethod = otelSpan.attributes[ATTR_RPC_METHOD] || 'Unknown'
-  const name = `WebTransaction/WebFrameworkUri/${rpcSystem}/${rpcService}.${rpcMethod}`
-  transaction.name = name
-  transaction.trace.attributes.addAttribute(DESTINATION, 'request.method', rpcMethod)
-  transaction.trace.attributes.addAttribute(DESTINATION, 'request.uri', name)
+  const name = `${rpcService}/${rpcMethod}`
   transaction.url = name
+  transaction.trace.attributes.addAttribute(DESTINATION, 'request.method', rpcMethod)
+  transaction.trace.attributes.addAttribute(DESTINATION, 'request.uri', transaction.url)
+  transaction.nameState.setPrefix(rpcSystem)
+  transaction.nameState.appendPath(transaction.url)
   const segment = agent.tracer.createSegment({
     name,
     recorder: httpRecorder,
@@ -56,34 +57,22 @@ function rpcSegment({ agent, otelSpan, transaction, rpcSystem }) {
   return segment
 }
 
-// most instrumentation will hit this case
-// I find that if the request is in a web framework, the web framework instrumentation
-// sets `http.route` and when the span closes it pulls that attribute in
-// we'll most likely need to wire up some naming reconciliation
-// to handle this use case.
 function httpSegment({ agent, otelSpan, transaction, httpMethod }) {
-  const httpRoute = otelSpan.attributes[ATTR_HTTP_ROUTE] || 'Unknown'
   const httpUrl = otelSpan.attributes[ATTR_HTTP_URL] || '/Unknown'
+  transaction.nameState.setVerb(httpMethod)
   const requestUrl = url.parse(httpUrl, true)
-  const name = `WebTransaction/Nodejs/${httpMethod}/${httpRoute}`
-  transaction.name = name
+  transaction.parsedUrl = requestUrl
   transaction.url = urltils.obfuscatePath(agent.config, requestUrl.pathname)
   transaction.trace.attributes.addAttribute(DESTINATION, 'request.uri', transaction.url)
-  transaction.trace.attributes.addAttribute(DESTINATION, 'request.method', httpMethod)
+  if (httpMethod) {
+    transaction.trace.attributes.addAttribute(DESTINATION, 'request.method', httpMethod)
+  }
+  transaction.applyUserNamingRules(requestUrl.pathname)
+  // accept dt headers?
+  // synthetics.assignHeadersToTransaction(agent.config, transaction, )
   return agent.tracer.createSegment({
-    name,
     recorder: httpRecorder,
-    parent: transaction.trace.root,
-    transaction
-  })
-}
-
-function genericHttpSegment({ agent, transaction }) {
-  const name = 'WebTransaction/NormalizedUri/*'
-  transaction.name = name
-  return agent.tracer.createSegment({
-    name,
-    recorder: httpRecorder,
+    name: requestUrl.pathname,
     parent: transaction.trace.root,
     transaction
   })

--- a/lib/otel/setup.js
+++ b/lib/otel/setup.js
@@ -10,6 +10,7 @@ const NrSpanProcessor = require('./span-processor')
 const ContextManager = require('./context-manager')
 const defaultLogger = require('../logger').child({ component: 'opentelemetry-bridge' })
 const createOtelLogger = require('./logger')
+const TracePropagator = require('./trace-propagator')
 
 const { ATTR_SERVICE_NAME } = require('./constants')
 
@@ -34,8 +35,8 @@ module.exports = function setupOtel(agent, logger = defaultLogger) {
 
   })
   provider.register({
-    contextManager: new ContextManager(agent)
-    // propagator: // todo: https://github.com/newrelic/node-newrelic/issues/2662
+    contextManager: new ContextManager(agent),
+    propagator: new TracePropagator(agent)
   })
 
   agent.metrics

--- a/lib/otel/span-processor.js
+++ b/lib/otel/span-processor.js
@@ -80,6 +80,9 @@ module.exports = class NrSpanProcessor {
       this.reconcileHttpAttributes({ segment, span, transaction })
     }
 
+    // End the corresponding transaction for the entry point server span.
+    // We do then when the span ends to ensure all data has been processed
+    // for the correspondig server span.
     transaction.end()
   }
 

--- a/lib/otel/span-processor.js
+++ b/lib/otel/span-processor.js
@@ -7,16 +7,25 @@
 const SegmentSynthesizer = require('./segment-synthesis')
 const { otelSynthesis } = require('../symbols')
 const { hrTimeToMilliseconds } = require('@opentelemetry/core')
+const { SpanKind } = require('@opentelemetry/api')
 const urltils = require('../util/urltils')
 const {
   ATTR_DB_NAME,
   ATTR_DB_STATEMENT,
   ATTR_DB_SYSTEM,
-  ATTR_HTTP_HOST,
+  ATTR_GRPC_STATUS_CODE,
+  ATTR_HTTP_ROUTE,
+  ATTR_HTTP_STATUS_CODE,
+  ATTR_HTTP_STATUS_TEXT,
   ATTR_NET_PEER_NAME,
   ATTR_NET_PEER_PORT,
-  ATTR_SERVER_ADDRESS,
+  ATTR_NET_HOST_NAME,
+  ATTR_NET_HOST_PORT,
+  ATTR_RPC_SYSTEM,
+  ATTR_SERVER_PORT,
+  ATTR_SERVER_ADDRESS
 } = require('./constants')
+const { DESTINATIONS } = require('../config/attribute-filter')
 
 module.exports = class NrSpanProcessor {
   constructor(agent) {
@@ -42,9 +51,9 @@ module.exports = class NrSpanProcessor {
    */
   onEnd(span) {
     if (span[otelSynthesis] && span[otelSynthesis].segment) {
-      const { segment } = span[otelSynthesis]
+      const { segment, transaction } = span[otelSynthesis]
       this.updateDuration(segment, span)
-      this.reconcileAttributes(segment, span)
+      this.reconcileAttributes({ segment, span, transaction })
       delete span[otelSynthesis]
     }
   }
@@ -55,14 +64,76 @@ module.exports = class NrSpanProcessor {
     segment.overwriteDurationInMillis(duration)
   }
 
-  // TODO: clean this up and break out by span.kind
-  reconcileAttributes(segment, span) {
+  reconcileAttributes({ segment, span, transaction }) {
+    if (span.kind === SpanKind.SERVER) {
+      this.reconcileServerAttributes({ segment, span, transaction })
+    } else if (span.kind === SpanKind.CLIENT && span.attributes[ATTR_DB_SYSTEM]) {
+      this.reconcileDbAttributes({ segment, span })
+    }
+    // TODO: add http external checks
+  }
+
+  reconcileServerAttributes({ segment, span, transaction }) {
+    if (span.attributes[ATTR_RPC_SYSTEM]) {
+      this.reconcileRpcAttributes({ segment, span, transaction })
+    } else {
+      this.reconcileHttpAttributes({ segment, span, transaction })
+    }
+
+    transaction.end()
+  }
+
+  reconcileHttpAttributes({ segment, span, transaction }) {
+    for (const [prop, value] of Object.entries(span.attributes)) {
+      let key = prop
+      let sanitized = value
+      if (key === ATTR_HTTP_ROUTE) {
+        // TODO: can we get the route params?
+        transaction.nameState.appendPath(sanitized)
+      } else if (key === ATTR_HTTP_STATUS_CODE) {
+        transaction.finalizeNameFromUri(transaction.parsedUrl, sanitized)
+        transaction.trace.attributes.addAttribute(DESTINATIONS.TRANS_COMMON, 'http.statusCode', sanitized)
+        key = 'http.statusCode'
+      // Not using const as it is not in semantic-conventions
+      } else if (key === ATTR_HTTP_STATUS_TEXT) {
+        transaction.trace.attributes.addAttribute(DESTINATIONS.TRANS_COMMON, 'http.statusText', sanitized)
+        key = 'http.statusText'
+      } else if (key === ATTR_SERVER_PORT || key === ATTR_NET_HOST_PORT) {
+        key = 'port'
+      } else if (key === ATTR_SERVER_ADDRESS || key === ATTR_NET_HOST_NAME) {
+        key = 'host'
+        if (urltils.isLocalhost(sanitized)) {
+          sanitized = this.agent.config.getHostnameSafe(sanitized)
+        }
+      }
+
+      // TODO: otel instrumentation does not collect headers
+      // a customer can specify which ones, we also specify this
+      // so i think we'd have to cross reference our list
+      // it also looks like we add all headers to the trace
+      // this isn't doing that
+      segment.addAttribute(key, sanitized)
+    }
+  }
+
+  // TODO: our grpc instrumentation handles errors when the status code is not 0
+  // we should prob do this here too
+  reconcileRpcAttributes({ segment, span, transaction }) {
+    for (const [prop, value] of Object.entries(span.attributes)) {
+      if (prop === ATTR_GRPC_STATUS_CODE) {
+        transaction.trace.attributes.addAttribute(DESTINATIONS.TRANS_COMMON, 'response.status', value)
+      }
+      segment.addAttribute(prop, value)
+    }
+  }
+
+  reconcileDbAttributes({ segment, span }) {
     for (const [prop, value] of Object.entries(span.attributes)) {
       let key = prop
       let sanitized = value
       if (key === ATTR_NET_PEER_PORT) {
         key = 'port_path_or_id'
-      } else if (prop === ATTR_NET_PEER_NAME || prop === ATTR_SERVER_ADDRESS || prop === ATTR_HTTP_HOST) {
+      } else if (prop === ATTR_NET_PEER_NAME) {
         key = 'host'
         if (urltils.isLocalhost(sanitized)) {
           sanitized = this.agent.config.getHostnameSafe(sanitized)

--- a/lib/otel/trace-propagator.js
+++ b/lib/otel/trace-propagator.js
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const { trace, isSpanContextValid, TraceFlags } = require('@opentelemetry/api')
+const { isTracingSuppressed } = require('@opentelemetry/core')
+const TRACE_PARENT_HEADER = 'traceparent'
+const TRACE_STATE_HEADER = 'tracestate'
+
+const VERSION = '00'
+const VERSION_PART = '(?!ff)[\\da-f]{2}'
+const TRACE_ID_PART = '(?![0]{32})[\\da-f]{32}'
+const PARENT_ID_PART = '(?![0]{16})[\\da-f]{16}'
+const FLAGS_PART = '[\\da-f]{2}'
+const TRACE_PARENT_REGEX = new RegExp(
+  `^\\s?(${VERSION_PART})-(${TRACE_ID_PART})-(${PARENT_ID_PART})-(${FLAGS_PART})(-.*)?\\s?$`
+)
+
+// TODO: handle trace state
+class TraceState {
+  constructor(state) {
+    this.state = state
+  }
+}
+
+/**
+ * Parses information from the [traceparent] span tag and converts it into {@link SpanContext}
+ * @param traceParent - A meta property that comes from server.
+ *     It should be dynamically generated server side to have the server's request trace Id,
+ *     a parent span Id that was set on the server's request span,
+ *     and the trace flags to indicate the server's sampling decision
+ *     (01 = sampled, 00 = not sampled).
+ *     for example: '{version}-{traceId}-{spanId}-{sampleDecision}'
+ *     For more information see {@link https://www.w3.org/TR/trace-context/}
+ * @param traceParen
+ */
+function parseTraceParent(traceParent) {
+  const match = TRACE_PARENT_REGEX.exec(traceParent)
+  if (!match) return null
+
+  // According to the specification the implementation should be compatible
+  // with future versions. If there are more parts, we only reject it if it's using version 00
+  // See https://www.w3.org/TR/trace-context/#versioning-of-traceparent
+  if (match[1] === '00' && match[5]) return null
+
+  return {
+    traceId: match[2],
+    spanId: match[3],
+    traceFlags: parseInt(match[4], 16),
+  }
+}
+
+module.exports = class NewRelicTracePropagator {
+  constructor(agent) {
+    this.agent = agent
+  }
+
+  inject(context, carrier, setter) {
+    if (context.constructor.name === 'BaseContext') {
+      context = this.agent.tracer._contextManager.getContext()
+    }
+    const spanContext = trace.getSpanContext(context)
+    if (
+      !spanContext ||
+      isTracingSuppressed(context) ||
+      !isSpanContextValid(spanContext)
+    ) { return }
+
+    const traceParent = `${VERSION}-${spanContext.traceId}-${
+      spanContext.spanId
+    }-0${Number(spanContext.traceFlags || TraceFlags.NONE).toString(16)}`
+
+    setter.set(carrier, TRACE_PARENT_HEADER, traceParent)
+    if (spanContext.traceState) {
+      setter.set(
+        carrier,
+        TRACE_STATE_HEADER,
+        spanContext.traceState.serialize()
+      )
+    }
+  }
+
+  extract(context, carrier, getter) {
+    if (context.constructor.name === 'BaseContext') {
+      context = this.agent.tracer._contextManager.getContext()
+    }
+    const traceParentHeader = getter.get(carrier, TRACE_PARENT_HEADER)
+    if (!traceParentHeader) return context
+    const traceParent = Array.isArray(traceParentHeader)
+      ? traceParentHeader[0]
+      : traceParentHeader
+    if (typeof traceParent !== 'string') return context
+    const spanContext = parseTraceParent(traceParent)
+    if (!spanContext) return context
+
+    spanContext.isRemote = true
+
+    const traceStateHeader = getter.get(carrier, TRACE_STATE_HEADER)
+    if (traceStateHeader) {
+      // If more than one `tracestate` header is found, we merge them into a
+      // single header.
+      const state = Array.isArray(traceStateHeader)
+        ? traceStateHeader.join(',')
+        : traceStateHeader
+      spanContext.traceState = new TraceState(
+        typeof state === 'string' ? state : undefined
+      )
+    }
+    return trace.setSpanContext(context, spanContext)
+  }
+
+  fields() {
+    return [TRACE_PARENT_HEADER, TRACE_STATE_HEADER]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
   },
   "imports": {
     "#agentlib/*.js": "./lib/*.js",
+    "#testlib/*.js": "./test/lib/*.js",
     "#test/assert": "./test/lib/custom-assertions/index.js"
   },
   "dependencies": {

--- a/test/unit/lib/otel/fixtures/span.js
+++ b/test/unit/lib/otel/fixtures/span.js
@@ -9,7 +9,7 @@ const { Span } = require('@opentelemetry/sdk-trace-base')
 
 module.exports = function createSpan({ parentId, tracer, tx, kind, name }) {
   const spanContext = {
-    traceId: tx?.trace?.id,
+    traceId: tx?.traceId,
     spanId: tx?.trace?.root?.id,
     traceFlags: TraceFlags.SAMPLED
   }

--- a/test/unit/lib/otel/segment-synthesizer.test.js
+++ b/test/unit/lib/otel/segment-synthesizer.test.js
@@ -145,11 +145,10 @@ test('should create rpc segment', (t) => {
   const { synthesizer, tracer } = t.nr
   const span = createRpcServerSpan({ tracer })
   const { segment, transaction } = synthesizer.synthesize(span)
-  const expectedName = 'WebTransaction/WebFrameworkUri/grpc/TestService.findUser'
+  const expectedName = 'TestService/findUser'
   assert.equal(segment.name, expectedName)
   assert.equal(segment.parentId, segment.root.id)
   assert.ok(transaction)
-  assert.equal(transaction.name, expectedName)
   const segmentAttrs = segment.getAttributes()
   assert.equal(segmentAttrs.component, 'grpc')
   assert.equal(transaction.url, expectedName)
@@ -163,11 +162,9 @@ test('should create http server segment', (t) => {
   const { synthesizer, tracer } = t.nr
   const span = createHttpServerSpan({ tracer })
   const { segment, transaction } = synthesizer.synthesize(span)
-  const expectedName = 'WebTransaction/Nodejs/PUT//user/:id'
-  assert.equal(segment.name, expectedName)
+  assert.equal(segment.name, '/user/1')
   assert.equal(segment.parentId, segment.root.id)
   assert.ok(transaction)
-  assert.equal(transaction.name, expectedName)
   assert.equal(transaction.url, '/user/1')
   assert.equal(transaction.baseSegment.name, segment.name)
   const attrs = transaction.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
@@ -180,12 +177,15 @@ test('should create base http server segment', (t) => {
   const { synthesizer, tracer } = t.nr
   const span = createBaseHttpSpan({ tracer })
   const { segment, transaction } = synthesizer.synthesize(span)
-  const expectedName = 'WebTransaction/NormalizedUri/*'
-  assert.equal(segment.name, expectedName)
+  assert.equal(segment.name, '/Unknown')
   assert.equal(segment.parentId, segment.root.id)
-  assert.equal(transaction.baseSegment.name, segment.name)
   assert.ok(transaction)
-  assert.equal(transaction.name, expectedName)
+  assert.equal(transaction.url, '/Unknown')
+  assert.equal(transaction.baseSegment.name, segment.name)
+  const attrs = transaction.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
+  assert.equal(attrs['request.uri'], '/Unknown')
+  assert.ok(!attrs['request.method'])
+  assert.ok(transaction)
 })
 
 test('should create topic producer segment', (t, end) => {

--- a/test/unit/lib/otel/trace-propagator.test.js
+++ b/test/unit/lib/otel/trace-propagator.test.js
@@ -6,9 +6,9 @@
 'use strict'
 const assert = require('node:assert')
 const test = require('node:test')
-const helper = require('../../../lib/agent_helper')
+const helper = require('#testlib/agent_helper.js')
 const otel = require('@opentelemetry/api')
-const NewRelicTracePropagator = require('../../../../lib/otel/trace-propagator')
+const NewRelicTracePropagator = require('#agentlib/otel/trace-propagator.js')
 
 test.beforeEach((ctx) => {
   const agent = helper.instrumentMockedAgent({

--- a/test/unit/lib/otel/trace-propagator.test.js
+++ b/test/unit/lib/otel/trace-propagator.test.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const assert = require('node:assert')
+const test = require('node:test')
+const helper = require('../../../lib/agent_helper')
+const otel = require('@opentelemetry/api')
+const NewRelicTracePropagator = require('../../../../lib/otel/trace-propagator')
+
+test.beforeEach((ctx) => {
+  const agent = helper.instrumentMockedAgent({
+    feature_flag: {
+      opentelemetry_bridge: true
+    }
+  })
+  ctx.nr = { agent }
+})
+
+test.afterEach((ctx) => {
+  helper.unloadAgent(ctx.nr.agent)
+})
+
+test('should set traceparent on context when otel root context is passed in', (t) => {
+  const { agent } = t.nr
+  const propagation = new NewRelicTracePropagator(agent)
+  helper.runInTransaction(agent, (tx) => {
+    otel.trace.getSpanContext = function wrappedSpanContext() {
+      return {
+        traceId: tx.traceId,
+        spanId: tx.trace.root.id,
+        traceFlags: otel.TraceFlags.SAMPLED
+      }
+    }
+
+    const carrier = {}
+    const setter = {
+      set: (c, key, payload) => {
+        assert.deepEqual(c, carrier)
+        assert.equal(key, 'traceparent')
+        assert.equal(payload, `00-${tx.traceId}-${tx.trace.root.id}-0${otel.TraceFlags.SAMPLED}`)
+      }
+    }
+    propagation.inject(otel.ROOT_CONTEXT, carrier, setter)
+  })
+})
+
+test('should return agent context when root context is passed in', (t) => {
+  const { agent } = t.nr
+  const propagation = new NewRelicTracePropagator(agent)
+  const carrier = {}
+  const getter = {
+    get: () => null
+  }
+  const ctx = propagation.extract(otel.ROOT_CONTEXT, carrier, getter)
+  assert.equal(ctx.transaction, undefined)
+  assert.equal(ctx.segment, undefined)
+  assert.ok(ctx._otelCtx)
+})


### PR DESCRIPTION
## Description
This PR starts the groundwork to properly propagate trace context. For now it's just being used to propagate our root context instead of otel's root context.  I also added logic to properly name server span transactions and reconcile the relevant segment attributes with tests. There is missing test coverage in the trace propagator which will be handled in #2662 

## Related Issues
Closes #2936 