### PR TITLE
fix: Updated span streamer to properly retry failed batches and handle flushing batch queue every 5 seconds

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,4 +1,3 @@
-
 # Third Party Notices
 
 The New Relic Node Agent uses source code from third party libraries which carry
@@ -87,11 +86,12 @@ code, the source code can be found at [https://github.com/newrelic/node-newrelic
 
 * [Symantec](#Symantec)
 
+
 ## dependencies
 
 ### @grpc/grpc-js
 
-This product includes source derived from [@grpc/grpc-js](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js) ([v1.12.4](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js/tree/v1.12.4)), distributed under the [Apache-2.0 License](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js/blob/v1.12.4/LICENSE):
+This product includes source derived from [@grpc/grpc-js](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js) ([v1.13.2](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js/tree/v1.13.2)), distributed under the [Apache-2.0 License](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js/blob/v1.13.2/LICENSE):
 
 ```
                                  Apache License
@@ -509,7 +509,7 @@ This product includes source derived from [@grpc/proto-loader](https://github.co
 
 ### @newrelic/security-agent
 
-This product includes source derived from [@newrelic/security-agent](https://github.com/newrelic/csec-node-agent) ([v2.3.1](https://github.com/newrelic/csec-node-agent/tree/v2.3.1)), distributed under the [UNKNOWN License](https://github.com/newrelic/csec-node-agent/blob/v2.3.1/LICENSE):
+This product includes source derived from [@newrelic/security-agent](https://github.com/newrelic/csec-node-agent) ([v2.4.0](https://github.com/newrelic/csec-node-agent/tree/v2.4.0)), distributed under the [UNKNOWN License](https://github.com/newrelic/csec-node-agent/blob/v2.4.0/LICENSE):
 
 ```
 ## New Relic Software License v1.0
@@ -1271,7 +1271,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ### import-in-the-middle
 
-This product includes source derived from [import-in-the-middle](https://github.com/nodejs/import-in-the-middle) ([v1.13.0](https://github.com/nodejs/import-in-the-middle/tree/v1.13.0)), distributed under the [Apache-2.0 License](https://github.com/nodejs/import-in-the-middle/blob/v1.13.0/LICENSE):
+This product includes source derived from [import-in-the-middle](https://github.com/nodejs/import-in-the-middle) ([v1.13.1](https://github.com/nodejs/import-in-the-middle/tree/v1.13.1)), distributed under the [Apache-2.0 License](https://github.com/nodejs/import-in-the-middle/blob/v1.13.1/LICENSE):
 
 ```
                                  Apache License
@@ -1615,7 +1615,7 @@ IN THE SOFTWARE.
 
 ### require-in-the-middle
 
-This product includes source derived from [require-in-the-middle](https://github.com/elastic/require-in-the-middle) ([v7.4.0](https://github.com/elastic/require-in-the-middle/tree/v7.4.0)), distributed under the [MIT License](https://github.com/elastic/require-in-the-middle/blob/v7.4.0/LICENSE):
+This product includes source derived from [require-in-the-middle](https://github.com/elastic/require-in-the-middle) ([v7.5.0](https://github.com/elastic/require-in-the-middle/tree/v7.5.0)), distributed under the [MIT License](https://github.com/elastic/require-in-the-middle/blob/v7.5.0/LICENSE):
 
 ```
 The MIT License (MIT)
@@ -1696,11 +1696,12 @@ SOFTWARE.
 
 ```
 
+
 ## devDependencies
 
 ### @aws-sdk/client-s3
 
-This product includes source derived from [@aws-sdk/client-s3](https://github.com/aws/aws-sdk-js-v3) ([v3.714.0](https://github.com/aws/aws-sdk-js-v3/tree/v3.714.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.714.0/LICENSE):
+This product includes source derived from [@aws-sdk/client-s3](https://github.com/aws/aws-sdk-js-v3) ([v3.726.1](https://github.com/aws/aws-sdk-js-v3/tree/v3.726.1)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.726.1/LICENSE):
 
 ```
                                 Apache License
@@ -1909,7 +1910,7 @@ This product includes source derived from [@aws-sdk/client-s3](https://github.co
 
 ### @aws-sdk/s3-request-presigner
 
-This product includes source derived from [@aws-sdk/s3-request-presigner](https://github.com/aws/aws-sdk-js-v3) ([v3.714.0](https://github.com/aws/aws-sdk-js-v3/tree/v3.714.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.714.0/LICENSE):
+This product includes source derived from [@aws-sdk/s3-request-presigner](https://github.com/aws/aws-sdk-js-v3) ([v3.726.1](https://github.com/aws/aws-sdk-js-v3/tree/v3.726.1)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.726.1/LICENSE):
 
 ```
                                 Apache License
@@ -3769,7 +3770,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ### eslint
 
-This product includes source derived from [eslint](https://github.com/eslint/eslint) ([v9.17.0](https://github.com/eslint/eslint/tree/v9.17.0)), distributed under the [MIT License](https://github.com/eslint/eslint/blob/v9.17.0/LICENSE):
+This product includes source derived from [eslint](https://github.com/eslint/eslint) ([v9.18.0](https://github.com/eslint/eslint/tree/v9.18.0)), distributed under the [MIT License](https://github.com/eslint/eslint/blob/v9.18.0/LICENSE):
 
 ```
 Copyright OpenJS Foundation and other contributors, <www.openjsf.org>
@@ -4534,6 +4535,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 
+
 ## optionalDependencies
 
 ### @contrast/fn-inspect
@@ -5050,9 +5052,10 @@ otherwise to any obligation.
 Root Certificate License Agreement v3.0 (January 2014)
 ```
 
----
+-----
 
 Portions copyright Node.js contributors. Depending on your existing libraries and package management settings,
 your systems may call externally maintained libraries in addition to those listed above.
 See [here](https://nodejs.org/en/docs/meta/topics/dependencies/) and [here](https://github.com/nodejs/node/blob/v4.3.1/LICENSE)
 for additional details regarding externally maintained libraries and certain related licenses and notices.
+

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1220,14 +1220,6 @@ defaultConfig.definition = () => ({
       batch_size: {
         formatter: int,
         default: 750
-      },
-      /**
-       * For testing only. This forces the infinite tracing ingest service to accept
-       * all spans with the attribute of `force-capture-trace`.
-       */
-      force_capture_trace: {
-        formatter: boolean,
-        default: false
       }
     },
     batching: {

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1197,6 +1197,10 @@ defaultConfig.definition = () => ({
       port: {
         formatter: int,
         default: 443
+      },
+      insecure: {
+        formatter: boolean,
+        default: false
       }
     },
     span_events: {
@@ -1206,6 +1210,13 @@ defaultConfig.definition = () => ({
       queue_size: {
         formatter: int,
         default: 10000
+      },
+      /**
+       * Size of batches to post to 8T server
+       */
+      batch_size: {
+        formatter: int,
+        default: 250
       }
     },
     batching: {

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1198,10 +1198,13 @@ defaultConfig.definition = () => ({
         formatter: int,
         default: 443
       },
+      /**
+       * For testing only. This allows the connection to an insecure gRPC server.
+       */
       insecure: {
         formatter: boolean,
         default: false
-      }
+      },
     },
     span_events: {
       /**
@@ -1216,7 +1219,15 @@ defaultConfig.definition = () => ({
        */
       batch_size: {
         formatter: int,
-        default: 250
+        default: 750
+      },
+      /**
+       * For testing only. This forces the infinite tracing ingest service to accept
+       * all spans with the attribute of `force-capture-trace`.
+       */
+      force_capture_trace: {
+        formatter: boolean,
+        default: false
       }
     },
     batching: {

--- a/lib/grpc/connection.js
+++ b/lib/grpc/connection.js
@@ -403,7 +403,7 @@ class GrpcConnection extends EventEmitter {
           retryPolicy: {
             maxAttempts: 10,
             initialBackoff: '0.1s',
-            maxBackoff: '15s',
+            maxBackoff: '1s',
             backoffMultiplier: 2,
             retryableStatusCodes: ['UNAVAILABLE', 'INTERNAL']
           }

--- a/lib/grpc/connection.js
+++ b/lib/grpc/connection.js
@@ -62,6 +62,7 @@ class GrpcConnection extends EventEmitter {
 
     const traceObserverConfig = infiniteTracingConfig.trace_observer
     this._endpoint = this.getTraceObserverEndpoint(traceObserverConfig)
+    this._insecureConnection = traceObserverConfig.insecure
 
     this._client = null
     this.stream = null
@@ -202,11 +203,13 @@ class GrpcConnection extends EventEmitter {
 
   _disconnect() {
     logger.trace('Disconnecting from gRPC endpoint.')
+    this._setState(connectionStates.disconnected)
 
     if (this.stream) {
       this.stream.removeAllListeners()
 
       const oldStream = this.stream
+
       this.stream.on('status', function endStreamStatusHandler(grpcStatus) {
         logger.trace('End stream status received [%s]: %s', grpcStatus.code, grpcStatus.details)
 
@@ -228,8 +231,6 @@ class GrpcConnection extends EventEmitter {
 
       this.stream = null
     }
-
-    this._setState(connectionStates.disconnected)
   }
 
   /**
@@ -374,10 +375,7 @@ class GrpcConnection extends EventEmitter {
 
     const traceApi = protoDescriptor.com.newrelic.trace.v1
 
-    const credentials = this._generateCredentials(grpc)
-
-    // If you want to use mock server use insecure creds
-    // const credentials = grpc.credentials.createInsecure()
+    const credentials = this._insecureConnection ? grpc.credentials.createInsecure() : this._generateCredentials(grpc)
 
     const opts = {}
     if (this._compression) {
@@ -392,6 +390,27 @@ class GrpcConnection extends EventEmitter {
         .getOrCreateMetric(`${NAMES.INFINITE_TRACING.COMPRESSION}/disabled`)
         .incrementCallCount()
     }
+
+    // this defines retries of writes to stream if it fails with `UNAVAILABLE` or `INTERNAL`
+    const serviceConfig = {
+      methodConfig: [
+        {
+          name: [
+            {
+              service: 'com.newrelic.trace.v1.IngestService'
+            }
+          ],
+          retryPolicy: {
+            maxAttempts: 10,
+            initialBackoff: '0.1s',
+            maxBackoff: '15s',
+            backoffMultiplier: 2,
+            retryableStatusCodes: ['UNAVAILABLE', 'INTERNAL']
+          }
+        }
+      ]
+    }
+    opts['grpc.service_config'] = JSON.stringify(serviceConfig)
 
     return new traceApi.IngestService(endpoint, credentials, opts)
   }

--- a/lib/grpc/connection.js
+++ b/lib/grpc/connection.js
@@ -378,6 +378,7 @@ class GrpcConnection extends EventEmitter {
     const credentials = this._insecureConnection ? grpc.credentials.createInsecure() : this._generateCredentials(grpc)
 
     const opts = {}
+
     if (this._compression) {
       // 2 = gzip compression
       // see: https://github.com/grpc/grpc-node/blob/master/packages/grpc-js/src/compression-algorithms.ts#L21

--- a/lib/spans/base-span-streamer.js
+++ b/lib/spans/base-span-streamer.js
@@ -52,7 +52,7 @@ class BaseSpanStreamer {
   write(span) {
     this._metrics.getOrCreateMetric(NAMES.SEEN).incrementCallCount()
 
-    // If not writeable (because of backpressure) queue the span
+    // If not writable (because of backpressure) queue the span
     if (!this._writable) {
       if (this.spans.length < this.queue_size) {
         logger.trace('stream not writable, add spans to queue')

--- a/lib/spans/base-span-streamer.js
+++ b/lib/spans/base-span-streamer.js
@@ -25,14 +25,14 @@ class BaseSpanStreamer {
     // 'connected' indicates a safely writeable stream.
     // May still be mid-connect to gRPC server.
     this.connection.on('connected', (stream) => {
-      logger.info('Span streamer connected')
+      logger.trace('Span streamer connected, flushing queue')
       this.stream = stream
       this._writable = true
       this.sendQueue()
     })
 
     this.connection.on('disconnected', () => {
-      logger.info('Span streamer disconnected')
+      logger.trace('Span streamer disconnected')
       this.stream = null
       this._writable = false
     })
@@ -55,6 +55,7 @@ class BaseSpanStreamer {
     // If not writeable (because of backpressure) queue the span
     if (!this._writable) {
       if (this.spans.length < this.queue_size) {
+        logger.trace('stream not writable, add spans to queue')
         this.addToQueue(span)
         return
       }
@@ -81,7 +82,6 @@ class BaseSpanStreamer {
    */
   send(data) {
     const spans = data?.spans?.length || 1
-    logger.trace('Sending span over stream', spans)
     this._writable = this.stream.write(data)
     this._metrics.getOrCreateMetric(NAMES.SENT).incrementCallCount(spans)
 

--- a/lib/spans/base-span-streamer.js
+++ b/lib/spans/base-span-streamer.js
@@ -78,16 +78,18 @@ class BaseSpanStreamer {
    *  span, a drain event handler is setup to continue writing when possible.
    *
    * @param {*} data spans or span
-   * @param {number} [spanLen] number of spans sent in a stream(defaults to 1)
    */
-  send(data, spanLen = 1) {
+  send(data) {
+    const spans = data?.spans?.length || 1
+    logger.trace('Sending span over stream', spans)
+    this._writable = this.stream.write(data)
+    this._metrics.getOrCreateMetric(NAMES.SENT).incrementCallCount(spans)
+
     // false indicates the stream has reached the highWaterMark
     // and future writes should be avoided until drained. written items,
     // including the one that returned false, will still be buffered.
-    this._writable = this.stream.write(data)
-    this._metrics.getOrCreateMetric(NAMES.SENT).incrementCallCount(spanLen)
-
     if (!this._writable) {
+      logger.trace('Stream is not writable, adding a drain listener to flush queue when it is writable.')
       const waitDrainStart = Date.now()
       const onDrain = this.drain.bind(this, waitDrainStart)
       this.stream.once('drain', onDrain)
@@ -112,7 +114,6 @@ class BaseSpanStreamer {
 
     // Once the 'drain' event fires we can begin writing to the stream again
     this._writable = true
-
     this.sendQueue()
   }
 

--- a/lib/spans/batch-span-streamer.js
+++ b/lib/spans/batch-span-streamer.js
@@ -14,8 +14,6 @@ class BatchSpanStreamer extends BaseSpanStreamer {
     this.sendTimer = null
     this.batchSize = batchSize
     this.queueInterval = 5000
-    // set connected time which gets reset if the queueInterval has been hit
-    this.time = Date.now()
   }
 
   addToQueue(span) {
@@ -27,6 +25,10 @@ class BatchSpanStreamer extends BaseSpanStreamer {
    */
   write(span) {
     const currTime = Date.now()
+
+    if (!this.time) {
+      this.time = currTime
+    }
     super.write(span)
 
     if (!this._writable) {
@@ -45,14 +47,16 @@ class BatchSpanStreamer extends BaseSpanStreamer {
    *  The Infinite Tracing trace observer will treat spans that are more than 10 seconds apart as not belonging to the same group.
    *  It is therefore recommended that the agent perform a RecordSpanBatch request when either a target maximum batch size is reached or 5 seconds have elapsed since the creation of a batch (giving precedence to whichever of these events takes place first).
    *  Otherwise, delayed recording of spans will lead to their being discarded.
-   * @param currTime
+   *
+   * @param {number} currTime timestamp in milliseconds
+   * @returns {boolean} if a batch can we sent
    */
   batchReady(currTime) {
     return this.spans.length >= this.batchSize || currTime - this.time >= this.queueInterval
   }
 
   /**
-   * Chunks the span queue into n per batch(currently at 750).
+   * Chunks the span queue into n per batch.
    * The avg span is generally 1kb, picking an option slightly under to avoid
    * being over 1MB uncompressed limit being imposed on the gRPC server.
    * Since the processing happens async it'll be very hard to split further

--- a/lib/spans/batch-span-streamer.js
+++ b/lib/spans/batch-span-streamer.js
@@ -9,22 +9,13 @@ const logger = require('../logger').child({ component: 'batch-span-streamer' })
 const BaseSpanStreamer = require('./base-span-streamer')
 
 class BatchSpanStreamer extends BaseSpanStreamer {
-  constructor(licenseKey, connection, metrics, queueSize) {
+  constructor(licenseKey, connection, metrics, queueSize, batchSize) {
     super(licenseKey, connection, metrics, queueSize)
     this.sendTimer = null
-    this.batchSize = 750
-    this.connection.on('connected', () => {
-      logger.debug('Setting up batch interval')
-      this.sendTimer = setInterval(this.sendQueue.bind(this), 5000)
-      this.sendTimer.unref()
-    })
-
-    this.connection.on('disconnected', () => {
-      logger.debug('Clearing batch interval')
-      if (this.sendTimer) {
-        clearInterval(this.sendTimer)
-      }
-    })
+    this.batchSize = batchSize
+    this.queueInterval = 5000
+    // set connected time which gets reset if the queueInterval has been hit
+    this.time = Date.now()
   }
 
   addToQueue(span) {
@@ -35,6 +26,7 @@ class BatchSpanStreamer extends BaseSpanStreamer {
    * or drops it depending on stream/queue state
    */
   write(span) {
+    const currTime = Date.now()
     super.write(span)
 
     if (!this._writable) {
@@ -43,18 +35,27 @@ class BatchSpanStreamer extends BaseSpanStreamer {
 
     this.addToQueue(span)
 
-    if (this.spans.length < this.queue_size) {
-      return
+    if (this.batchReady(currTime)) {
+      this.sendQueue()
+      this.time = currTime
     }
+  }
 
-    this.sendQueue()
+  /**
+   *  The Infinite Tracing trace observer will treat spans that are more than 10 seconds apart as not belonging to the same group.
+   *  It is therefore recommended that the agent perform a RecordSpanBatch request when either a target maximum batch size is reached or 5 seconds have elapsed since the creation of a batch (giving precedence to whichever of these events takes place first).
+   *  Otherwise, delayed recording of spans will lead to their being discarded.
+   * @param currTime
+   */
+  batchReady(currTime) {
+    return this.spans.length >= this.batchSize || currTime - this.time >= this.queueInterval
   }
 
   /**
    * Chunks the span queue into n per batch(currently at 750).
    * The avg span is generally 1kb, picking an option slightly under to avoid
    * being over 1MB uncompressed limit being imposed on the gRPC server.
-   * Since the processing happens asyc it'll be very hard to split further
+   * Since the processing happens async it'll be very hard to split further
    * if a span batch is too big. We are being conservative here and other
    * language agents transmit even smaller batches(100 per batch).
    */
@@ -64,15 +65,13 @@ class BatchSpanStreamer extends BaseSpanStreamer {
       return
     }
 
-    for (let i = 0; i < this.spans.length; i += this.batchSize) {
-      const spans = this.spans.slice(i, i + this.batchSize)
+    while (this.spans.length > 0 && this._writable) {
+      const spans = this.spans.splice(0, this.batchSize)
       logger.trace('Sending spans from queue: %s', spans.length)
-      this.send({ spans }, spans.length)
+      this.send({ spans })
     }
 
-    this.spans = []
-
-    logger.trace('Finished sending spans from queue.')
+    logger.trace('Finished sending spans from queue. Items left in queue: %s', this.spans.length)
   }
 }
 

--- a/lib/spans/create-span-event-aggregator.js
+++ b/lib/spans/create-span-event-aggregator.js
@@ -54,7 +54,8 @@ function createStreamingAggregator(config, agent) {
       config.license_key,
       connection,
       metrics,
-      config.infinite_tracing.span_events.queue_size
+      config.infinite_tracing.span_events.queue_size,
+      config.infinite_tracing.span_events.batch_size
     )
     metrics.getOrCreateMetric(`${NAMES.BATCHING}/enabled`).incrementCallCount()
   } else {

--- a/lib/spans/span-streamer.js
+++ b/lib/spans/span-streamer.js
@@ -44,7 +44,7 @@ class SpanStreamer extends BaseSpanStreamer {
 
     logger.trace('Sending spans from queue: %s.', this.spans.length)
 
-    // Continue sending the spans that were in the queue. _writable is checked
+    // Continue sending the spans that were in the queue. this._writable is checked
     // so that if a send fails while clearing the queue, this drain handler can
     // finish, and the drain handler setup on the failed send will then attempt
     // to clear the queue

--- a/lib/spans/streaming-span-event.js
+++ b/lib/spans/streaming-span-event.js
@@ -147,6 +147,8 @@ class StreamingSpanEvent {
     span.addIntrinsicAttribute('sampled', transaction.sampled)
     span.addIntrinsicAttribute('priority', transaction.priority)
     span.addIntrinsicAttribute('name', segment.name)
+    // uncomment if you want to force capturing all for local testing purposes
+    // span.addIntrinsicAttribute('force-capture-trace', true)
 
     if (isRoot) {
       span.addIntrinsicAttribute('trustedParentId', transaction.traceContext.trustedParentId)

--- a/lib/spans/streaming-span-event.js
+++ b/lib/spans/streaming-span-event.js
@@ -147,8 +147,11 @@ class StreamingSpanEvent {
     span.addIntrinsicAttribute('sampled', transaction.sampled)
     span.addIntrinsicAttribute('priority', transaction.priority)
     span.addIntrinsicAttribute('name', segment.name)
-    // uncomment if you want to force capturing all for local testing purposes
-    // span.addIntrinsicAttribute('force-capture-trace', true)
+    // This should only be used for testing. It allows all spans with this attribute to be
+    // accepted by the infinite tracing service.
+    if (transaction?.agent?.config?.infinite_tracing?.span_events?.force_capture_trace === true) {
+      span.addIntrinsicAttribute('force-capture-trace', true)
+    }
 
     if (isRoot) {
       span.addIntrinsicAttribute('trustedParentId', transaction.traceContext.trustedParentId)

--- a/lib/spans/streaming-span-event.js
+++ b/lib/spans/streaming-span-event.js
@@ -147,11 +147,6 @@ class StreamingSpanEvent {
     span.addIntrinsicAttribute('sampled', transaction.sampled)
     span.addIntrinsicAttribute('priority', transaction.priority)
     span.addIntrinsicAttribute('name', segment.name)
-    // This should only be used for testing. It allows all spans with this attribute to be
-    // accepted by the infinite tracing service.
-    if (transaction?.agent?.config?.infinite_tracing?.span_events?.force_capture_trace === true) {
-      span.addIntrinsicAttribute('force-capture-trace', true)
-    }
 
     if (isRoot) {
       span.addIntrinsicAttribute('trustedParentId', transaction.traceContext.trustedParentId)

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "#test/assert": "./test/lib/custom-assertions/index.js"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.12.2",
+    "@grpc/grpc-js": "^1.13.2",
     "@grpc/proto-loader": "^0.7.5",
     "@newrelic/security-agent": "^2.3.0",
     "@opentelemetry/api": "^1.9.0",

--- a/test/unit/grpc/connection.test.js
+++ b/test/unit/grpc/connection.test.js
@@ -29,6 +29,9 @@ const fakeTraceObserverConfig = {
 
 class FakeStreamer extends EventEmitter {
   emitStatus(status) {
+    if (status.code !== 0) {
+      this.emit('error', status)
+    }
     this.emit('status', status)
   }
 }
@@ -344,6 +347,9 @@ test('grpc stream event handling', async (t) => {
       )
 
       assert.equal(metric.callCount, 1, 'incremented metric')
+
+      const resErrorMetric = metrics.getOrCreateMetric(NAMES.INFINITE_TRACING.SPAN_RESPONSE_ERROR)
+      assert.equal(resErrorMetric.callCount, 1)
     }
   )
 })

--- a/test/unit/spans/create-span-event-aggregator.test.js
+++ b/test/unit/spans/create-span-event-aggregator.test.js
@@ -120,7 +120,8 @@ test('should trim host and port options when they are strings', async () => {
   createSpanEventAggregator(config, agent)
   assert.deepEqual(config.infinite_tracing.trace_observer, {
     host: VALID_HOST,
-    port: '300'
+    port: '300',
+    insecure: false
   })
 })
 

--- a/test/unit/spans/streaming-span-event.test.js
+++ b/test/unit/spans/streaming-span-event.test.js
@@ -420,20 +420,6 @@ test('fromSegment()', async (t) => {
 
       assert.deepEqual(span._intrinsicAttributes.category, { [STRING_TYPE]: CATEGORIES.DATASTORE })
       assert.deepEqual(span._intrinsicAttributes['span.kind'], { [STRING_TYPE]: 'client' })
-      assert.ok(!span._intrinsicAttributes['force-capture-trace'])
-
-      end()
-    })
-  })
-
-  await t.test('should add force-capture-trace to span when `config.infinite_tracing.span_events.force_capture_trace` is true', (t, end) => {
-    const { agent } = t.nr
-    agent.config.infinite_tracing.span_events.force_capture_trace = true
-    helper.runInTransaction(agent, (transaction) => {
-      const segment = transaction.trace.add('TestSegment')
-      const span = StreamingSpanEvent.fromSegment(segment, transaction)
-      assert.equal(span._intrinsicAttributes['force-capture-trace'].bool_value, true)
-      transaction.end()
       end()
     })
   })

--- a/test/unit/spans/streaming-span-event.test.js
+++ b/test/unit/spans/streaming-span-event.test.js
@@ -420,7 +420,20 @@ test('fromSegment()', async (t) => {
 
       assert.deepEqual(span._intrinsicAttributes.category, { [STRING_TYPE]: CATEGORIES.DATASTORE })
       assert.deepEqual(span._intrinsicAttributes['span.kind'], { [STRING_TYPE]: 'client' })
+      assert.ok(!span._intrinsicAttributes['force-capture-trace'])
 
+      end()
+    })
+  })
+
+  await t.test('should add force-capture-trace to span when `config.infinite_tracing.span_events.force_capture_trace` is true', (t, end) => {
+    const { agent } = t.nr
+    agent.config.infinite_tracing.span_events.force_capture_trace = true
+    helper.runInTransaction(agent, (transaction) => {
+      const segment = transaction.trace.add('TestSegment')
+      const span = StreamingSpanEvent.fromSegment(segment, transaction)
+      assert.equal(span._intrinsicAttributes['force-capture-trace'].bool_value, true)
+      transaction.end()
       end()
     })
   })

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Thu Mar 27 2025 08:39:56 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Thu Apr 10 2025 12:23:21 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -44,15 +44,15 @@
   },
   "includeDev": true,
   "dependencies": {
-    "@grpc/grpc-js@1.12.4": {
+    "@grpc/grpc-js@1.13.2": {
       "name": "@grpc/grpc-js",
-      "version": "1.12.4",
-      "range": "^1.12.2",
+      "version": "1.13.2",
+      "range": "^1.13.2",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",
-      "versionedRepoUrl": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js/tree/v1.12.4",
+      "versionedRepoUrl": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js/tree/v1.13.2",
       "licenseFile": "node_modules/@grpc/grpc-js/LICENSE",
-      "licenseUrl": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js/blob/v1.12.4/LICENSE",
+      "licenseUrl": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js/blob/v1.13.2/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Google Inc."
     },
@@ -68,15 +68,15 @@
       "licenseTextSource": "file",
       "publisher": "Google Inc."
     },
-    "@newrelic/security-agent@2.3.1": {
+    "@newrelic/security-agent@2.4.0": {
       "name": "@newrelic/security-agent",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "range": "^2.3.0",
       "licenses": "UNKNOWN",
       "repoUrl": "https://github.com/newrelic/csec-node-agent",
-      "versionedRepoUrl": "https://github.com/newrelic/csec-node-agent/tree/v2.3.1",
+      "versionedRepoUrl": "https://github.com/newrelic/csec-node-agent/tree/v2.4.0",
       "licenseFile": "node_modules/@newrelic/security-agent/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/csec-node-agent/blob/v2.3.1/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/csec-node-agent/blob/v2.4.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "newrelic"
     },
@@ -156,15 +156,15 @@
       "email": "nathan@tootallnate.net",
       "url": "http://n8.io/"
     },
-    "import-in-the-middle@1.13.0": {
+    "import-in-the-middle@1.13.1": {
       "name": "import-in-the-middle",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "range": "^1.13.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/nodejs/import-in-the-middle",
-      "versionedRepoUrl": "https://github.com/nodejs/import-in-the-middle/tree/v1.13.0",
+      "versionedRepoUrl": "https://github.com/nodejs/import-in-the-middle/tree/v1.13.1",
       "licenseFile": "node_modules/import-in-the-middle/LICENSE",
-      "licenseUrl": "https://github.com/nodejs/import-in-the-middle/blob/v1.13.0/LICENSE",
+      "licenseUrl": "https://github.com/nodejs/import-in-the-middle/blob/v1.13.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Bryan English",
       "email": "bryan.english@datadoghq.com"
@@ -221,15 +221,15 @@
       "licenseUrl": "https://github.com/nodejs/readable-stream/blob/v3.6.2/LICENSE",
       "licenseTextSource": "file"
     },
-    "require-in-the-middle@7.4.0": {
+    "require-in-the-middle@7.5.0": {
       "name": "require-in-the-middle",
-      "version": "7.4.0",
+      "version": "7.5.0",
       "range": "^7.4.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/elastic/require-in-the-middle",
-      "versionedRepoUrl": "https://github.com/elastic/require-in-the-middle/tree/v7.4.0",
+      "versionedRepoUrl": "https://github.com/elastic/require-in-the-middle/tree/v7.5.0",
       "licenseFile": "node_modules/require-in-the-middle/LICENSE",
-      "licenseUrl": "https://github.com/elastic/require-in-the-middle/blob/v7.4.0/LICENSE",
+      "licenseUrl": "https://github.com/elastic/require-in-the-middle/blob/v7.5.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Thomas Watson Steen",
       "email": "w@tson.dk",
@@ -262,28 +262,28 @@
     }
   },
   "devDependencies": {
-    "@aws-sdk/client-s3@3.714.0": {
+    "@aws-sdk/client-s3@3.726.1": {
       "name": "@aws-sdk/client-s3",
-      "version": "3.714.0",
+      "version": "3.726.1",
       "range": "^3.556.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/aws/aws-sdk-js-v3",
-      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.714.0",
+      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.726.1",
       "licenseFile": "node_modules/@aws-sdk/client-s3/LICENSE",
-      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.714.0/LICENSE",
+      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.726.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "AWS SDK for JavaScript Team",
       "url": "https://aws.amazon.com/javascript/"
     },
-    "@aws-sdk/s3-request-presigner@3.714.0": {
+    "@aws-sdk/s3-request-presigner@3.726.1": {
       "name": "@aws-sdk/s3-request-presigner",
-      "version": "3.714.0",
+      "version": "3.726.1",
       "range": "^3.556.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/aws/aws-sdk-js-v3",
-      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.714.0",
+      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.726.1",
       "licenseFile": "node_modules/@aws-sdk/s3-request-presigner/LICENSE",
-      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.714.0/LICENSE",
+      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.726.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "AWS SDK for JavaScript Team",
       "url": "https://aws.amazon.com/javascript/"
@@ -543,15 +543,15 @@
       "email": "gajus@gajus.com",
       "url": "http://gajus.com"
     },
-    "eslint@9.17.0": {
+    "eslint@9.18.0": {
       "name": "eslint",
-      "version": "9.17.0",
+      "version": "9.18.0",
       "range": "^9.17.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/eslint/eslint",
-      "versionedRepoUrl": "https://github.com/eslint/eslint/tree/v9.17.0",
+      "versionedRepoUrl": "https://github.com/eslint/eslint/tree/v9.18.0",
       "licenseFile": "node_modules/eslint/LICENSE",
-      "licenseUrl": "https://github.com/eslint/eslint/blob/v9.17.0/LICENSE",
+      "licenseUrl": "https://github.com/eslint/eslint/blob/v9.18.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Nicholas C. Zakas",
       "email": "nicholas+npm@nczconsulting.com"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

A customer reported missing spans for certain traces.  I was able to reproduce this with a [local mock server](https://github.com/newrelic/newrelic-node-examples/pull/320). There were several issues:
 * the batch streamer was sending batches when the stream wasn't connected so they were floating into the ether
 * the logic to flush the queue every 5 seconds was also sending batches into the ether
 * lastly on failures we weren't retrying. grpc-js has built-in retries but it must be configured via a retry policy

I also tweaked the batch streamer to flush queue when timer(5 seconds elapses) or there's a batch(250). I also added some more unit tests and an integration test that asserts that retries occur after failures. Lastly our integration tests weren't asserting the seen/sent/dropped, it now does.

## Related Issues

Closes #3024
