### PR TITLE
chore: Removed unused transaction method

### DIFF
--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -15,7 +15,6 @@ const props = require('../util/properties')
 const Timer = require('../timer')
 const Trace = require('./trace')
 const synthetics = require('../synthetics')
-const url = require('url')
 const urltils = require('../util/urltils')
 const TraceContext = require('./tracecontext').TraceContext
 const Logs = require('./logs')
@@ -607,49 +606,6 @@ Transaction.prototype.getFullName = function getFullName() {
   }
 
   return fullName
-}
-
-/**
- * Returns the full URL of the transaction with query, search, or hash portions
- * removed. This is only applicable for web transactions.
- *
- * Caches to ._scrubbedUrl, pulls in from .parsedUrl if it is available,
- * otherwise it will parse .url, store it on .parsedUrl, then scrub the URL and
- * store it in the cache.
- *
- * @returns {(string|undefined)} Returns a string or undefined.
- */
-Transaction.prototype.getScrubbedUrl = function getScrubbedUrl() {
-  if (!this.isWeb()) {
-    return
-  }
-  if (this._scrubbedUrl) {
-    return this._scrubbedUrl
-  }
-
-  // If we don't have a parsedUrl, lets populate it from .url
-  if (!this.parsedUrl) {
-    // At time of writing .url should always be set by the time we get here
-    // because that is what .isWeb() checks against. In the future it may be
-    // instead checking a enum or other property so guard ourselves just in
-    // case.
-    if (!this.url) {
-      return
-    }
-
-    this.parsedUrl = url.parse(this.url)
-  }
-
-  const scrubbedParsedUrl = Object.assign(Object.create(null), this.parsedUrl)
-  scrubbedParsedUrl.search = null
-  scrubbedParsedUrl.query = null
-  scrubbedParsedUrl.href = null
-  scrubbedParsedUrl.path = null
-  scrubbedParsedUrl.hash = null
-
-  this._scrubbedUrl = url.format(scrubbedParsedUrl)
-
-  return this._scrubbedUrl
 }
 
 /**


### PR DESCRIPTION
While researching how we might implement honoring the w3c sampling flag I noticed that the `getScrubbedUrl` method is not used anywhere. So this PR removes it.