### PR TITLE
ci: Pinned pg-native to below 3.4.0

### DIFF
--- a/test/versioned/pg-esm/package.json
+++ b/test/versioned/pg-esm/package.json
@@ -11,7 +11,7 @@
       },
       "dependencies": {
         "pg": ">=8.2.0",
-        "pg-native": ">=3.0.0"
+        "pg-native": ">=3.0.0 <3.4.0"
       },
       "files": [
         "force-native.test.mjs",

--- a/test/versioned/pg/package.json
+++ b/test/versioned/pg/package.json
@@ -10,7 +10,7 @@
       },
       "dependencies": {
         "pg": ">=8.2.0",
-        "pg-native": ">=3.0.0"
+        "pg-native": ">=3.0.0 <3.4.0"
       },
       "files": [
         "force-native.test.js",


### PR DESCRIPTION
3.4.0 is failing versioned tests; this unblocks us until we resolve the test failures.

## Related Issues

The actual failures will be resolved by work on #3048 