### PR TITLE
test: Fixed handling require esm for >20.19.0+

### DIFF
--- a/test/integration/config/config-esm.test.js
+++ b/test/integration/config/config-esm.test.js
@@ -21,7 +21,7 @@ const exec = util.promisify(require('child_process').exec)
 test('should gracefully handle ESM imports', async (t) => {
   await t.test('when requiring newrelic.js in ESM app', async () => {
     const { stdout, stderr } = await exec('node index.mjs', { cwd: path.join(__dirname, 'esm-js') })
-    if (semver.gte(process.version, '22.12.0')) {
+    if (semver.satisfies(process.version, '>=20.19.0 <22 || >=22.12.0')) {
       match(stdout, 'Hello esm-test')
     } else {
       match(stderr, 'ERR_REQUIRE_ESM', 'should mention ERR_REQUIRE_ESM in error message')
@@ -30,7 +30,7 @@ test('should gracefully handle ESM imports', async (t) => {
 
   await t.test('when requiring newrelic.mjs in ESM app', async () => {
     const { stdout, stderr } = await exec('node index.mjs', { cwd: path.join(__dirname, 'esm-mjs') })
-    if (semver.gte(process.version, '22.12.0')) {
+    if (semver.satisfies(process.version, '>=20.19.0 <22 || >=22.12.0')) {
       match(stdout, 'Hello esm-test')
     } else {
       match(stderr, 'ERR_REQUIRE_ESM', 'should mention ERR_REQUIRE_ESM in error message')


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

As of [20.19.0](https://nodejs.org/en/blog/release/v20.19.0) you can require an esm module.  This test assumed you could not for versions < 22.12.0, now it works with the appropriate ranges.
