### PR TITLE
test: Pinned prisma version below 7

### DIFF
--- a/test/versioned/prisma/package.json
+++ b/test/versioned/prisma/package.json
@@ -12,7 +12,7 @@
         "node": ">=18"
       },
       "dependencies": {
-        "@prisma/client": ">=5.0.0 <5.9.0 || >=5.9.1"
+        "@prisma/client": ">=5.0.0 <5.9.0 || >=5.9.1 <7.0.0"
       },
       "files": [
         "prisma.test.js"


### PR DESCRIPTION
We're getting a CI failure with prisma 7.0.0 so we need to pin temporarily while we troubleshoot the issue. 

Relates to issue #3029 