### PR TITLE
fix: Updated `api.recordLogEvent` to no longer truncate the message key in log event

### DIFF
--- a/api.js
+++ b/api.js
@@ -513,7 +513,6 @@ API.prototype.recordLogEvent = function recordLogEvent(logEvent = {}) {
     )
     return
   }
-  logEvent.message = applicationLogging.truncate(logEvent.message)
 
   if (!logEvent.level) {
     logger.debug('no log level set, setting it to UNKNOWN')

--- a/test/unit/api/api-record-log-events.test.js
+++ b/test/unit/api/api-record-log-events.test.js
@@ -165,7 +165,7 @@ test('Agent API - recordCustomEvent', async (t) => {
         prop1: 123,
         prop2: 'a string',
       },
-      array: Array.from({ length: 1000 }, i => 'item number ' + i),
+      array: Array.from({ length: 1000 }, (_, i) => 'item number ' + i),
       nonPrimitive: new Date(),
     })
     api.recordLogEvent({ message: json })

--- a/test/unit/api/api-record-log-events.test.js
+++ b/test/unit/api/api-record-log-events.test.js
@@ -156,6 +156,23 @@ test('Agent API - recordCustomEvent', async (t) => {
     assert.equal(apiMetric.callCount, 1, 'and one API call was counted anyway')
     end()
   })
+
+  await t.test('it works with large JSON log messages', (t, end) => {
+    const { agent, api } = t.nr
+    const json = JSON.stringify({
+      message: message.repeat(100),
+      nested: {
+        prop1: 123,
+        prop2: 'a string',
+      },
+      array: Array.from({ length: 1000 }, i => 'item number ' + i),
+      nonPrimitive: new Date(),
+    })
+    api.recordLogEvent({ message: json })
+    const logEvent = popTopLogMessage(agent)
+    assert.equal(logEvent.message, json)
+    end()
+  })
 })
 
 test('does not collect logs when high security mode is on', (_t, end) => {


### PR DESCRIPTION
See the related issue: fixes #2921 

In short: `logEvent.message` can either be a simple string message, in which truncating is OK, but it can also be the full JSON log (stringified), in which case it mustn't be truncated.