### PR TITLE
feat: Allowed undici error reporting to be disabled with feature flag `undici_error_tracking`

### DIFF
--- a/documentation/feature-flags.md
+++ b/documentation/feature-flags.md
@@ -39,3 +39,9 @@ Any prerelease flags can be enabled or disabled in your agent config by adding a
 * Environment Variable: `NEW_RELIC_FEATURE_FLAG_OTEL_INSTRUMENTATION`
 * Description: Enables the creation of Transaction Trace segments and time slices metrics from opentelemetry spans. This will help drive New Relic UI experience for opentelemetry spans. 
 * **WARNING**: This is not feature complete and is not intended to be enabled yet.
+
+#### undici_error_tracking
+* Enabled by default: `true`
+* Configuration: `{ feature_flag: { undici_error_tracking: true|false }}`
+* Environment Variable: `NEW_RELIC_FEATURE_FLAG_UNDICI_ERROR_TRACKING`
+* Description: Enables the creation of errors when a request with undici fails. To disable tracking errors with undici, set the value to `false`.

--- a/lib/feature_flags.js
+++ b/lib/feature_flags.js
@@ -14,7 +14,8 @@ exports.prerelease = {
   promise_segments: false,
   reverse_naming_rules: false,
   unresolved_promise_cleanup: true,
-  kafkajs_instrumentation: false
+  kafkajs_instrumentation: false,
+  undici_error_tracking: true
 }
 
 // flags that are no longer used for released features

--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -192,6 +192,7 @@ function requestHeadersHook(shim, { request, response }) {
  * @param {Error} params.error error from undici request
  */
 function endAndRestoreSegment(shim, { request, error }) {
+  const { config } = shim.agent
   const activeSegment = request[symbols.segment]
   const parentSegment = request[symbols.parentSegment]
   const tx = request[symbols.transaction]
@@ -199,7 +200,7 @@ function endAndRestoreSegment(shim, { request, error }) {
     activeSegment.end()
   }
 
-  if (error && tx) {
+  if (error && tx && config.feature_flag.undici_error_tracking === true) {
     handleError(shim, tx, error)
   }
 

--- a/test/unit/feature_flag.test.js
+++ b/test/unit/feature_flag.test.js
@@ -41,7 +41,8 @@ const used = [
   'undici_async_tracking',
   'aws_bedrock_instrumentation',
   'langchain_instrumentation',
-  'kafkajs_instrumentation'
+  'kafkajs_instrumentation',
+  'undici_error_tracking'
 ]
 
 test.beforeEach((ctx) => {

--- a/test/versioned/undici/requests.test.js
+++ b/test/versioned/undici/requests.test.js
@@ -447,7 +447,11 @@ test('Undici error reporting tests', async (t) => {
           method: 'GET'
         })
       } catch (e) {
-        assert.equal(e.message, 'getaddrinfo ENOTFOUND invalidurl')
+        assert.ok(e)
+        assertSegments(tx.trace, tx.trace.root, ['External/invalidurl/foo'], { exact: false })
+        assert.equal(tx.exceptions.length, 0)
+        tx.end()
+
       }
 
       assert.equal(tx.exceptions.length, 0)

--- a/test/versioned/undici/requests.test.js
+++ b/test/versioned/undici/requests.test.js
@@ -312,6 +312,26 @@ test('Undici request tests', async (t) => {
     })
   })
 
+  await t.test('should not log error when `feature_flag.undici_error_tracking` is false', async (t) => {
+    agent.config.feature_flag.undici_error_tracking = false
+    t.after(() => {
+      agent.config.feature_flag.undici_error_tracking = true
+    })
+    await helper.runInTransaction(agent, async (tx) => {
+      try {
+        await undici.request('https://invalidurl', {
+          path: '/foo',
+          method: 'GET'
+        })
+      } catch (err) {
+        assert.ok(err)
+        assertSegments(tx.trace, tx.trace.root, ['External/invalidurl/foo'], { exact: false })
+        assert.equal(tx.exceptions.length, 0)
+        tx.end()
+      }
+    })
+  })
+
   await t.test('segments should end on error', async () => {
     const socketEndServer = http.createServer(function badHandler(req) {
       req.socket.end()
@@ -423,38 +443,6 @@ test('Undici request tests', async (t) => {
           end()
         }
       )
-    })
-  })
-})
-
-test('Undici error reporting tests', async (t) => {
-  const agent = helper.instrumentMockedAgent({
-    feature_flag: {
-      undici_error_tracking: false
-    }
-  })
-  const undici = require('undici')
-
-  t.after(() => {
-    helper.unloadAgent(agent)
-  })
-
-  await t.test('should not report undici errors', async () => {
-    await helper.runInTransaction(agent, async (tx) => {
-      try {
-        await undici.request('https://invalidurl', {
-          path: '/foo',
-          method: 'GET'
-        })
-      } catch (e) {
-        assert.ok(e)
-        assertSegments(tx.trace, tx.trace.root, ['External/invalidurl/foo'], { exact: false })
-        assert.equal(tx.exceptions.length, 0)
-        tx.end()
-
-      }
-
-      assert.equal(tx.exceptions.length, 0)
     })
   })
 })


### PR DESCRIPTION
## Description

When `fetch` in node 20+ is wrapped in a try/catch the error that is thrown even if the user doesn't rethrow the error. At best this means errors being reported that are not errors, at worst it means errors are being reported twice.

This adds the feature flag `undici_error_tracking` as suggested by @bizob2828 to allow disabling error capture via undici message channels.

## How to Test

See test in the files changed. I've caught an undici error and ensured that when the flag is turned off the transaction error array is empty.

## Related Issues

Fixes #2954