### PR TITLE
chore: Reverted restriction in NestJS versioned tests

### DIFF
--- a/test/versioned/nestjs/package.json
+++ b/test/versioned/nestjs/package.json
@@ -9,7 +9,7 @@
         "node": ">=18"
       },
       "dependencies": {
-        "@nestjs/cli": ">=9.0.0 && <10.0.0 || >=11.0.0"
+        "@nestjs/cli": ">=9.0.0"
       },
       "files": [
         "nest.test.js"


### PR DESCRIPTION
This PR resolves #2974. Upstream packages have fixed their dependency version ranges, thus resolving this problem.