### PR TITLE
fix: missing transaction or segment could throw

### DIFF
--- a/api.js
+++ b/api.js
@@ -1542,7 +1542,7 @@ API.prototype.getTraceMetadata = function getTraceMetadata() {
 
   const segment = this.agent.tracer.getSegment()
   const transaction = this.agent.tracer.getTransaction()
-  if (!(segment || transaction)) {
+  if (!segment || !transaction) {
     logger.debug('No transaction found when calling API#getTraceMetadata')
   } else if (!this.agent.config.distributed_tracing.enabled) {
     logger.debug('Distributed tracing disabled when calling API#getTraceMetadata')


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

The code as written is crashing our app because `!(segment || transaction)` is equivalent to `!segment && !transaction`, but what really needed is `!segment || !transaction` because both of these are used without chaining in the final else block.

Edit: `!(segment && transaction)` would also do the job.
