### PR TITLE
test: Fixed fastify assertions around span kind while running security agent

### DIFF
--- a/test/lib/custom-assertions/assert-span-kind.js
+++ b/test/lib/custom-assertions/assert-span-kind.js
@@ -28,7 +28,7 @@ module.exports = function assertSpanKind({ agent, segments, assert = require('no
       if (!span) {
         assert.fail(`Could not find span: ${segment.name}`)
       }
-      assert.equal(span.intrinsics['span.kind'], segment.kind)
+      assert.equal(span.intrinsics['span.kind'], segment.kind, `${segment.name} span kind differs. expected: ${segment.kind}, got: ${span.intrinsics['span.kind']}`)
     })
   } else {
     assert.fail('Custom assertion must either pass in an array of span kinds or a collection of segment names to span kind')

--- a/test/versioned/fastify/naming-common.js
+++ b/test/versioned/fastify/naming-common.js
@@ -44,20 +44,7 @@ module.exports = async function runTests(t, getExpectedSegments) {
         }
 
         assertSegments(transaction.trace, transaction.trace.root, expectedSegments)
-        const flattenedSegments = expectedSegments[1].reduce((segments, segment) => {
-          if (Array.isArray(segment)) {
-            segments.push(...segment.map((s) => {
-              return {
-                name: s,
-                kind: 'internal'
-              }
-            }))
-          } else {
-            segments.push({ name: segment, kind: 'internal' })
-          }
-
-          return segments
-        }, [])
+        const [,...flattenedSegments] = expectedSegments.flat(3).map((name) => ({ name, kind: 'internal' }))
         assertSpanKind({
           agent,
           segments: [


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

When I added asserting span kind(#2976) there was some naive code for flattening the segments.  This PR fixes that and makes CI happy whilst running versioned tests with security agent.

## How to test

```sh
npm run versioned:internal:major fastify
```

```sh
npm run versioned:security:major fastify 
```

