### PR TITLE
refactor: Added defensive code when calculating exclusive time on a segment where it cannot locate the segment in the transaction trace tree

### DIFF
--- a/lib/transaction/trace/exclusive-time-calculator.js
+++ b/lib/transaction/trace/exclusive-time-calculator.js
@@ -7,7 +7,10 @@
 
 class ExclusiveCalculator {
   constructor(root, trace) {
-    this.node = trace.getNode(root.id)
+    const node = trace.getNode(root.id)
+    // could not find segment in trace, typically because context propagation is broken
+    // add some defensive and essentially set the exclusive time to the segment duration
+    this.node = node ?? { children: [], segment: root }
     // use a second stack to do a post-order traversal
     this.parentStack = []
   }

--- a/test/unit/transaction/trace/segment.test.js
+++ b/test/unit/transaction/trace/segment.test.js
@@ -67,6 +67,22 @@ test('TraceSegment', async (t) => {
     assert.equal(segment.timer.isRunning(), false)
   })
 
+  await t.test('does not crash when calculating exclusive time', (t) => {
+    const { agent } = t.nr
+    const trans = new Transaction(agent)
+    const root = trans.trace.root
+    const segment = new TraceSegment({
+      config: agent.config,
+      name: 'UnitTest',
+      collect: true,
+      root
+    })
+    segment.start()
+    segment.touch()
+    const duration = segment.getExclusiveDurationInMillis(trans.trace)
+    assert.ok(duration > 0)
+  })
+
   await t.test('allows the timer to be updated without ending it', (t) => {
     const { agent } = t.nr
     const trans = new Transaction(agent)


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
I do not know how this occurs but I suspect it's an issue around async context propagation where a segment was either not added to the transaction trace tree or it was added to the wrong transaction trace.  This PR adds some defensive code that essentially defaults the exclusive time to the segment time in these situations.  We have had [report](https://github.com/newrelic/node-newrelic/issues/2881#issuecomment-2789787287) on a similar, closed issue,  but have not provided a reproduction case.
