### PR TITLE
chore: Clarified system metrics sampler naming

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -21,7 +21,7 @@ const MetricNormalizer = require('./metrics/normalizer')
 const MetricAggregator = require('./metrics/metric-aggregator')
 const NAMES = require('./metrics/names')
 const QueryTraceAggregator = require('./db/query-trace-aggregator')
-const sampler = require('./sampler')
+const systemMetricsSampler = require('./system-metrics-sampler')
 const TransactionTraceAggregator = require('./transaction/trace/aggregator')
 const TransactionEventAggregator = require('./transaction/transaction-event-aggregator')
 const Tracer = require('./transaction/tracer')
@@ -334,7 +334,7 @@ Agent.prototype.start = function start(callback) {
     return process.nextTick(callback)
   }
 
-  sampler.start(agent)
+  systemMetricsSampler.start(agent)
 
   if (this.config.serverless_mode.enabled) {
     return this._serverlessModeStart(callback)
@@ -349,7 +349,7 @@ Agent.prototype.start = function start(callback) {
     this.healthReporter.setStatus(HealthReporter.STATUS_LICENSE_KEY_MISSING)
 
     this.setState('errored')
-    sampler.stop()
+    systemMetricsSampler.stop()
     return process.nextTick(function onNextTick() {
       agent.healthReporter.stop(() => {
         callback(new Error('Not starting without license key!'))
@@ -362,7 +362,7 @@ Agent.prototype.start = function start(callback) {
     if (error || response.shouldShutdownRun()) {
       agent.healthReporter.setStatus(HealthReporter.STATUS_CONNECT_ERROR)
       agent.setState('errored')
-      sampler.stop()
+      systemMetricsSampler.stop()
       callback(error || new Error('Failed to connect to collector'), response && response.payload)
       return
     }
@@ -482,7 +482,7 @@ Agent.prototype.stop = function stop(callback) {
 
   this.harvester.stop()
 
-  sampler.stop()
+  systemMetricsSampler.stop()
 
   this.healthReporter.setStatus(HealthReporter.STATUS_AGENT_SHUTDOWN)
   this.healthReporter.stop(() => {

--- a/lib/system-metrics-sampler.js
+++ b/lib/system-metrics-sampler.js
@@ -23,12 +23,12 @@ const SAMPLE_INTERVAL = 15 * MILLIS
 
 let samplers = []
 
-function Sampler(sampler, interval) {
+function SystemMetricsSampler(sampler, interval) {
   this.id = setInterval(sampler, interval)
   this.id.unref()
 }
 
-Sampler.prototype.stop = function stop() {
+SystemMetricsSampler.prototype.stop = function stop() {
   clearInterval(this.id)
 }
 
@@ -149,8 +149,8 @@ module.exports = {
   nativeMetrics: null,
 
   start: function start(agent) {
-    samplers.push(new Sampler(sampleMemory(agent), 5 * MILLIS))
-    samplers.push(new Sampler(checkEvents(agent), SAMPLE_INTERVAL))
+    samplers.push(new SystemMetricsSampler(sampleMemory(agent), 5 * MILLIS))
+    samplers.push(new SystemMetricsSampler(checkEvents(agent), SAMPLE_INTERVAL))
 
     // This requires a native module which may have failed to build.
     if (agent.config.plugins.native_metrics.enabled && !this.nativeMetrics) {
@@ -176,17 +176,17 @@ module.exports = {
 
       // Add GC events if available.
       if (this.nativeMetrics.gcEnabled) {
-        samplers.push(new Sampler(sampleGc(agent, this.nativeMetrics), SAMPLE_INTERVAL))
+        samplers.push(new SystemMetricsSampler(sampleGc(agent, this.nativeMetrics), SAMPLE_INTERVAL))
       }
 
       // Add loop metrics if available.
       if (this.nativeMetrics.loopEnabled) {
-        samplers.push(new Sampler(sampleLoop(agent, this.nativeMetrics), SAMPLE_INTERVAL))
+        samplers.push(new SystemMetricsSampler(sampleLoop(agent, this.nativeMetrics), SAMPLE_INTERVAL))
       }
     }
 
     // Add CPU sampling using the built-in data (introduced in 6.1.0)
-    samplers.push(new Sampler(sampleCpu(agent), SAMPLE_INTERVAL))
+    samplers.push(new SystemMetricsSampler(sampleCpu(agent), SAMPLE_INTERVAL))
 
     this.state = 'running'
   },

--- a/lib/system-metrics-sampler.js
+++ b/lib/system-metrics-sampler.js
@@ -5,10 +5,11 @@
 
 'use strict'
 
-const NAMES = require('./metrics/names')
-const logger = require('./logger').child({ component: 'sampler' })
+const os = require('node:os')
+const logger = require('./logger').child({ component: 'system-metrics-sampler' })
 const Timer = require('./timer')
-const os = require('os')
+
+const NAMES = require('./metrics/names')
 
 /*
  *

--- a/test/unit/agent/agent.test.js
+++ b/test/unit/agent/agent.test.js
@@ -12,7 +12,7 @@ const Collector = require('../../lib/test-collector')
 
 const sinon = require('sinon')
 const helper = require('../../lib/agent_helper')
-const sampler = require('../../../lib/sampler')
+const systemMetricsSampler = require('#agentlib/system-metrics-sampler.js')
 const configurator = require('../../../lib/config')
 const Agent = require('../../../lib/agent')
 const Transaction = require('../../../lib/transaction')
@@ -590,10 +590,10 @@ test('when stopping', async (t) => {
 
   await t.test('should stop sampler', (t) => {
     const { agent } = t.nr
-    sampler.start(agent)
+    systemMetricsSampler.start(agent)
     agent.collector.shutdown = () => {}
     agent.stop(() => {})
-    assert.equal(sampler.state, 'stopped')
+    assert.equal(systemMetricsSampler.state, 'stopped')
   })
 
   await t.test('should stop health reporter', async (t) => {
@@ -609,7 +609,7 @@ test('when stopping', async (t) => {
     }
 
     const { agent } = t.nr
-    sampler.start(agent)
+    systemMetricsSampler.start(agent)
     agent.collector.shutdown = () => {}
     agent.stop(() => {})
 
@@ -618,7 +618,7 @@ test('when stopping', async (t) => {
 
   await t.test('should change state to "stopping"', (t) => {
     const { agent } = t.nr
-    sampler.start(agent)
+    systemMetricsSampler.start(agent)
     agent.collector.shutdown = () => {}
     agent.stop(() => {})
     assert.equal(agent._state, 'stopping')

--- a/test/unit/system-metrics-sampler.test.js
+++ b/test/unit/system-metrics-sampler.test.js
@@ -4,14 +4,16 @@
  */
 
 'use strict'
+
 const assert = require('node:assert')
 const test = require('node:test')
-const Agent = require('../../lib/agent')
-const configurator = require('../../lib/config')
-const sampler = require('../../lib/sampler')
 const sinon = require('sinon')
-const numCpus = require('os').cpus().length
-const NAMES = require('../../lib/metrics/names')
+const Agent = require('#agentlib/agent.js')
+const configurator = require('#agentlib/config/index.js')
+const sampler = require('#agentlib/system-metrics-sampler.js')
+
+const numCpus = require('node:os').cpus().length
+const NAMES = require('#agentlib/metrics/names.js')
 
 test('environmental sampler', async function (t) {
   t.beforeEach(function (ctx) {

--- a/test/unit/system-metrics-sampler.test.js
+++ b/test/unit/system-metrics-sampler.test.js
@@ -10,7 +10,7 @@ const test = require('node:test')
 const sinon = require('sinon')
 const Agent = require('#agentlib/agent.js')
 const configurator = require('#agentlib/config/index.js')
-const sampler = require('#agentlib/system-metrics-sampler.js')
+const systemMetricsSampler = require('#agentlib/system-metrics-sampler.js')
 
 const numCpus = require('node:os').cpus().length
 const NAMES = require('#agentlib/metrics/names.js')
@@ -30,7 +30,7 @@ test('environmental sampler', async function (t) {
   })
 
   t.afterEach(function (ctx) {
-    sampler.stop()
+    systemMetricsSampler.stop()
     ctx.nr.sandbox.restore()
   })
 
@@ -42,17 +42,17 @@ test('environmental sampler', async function (t) {
 
   await t.test('should still gather native metrics when bound and unbound', function (t, end) {
     const { agent } = t.nr
-    sampler.start(agent)
-    sampler.stop()
-    sampler.start(agent)
+    systemMetricsSampler.start(agent)
+    systemMetricsSampler.stop()
+    systemMetricsSampler.start(agent)
 
     // Clear up the current state of the metrics.
-    sampler.nativeMetrics.getGCMetrics()
-    sampler.nativeMetrics.getLoopMetrics()
+    systemMetricsSampler.nativeMetrics.getGCMetrics()
+    systemMetricsSampler.nativeMetrics.getLoopMetrics()
 
     spinLoop(function runLoop() {
-      sampler.sampleLoop(agent, sampler.nativeMetrics)()
-      sampler.sampleGc(agent, sampler.nativeMetrics)()
+      systemMetricsSampler.sampleLoop(agent, systemMetricsSampler.nativeMetrics)()
+      systemMetricsSampler.sampleGc(agent, systemMetricsSampler.nativeMetrics)()
 
       const loop = agent.metrics.getOrCreateMetric(NAMES.LOOP.USAGE)
       assert.ok(loop.callCount > 1)
@@ -83,10 +83,10 @@ test('environmental sampler', async function (t) {
 
   await t.test('should gather loop metrics', function (t, end) {
     const { agent } = t.nr
-    sampler.start(agent)
-    sampler.nativeMetrics.getLoopMetrics()
+    systemMetricsSampler.start(agent)
+    systemMetricsSampler.nativeMetrics.getLoopMetrics()
     spinLoop(function runLoop() {
-      sampler.sampleLoop(agent, sampler.nativeMetrics)()
+      systemMetricsSampler.sampleLoop(agent, systemMetricsSampler.nativeMetrics)()
 
       const stats = agent.metrics.getOrCreateMetric(NAMES.LOOP.USAGE)
       assert.ok(stats.callCount > 1)
@@ -100,34 +100,34 @@ test('environmental sampler', async function (t) {
   await t.test('should depend on Agent to provide the current metrics summary', function (t) {
     const { agent } = t.nr
     assert.doesNotThrow(function () {
-      sampler.start(agent)
+      systemMetricsSampler.start(agent)
     })
     assert.doesNotThrow(function () {
-      sampler.stop(agent)
+      systemMetricsSampler.stop(agent)
     })
   })
 
   await t.test('should default to a state of stopped', function () {
-    assert.equal(sampler.state, 'stopped')
+    assert.equal(systemMetricsSampler.state, 'stopped')
   })
 
   await t.test('should say it is running after start', function (t) {
     const { agent } = t.nr
-    sampler.start(agent)
-    assert.equal(sampler.state, 'running')
+    systemMetricsSampler.start(agent)
+    assert.equal(systemMetricsSampler.state, 'running')
   })
 
   await t.test('should say it is stopped after stop', function (t) {
     const { agent } = t.nr
-    sampler.start(agent)
-    assert.equal(sampler.state, 'running')
-    sampler.stop(agent)
-    assert.equal(sampler.state, 'stopped')
+    systemMetricsSampler.start(agent)
+    assert.equal(systemMetricsSampler.state, 'running')
+    systemMetricsSampler.stop(agent)
+    assert.equal(systemMetricsSampler.state, 'stopped')
   })
 
   await t.test('should gather CPU user utilization metric', function (t) {
     const { agent } = t.nr
-    sampler.sampleCpu(agent)()
+    systemMetricsSampler.sampleCpu(agent)()
 
     const stats = agent.metrics.getOrCreateMetric(NAMES.CPU.USER_UTILIZATION)
     assert.equal(stats.callCount, 1)
@@ -136,7 +136,7 @@ test('environmental sampler', async function (t) {
 
   await t.test('should gather CPU system utilization metric', function (t) {
     const { agent } = t.nr
-    sampler.sampleCpu(agent)()
+    systemMetricsSampler.sampleCpu(agent)()
 
     const stats = agent.metrics.getOrCreateMetric(NAMES.CPU.SYSTEM_UTILIZATION)
     assert.equal(stats.callCount, 1)
@@ -145,7 +145,7 @@ test('environmental sampler', async function (t) {
 
   await t.test('should gather CPU user time metric', function (t) {
     const { agent } = t.nr
-    sampler.sampleCpu(agent)()
+    systemMetricsSampler.sampleCpu(agent)()
 
     const stats = agent.metrics.getOrCreateMetric(NAMES.CPU.USER_TIME)
     assert.equal(stats.callCount, 1)
@@ -154,7 +154,7 @@ test('environmental sampler', async function (t) {
 
   await t.test('should gather CPU sytem time metric', function (t) {
     const { agent } = t.nr
-    sampler.sampleCpu(agent)()
+    systemMetricsSampler.sampleCpu(agent)()
 
     const stats = agent.metrics.getOrCreateMetric(NAMES.CPU.SYSTEM_TIME)
     assert.equal(stats.callCount, 1)
@@ -163,13 +163,13 @@ test('environmental sampler', async function (t) {
 
   await t.test('should gather GC metrics', function (t, end) {
     const { agent } = t.nr
-    sampler.start(agent)
+    systemMetricsSampler.start(agent)
 
     // Clear up the current state of the metrics.
-    sampler.nativeMetrics.getGCMetrics()
+    systemMetricsSampler.nativeMetrics.getGCMetrics()
 
     spinLoop(function runLoop() {
-      sampler.sampleGc(agent, sampler.nativeMetrics)()
+      systemMetricsSampler.sampleGc(agent, systemMetricsSampler.nativeMetrics)()
 
       // Find at least one typed GC metric.
       const type = [
@@ -199,15 +199,15 @@ test('environmental sampler', async function (t) {
   await t.test('should not gather GC metrics if disabled', function (t) {
     const { agent } = t.nr
     agent.config.plugins.native_metrics.enabled = false
-    sampler.start(agent)
-    assert.ok(!sampler.nativeMetrics)
+    systemMetricsSampler.start(agent)
+    assert.ok(!systemMetricsSampler.nativeMetrics)
   })
 
   await t.test('should catch if process.cpuUsage throws an error', function (t) {
     const { agent } = t.nr
     const err = new Error('ohhhhhh boyyyyyy')
     process.cpuUsage.throws(err)
-    sampler.sampleCpu(agent)()
+    systemMetricsSampler.sampleCpu(agent)()
 
     const stats = agent.metrics.getOrCreateMetric('CPU/User/Utilization')
     assert.equal(stats.callCount, 0)
@@ -215,7 +215,7 @@ test('environmental sampler', async function (t) {
 
   await t.test('should collect all specified memory statistics', function (t) {
     const { agent } = t.nr
-    sampler.sampleMemory(agent)()
+    systemMetricsSampler.sampleMemory(agent)()
 
     Object.keys(NAMES.MEMORY).forEach(function testStat(memoryStat) {
       const metricName = NAMES.MEMORY[memoryStat]
@@ -230,7 +230,7 @@ test('environmental sampler', async function (t) {
     sandbox.stub(process, 'memoryUsage').callsFake(() => {
       throw new Error('your computer is on fire')
     })
-    sampler.sampleMemory(agent)()
+    systemMetricsSampler.sampleMemory(agent)()
 
     const stats = agent.metrics.getOrCreateMetric('Memory/Physical')
     assert.equal(stats.callCount, 0)
@@ -238,7 +238,7 @@ test('environmental sampler', async function (t) {
 
   await t.test('should have some rough idea of how deep the event queue is', function (t, end) {
     const { agent } = t.nr
-    sampler.checkEvents(agent)()
+    systemMetricsSampler.checkEvents(agent)()
 
     /* sampler.checkEvents works by creating a timer and using
      * setTimeout to schedule an "immediate" callback execution,


### PR DESCRIPTION
While researching what it might take to support honoring the w3c sampling flag, I discovered that we have multiple "samplers." In order to reduce confusion when working with one sampler or the other, this PR renames the system metrics sampler from just "sampler" to a very clear "systemMetricsSampler."