### PR TITLE
fix: Fixed queueing of logs from child loggers

### DIFF
--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -94,7 +94,8 @@ Object.keys(LEVELS).forEach(function buildLevel(_level) {
 
   function log(extra) {
     if (!this.options.configured) {
-      this.logQueue.unshift({ level: _level, args: arguments })
+      // queue a log line with level, args passed to logger and their respective extras
+      this.logQueue.unshift({ level: _level, args: arguments, extra: this.extra })
       return
     }
 
@@ -175,8 +176,9 @@ Object.keys(LEVELS).forEach(function buildLevel(_level) {
 
 Logger.prototype._flushQueuedLogs = function _flushQueuedLogs() {
   while (this.logQueue.length) {
-    const { level, args } = this.logQueue.shift()
-    this[level].apply(this, args)
+    const { level, args, extra } = this.logQueue.shift()
+    // log an entry now that the logger has been configured
+    this[level](extra, ...args)
   }
 }
 
@@ -188,6 +190,7 @@ Logger.prototype.child = function child(extra) {
   childLogger.extra = Object.assign(Object.create(null), this.extra, extra)
 
   const parent = this
+  childLogger.logQueue = parent.logQueue
   childLogger.options = parent.options
 
   childLogger.write = function write(level, args, _extra) {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

It was discovered that components of the agent that rely on child loggers and adding logging from those child loggers before a root logger is configured crashes the agent.  This is because the child logger did not get assigned a log queue.  Once I assigned that, I realized it was missing the extras associated with a logger, most notably the component.  This PR fixes both of those issues and adds tests to ensure that you can queue logs from a child logger and it gets the appropriate component in a given log like when the queue is flushed and logged accordingly.

## Related Issues
Closes #2941
