### PR TITLE
feat: Support Azure functions background trigger types

### DIFF
--- a/lib/instrumentation/@azure/functions.js
+++ b/lib/instrumentation/@azure/functions.js
@@ -50,7 +50,20 @@ module.exports = function initialize(agent, azureFunctions, _moduleName, shim, {
   const httpMethods = ['http', 'get', 'put', 'post', 'patch', 'deleteRequest']
   shim.wrap(azureFunctions.app, httpMethods, wrapAzureHttpMethods)
 
-  const backgroundMethods = ['timer']
+  const backgroundMethods = [
+    'cosmosDB',
+    'eventGrid',
+    'eventHub',
+    'mySql',
+    'serviceBusQueue',
+    'serviceBusTopic',
+    'sql',
+    'storageBlob',
+    'storageQueue',
+    'timer',
+    'warmup',
+    'webPubSub'
+  ]
   shim.wrap(azureFunctions.app, backgroundMethods, wrapAzureBackgroundMethods)
 }
 
@@ -165,7 +178,7 @@ function wrapAzureBackgroundMethods(shim, appMethod) {
       tx.setPartialName(`AzureFunction/${context.functionName}`)
 
       const segment = tracer.createSegment({
-        name: 'timer-trigger',
+        name: `${appMethod}-trigger`,
         recorder: backgroundRecorder,
         parent: ctx.segment,
         transaction: tx

--- a/lib/instrumentation/@azure/functions.js
+++ b/lib/instrumentation/@azure/functions.js
@@ -7,11 +7,16 @@
 
 const defaultLogger = require('../../logger').child({ component: 'azure-functions' })
 const urltils = require('../../util/urltils')
-const recordWeb = require('../../metrics/recorders/http')
 const headerProcessing = require('../../header-processing')
 const synthetics = require('../../synthetics')
 
-const DESTS = require('../../config/attribute-filter').DESTINATIONS
+const backgroundRecorder = require('../../metrics/recorders/other.js')
+const recordWeb = require('../../metrics/recorders/http')
+
+const {
+  DESTINATIONS: DESTS,
+  TYPES
+} = require('../../transaction/index.js')
 
 const {
   WEBSITE_OWNER_NAME,
@@ -23,8 +28,12 @@ const RESOURCE_GROUP_NAME = WEBSITE_RESOURCE_GROUP ?? WEBSITE_OWNER_NAME?.split(
 const AZURE_FUNCTION_APP_NAME = WEBSITE_SITE_NAME
 
 let coldStart = true
+let _agent
+let _logger
 
 module.exports = function initialize(agent, azureFunctions, _moduleName, shim, { logger = defaultLogger } = {}) {
+  _agent = agent
+  _logger = logger
   if (!SUBSCRIPTION_ID || !RESOURCE_GROUP_NAME || !AZURE_FUNCTION_APP_NAME) {
     logger.warn(
       {
@@ -38,98 +47,150 @@ module.exports = function initialize(agent, azureFunctions, _moduleName, shim, {
     return
   }
 
-  const methods = ['http', 'get', 'put', 'post', 'patch', 'deleteRequest']
-  shim.wrap(azureFunctions.app, methods, function wrapAzureHttpMethods(shim, appMethod) {
-    return async function wrappedAzureHttpMethod(...args) {
-      // If the app doesn't need an options object, the user can pass the
-      // handler function as the second argument
-      // (e.g. `app.get('name', handler)`).
-      // See https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#registering-a-function
-      let handler
-      if (typeof args[1] === 'function') {
-        handler = args[1]
-        args[1] = { handler }
+  const httpMethods = ['http', 'get', 'put', 'post', 'patch', 'deleteRequest']
+  shim.wrap(azureFunctions.app, httpMethods, wrapAzureHttpMethods)
+
+  const backgroundMethods = ['timer']
+  shim.wrap(azureFunctions.app, backgroundMethods, wrapAzureBackgroundMethods)
+}
+
+function wrapAzureHttpMethods(shim, appMethod) {
+  return async function wrappedAzureHttpMethod(...args) {
+    // If the app doesn't need an options object, the user can pass the
+    // handler function as the second argument
+    // (e.g. `app.get('name', handler)`).
+    // See https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#registering-a-function
+    let handler
+    if (typeof args[1] === 'function') {
+      handler = args[1]
+      args[1] = { handler }
+    } else {
+      handler = args[1].handler
+    }
+
+    const tracer = shim.tracer
+    args[1].handler = tracer.transactionProxy(async function wrappedHandler(...args) {
+      const [request, context] = args
+      const ctx = tracer.getContext()
+      const tx = tracer.getTransaction()
+
+      // Set the transaction name according to our spec (category + function name).
+      tx.setPartialName(`AzureFunction/${context.functionName}`)
+
+      const url = new URL(request.url)
+      const segment = tracer.createSegment({
+        name: request.url,
+        recorder: recordWeb,
+        parent: ctx.segment,
+        transaction: tx
+      })
+      segment.start()
+
+      const transport = url.protocol === 'https:' ? 'HTTPS' : 'HTTP'
+      tx.type = TYPES.WEB
+      tx.baseSegment = segment
+      tx.parsedUrl = url
+      tx.url = urltils.obfuscatePath(_agent.config, url.pathname)
+      tx.verb = request.method
+      if (url.port === '') {
+        tx.port = transport === 'HTTPS' ? '443' : '80'
       } else {
-        handler = args[1].handler
+        tx.port = url.port
       }
 
-      const tracer = shim.tracer
-      args[1].handler = tracer.transactionProxy(async function wrappedHandler(...args) {
-        const [request, context] = args
-        const ctx = tracer.getContext()
-        const tx = tracer.getTransaction()
+      tx.trace.attributes.addAttribute(
+        DESTS.TRANS_EVENT | DESTS.ERROR_EVENT,
+        'request.uri',
+        tx.url
+      )
+      segment.addSpanAttribute('request.uri', tx.url)
+      if (request.method != null) {
+        segment.addSpanAttribute('request.method', request.method)
+      }
+      addAttributes({ transaction: tx, functionContext: context })
 
-        // Set the transaction name according to our spec (category + function name).
-        tx.setPartialName(`AzureFunction/${context.functionName}`)
+      const queueTimeStamp = headerProcessing.getQueueTime(_logger, request.headers)
+      if (queueTimeStamp) {
+        tx.queueTime = Date.now() - queueTimeStamp
+      }
 
-        const url = new URL(request.url)
-        const segment = tracer.createSegment({
-          name: request.url,
-          recorder: recordWeb,
-          parent: ctx.segment,
-          transaction: tx
-        })
-        segment.start()
+      synthetics.assignHeadersToTransaction(_agent.config, tx, request.headers)
+      if (_agent.config.distributed_tracing.enabled === true) {
+        tx.acceptDistributedTraceHeaders(transport, request.headers)
+      }
 
-        const transport = url.protocol === 'https:' ? 'HTTPS' : 'HTTP'
-        tx.type = 'web'
-        tx.baseSegment = segment
-        tx.parsedUrl = url
-        tx.url = urltils.obfuscatePath(agent.config, url.pathname)
-        tx.verb = request.method
-        if (url.port === '') {
-          tx.port = transport === 'HTTPS' ? '443' : '80'
-        } else {
-          tx.port = url.port
-        }
+      const newContext = ctx.enterSegment({ segment })
+      const boundHandler = tracer.bindFunction(handler, newContext)
 
+      const result = await boundHandler(...args)
+      // Responses should have a shape as described at:
+      // https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response
+      if (result.status) {
         tx.trace.attributes.addAttribute(
-          DESTS.TRANS_EVENT | DESTS.ERROR_EVENT,
-          'request.uri',
-          tx.url
+          DESTS.TRANS_COMMON,
+          'http.statusCode',
+          result.status
         )
-        segment.addSpanAttribute('request.uri', tx.url)
-        if (request.method != null) {
-          segment.addSpanAttribute('request.method', request.method)
-        }
-        addAttributes({ transaction: tx, functionContext: context })
+      }
 
-        const queueTimeStamp = headerProcessing.getQueueTime(logger, request.headers)
-        if (queueTimeStamp) {
-          tx.queueTime = Date.now() - queueTimeStamp
-        }
+      if (coldStart === true) {
+        tx.trace.attributes.addAttribute(DESTS.TRANS_COMMON, 'faas.coldStart', true)
+        coldStart = false
+      }
 
-        synthetics.assignHeadersToTransaction(agent.config, tx, request.headers)
-        if (agent.config.distributed_tracing.enabled === true) {
-          tx.acceptDistributedTraceHeaders(transport, request.headers)
-        }
+      tx.end()
+      return result
+    })
 
-        const newContext = ctx.enterSegment({ segment })
-        const boundHandler = tracer.bindFunction(handler, newContext)
+    await appMethod(...args)
+  }
+}
 
-        const result = await boundHandler(...args)
-        // Responses should have a shape as described at:
-        // https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response
-        if (result.status) {
-          tx.trace.attributes.addAttribute(
-            DESTS.TRANS_COMMON,
-            'http.statusCode',
-            result.status
-          )
-        }
-
-        if (coldStart === true) {
-          tx.trace.attributes.addAttribute(DESTS.TRANS_COMMON, 'faas.coldStart', true)
-          coldStart = false
-        }
-
-        tx.end()
-        return result
-      })
-
-      await appMethod(...args)
+function wrapAzureBackgroundMethods(shim, appMethod) {
+  return async function wrappedAzureBackgroundMethod(...args) {
+    let handler
+    if (typeof args[1] === 'function') {
+      handler = args[1]
+      args[1] = { handler }
+    } else {
+      handler = args[1].handler
     }
-  })
+
+    const tracer = shim.tracer
+    args[1].handler = tracer.transactionProxy(async function wrappedHandler(...args) {
+      const [, context] = args
+      const ctx = tracer.getContext()
+      const tx = tracer.getTransaction()
+
+      tx.setPartialName(`AzureFunction/${context.functionName}`)
+
+      const segment = tracer.createSegment({
+        name: 'timer-trigger',
+        recorder: backgroundRecorder,
+        parent: ctx.segment,
+        transaction: tx
+      })
+      segment.start()
+
+      tx.type = TYPES.BG
+      tx.baseSegment = segment
+      addAttributes({ transaction: tx, functionContext: context })
+
+      const newContext = ctx.enterSegment({ segment })
+      const boundHandler = tracer.bindFunction(handler, newContext)
+
+      const result = await boundHandler(...args)
+      if (coldStart === true) {
+        tx.trace.attributes.addAttribute(DESTS.TRANS_COMMON, 'faas.coldStart', true)
+        coldStart = false
+      }
+
+      tx.end()
+      return result
+    })
+
+    await appMethod(...args)
+  }
 }
 
 /**
@@ -178,6 +239,7 @@ function mapTriggerType({ functionContext }) {
 
   // Input types are found at:
   // https://github.com/Azure/azure-functions-nodejs-library/blob/138c021/src/trigger.ts
+  // https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings?tabs=isolated-process%2Cnode-v4%2Cpython-v2&pivots=programming-language-javascript#supported-bindings
   switch (input) {
     case 'httpTrigger': {
       return 'http'
@@ -187,16 +249,25 @@ function mapTriggerType({ functionContext }) {
       return 'timer'
     }
 
+    case 'blobTrigger':
     case 'cosmosDBTrigger':
-    case 'sqlTrigger':
-    case 'mysqlTrigger': {
+    case 'daprBindingTrigger':
+    case 'mysqlTrigger':
+    case 'queueTrigger':
+    case 'sqlTrigger': {
       return 'datasource'
     }
 
-    case 'queueTrigger':
-    case 'serviceBusTrigger':
-    case 'eventHubTrigger':
+    case 'daprTopicTrigger':
     case 'eventGridTrigger':
+    case 'eventHubTrigger':
+    case 'kafkaTrigger':
+    case 'rabbitMQTrigger':
+    case 'redisListTrigger':
+    case 'redisPubSubTrigger':
+    case 'redisStreamTrigger':
+    case 'serviceBusTrigger':
+    case 'signalRTrigger':
     case 'webPubSubTrigger': {
       return 'pubsub'
     }

--- a/test/unit/instrumentation/@azure/functions.test.js
+++ b/test/unit/instrumentation/@azure/functions.test.js
@@ -102,17 +102,27 @@ test('mapTriggerType maps recognized keys', t => {
   bootstrapModule({ t })
   const { mapTriggerType } = t.nr.initialize.internals
   const testData = [
-    ['httpTrigger', 'http'],
-    ['timerTrigger', 'timer'],
+    ['blobTrigger', 'datasource'],
     ['cosmosDBTrigger', 'datasource'],
-    ['sqlTrigger', 'datasource'],
-    ['mysqlTrigger', 'datasource'],
-    ['queueTrigger', 'pubsub'],
-    ['serviceBusTrigger', 'pubsub'],
-    ['eventHubTrigger', 'pubsub'],
+    ['daprBindingTrigger', 'datasource'],
+    ['daprServiceInvocationTrigger', 'other'],
+    ['daprTopicTrigger', 'pubsub'],
     ['eventGridTrigger', 'pubsub'],
+    ['eventHubTrigger', 'pubsub'],
+    ['httpTrigger', 'http'],
+    ['kafkaTrigger', 'pubsub'],
+    ['mysqlTrigger', 'datasource'],
+    ['not-recognized', 'other'],
+    ['queueTrigger', 'datasource'],
+    ['rabbitMQTrigger', 'pubsub'],
+    ['redisListTrigger', 'pubsub'],
+    ['redisPubSubTrigger', 'pubsub'],
+    ['redisStreamTrigger', 'pubsub'],
+    ['serviceBusTrigger', 'pubsub'],
+    ['signalRTrigger', 'pubsub'],
+    ['sqlTrigger', 'datasource'],
+    ['timerTrigger', 'timer'],
     ['webPubSubTrigger', 'pubsub'],
-    ['not-recognized', 'other']
   ]
 
   for (const [input, expected] of testData) {

--- a/test/versioned/azure-functions/background.test.js
+++ b/test/versioned/azure-functions/background.test.js
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert')
+const { once } = require('node:events')
+
+const helper = require('../../lib/agent_helper.js')
+const { removeMatchedModules } = require('../../lib/cache-buster.js')
+const GenericShim = require('../../../lib/shim/shim.js')
+const Transaction = require('../../../lib/transaction/index.js')
+
+const { DESTINATIONS: DESTS } = Transaction
+const MODULE_NAME = 'azure-functions'
+
+test.beforeEach(ctx => {
+  ctx.nr = {}
+  ctx.nr.agent = helper.loadMockedAgent()
+  ctx.nr.shim = new GenericShim(ctx.nr.agent, 'azure-functions')
+
+  ctx.nr.logs = []
+  ctx.nr.logger = {
+    warn(...args) {
+      ctx.nr.logs.push(args)
+    }
+  }
+
+  process.env.WEBSITE_OWNER_NAME = 'b999997b-cb91-49e0-b922-c9188372bdba+testing-rg-EastUS2webspace-Linux'
+  process.env.WEBSITE_RESOURCE_GROUP = 'test-group'
+  process.env.WEBSITE_SITE_NAME = 'test-site'
+})
+
+test.afterEach(ctx => {
+  helper.unloadAgent(ctx.nr.agent)
+  removeMatchedModules(/lib\/instrumentation\/@azure\/functions\.js/)
+
+  delete process.env.WEBSITE_OWNER_NAME
+  delete process.env.WEBSITE_RESOURCE_GROUP
+  delete process.env.WEBSITE_SITE_NAME
+})
+
+function bootstrapModule({ t }) {
+  t.nr.initialize = require('../../../lib/instrumentation/@azure/functions.js')
+
+  const mockApi = {
+    handlers: {},
+    request(triggerType) {
+      if (triggerType === 'timer') {
+        if (Object.hasOwn(mockApi.handlers, 'TIMER') === false) throw Error('must register timer handler first')
+        // See https://github.com/Azure/azure-functions-nodejs-library/blob/138c021/types/timer.d.ts#L45-L69
+        // if we ever need to mock out a legit shaped payload.
+        return mockApi.handlers.TIMER({ timer: 'payload' }, {
+          invocationId: 'test-123',
+          functionName: 'test-func',
+          options: {
+            trigger: {
+              type: 'timerTrigger'
+            }
+          }
+        })
+      }
+    },
+    app: {
+      timer(name, options) {
+        mockApi.handlers.TIMER = options.handler
+      }
+    }
+  }
+  t.nr.mockApi = mockApi
+}
+
+test('instruments timer method', async t => {
+  bootstrapModule({ t })
+  const { agent, initialize, mockApi, shim } = t.nr
+  initialize(agent, mockApi, MODULE_NAME, shim)
+
+  const txFinished = once(agent, 'transactionFinished')
+  const handler = async function (payload) {
+    assert.deepStrictEqual(payload, { timer: 'payload' })
+  }
+
+  mockApi.app.timer('timer-test', { handler })
+  await mockApi.request('timer')
+
+  const [tx] = await txFinished
+  assert.ok(tx)
+
+  const attributes = tx.trace.attributes.get(DESTS.TRANS_COMMON)
+  assert.equal(attributes['faas.coldStart'], true)
+  assert.equal(attributes['faas.invocation_id'], 'test-123')
+  assert.equal(attributes['faas.name'], 'test-func')
+  assert.equal(attributes['faas.trigger'], 'timer')
+  assert.equal(
+    attributes['cloud.resource_id'],
+    '/subscriptions/b999997b-cb91-49e0-b922-c9188372bdba/resourceGroups/test-group/providers/Microsoft.Web/sites/test-site/functions/test-func'
+  )
+
+  const metrics = tx.metrics.unscoped
+  const expectedMetrics = [
+    'OtherTransaction/all',
+    'OtherTransaction/AzureFunction/test-func',
+    'OtherTransactionTotalTime',
+    'OtherTransactionTotalTime/AzureFunction/test-func'
+  ]
+  for (const expectedMetric of expectedMetrics) {
+    assert.equal(metrics[expectedMetric]?.callCount, 1, `callCount for ${expectedMetric} should be 1`)
+  }
+})

--- a/test/versioned/azure-functions/background.test.js
+++ b/test/versioned/azure-functions/background.test.js
@@ -17,6 +17,84 @@ const Transaction = require('../../../lib/transaction/index.js')
 const { DESTINATIONS: DESTS } = Transaction
 const MODULE_NAME = 'azure-functions'
 
+// As pulled from https://github.com/Azure/azure-functions-nodejs-library/blob/138c021/src/app.ts
+// Excludes HTTP methods as they are tested by the HTTP trigger
+// instrumentation.
+// Excludes the "generic" method as it should be verified on its own.
+const azureFunctionsAppMethods = {
+  cosmosDB: {
+    trigger: 'cosmosDBTrigger',
+    triggerType: 'datasource',
+    payload: {}
+  },
+
+  eventGrid: {
+    trigger: 'eventGridTrigger',
+    triggerType: 'pubsub',
+    payload: {}
+  },
+
+  eventHub: {
+    trigger: 'eventHubTrigger',
+    triggerType: 'pubsub',
+    payload: {}
+  },
+
+  mySql: {
+    trigger: 'mysqlTrigger',
+    triggerType: 'datasource',
+    payload: {}
+  },
+
+  serviceBusQueue: {
+    trigger: 'serviceBusTrigger',
+    triggerType: 'pubsub',
+    payload: {}
+  },
+
+  serviceBusTopic: {
+    trigger: 'serviceBusTrigger',
+    triggerType: 'pubsub',
+    payload: {}
+  },
+
+  sql: {
+    trigger: 'sqlTrigger',
+    triggerType: 'datasource',
+    payload: {}
+  },
+
+  storageBlob: {
+    trigger: 'blobTrigger',
+    triggerType: 'datasource',
+    payload: {}
+  },
+
+  storageQueue: {
+    trigger: 'queueTrigger',
+    triggerType: 'datasource',
+    payload: {}
+  },
+
+  timer: {
+    trigger: 'timerTrigger',
+    triggerType: 'timer',
+    payload: { timer: 'payload' }
+  },
+
+  warmup: {
+    trigger: 'warmupTrigger',
+    triggerType: 'other',
+    payload: {}
+  },
+
+  webPubSub: {
+    trigger: 'webPubSubTrigger',
+    triggerType: 'pubsub',
+    payload: {}
+  }
+}
+
 test.beforeEach(ctx => {
   ctx.nr = {}
   ctx.nr.agent = helper.loadMockedAgent()
@@ -48,65 +126,76 @@ function bootstrapModule({ t }) {
 
   const mockApi = {
     handlers: {},
-    request(triggerType) {
-      if (triggerType === 'timer') {
-        if (Object.hasOwn(mockApi.handlers, 'TIMER') === false) throw Error('must register timer handler first')
-        // See https://github.com/Azure/azure-functions-nodejs-library/blob/138c021/types/timer.d.ts#L45-L69
-        // if we ever need to mock out a legit shaped payload.
-        return mockApi.handlers.TIMER({ timer: 'payload' }, {
-          invocationId: 'test-123',
-          functionName: 'test-func',
-          options: {
-            trigger: {
-              type: 'timerTrigger'
-            }
+    request(method, triggerType) {
+      triggerType = triggerType.toUpperCase()
+      const key = `${triggerType}_${method}`
+      if (Object.hasOwn(mockApi.handlers, key) === false) {
+        throw Error(`no handler registered for trigger: ${key}`)
+      }
+      const handler = mockApi.handlers[key]
+      return handler(azureFunctionsAppMethods[method].payload, {
+        invocationId: 'test-123',
+        functionName: `test-func-${method}`,
+        options: {
+          trigger: {
+            type: azureFunctionsAppMethods[method].trigger
           }
-        })
-      }
+        }
+      })
     },
-    app: {
-      timer(name, options) {
-        mockApi.handlers.TIMER = options.handler
-      }
+    app: {}
+  }
+
+  for (const [method, value] of Object.entries(azureFunctionsAppMethods)) {
+    const TRIGGER_TYPE = value.triggerType.toUpperCase()
+    mockApi.app[method] = (name, options) => {
+      const key = `${TRIGGER_TYPE}_${method}`
+      mockApi.handlers[key] = options.handler
     }
   }
+
   t.nr.mockApi = mockApi
 }
 
-test('instruments timer method', async t => {
+test('instruments background methods', async t => {
   bootstrapModule({ t })
   const { agent, initialize, mockApi, shim } = t.nr
   initialize(agent, mockApi, MODULE_NAME, shim)
 
-  const txFinished = once(agent, 'transactionFinished')
-  const handler = async function (payload) {
-    assert.deepStrictEqual(payload, { timer: 'payload' })
-  }
+  for (const [method, value] of Object.entries(azureFunctionsAppMethods)) {
+    const txFinished = once(agent, 'transactionFinished')
+    const handler = async function (input) {
+      assert.deepStrictEqual(input, value.payload)
+    }
 
-  mockApi.app.timer('timer-test', { handler })
-  await mockApi.request('timer')
+    const key = `${value.triggerType.toUpperCase()}_${method}`
+    mockApi.app[method](`${key}-test`, { handler })
+    await mockApi.request(method, value.triggerType)
 
-  const [tx] = await txFinished
-  assert.ok(tx)
+    const [tx] = await txFinished
+    assert.ok(tx)
 
-  const attributes = tx.trace.attributes.get(DESTS.TRANS_COMMON)
-  assert.equal(attributes['faas.coldStart'], true)
-  assert.equal(attributes['faas.invocation_id'], 'test-123')
-  assert.equal(attributes['faas.name'], 'test-func')
-  assert.equal(attributes['faas.trigger'], 'timer')
-  assert.equal(
-    attributes['cloud.resource_id'],
-    '/subscriptions/b999997b-cb91-49e0-b922-c9188372bdba/resourceGroups/test-group/providers/Microsoft.Web/sites/test-site/functions/test-func'
-  )
+    const attributes = tx.trace.attributes.get(DESTS.TRANS_COMMON)
+    if (Object.hasOwn(attributes, 'faas.coldStart')) {
+      assert.equal(attributes['faas.coldStart'], true)
+    }
+    assert.equal(attributes['faas.invocation_id'], 'test-123')
+    assert.equal(attributes['faas.name'], `test-func-${method}`)
+    assert.equal(attributes['faas.trigger'], value.triggerType, `${method} maps to correct faas.trigger`)
+    assert.equal(
+      attributes['cloud.resource_id'],
+      `/subscriptions/b999997b-cb91-49e0-b922-c9188372bdba/resourceGroups/test-group/providers/Microsoft.Web/sites/test-site/functions/test-func-${method}`
+    )
 
-  const metrics = tx.metrics.unscoped
-  const expectedMetrics = [
-    'OtherTransaction/all',
-    'OtherTransaction/AzureFunction/test-func',
-    'OtherTransactionTotalTime',
-    'OtherTransactionTotalTime/AzureFunction/test-func'
-  ]
-  for (const expectedMetric of expectedMetrics) {
-    assert.equal(metrics[expectedMetric]?.callCount, 1, `callCount for ${expectedMetric} should be 1`)
+    const metrics = tx.metrics.unscoped
+    const expectedMetrics = [
+      'OtherTransaction/all',
+      `OtherTransaction/AzureFunction/test-func-${method}`,
+      'OtherTransactionTotalTime',
+      `OtherTransactionTotalTime/AzureFunction/test-func-${method}`
+    ]
+    for (const expectedMetric of expectedMetrics) {
+      assert.equal(metrics[expectedMetric]?.callCount, 1, `callCount for ${expectedMetric} should be 1`)
+    }
   }
 })

--- a/test/versioned/azure-functions/http.test.js
+++ b/test/versioned/azure-functions/http.test.js
@@ -194,7 +194,7 @@ test('instruments all HTTP methods', async (t) => {
       'WebTransactionTotalTime/AzureFunction/test-func'
     ]
     for (const expectedMetric of expectedMetrics) {
-      assert.equal(metrics[expectedMetric].callCount, 1)
+      assert.equal(metrics[expectedMetric]?.callCount, 1, `callCount for ${expectedMetric} should be 1`)
     }
     assert.equal(metrics.Apdex.apdexT, 0.1)
     assert.equal(metrics['Apdex/AzureFunction/test-func'].apdexT, 0.1)

--- a/test/versioned/azure-functions/package.json
+++ b/test/versioned/azure-functions/package.json
@@ -1,6 +1,10 @@
 {
   "name": "azure-functions-tests",
-  "targets": [{ "name": "@azure/functions", "minAgentVersion": "12.18.0" }],
+  "targets": [{
+    "name": "@azure/functions",
+    "minAgentVersion": "12.18.0",
+    "minSupported": "4.7.0"
+  }],
   "version": "0.0.0",
   "private": true,
   "tests": [
@@ -12,6 +16,7 @@
         "@azure/functions": ">=4.7.0"
       },
       "files": [
+        "background.test.js",
         "http.test.js"
       ]
     }


### PR DESCRIPTION
This PR resolves #2997.

-----

I believe that our other instrumentations will fill in any other required attributes. For example, if the trigger is a Redis based trigger, the work in the PR should start the transaction and then the Redis instrumentation should add spans that include required datastore attributes.

I wanted to write a test that proves this. But as of right now, the only such trigger I think we could test with is Redis, and the current version of `@azure/functions` doesn't actually support it:

https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cache-trigger-redispubsub?tabs=isolated-process%2Cnode-v3%2Cpython-v1&pivots=programming-language-javascript
<img width="701" alt="image" src="https://github.com/user-attachments/assets/f01a35c4-ab61-4186-8314-2435a9a15635" />

I looked at their RabbitMQ docs as well, https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-rabbitmq-trigger?tabs=isolated-process&pivots=programming-language-javascript, but there's no indication there of what an incoming payload looks like, nor any code examples. I think the "background" triggers are not well supported or documented. So we will just have to fix these up as we go.

----

I have left out support for distributed tracing in these methods. It's not clear to me that there would ever be any invocations with such headers, and I can't find any documentation that shows how headers might be delivered to such functions. So I am going with the "MAY" portion of our internal spec:

> Support for distributed tracing for other invocation triggers MAY be added at the discrection of the language agent.