### PR TITLE
chore: Limit nestjs to enable successful CI

### DIFF
--- a/test/versioned/nestjs/package.json
+++ b/test/versioned/nestjs/package.json
@@ -9,7 +9,7 @@
         "node": ">=18"
       },
       "dependencies": {
-        "@nestjs/cli": ">=9.0.0"
+        "@nestjs/cli": ">=9.0.0 && <10.0.0 || >=11.0.0"
       },
       "files": [
         "nest.test.js"


### PR DESCRIPTION
Something in https://github.com/nestjs/nest-cli/compare/11.0.4...11.0.5 has caused our versioned tests to fail. See https://github.com/newrelic/node-newrelic/actions/runs/13627134844/job/38103055795#step:7:364