### PR TITLE
refactor: Updated how otel bridge trace propagator assigns traceparent/tracestate headers

### DIFF
--- a/lib/otel/trace-propagator.js
+++ b/lib/otel/trace-propagator.js
@@ -69,7 +69,7 @@ module.exports = class NewRelicTracePropagator {
       !isSpanContextValid(spanContext)
     ) { return }
 
-    context?.transaction?.insertDistributedTraceHeaders(carrier, spanContext)
+    context?.transaction?.insertDistributedTraceHeaders(carrier, setter, spanContext)
   }
 
   extract(context, carrier, getter) {

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -906,10 +906,11 @@ function acceptDistributedTraceHeaders(transportType, headers) {
  * Inserts distributed trace headers into the provided headers map.
  *
  * @param {object} headers
+ * @param {object} setter - otel bridge setter to assign headers
  * @param {object} spanContext otel span context
  */
 Transaction.prototype.insertDistributedTraceHeaders = insertDistributedTraceHeaders
-function insertDistributedTraceHeaders(headers, spanContext) {
+function insertDistributedTraceHeaders(headers, setter, spanContext) {
   if (!headers) {
     logger.trace('insertDistributedTraceHeaders called without headers.')
     return
@@ -920,7 +921,7 @@ function insertDistributedTraceHeaders(headers, spanContext) {
   // Ensure we have priority before generating trace headers.
   this._calculatePriority()
 
-  this.traceContext.addTraceContextHeaders(headers, spanContext)
+  this.traceContext.addTraceContextHeaders(headers, setter, spanContext)
   this.isDistributedTrace = true
 
   logger.trace('Added outbound request w3c trace context headers in transaction %s', this.id)

--- a/lib/transaction/tracecontext.js
+++ b/lib/transaction/tracecontext.js
@@ -134,21 +134,30 @@ class TraceContext {
    * Takes a headers object and modifies it in place by adding Trace Context headers
    *
    * @param {object} headers - Headers for an HTTP request
+   * @param {object} setter - otel bridge setter to assign headers to outgoing payload. Doing this instead of assigning to headers because some libraries have special logic for handling outgoing headers(gcp-pubsub)
    * @param {object} spanContext if passed in, it'll use this to construct traceparent/tracestate. only used in otel bridge mode.
    */
-  addTraceContextHeaders(headers, spanContext) {
+  addTraceContextHeaders(headers, setter, spanContext) {
     if (!headers) {
       return
     }
 
     const traceParent = this.createTraceparent(spanContext)
-    headers[TRACE_CONTEXT_PARENT_HEADER] = traceParent
+    if (setter) {
+      setter.set(headers, TRACE_CONTEXT_PARENT_HEADER, traceParent)
+    } else {
+      headers[TRACE_CONTEXT_PARENT_HEADER] = traceParent
+    }
 
     logger.trace('traceparent added with %s', traceParent)
 
     const tracestate = this.createTracestate(spanContext)
     if (tracestate) {
-      headers[TRACE_CONTEXT_STATE_HEADER] = tracestate
+      if (setter) {
+        setter.set(headers, TRACE_CONTEXT_STATE_HEADER, tracestate)
+      } else {
+        headers[TRACE_CONTEXT_STATE_HEADER] = tracestate
+      }
       logger.trace('tracestate added with %s', tracestate)
     }
 

--- a/test/unit/transaction.test.js
+++ b/test/unit/transaction.test.js
@@ -1573,9 +1573,14 @@ test('insertDistributedTraceHeaders', async (t) => {
 
     }
     const headers = {}
-    txn.insertDistributedTraceHeaders(headers, spanContext)
-    assert.equal(headers.traceparent, `00-${traceId}-${spanId}-01`)
-    const { tracestate } = headers
+    const setter = {
+      set(carrier, header, value) {
+        carrier[header] = value
+      }
+    }
+    txn.insertDistributedTraceHeaders(headers, setter, spanContext)
+    const { traceparent, tracestate } = headers
+    assert.equal(traceparent, `00-${traceId}-${spanId}-01`)
     assert.ok(tracestate.startsWith(`${trustedAccountKey}@nr=0-0-AccountId1-Application1-${spanId}-${txn.id}`))
   })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

While digging into how we could propagate gcp pub/sub `googclient_traceparent` I realized our trace propagator wasn't 100% correct.  We were injecting traceparent/tracestate by just assigning the values to the headers object.  The [propagation spec](https://opentelemetry.io/docs/specs/otel/context/api-propagators/) states you should call the `setter.set` to assign the header value.  In most cases this just does `headers[key] = value`. However, in the case of gcp pub sub, the library has its own [setter](https://github.com/googleapis/nodejs-pubsub/blob/8b514934fe55a66a27bbc00b4c76f648d6aa7c50/src/telemetry-tracing.ts#L186) that prefixes all headers with `googclient_`.  By updating our `insertDistributedTracingHeaders` to call `setter.set` this mapping logic will properly work and DT functions in gcp pub sub.

## Related Issues
Closes #3045
