### PR TITLE
fix: Only add `newrelic` header to outgoing headers if has a value

### DIFF
--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -933,8 +933,10 @@ function insertDistributedTraceHeaders(headers, setter, spanContext) {
 
   try {
     const newrelicFormatData = this._createDistributedTracePayload().httpSafe()
-    headers[NEWRELIC_TRACE_HEADER] = newrelicFormatData
-    logger.trace('Added outbound request distributed tracing headers in transaction %s', this.id)
+    if (newrelicFormatData) {
+      headers[NEWRELIC_TRACE_HEADER] = newrelicFormatData
+      logger.trace('Added outbound request distributed tracing headers in transaction %s', this.id)
+    }
   } catch (error) {
     logger.trace(error, 'Failed to create distributed trace payload')
   }

--- a/test/unit/instrumentation/undici.test.js
+++ b/test/unit/instrumentation/undici.test.js
@@ -101,10 +101,9 @@ test('undici instrumentation', async function (t) {
       helper.runInTransaction(agent, function (tx) {
         const addHeader = sandbox.stub()
         channels.create.publish({ request: { origin: HOST, path: '/foo-2', addHeader } })
-        assert.equal(addHeader.callCount, 2)
+        assert.equal(addHeader.callCount, 1)
         assert.equal(addHeader.args[0][0], 'traceparent')
         assert.match(addHeader.args[0][1], /^[\w-]{55}$/)
-        assert.deepEqual(addHeader.args[1], ['newrelic', ''])
         tx.end()
         end()
       })

--- a/test/unit/shim/message-shim.test.js
+++ b/test/unit/shim/message-shim.test.js
@@ -421,20 +421,17 @@ test('MessageShim', async function (t) {
         match(messages, [
           {
             headers: {
-              newrelic: '',
               traceparent: `00-${tx.traceId}-${segment.id}-01`
             }
           },
           {
             headers: {
-              newrelic: '',
               traceparent: `00-${tx.traceId}-${segment.id}-01`,
               foo: 'foo'
             }
           },
           {
             headers: {
-              newrelic: '',
               traceparent: `00-${tx.traceId}-${segment.id}-01`
             }
           }

--- a/test/unit/transaction.test.js
+++ b/test/unit/transaction.test.js
@@ -1583,6 +1583,19 @@ test('insertDistributedTraceHeaders', async (t) => {
     assert.equal(traceparent, `00-${traceId}-${spanId}-01`)
     assert.ok(tracestate.startsWith(`${trustedAccountKey}@nr=0-0-AccountId1-Application1-${spanId}-${txn.id}`))
   })
+
+  await t.test('should not set newrelic header if empty string', (t) => {
+    const { agent } = t.nr
+    agent.config.distributed_tracing.enabled = true
+    agent.config.span_events.enabled = true
+    const txn = new Transaction(agent)
+    const headers = {}
+    txn.insertDistributedTraceHeaders(headers)
+    console.log(headers)
+    assert.ok(headers.traceparent)
+    assert.ok(!Object.prototype.hasOwnProperty.call(headers, 'tracestate'))
+    assert.ok(!Object.prototype.hasOwnProperty.call(headers, 'newrelic'))
+  })
 })
 
 test('acceptTraceContextPayload', async (t) => {

--- a/test/versioned/grpc-esm/client-unary.test.mjs
+++ b/test/versioned/grpc-esm/client-unary.test.mjs
@@ -87,7 +87,6 @@ test('should include distributed trace headers when enabled', (t, end) => {
       /^[\w-]{55}$/,
       'should have traceparent in server metadata'
     )
-    assert.equal(dtMeta.get('newrelic')[0], '', 'should have newrelic in server metadata')
     tx.end()
     end()
   })

--- a/test/versioned/grpc/client-bidi-streaming.test.js
+++ b/test/versioned/grpc/client-bidi-streaming.test.js
@@ -83,7 +83,6 @@ test('should include distributed trace headers when enabled', (t, end) => {
       /^[\w-]{55}$/,
       'should have traceparent in server metadata'
     )
-    assert.equal(dtMeta.get('newrelic')[0], '', 'should have newrelic in server metadata')
     tx.end()
     end()
   })

--- a/test/versioned/grpc/client-server-streaming.test.js
+++ b/test/versioned/grpc/client-server-streaming.test.js
@@ -78,7 +78,6 @@ test('should include distributed trace headers when enabled', (t, end) => {
         /^[\w-]{55}$/,
         'should have traceparent in server metadata'
       )
-      assert.equal(dtMeta.get('newrelic')[0], '', 'should have newrelic in server metadata')
     })
     tx.end()
     end()

--- a/test/versioned/grpc/client-streaming.test.js
+++ b/test/versioned/grpc/client-streaming.test.js
@@ -81,7 +81,6 @@ test('should include distributed trace headers when enabled', (t, end) => {
         /^[\w-]{55}$/,
         'should have traceparent in server metadata'
       )
-      assert.equal(dtMeta.get('newrelic')[0], '', 'should have newrelic in server metadata')
     })
     tx.end()
     end()

--- a/test/versioned/grpc/client-unary.test.js
+++ b/test/versioned/grpc/client-unary.test.js
@@ -75,7 +75,6 @@ test('should include distributed trace headers when enabled', (t, end) => {
       /^[\w-]{55}$/,
       'should have traceparent in server metadata'
     )
-    assert.equal(dtMeta.get('newrelic')[0], '', 'should have newrelic in server metadata')
     tx.end()
     end()
   })

--- a/test/versioned/grpc/server-unary.test.js
+++ b/test/versioned/grpc/server-unary.test.js
@@ -102,11 +102,6 @@ test('should not include distributed trace headers when there is no client trans
   const attributes = serverTransaction.trace.attributes.get(DESTINATION)
   notHas({
     found: attributes,
-    doNotWant: 'request.header.newrelic',
-    msg: 'should not have newrelic in headers'
-  })
-  notHas({
-    found: attributes,
     doNotWant: 'request.header.traceparent',
     msg: 'should not have traceparent in headers'
   })
@@ -136,11 +131,6 @@ test('should not add DT headers when `distributed_tracing` is disabled', async (
   })
 
   const attributes = serverTransaction.trace.attributes.get(DESTINATION)
-  notHas({
-    found: attributes,
-    doNotWant: 'request.header.newrelic',
-    msg: 'should not have newrelic in headers'
-  })
   notHas({
     found: attributes,
     doNotWant: 'request.header.traceparent',

--- a/test/versioned/grpc/util.cjs
+++ b/test/versioned/grpc/util.cjs
@@ -240,7 +240,6 @@ util.assertDistributedTracing = function assertDistributedTracing(
     'should get different transactions for client and server'
   )
   match(serverAttributes['request.headers.traceparent'], /^[\w-]{55}$/, { assert })
-  assert.equal(serverAttributes['request.headers.newrelic'], '', 'should have the newrelic header')
   assert.equal(
     clientTransaction.traceId,
     serverTransaction.traceId,

--- a/test/versioned/kafkajs/kafka.test.js
+++ b/test/versioned/kafkajs/kafka.test.js
@@ -55,7 +55,7 @@ test.afterEach(async (ctx) => {
 })
 
 test('send records correctly', async (t) => {
-  const plan = tspl(t, { plan: 9 })
+  const plan = tspl(t, { plan: 8 })
   const { agent, consumer, producer, topic } = t.nr
   const message = 'test message'
   const expectedName = 'produce-tx'
@@ -92,7 +92,6 @@ test('send records correctly', async (t) => {
         eachMessage: async ({ message: actualMessage }) => {
           plan.equal(actualMessage.value.toString(), message)
           plan.equal(actualMessage.headers['x-foo'].toString(), 'foo')
-          plan.equal(actualMessage.headers.newrelic.toString(), '')
           plan.equal(actualMessage.headers.traceparent.toString().startsWith('00-'), true)
           resolve()
         }
@@ -183,7 +182,7 @@ test('send passes along DT headers', async (t) => {
 })
 
 test('sendBatch records correctly', async (t) => {
-  const plan = tspl(t, { plan: 10 })
+  const plan = tspl(t, { plan: 9 })
   const { agent, consumer, producer, topic } = t.nr
   const message = 'test message'
   const expectedName = 'produce-tx'
@@ -222,7 +221,6 @@ test('sendBatch records correctly', async (t) => {
         eachMessage: async ({ message: actualMessage }) => {
           plan.equal(actualMessage.value.toString(), message)
           match(actualMessage.headers['x-foo'].toString(), 'foo', { assert: plan })
-          plan.equal(actualMessage.headers.newrelic.toString(), '')
           plan.equal(actualMessage.headers.traceparent.toString().startsWith('00-'), true)
           resolve()
         }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This PR updates the `insertDistributedTraceHeaders` logic to only include the `newrelic` header if it contains a value.

## Related Links
Closes #3047
