### PR TITLE
fix: Fixed `api.getTraceMetadata` to handle when there is an active transaction but not active segment

### DIFF
--- a/api.js
+++ b/api.js
@@ -1537,18 +1537,24 @@ API.prototype.getTraceMetadata = function getTraceMetadata() {
     NAMES.SUPPORTABILITY.API + '/getTraceMetadata'
   )
   metric.incrementCallCount()
-
   const metadata = {}
 
-  const segment = this.agent.tracer.getSegment()
+  if (this.agent.config.distributed_tracing.enabled === false) {
+    return metadata
+  }
+
   const transaction = this.agent.tracer.getTransaction()
-  if (!(segment || transaction)) {
+  if (!transaction) {
     logger.debug('No transaction found when calling API#getTraceMetadata')
-  } else if (!this.agent.config.distributed_tracing.enabled) {
-    logger.debug('Distributed tracing disabled when calling API#getTraceMetadata')
   } else {
     metadata.traceId = transaction.traceId
+  }
 
+  const segment = this.agent.tracer.getSegment()
+
+  if (!segment) {
+    logger.debug('No segment found when calling API#getTraceMetadata')
+  } else {
     const spanId = segment.getSpanId()
     if (spanId) {
       metadata.spanId = spanId

--- a/test/unit/api/api-get-trace-metadata.test.js
+++ b/test/unit/api/api-get-trace-metadata.test.js
@@ -71,4 +71,22 @@ test('Agent API - trace metadata', async (t) => {
       end()
     })
   })
+
+  await t.test('should not include transaction when not in active transaction', (t) => {
+    const { api } = t.nr
+    const metadata = api.getTraceMetadata()
+    assert.deepEqual(metadata, {})
+  })
+
+  await t.test('should not include spanId when in active active transaction but not active segment', (t, end) => {
+    const { api, agent } = t.nr
+
+    helper.runInTransaction(agent, function (txn) {
+      agent.tracer.setSegment({ segment: null })
+      const metadata = api.getTraceMetadata()
+      assert.equal(metadata.traceId, txn.traceId)
+      assert.ok(!metadata.spanId)
+      end()
+    })
+  })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

A regression existed from the refactor of [12.11.0](https://github.com/newrelic/node-newrelic/commit/7078554a546971d876f41da0823af3d0def33eb2#diff-1cbda34460db92d4ad755248356e01a93fa8afb3e78f3ae866547fddf34c163bR1542-R1552). A PR(#2943) was opened around a gap in test coveraege around this `getTraceMetadata` method. A customer had an active transaction but not segment.  We assumed this could never happen, however this does happen at times due to context propagation breaking.  This PR addresses this issue by handling of adding `traceId` and `spanId` separately.  The customer experiencing this will still have invalid trace metadata(lacking a spanId) but that's a different issue.

