### PR TITLE
feat: Assign all attributes on internal spans to segment

### DIFF
--- a/lib/otel/segments/internal.js
+++ b/lib/otel/segments/internal.js
@@ -4,7 +4,7 @@
  */
 
 'use strict'
-const customRecorder = require('../../metrics/recorders/custom')
+const genericRecorder = require('../../metrics/recorders/generic')
 
 module.exports = function createInternalSegment(agent, otelSpan) {
   const context = agent.tracer.getContext()
@@ -13,7 +13,7 @@ module.exports = function createInternalSegment(agent, otelSpan) {
     id: otelSpan?.spanContext()?.spanId,
     name,
     parent: context.segment,
-    recorder: customRecorder,
+    recorder: genericRecorder,
     transaction: context.transaction
   })
   return { segment, transaction: context.transaction }

--- a/lib/otel/span-processor.js
+++ b/lib/otel/span-processor.js
@@ -113,6 +113,8 @@ module.exports = class NrSpanProcessor {
       this.reconcileProducerAttributes({ segment, span })
     } else if (span.kind === SpanKind.CLIENT && (span.attributes[ATTR_HTTP_METHOD] || span.attributes[ATTR_HTTP_REQUEST_METHOD])) {
       this.reconcileHttpExternalAttributes({ segment, span })
+    } else {
+      this.#reconciler.reconcile({ segment, otelSpan: span })
     }
 
     this.addAWSLinkingAttributes({ segment, span })

--- a/test/versioned/otel-bridge/span.test.js
+++ b/test/versioned/otel-bridge/span.test.js
@@ -108,10 +108,13 @@ test('mix internal and NR span tests', (t, end) => {
   helper.runInTransaction(agent, (tx) => {
     tx.name = 'otel-example-tx'
     tracer.startActiveSpan('main', (span) => {
+      span.setAttribute('custom-key', 'custom-value')
       const segment = agent.tracer.getSegment()
       assert.equal(tx.traceId, span.spanContext().traceId)
       main(segment, tx)
       span.end()
+      const attrs = segment.getAttributes()
+      assert.equal(attrs['custom-key'], 'custom-value')
       assert.equal(span[otelSynthesis], undefined)
       assert.equal(segment.name, span.name)
       assert.equal(segment.parentId, tx.trace.root.id)
@@ -128,13 +131,13 @@ test('mix internal and NR span tests', (t, end) => {
         ]
       })
       const metrics = tx.metrics.scoped[tx.name]
-      assert.equal(metrics['Custom/main'].callCount, 1)
-      assert.equal(metrics['Custom/hi'].callCount, 1)
-      assert.equal(metrics['Custom/bye'].callCount, 1)
+      assert.equal(metrics['main'].callCount, 1)
+      assert.equal(metrics['hi'].callCount, 1)
+      assert.equal(metrics['bye'].callCount, 1)
       const unscopedMetrics = tx.metrics.unscoped
-      assert.equal(unscopedMetrics['Custom/main'].callCount, 1)
-      assert.equal(unscopedMetrics['Custom/hi'].callCount, 1)
-      assert.equal(unscopedMetrics['Custom/bye'].callCount, 1)
+      assert.equal(unscopedMetrics['main'].callCount, 1)
+      assert.equal(unscopedMetrics['hi'].callCount, 1)
+      assert.equal(unscopedMetrics['bye'].callCount, 1)
       end()
     })
   })


### PR DESCRIPTION

## Description
This PR updates span processor to reconcile attributes on internal spans.  I also realized we're assigning the wrong time slice metrics recorder for internal spans. It should be the generic recorder.


## Related Issues
Closes #2998 