### PR TITLE
feat: Updated Context class to ensure bi-directional context propagation with opentelemetry bridge

### DIFF
--- a/lib/context-manager/context.js
+++ b/lib/context-manager/context.js
@@ -5,6 +5,7 @@
 
 'use strict'
 const { otelSynthesis } = require('../symbols')
+const FakeSpan = require('../otel/fake-span')
 
 module.exports = class Context {
   constructor(transaction, segment, parentContext) {
@@ -21,12 +22,41 @@ module.exports = class Context {
     return this._transaction
   }
 
+  /**
+   * Constructs a new context from segment about to be bound to context manager
+   * along with the current transaction.
+   *
+   * If agent is in otel bridge mode it will also bind a FakeSpan to the otel ctx.
+   *
+   * @param {object} params to function
+   * @param {TraceSegment} params.segment segment to bind to context
+   * @param {Transaction} params.transaction active transaction
+   * @returns {Context} a newly constructed context
+   */
   enterSegment({ segment, transaction = this._transaction }) {
-    return new this.constructor(transaction, segment)
+    if (transaction?.agent?.otelSpanKey) {
+      this._otelCtx.set(transaction.agent.otelSpanKey, new FakeSpan(segment, transaction))
+    }
+    return new this.constructor(transaction, segment, this._otelCtx)
   }
 
+  /**
+   * Constructs a new context from transaction about to be bound to context manager.
+   * It uses the trace root segment as the segment in context.
+   *
+   * If agent is in otel bridge mode it will also bind a FakeSpan to the otel ctx.
+   *
+   * @param {object} params to function
+   * @param {TraceSegment} params.segment transaction trace root segment
+   * @param {Transaction} params.transaction transaction to bind to context
+   * @param transaction
+   * @returns {Context} a newly constructed context
+   */
   enterTransaction(transaction) {
-    return new this.constructor(transaction, transaction.trace.root)
+    if (transaction?.agent?.otelSpanKey) {
+      this._otelCtx.set(transaction.agent.otelSpanKey, new FakeSpan(transaction.trace.root, transaction))
+    }
+    return new this.constructor(transaction, transaction.trace.root, this._otelCtx)
   }
 
   /**

--- a/lib/otel/fake-span.js
+++ b/lib/otel/fake-span.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/**
+ * In order to be able to return the appropriate span context
+ * wihtin otel bridge. We have to create fake spans for new relic
+ * segments.  The only thing needed is a method for `spanContext`
+ * which should return the spanId(segment id) and traceId(transaction trace id).
+ * We hardcode traceFlags to 1.
+ */
+module.exports = class FakeSpan {
+  constructor(segment, transaction) {
+    this.segment = segment
+    this.transaction = transaction
+  }
+
+  spanContext() {
+    return {
+      spanId: this.segment.id,
+      traceId: this.transaction.traceId,
+      traceFlags: 1
+    }
+  }
+}

--- a/lib/otel/segments/utils.js
+++ b/lib/otel/segments/utils.js
@@ -16,7 +16,7 @@
  */
 function propagateTraceContext({ transaction, otelSpan, transport }) {
   const spanContext = otelSpan.spanContext()
-  const parentSpanId = otelSpan.parentSpanId || otelSpan?.parentSpanContext?.spanId
+  const parentSpanId = otelSpan?.parentSpanId || otelSpan?.parentSpanContext?.spanId
 
   if (parentSpanId) {
     // prefix traceFlags with 0 as it is stored as a parsed int on spanContext

--- a/lib/otel/segments/utils.js
+++ b/lib/otel/segments/utils.js
@@ -5,12 +5,22 @@
 
 'use strict'
 
+/**
+ * Accepts trace context payload if span has a parent. It will use the
+ * span context to extract the traceId, traceFlags and trace state.
+ *
+ * @param {object} params to function
+ * @param {Transaction} params.transaction active transaction
+ * @param {object} params.otelSpan active span
+ * @param {string} params.transport indicator of type of span(http, kafkajs, rabbitmq, etc)
+ */
 function propagateTraceContext({ transaction, otelSpan, transport }) {
   const spanContext = otelSpan.spanContext()
+  const parentSpanId = otelSpan.parentSpanId || otelSpan?.parentSpanContext?.spanId
 
-  if (otelSpan.parentSpanId) {
+  if (parentSpanId) {
     // prefix traceFlags with 0 as it is stored as a parsed int on spanContext
-    const traceparent = `00-${spanContext.traceId}-${otelSpan.parentSpanId}-0${spanContext.traceFlags}`
+    const traceparent = `00-${spanContext.traceId}-${parentSpanId}-0${spanContext.traceFlags}`
     transaction.acceptTraceContextPayload(traceparent, spanContext?.traceState?.state, transport)
   }
 }

--- a/lib/otel/setup.js
+++ b/lib/otel/setup.js
@@ -14,6 +14,7 @@ const createOtelLogger = require('./logger')
 const TracePropagator = require('./trace-propagator')
 
 const { ATTR_SERVICE_NAME } = require('./constants')
+const interceptSpanKey = require('./span-key-interceptor')
 
 module.exports = function setupOtel(agent, logger = defaultLogger) {
   if (agent.config.feature_flag.opentelemetry_bridge !== true) {
@@ -35,6 +36,7 @@ module.exports = function setupOtel(agent, logger = defaultLogger) {
     }
   }))
 
+  interceptSpanKey(agent)
   opentelemetry.context.setGlobalContextManager(new ContextManager(agent))
   opentelemetry.propagation.setGlobalPropagator(new TracePropagator(agent))
 

--- a/lib/otel/span-key-interceptor.js
+++ b/lib/otel/span-key-interceptor.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const otelApi = require('@opentelemetry/api')
+
+module.exports = function interceptSpanKey(agent) {
+  const fakeCtx = {
+    spanKey: null,
+    setValue(key) {
+      this.spanKey = key
+    }
+  }
+
+  const fakeSpan = {}
+  otelApi.trace.setSpan(fakeCtx, fakeSpan)
+  agent.otelSpanKey = fakeCtx.spanKey
+}

--- a/lib/otel/span-key-interceptor.js
+++ b/lib/otel/span-key-interceptor.js
@@ -7,6 +7,15 @@
 
 const otelApi = require('@opentelemetry/api')
 
+/**
+ * Called before setting up the otel bridge ContextManager.
+ * This creates a fake context and uses the otel api to set a span.
+ * By creating a fake `setValue` when it will give us the symbol used for enqueueing spans to the context.
+ * This is assigned as a key on the agent.
+ * We will use this key to enqueue our FakeSpan when we enter a segment or transaction so that when using otel API it will return the appropriate traceId and spanId.
+ *
+ * @param {Agent} agent instance
+ */
 module.exports = function interceptSpanKey(agent) {
   const fakeCtx = {
     spanKey: null,

--- a/lib/otel/trace-propagator.js
+++ b/lib/otel/trace-propagator.js
@@ -32,7 +32,6 @@ class TraceState {
  *     (01 = sampled, 00 = not sampled).
  *     for example: '{version}-{traceId}-{spanId}-{sampleDecision}'
  *     For more information see {@link https://www.w3.org/TR/trace-context/}
- * @param traceParen
  */
 function parseTraceParent(traceParent) {
   const match = TRACE_PARENT_REGEX.exec(traceParent)

--- a/test/unit/lib/otel/fake-span.test.js
+++ b/test/unit/lib/otel/fake-span.test.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert')
+const helper = require('#testlib/agent_helper.js')
+const FakeSpan = require('#agentlib/otel/fake-span.js')
+
+test('should create a fake span from segment and transaction', (t) => {
+  const agent = helper.loadMockedAgent()
+  t.after(() => {
+    helper.unloadAgent(agent)
+  })
+
+  const segment = { id: 'id' }
+  const tx = { traceId: 'traceId' }
+  const span = new FakeSpan(segment, tx)
+  const spanCtx = span.spanContext()
+  assert.deepEqual(spanCtx, {
+    spanId: 'id',
+    traceId: 'traceId',
+    traceFlags: 1
+  })
+})

--- a/test/unit/lib/otel/segment-utils.test.js
+++ b/test/unit/lib/otel/segment-utils.test.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert')
+const sinon = require('sinon')
+const helper = require('#testlib/agent_helper.js')
+const { propagateTraceContext } = require('#agentlib/otel/segments/utils.js')
+
+test.beforeEach((ctx) => {
+  const agent = helper.loadMockedAgent()
+  const transaction = {
+    acceptTraceContextPayload: sinon.stub()
+  }
+  ctx.nr = {
+    agent,
+    transaction
+  }
+})
+
+test.afterEach((ctx) => {
+  helper.unloadAgent(ctx.nr.agent)
+})
+
+test('should accept traceparent when span has parentSpanId', (t) => {
+  const { transaction } = t.nr
+  const otelSpan = {
+    parentSpanId: 'parentId',
+    spanContext() {
+      return {
+        traceId: 'traceId',
+        traceFlags: 1,
+        traceState: { state: 'state' }
+      }
+    }
+  }
+  propagateTraceContext({ transaction, otelSpan, transport: 'transport' })
+  assert.equal(transaction.acceptTraceContextPayload.callCount, 1)
+  assert.deepEqual(transaction.acceptTraceContextPayload.args[0], [
+    '00-traceId-parentId-01', 'state', 'transport'
+  ])
+})
+
+test('should accept traceparent when span has parentSpanContext.spanId', (t) => {
+  const { transaction } = t.nr
+  const otelSpan = {
+    parentSpanContext: { spanId: 'parentId' },
+    spanContext() {
+      return {
+        traceId: 'traceId',
+        traceFlags: 1,
+        traceState: { state: 'state' }
+      }
+    }
+  }
+  propagateTraceContext({ transaction, otelSpan, transport: 'transport' })
+  assert.equal(transaction.acceptTraceContextPayload.callCount, 1)
+  assert.deepEqual(transaction.acceptTraceContextPayload.args[0], [
+    '00-traceId-parentId-01', 'state', 'transport'
+  ])
+})
+
+test('should not accept traceparent when span has not parent span id', (t) => {
+  const { transaction } = t.nr
+  const otelSpan = { spanContext() { return {} } }
+  propagateTraceContext({ transaction, otelSpan, transport: 'transport' })
+  assert.equal(transaction.acceptTraceContextPayload.callCount, 0)
+})

--- a/test/unit/lib/otel/setup.test.js
+++ b/test/unit/lib/otel/setup.test.js
@@ -49,3 +49,10 @@ test('should not create provider when `feature_flag.opentelemetry_bridge` is fal
   assert.equal(provider, null)
   assert.equal(loggerMock.warn.args[0][0], '`feature_flag.opentelemetry_bridge` is not enabled, skipping setup of opentelemetry-bridge')
 })
+
+test('should assign span key to agent', (t) => {
+  const { agent, loggerMock } = t.nr
+  agent.config.feature_flag.opentelemetry_bridge = true
+  otelSetup(agent, loggerMock)
+  assert.ok(agent.otelSpanKey)
+})


### PR DESCRIPTION
## Description
During testing of otel example apps I was finding DT was incorrect at times.  The situation was if a transaction was started with agent and the next span was an otel span, when it retrieved the span context is thought there wasn't a parent.  That's because there wasn't a parent in otel but the agent had created a transaction with a root segment.  This PR addresses that issue by doing 2 things.  At setup of otel bridge, there's a function that is run to intercept the key that is used by otel to bind spans to the context.  Then when we bind a segment or transaction to context we also check if this span key is present and add a fake span to the otelCtx.  The span only needs a `spanContext` method which returns the appropriate spanid, traceId, and traceFlags(we hardcode to sampled).  Once I did this my issues while testing otel apps was fixed.

## Related Issues
Closes #2960 