### PR TITLE
test: pin openai to 4.90.0 to work with @langchain/openai

### DIFF
--- a/test/versioned/langchain/package.json
+++ b/test/versioned/langchain/package.json
@@ -28,6 +28,7 @@
       "comment": "Using latest of `@langchain/openai` only as it is being used to seed embeddings, nothing to test that hasn't been done in the above stanza",
       "dependencies": {
         "@langchain/openai": "latest",
+        "openai": "4.90.0",
         "@langchain/community": ">=0.2.2",
         "@elastic/elasticsearch": "8.13.1"
       },


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Our langchain versioned tests started failing and I was able to track it down to the fix in [openai@4.91.0](https://github.com/openai/openai-node/pull/1312/files). The default to was `float32` but now it is `base64`. The langchain openai package does not allow us to pass in an [encoding format](https://github.com/langchain-ai/langchainjs/blob/main/libs/langchain-openai/src/embeddings.ts#L156), it only allows to set the model, input, and optional dimensions.  This apparently becomes a problem when loading the documents into a vectorstore, like elasticsearch.  So for now I'm pinning this version of openai to get our tests passing.
