### PR TITLE
fix: Fixed undici/fetch instrumentation to properly assign the parent-id portion of the `traceparent` header on outgoing requests to the active http external span id

### DIFF
--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -136,8 +136,8 @@ function requestCreateHook(shim, { request }) {
   }
 
   try {
-    addDTHeaders({ transaction, config, request })
     createExternalSegment({ shim, request, segment })
+    addDTHeaders({ transaction, config, request })
   } catch (err) {
     logger.warn(err, 'Unable to create external segment')
   }

--- a/test/unit/instrumentation/http/outbound.test.js
+++ b/test/unit/instrumentation/http/outbound.test.js
@@ -565,9 +565,15 @@ test('when working with http.request', async (t) => {
     nock(host)
       .get(path)
       .reply(200, function () {
+        const { transaction, segment } = agent.tracer.getContext()
+        assert.equal(segment.name, 'External/www.google.com')
         headers = this.req.headers
         assert.ok(headers.traceparent, 'traceparent header')
-        assert.equal(headers.traceparent.split('-').length, 4)
+        const [version, traceId, parentSpanId, sampledFlag] = headers.traceparent.split('-')
+        assert.equal(version, '00')
+        assert.equal(traceId, transaction.traceId)
+        assert.equal(parentSpanId, segment.id)
+        assert.equal(sampledFlag, '01')
         assert.ok(headers.tracestate, 'tracestate header')
         assert.ok(!headers.tracestate.includes('null'))
         assert.ok(!headers.tracestate.includes('true'))

--- a/test/unit/shim/transaction-shim.test.js
+++ b/test/unit/shim/transaction-shim.test.js
@@ -662,7 +662,7 @@ test('TransactionShim', async function (t) {
           const outboundHeaders = {}
           tx.insertDistributedTraceHeaders(outboundHeaders)
 
-          assert.ok(outboundHeaders.traceparent.startsWith('00-4bf92f3577b3'))
+          assert.equal(outboundHeaders.traceparent, `00-${tx.traceId}-${segment.id}-01`)
           assert.ok(outboundHeaders.tracestate.endsWith(tracestate))
           end()
         })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

See details in #2950 as to why. This PR adds more tests to the relevant places that inject `traceparent` to ensure the parts are the expected values.


## Related Issues
Closes #2950
