### PR TITLE
test: Updated elasticsearch image for versioned tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
 
   elasticsearch:
     container_name: nr_node_elastic
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.8.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.0.0
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       # Set cluster to single node


### PR DESCRIPTION
Now that ElasticSearch v9.0.0 is released, our versioned tests will test it automatically. Our test image for ElasticSearch, however, needed to be updated for compatibility with v9
