### PR TITLE
test: Skipped regressions in pg-native versioned tests 

### DIFF
--- a/test/versioned/pg-esm/package.json
+++ b/test/versioned/pg-esm/package.json
@@ -11,7 +11,7 @@
       },
       "dependencies": {
         "pg": ">=8.2.0",
-        "pg-native": ">=3.0.0 <3.4.0"
+        "pg-native": ">=3.0.0 <3.4.0 || >=3.4.5"
       },
       "files": [
         "force-native.test.mjs",

--- a/test/versioned/pg/package.json
+++ b/test/versioned/pg/package.json
@@ -10,7 +10,7 @@
       },
       "dependencies": {
         "pg": ">=8.2.0",
-        "pg-native": ">=3.0.0 <3.4.0"
+        "pg-native": ">=3.0.0 <3.4.0 || >=3.4.5"
       },
       "files": [
         "force-native.test.js",


### PR DESCRIPTION
Updated pg-native versions in `pg` and `pg-esm` versioned tests. ESM support was introduced in 3.4.0, but not all required files were exported. `pg-native@3.4.5` corrects the export. Thanks to @brianc for fixing this!

## Related Issues

Closes #3048 
Closes NR-406454