### PR TITLE
refactor: Updated span event generation to assign the appropriate `span.kind` based on the segment name

### DIFF
--- a/api.js
+++ b/api.js
@@ -992,6 +992,7 @@ API.prototype.startWebTransaction = function startWebTransaction(url, handle) {
       transaction: tx,
       parent
     })
+    tx.baseSegment.spanKind = 'server'
     const newContext = context.enterSegment({ transaction: tx, segment: tx.baseSegment })
     tx.baseSegment.start()
 
@@ -1101,6 +1102,7 @@ function startBackgroundTransaction(name, group, handle) {
       parent
     })
     const newContext = context.enterSegment({ transaction: tx, segment: tx.baseSegment })
+    tx.baseSegment.spanKind = 'server'
     tx.baseSegment.partialName = group
     tx.baseSegment.start()
 

--- a/lib/context-manager/context.js
+++ b/lib/context-manager/context.js
@@ -29,7 +29,7 @@ module.exports = class Context {
    * @returns {Context} a newly constructed context
    */
   enterSegment({ segment, transaction = this._transaction }) {
-    return new this.constructor(transaction, segment, this._otelCtx)
+    return new this.constructor(transaction, segment)
   }
 
   /**

--- a/lib/instrumentation/kafkajs/consumer.js
+++ b/lib/instrumentation/kafkajs/consumer.js
@@ -42,7 +42,7 @@ function wrapConsumer(shim, orig) {
       consumer,
       'run',
       new MessageSubscribeSpec({
-        name: `${SEGMENT_PREFIX}#run`,
+        name: `${SEGMENT_PREFIX}run`,
         destinationType: shim.TOPIC,
         promise: true,
         consumer: shim.FIRST,

--- a/lib/spans/helpers.js
+++ b/lib/spans/helpers.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const HTTP_LIBRARY = 'http'
+const CATEGORIES = {
+  HTTP: 'http',
+  DATASTORE: 'datastore',
+  GENERIC: 'generic'
+}
+
+const SPAN_KIND = {
+  CONSUMER: 'consumer',
+  CLIENT: 'client',
+  INTERNAL: 'internal',
+  PRODUCER: 'producer',
+  SERVER: 'server'
+}
+
+const REGEXS = {
+  CONSUMER: /^(?:Truncated\/)?OtherTransaction\/Message\//,
+  CLIENT: {
+    EXTERNAL: /^(?:Truncated\/)?External\//,
+    DATASTORE: /^(?:Truncated\/)?Datastore\//,
+  },
+  PRODUCER: /^(?:Truncated\/)?MessageBroker\//,
+  SERVER: /^(?:Truncated\/)?(WebTransaction)\//
+}
+
+/**
+ * Assigns the appropriate span kind based on the segment name.
+ * Does not handle client kind as this is done in the `HttpSpanEvent` and `DatastoreSpanEvent`
+ * Our agent has conventions for naming all types of segments.
+ * The only place this convention does not exist is within the `api.startWebTransaction`
+ * and `api.startBackgroundTransaction`. For those, we have assigned a `spanKind` property
+ * on the segment.  We default to `internal` if it cannot match a regex.
+ *
+ * @param {object} params to function
+ * @param {TraceSegment} params.segment segment that is creating span
+ * @param {object} params.span span to add `intrinsics['span.kind']`
+ */
+function addSpanKind({ segment, span }) {
+  const intrinsics = span.getIntrinsicAttributes()
+  if (!intrinsics['span.kind']) {
+    let spanKind
+    if (segment.spanKind) {
+      spanKind = segment.spanKind
+    } else if (REGEXS.CONSUMER.test(segment.name)) {
+      spanKind = SPAN_KIND.CONSUMER
+    } else if (REGEXS.PRODUCER.test(segment.name)) {
+      spanKind = SPAN_KIND.PRODUCER
+    } else if (REGEXS.SERVER.test(segment.name)) {
+      spanKind = SPAN_KIND.SERVER
+    } else {
+      spanKind = SPAN_KIND.INTERNAL
+    }
+
+    span.addIntrinsicAttribute('span.kind', spanKind)
+  }
+}
+
+module.exports = {
+  HTTP_LIBRARY,
+  CATEGORIES,
+  SPAN_KIND,
+  REGEXS,
+  addSpanKind
+}

--- a/lib/spans/span-event.js
+++ b/lib/spans/span-event.js
@@ -9,18 +9,7 @@ const Config = require('../config')
 const { truncate } = require('../util/byte-limit')
 
 const { DESTINATIONS } = require('../config/attribute-filter')
-
-const HTTP_LIBRARY = 'http'
-const CLIENT_KIND = 'client'
-const CATEGORIES = {
-  HTTP: 'http',
-  DATASTORE: 'datastore',
-  GENERIC: 'generic'
-}
-
-const EXTERNAL_REGEX = /^(?:Truncated\/)?External\//
-const DATASTORE_REGEX = /^(?:Truncated\/)?Datastore\//
-
+const { addSpanKind, HTTP_LIBRARY, REGEXS, SPAN_KIND, CATEGORIES } = require('./helpers')
 const EMPTY_USER_ATTRS = Object.freeze(Object.create(null))
 const SERVER_ADDRESS = 'server.address'
 
@@ -72,6 +61,14 @@ class SpanEvent {
       this.addAttribute('server.port', attributes.port, true)
       attributes.port = null
     }
+  }
+
+  getIntrinsicAttributes() {
+    return this.intrinsics
+  }
+
+  addIntrinsicAttribute(key, value) {
+    this.intrinsics[key] = value
   }
 
   static get CATEGORIES() {
@@ -153,6 +150,7 @@ class SpanEvent {
     span.intrinsics.timestamp = segment.timer.start
     span.intrinsics.duration = segment.timer.getDurationInMillis() / 1000
 
+    addSpanKind({ segment, span })
     return span
   }
 
@@ -193,7 +191,7 @@ class HttpSpanEvent extends SpanEvent {
 
     this.intrinsics.category = CATEGORIES.HTTP
     this.intrinsics.component = attributes.library || HTTP_LIBRARY
-    this.intrinsics['span.kind'] = CLIENT_KIND
+    this.intrinsics['span.kind'] = SPAN_KIND.CLIENT
 
     if (attributes.library) {
       attributes.library = null
@@ -217,7 +215,7 @@ class HttpSpanEvent extends SpanEvent {
   }
 
   static testSegment(segment) {
-    return EXTERNAL_REGEX.test(segment.name)
+    return REGEXS.CLIENT.EXTERNAL.test(segment.name)
   }
 }
 
@@ -232,7 +230,7 @@ class DatastoreSpanEvent extends SpanEvent {
     super(attributes, customAttributes)
 
     this.intrinsics.category = CATEGORIES.DATASTORE
-    this.intrinsics['span.kind'] = CLIENT_KIND
+    this.intrinsics['span.kind'] = SPAN_KIND.CLIENT
 
     if (attributes.product) {
       this.intrinsics.component = attributes.product
@@ -279,7 +277,7 @@ class DatastoreSpanEvent extends SpanEvent {
   }
 
   static testSegment(segment) {
-    return DATASTORE_REGEX.test(segment.name)
+    return REGEXS.CLIENT.DATASTORE.test(segment.name)
   }
 }
 

--- a/lib/spans/streaming-span-event.js
+++ b/lib/spans/streaming-span-event.js
@@ -10,17 +10,7 @@ const { truncate } = require('../util/byte-limit')
 const Config = require('../config')
 
 const { DESTINATIONS } = require('../config/attribute-filter')
-
-const HTTP_LIBRARY = 'http'
-const CLIENT_KIND = 'client'
-const CATEGORIES = {
-  HTTP: 'http',
-  DATASTORE: 'datastore',
-  GENERIC: 'generic'
-}
-
-const EXTERNAL_REGEX = /^(?:Truncated\/)?External\//
-const DATASTORE_REGEX = /^(?:Truncated\/)?Datastore\//
+const { addSpanKind, HTTP_LIBRARY, REGEXS, SPAN_KIND, CATEGORIES } = require('./helpers')
 
 /**
  * Specialized span event class for use with infinite streaming.
@@ -59,13 +49,17 @@ class StreamingSpanEvent {
   }
 
   /**
-   * Add a key/value pair to the Span's instrinisics collection.
+   * Add a key/value pair to the Span's intrinsics collection.
    *
    * @param {string} key Name of the attribute to be stored.
    * @param {string|boolean|number} value Value of the attribute to be stored.
    */
   addIntrinsicAttribute(key, value) {
     this._intrinsicAttributes.addAttribute(key, value)
+  }
+
+  getIntrinsicAttributes() {
+    return this._intrinsicAttributes
   }
 
   /**
@@ -169,6 +163,7 @@ class StreamingSpanEvent {
     // Timestamp in milliseconds, duration in seconds. Yay consistency!
     span.addIntrinsicAttribute('timestamp', segment.timer.start)
     span.addIntrinsicAttribute('duration', segment.timer.getDurationInMillis() / 1000)
+    addSpanKind({ segment, span })
 
     return span
   }
@@ -196,7 +191,7 @@ class StreamingHttpSpanEvent extends StreamingSpanEvent {
 
     this.addIntrinsicAttribute('category', CATEGORIES.HTTP)
     this.addIntrinsicAttribute('component', library || HTTP_LIBRARY)
-    this.addIntrinsicAttribute('span.kind', CLIENT_KIND)
+    this.addIntrinsicAttribute('span.kind', SPAN_KIND.CLIENT)
 
     if (url) {
       this.addAgentAttribute('http.url', url)
@@ -213,7 +208,7 @@ class StreamingHttpSpanEvent extends StreamingSpanEvent {
   }
 
   static isHttpSegment(segment) {
-    return EXTERNAL_REGEX.test(segment.name)
+    return REGEXS.CLIENT.EXTERNAL.test(segment.name)
   }
 }
 
@@ -248,7 +243,7 @@ class StreamingDatastoreSpanEvent extends StreamingSpanEvent {
     super(traceId, agentAttrs, customAttributes)
 
     this.addIntrinsicAttribute('category', CATEGORIES.DATASTORE)
-    this.addIntrinsicAttribute('span.kind', CLIENT_KIND)
+    this.addIntrinsicAttribute('span.kind', SPAN_KIND.CLIENT)
 
     if (product) {
       this.addIntrinsicAttribute('component', product)
@@ -288,7 +283,7 @@ class StreamingDatastoreSpanEvent extends StreamingSpanEvent {
   /* eslint-enable camelcase */
 
   static isDatastoreSegment(segment) {
-    return DATASTORE_REGEX.test(segment.name)
+    return REGEXS.CLIENT.DATASTORE.test(segment.name)
   }
 }
 

--- a/lib/transaction/trace/segment.js
+++ b/lib/transaction/trace/segment.js
@@ -64,6 +64,9 @@ function TraceSegment({ id, config, name, collect, parentId, root, isRoot = fals
   this.state = STATE.EXTERNAL
   this.async = true
   this.ignore = false
+  // only use to specify spanKind on segments created with `api.startBackgroundTransaction` and `api.startWebTransaction`
+  // we typically determine the span kind based on the segment name
+  this.spanKind = null
 }
 
 TraceSegment.prototype.getSpanContext = function getSpanContext() {

--- a/test/lib/custom-assertions/assert-span-kind.js
+++ b/test/lib/custom-assertions/assert-span-kind.js
@@ -6,7 +6,14 @@
 'use strict'
 
 /**
- * Gets all spans created during transaction and iterates over to assert the span kind.
+ * Gets all spans created during transaction and iterates over to assert the span kind
+ * for each segment in the transaction matches the provided expected `segments`.
+ *
+ * @example
+ * assertSpanKind({
+ *   agent,
+ *   segments: [{ name: 'expectedSegment', kind: 'server' }]
+ * })
  *
  * @param {object} params to function
  * @param {Agent} params.agent instance of agent

--- a/test/lib/custom-assertions/assert-span-kind.js
+++ b/test/lib/custom-assertions/assert-span-kind.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/**
+ * Gets all spans created during transaction and iterates over to assert the span kind.
+ *
+ * @param {object} params to function
+ * @param {Agent} params.agent instance of agent
+ * @param {segments} params.segments collection of span names and their respective span kind
+ * @param {object} params.assert assertion library
+ */
+module.exports = function assertSpanKind({ agent, segments, assert = require('node:assert') }) {
+  const spans = agent.spanEventAggregator.getEvents()
+  if (segments) {
+    segments.forEach((segment) => {
+      const span = spans.find((s) => s.intrinsics.name === segment.name)
+      if (!span) {
+        assert.fail(`Could not find span: ${segment.name}`)
+      }
+      assert.equal(span.intrinsics['span.kind'], segment.kind)
+    })
+  } else {
+    assert.fail('Custom assertion must either pass in an array of span kinds or a collection of segment names to span kind')
+  }
+}

--- a/test/unit/api/api-start-background-transaction.test.js
+++ b/test/unit/api/api-start-background-transaction.test.js
@@ -8,7 +8,7 @@ const test = require('node:test')
 const assert = require('node:assert')
 const API = require('../../../api')
 const helper = require('../../lib/agent_helper')
-const { assertCLMAttrs } = require('../../lib/custom-assertions')
+const { assertCLMAttrs, assertSpanKind } = require('../../lib/custom-assertions')
 
 function nested({ api }) {
   api.startBackgroundTransaction('nested', function nestedHandler() {})
@@ -72,6 +72,7 @@ test('Agent API - startBackgroundTransaction', async (t) => {
     })
 
     assert.ok(!transaction.isActive())
+    assertSpanKind({ agent, segments: [{ name: transaction.name, kind: 'server' }] })
 
     end()
   })

--- a/test/unit/api/api-start-web-transaction.test.js
+++ b/test/unit/api/api-start-web-transaction.test.js
@@ -8,7 +8,7 @@ const test = require('node:test')
 const assert = require('node:assert')
 const API = require('../../../api')
 const helper = require('../../lib/agent_helper')
-const { assertCLMAttrs } = require('../../lib/custom-assertions')
+const { assertCLMAttrs, assertSpanKind } = require('../../lib/custom-assertions')
 function nested({ api }) {
   api.startWebTransaction('nested', function nestedHandler() {})
 }
@@ -70,6 +70,7 @@ test('Agent API - startWebTransaction', async (t) => {
     })
 
     assert.ok(!transaction.isActive())
+    assertSpanKind({ agent, segments: [{ name: transaction.name, kind: 'server' }] })
     end()
   })
 

--- a/test/unit/spans/span-event.test.js
+++ b/test/unit/spans/span-event.test.js
@@ -93,7 +93,7 @@ test('fromSegment()', async (t) => {
         assert.ok(span.intrinsics.duration >= 0.03 && span.intrinsics.duration <= 0.3)
 
         // Generic should not have 'span.kind' or 'component'
-        assert.equal(span.intrinsics['span.kind'], null)
+        assert.equal(span.intrinsics['span.kind'], 'internal')
         assert.equal(span.intrinsics.component, null)
 
         assert.ok(span.customAttributes)

--- a/test/unit/spans/streaming-span-event.test.js
+++ b/test/unit/spans/streaming-span-event.test.js
@@ -85,13 +85,13 @@ test('fromSegment()', async (t) => {
         assert.deepEqual(span._intrinsicAttributes.priority, { [INT_TYPE]: 42 })
         assert.deepEqual(span._intrinsicAttributes.name, { [STRING_TYPE]: 'timers.setTimeout' })
         assert.deepEqual(span._intrinsicAttributes.timestamp, { [INT_TYPE]: segment.timer.start })
+        assert.deepEqual(span._intrinsicAttributes['span.kind'], { [STRING_TYPE]: 'internal' })
 
         assert.ok(span._intrinsicAttributes.duration)
         assert.ok(span._intrinsicAttributes.duration[DOUBLE_TYPE])
 
         // Generic should not have 'span.kind' or 'component'
         const hasIntrinsic = Object.hasOwnProperty.bind(span._intrinsicAttributes)
-        assert.ok(!hasIntrinsic('span.kind'))
         assert.ok(!hasIntrinsic('component'))
 
         const customAttributes = span._customAttributes

--- a/test/versioned/express/segments.test.js
+++ b/test/versioned/express/segments.test.js
@@ -9,7 +9,7 @@ const test = require('node:test')
 const { makeRequest, setup, teardown } = require('./utils')
 const NAMES = require('../../../lib/metrics/names')
 const { findSegment } = require('../../lib/metrics_helper')
-const { assertMetrics, assertSegments, assertCLMAttrs } = require('../../lib/custom-assertions')
+const { assertMetrics, assertSegments, assertCLMAttrs, assertSpanKind } = require('../../lib/custom-assertions')
 
 const assertSegmentsOptions = {
   exact: true,
@@ -153,6 +153,15 @@ test('each handler in route has its own segment', function (t, end) {
       ],
       assertSegmentsOptions
     )
+    assertSpanKind({
+      agent: transaction.agent,
+      segments: [
+        { name: transaction.name, kind: 'server' },
+        { name: 'Expressjs/Route Path: /test', kind: 'internal' },
+        { name: NAMES.EXPRESS.MIDDLEWARE + 'handler1', kind: 'internal' },
+        { name: NAMES.EXPRESS.MIDDLEWARE + 'handler2', kind: 'internal' },
+      ]
+    })
 
     checkMetrics(transaction.metrics, [
       NAMES.EXPRESS.MIDDLEWARE + 'handler1//test',

--- a/test/versioned/grpc-esm/server-unary.test.mjs
+++ b/test/versioned/grpc-esm/server-unary.test.mjs
@@ -43,6 +43,8 @@ const client = getClient(grpc, proto, port)
 
 test.afterEach(() => {
   agent.errors.traceAggregator.clear()
+  agent.transactionSampler._reset()
+  agent.spanEventAggregator.clear()
   agent.metrics.clear()
 })
 
@@ -142,9 +144,11 @@ test('should not add DT headers when `distributed_tracing` is disabled', async (
         serverTransaction = tx
       }
     })
+    agent.config.distributed_tracing.enabled = true
   })
 
   agent.config.distributed_tracing.enabled = false
+
   await helper.runInTransaction(agent, 'web', async (tx) => {
     clientTransaction = tx
     clientTransaction.name = 'clientTransaction'

--- a/test/versioned/kafkajs/utils.js
+++ b/test/versioned/kafkajs/utils.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-const { assertMetrics } = require('../../lib/custom-assertions')
+const { assertMetrics, assertSpanKind } = require('../../lib/custom-assertions')
 const { makeId } = require('../../../lib/util/hashes')
 const utils = module.exports
 const metrics = require('../../lib/metrics_helper')
@@ -98,6 +98,13 @@ utils.verifyConsumeTransaction = ({ plan, tx, topic, clientId }) => {
   plan.equal(tx.getFullName(), expectedName)
   const consume = metrics.findSegment(tx.trace, tx.trace.root, expectedName)
   plan.equal(consume, tx.baseSegment)
+  assertSpanKind({
+    agent: tx.agent,
+    segments: [
+      { name: expectedName, kind: 'consumer' }
+    ],
+    assert: plan
+  })
 
   const attributes = tx.trace.attributes.get(DESTINATIONS.TRANS_SCOPE)
   plan.ok(attributes['kafka.consume.byteCount'], 'should have byteCount')

--- a/test/versioned/koa/koa-route.test.js
+++ b/test/versioned/koa/koa-route.test.js
@@ -10,7 +10,7 @@ const assert = require('node:assert')
 
 const { removeModules } = require('../../lib/cache-buster')
 const { run } = require('./utils')
-const assertSegments = require('../../lib/custom-assertions/assert-segments')
+const { assertSegments, assertSpanKind } = require('../../lib/custom-assertions')
 const helper = require('../../lib/agent_helper')
 
 test.beforeEach((ctx) => {
@@ -44,6 +44,13 @@ test('should name and produce segments for koa-route middleware', (t, end) => {
       'WebTransaction/WebFrameworkUri/Koa/GET//resource',
       'transaction should be named after the middleware responsible for responding'
     )
+    assertSpanKind({
+      agent,
+      segments: [
+        { name: 'WebTransaction/WebFrameworkUri/Koa/GET//resource', kind: 'server' },
+        { name: 'Nodejs/Middleware/Koa/firstMiddleware//resource', kind: 'internal' }
+      ]
+    })
     end()
   })
   run({ path: '/resource', context: t.nr })

--- a/test/versioned/koa/koa.test.js
+++ b/test/versioned/koa/koa.test.js
@@ -10,7 +10,7 @@ const http = require('node:http')
 const tspl = require('@matteo.collina/tspl')
 
 const { removeModules } = require('../../lib/cache-buster')
-const assertSegments = require('../../lib/custom-assertions/assert-segments')
+const { assertSegments, assertSpanKind } = require('../../lib/custom-assertions')
 const helper = require('../../lib/agent_helper')
 
 test.beforeEach((ctx) => {
@@ -65,6 +65,14 @@ function checkSegments(plan, tx) {
     {},
     { assert: plan }
   )
+  assertSpanKind({
+    agent: tx.agent,
+    segments: [
+      { name: tx.name, kind: 'server' },
+      { name: 'Nodejs/Middleware/Koa/one', kind: 'internal' },
+      { name: 'Nodejs/Middleware/Koa/two', kind: 'internal' }
+    ]
+  })
 }
 
 test('Should name after koa framework and verb when body set', async (t) => {

--- a/test/versioned/koa/router-common.js
+++ b/test/versioned/koa/router-common.js
@@ -10,7 +10,7 @@ const assert = require('node:assert')
 const fs = require('node:fs')
 const path = require('node:path')
 
-const assertSegments = require('../../lib/custom-assertions/assert-segments')
+const { assertSegments, assertSpanKind } = require('../../lib/custom-assertions')
 
 /**
  * koa-router and @koa/router updated how they defined wildcard routing
@@ -113,6 +113,15 @@ module.exports = (pkg) => {
             'WebTransaction/WebFrameworkUri/Koa/GET//:first',
             'transaction should be named after the matched path'
           )
+          assertSpanKind({
+            agent,
+            segments: [
+              { name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first', kind: 'server' },
+              { name: 'Koa/Router: /', kind: 'internal' },
+              { name: 'Nodejs/Middleware/Koa/firstMiddleware//:first', kind: 'internal' },
+              { name: 'Nodejs/Middleware/Koa/secondMiddleware//:first', kind: 'internal' },
+            ]
+          })
           end()
         })
         run({ context: t.nr })

--- a/test/versioned/langchain/runnables-streaming.test.js
+++ b/test/versioned/langchain/runnables-streaming.test.js
@@ -9,7 +9,7 @@ const test = require('node:test')
 const assert = require('node:assert')
 
 const { removeModules } = require('../../lib/cache-buster')
-const { assertSegments, match } = require('../../lib/custom-assertions')
+const { assertSegments, assertSpanKind, match } = require('../../lib/custom-assertions')
 const {
   assertLangChainChatCompletionMessages,
   assertLangChainChatCompletionSummary,
@@ -408,8 +408,8 @@ test('streaming enabled', async (t) => {
       }
 
       assertSegments(tx.trace, tx.trace.root, ['Llm/chain/Langchain/stream'], { exact: false })
-
       tx.end()
+      assertSpanKind({ agent, segments: [{ name: 'Llm/chain/Langchain/stream', kind: 'internal' }] })
       end()
     })
   })

--- a/test/versioned/langchain/runnables.test.js
+++ b/test/versioned/langchain/runnables.test.js
@@ -9,7 +9,7 @@ const test = require('node:test')
 const assert = require('node:assert')
 
 const { removeModules } = require('../../lib/cache-buster')
-const { assertSegments } = require('../../lib/custom-assertions')
+const { assertSegments, assertSpanKind } = require('../../lib/custom-assertions')
 const {
   assertLangChainChatCompletionMessages,
   assertLangChainChatCompletionSummary,
@@ -359,8 +359,8 @@ test('should create span on successful runnables create', (t, end) => {
 
     assert.ok(result)
     assertSegments(tx.trace, tx.trace.root, ['Llm/chain/Langchain/invoke'], { exact: false })
-
     tx.end()
+    assertSpanKind({ agent, segments: [{ name: 'Llm/chain/Langchain/invoke', kind: 'internal' }] })
     end()
   })
 })

--- a/test/versioned/langchain/tools.test.js
+++ b/test/versioned/langchain/tools.test.js
@@ -9,7 +9,7 @@ const test = require('node:test')
 const assert = require('node:assert')
 
 const { removeModules, removeMatchedModules } = require('../../lib/cache-buster')
-const { assertSegments, match } = require('../../lib/custom-assertions')
+const { assertSegments, assertSpanKind, match } = require('../../lib/custom-assertions')
 const { version: pkgVersion } = require('@langchain/core/package.json')
 const helper = require('../../lib/agent_helper')
 
@@ -48,6 +48,7 @@ test('should create span on successful tools create', (t, end) => {
       exact: false
     })
     tx.end()
+    assertSpanKind({ agent, segments: [{ name: 'Llm/tool/Langchain/node-agent-test-tool', kind: 'internal' }] })
     end()
   })
 })

--- a/test/versioned/langchain/vectorstore.test.js
+++ b/test/versioned/langchain/vectorstore.test.js
@@ -9,7 +9,7 @@ const test = require('node:test')
 const assert = require('node:assert')
 
 const { removeModules } = require('../../lib/cache-buster')
-const { assertSegments } = require('../../lib/custom-assertions')
+const { assertSegments, assertSpanKind } = require('../../lib/custom-assertions')
 const {
   assertLangChainVectorSearch,
   assertLangChainVectorSearchResult,
@@ -99,6 +99,7 @@ test('should create span on successful vectorstore create', (t, end) => {
       exact: false
     })
     tx.end()
+    assertSpanKind({ agent, segments: [{ name: 'Llm/vectorstore/Langchain/similaritySearch', kind: 'internal' }] })
     end()
   })
 })

--- a/test/versioned/prisma/utils.js
+++ b/test/versioned/prisma/utils.js
@@ -28,7 +28,7 @@ const raw = `${PRISMA.STATEMENT}User/select`
 utils.raw = raw
 const rawUpdate = `${PRISMA.STATEMENT}User/update`
 utils.rawUpdate = rawUpdate
-const { assertSegments } = require('../../lib/custom-assertions')
+const { assertSegments, assertSpanKind } = require('../../lib/custom-assertions')
 
 /**
  * Asserts all the expected datastore metrics for a given query
@@ -60,6 +60,13 @@ function verifyTraces(agent, transaction) {
   assert.ok(trace.root, 'root element should exist')
 
   assertSegments(trace, trace.root, [findMany, update, update, findMany], { exact: true })
+  assertSpanKind({
+    agent,
+    segments: [
+      { name: findMany, kind: 'client' },
+      { name: update, kind: 'client' }
+    ]
+  })
   const findManySegment = findSegment(trace, trace.root, findMany)
   assert.ok(findManySegment.timer.hrDuration, 'findMany segment should have ended')
   const updateSegment = findSegment(trace, trace.root, update)

--- a/test/versioned/undici/requests.test.js
+++ b/test/versioned/undici/requests.test.js
@@ -7,7 +7,7 @@
 
 const test = require('node:test')
 const assert = require('node:assert')
-const { assertSegments } = require('../../lib/custom-assertions')
+const { assertSegments, assertSpanKind } = require('../../lib/custom-assertions')
 const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
 const helper = require('../../lib/agent_helper')
 const metrics = require('../../lib/metrics_helper')
@@ -89,8 +89,10 @@ test('Undici request tests', async (t) => {
       })
       assert.equal(statusCode, 200)
 
-      assertSegments(tx.trace, tx.trace.root, [`External/${HOST}/post`], { exact: false })
+      const name = `External/${HOST}/post`
+      assertSegments(tx.trace, tx.trace.root, [name], { exact: false })
       tx.end()
+      assertSpanKind({ agent, segments: [{ name, kind: 'client' }] })
     })
   })
 

--- a/test/versioned/when/segments.test.js
+++ b/test/versioned/when/segments.test.js
@@ -9,7 +9,7 @@ const test = require('node:test')
 const tspl = require('@matteo.collina/tspl')
 
 const { removeModules } = require('../../lib/cache-buster')
-const assertSegments = require('../../lib/custom-assertions/assert-segments')
+const { assertSegments, assertSpanKind } = require('../../lib/custom-assertions')
 const helper = require('../../lib/agent_helper')
 
 // simulates a function that returns a promise and has a segment created for itself
@@ -74,6 +74,15 @@ test('segments enabled', async (t) => {
         {},
         { assert: plan }
       )
+      assertSpanKind({
+        agent,
+        segments: [
+          { name: 'doSomeWork', kind: 'internal' },
+          { name: 'Promise startSomeWork', kind: 'internal' },
+          { name: 'Promise#then <anonymous>', kind: 'internal' },
+          { name: 'someChildSegment', kind: 'internal' }
+        ]
+      })
     })
 
     helper.runInTransaction(agent, function transactionWrapper(transaction) {


### PR DESCRIPTION
## Description

We only assigned `span.kind` on client spans.  This PR updates the span event generation to properly assign span kind.  There are 2 places where naming conventions do not work: `api.setBackgroundTransaction` and `api.startWebTransaction`. For those, I've added a new property on segment to indicate the kind. I added tests in otel bridge and most versioned tests to assert span kinds.

## Related Issues
Closes #2965 