### PR TITLE
fix: Updated `createSegment` to stop adding segments to trace when `max_trace_segments` is exceeded

### DIFF
--- a/lib/transaction/tracer/index.js
+++ b/lib/transaction/tracer/index.js
@@ -138,6 +138,8 @@ function createSegment({ id, name, recorder, parent, transaction }) {
 
   if (collect) {
     transaction.trace.segments.add(segment)
+  } else {
+    console.log('dropping segment', segment.name)
   }
 
   return segment

--- a/lib/transaction/tracer/index.js
+++ b/lib/transaction/tracer/index.js
@@ -138,8 +138,6 @@ function createSegment({ id, name, recorder, parent, transaction }) {
 
   if (collect) {
     transaction.trace.segments.add(segment)
-  } else {
-    console.log('dropping segment', segment.name)
   }
 
   return segment

--- a/lib/transaction/tracer/index.js
+++ b/lib/transaction/tracer/index.js
@@ -135,7 +135,10 @@ function createSegment({ id, name, recorder, parent, transaction }) {
   if (recorder) {
     transaction.addRecorder(recorder.bind(null, segment))
   }
-  transaction.trace.segments.add(segment)
+
+  if (collect) {
+    transaction.trace.segments.add(segment)
+  }
 
   return segment
 }

--- a/test/unit/transaction/tracer.test.js
+++ b/test/unit/transaction/tracer.test.js
@@ -259,5 +259,19 @@ test('Tracer', async function (t) {
       assert.equal(segment.id, id)
       tx.end()
     })
+
+    await t.test('should stop adding segments to trace when `max_trace_segments` is exceeded', (t) => {
+      const { agent, tracer } = t.nr
+      const tx = new Transaction(agent)
+
+      const ar = new Array(1000).fill('a')
+      ar.forEach((_el, i) => {
+        tracer.createSegment({ name: `Test Segment ${i}`, parent: tx.trace.root, transaction: tx })
+      })
+
+      const [,,,,childSegments] = tx.trace.toJSON()
+      // max_trace_segments is 900(ROOT + 899 child segments
+      assert.equal(childSegments.length, 899)
+    })
   })
 })

--- a/test/versioned/kafkajs/kafka.test.js
+++ b/test/versioned/kafkajs/kafka.test.js
@@ -66,6 +66,8 @@ test('send records correctly', async (t) => {
       const segment = tx.agent.tracer.getSegment()
       const children = tx.trace.getChildren(segment.id)
 
+      const segments = children.map((s) => s.name)
+      console.log(segments)
       const foundSegment = children.find((s) => s.name.endsWith(topic))
       plan.equal(foundSegment.name, name)
 

--- a/test/versioned/kafkajs/kafka.test.js
+++ b/test/versioned/kafkajs/kafka.test.js
@@ -64,6 +64,7 @@ test('send records correctly', async (t) => {
     if (tx.name === expectedName) {
       const name = `MessageBroker/Kafka/Topic/Produce/Named/${topic}`
       const segment = tx.agent.tracer.getSegment()
+      console.log(segment.name)
       const children = tx.trace.getChildren(segment.id)
 
       const segments = children.map((s) => s.name)

--- a/test/versioned/kafkajs/kafka.test.js
+++ b/test/versioned/kafkajs/kafka.test.js
@@ -20,6 +20,11 @@ const broker = `${params.kafka_host}:${params.kafka_port}`
 test.beforeEach(async (ctx) => {
   ctx.nr = {}
   ctx.nr.agent = helper.instrumentMockedAgent({
+    instrumentation: {
+      timers: {
+        enabled: false
+      }
+    },
     feature_flag: {
       kafkajs_instrumentation: true
     }
@@ -64,11 +69,8 @@ test('send records correctly', async (t) => {
     if (tx.name === expectedName) {
       const name = `MessageBroker/Kafka/Topic/Produce/Named/${topic}`
       const segment = tx.agent.tracer.getSegment()
-      console.log(segment.name)
       const children = tx.trace.getChildren(segment.id)
 
-      const segments = children.map((s) => s.name)
-      console.log(segments)
       const foundSegment = children.find((s) => s.name.endsWith(topic))
       plan.equal(foundSegment.name, name)
 

--- a/test/versioned/kafkajs/utils.js
+++ b/test/versioned/kafkajs/utils.js
@@ -120,7 +120,7 @@ utils.verifyConsumeTransaction = ({ plan, tx, topic, clientId }) => {
  */
 utils.verifyDistributedTrace = ({ plan, consumeTxs, produceTx }) => {
   plan.ok(produceTx.isDistributedTrace, 'should mark producer as distributed')
-  const [, , , produceSegment] = produceTx.trace.getChildren(produceTx.trace.root.id)
+  const [, ,produceSegment] = produceTx.trace.getChildren(produceTx.trace.root.id)
   consumeTxs.forEach((consumeTx) => {
     plan.ok(consumeTx.isDistributedTrace, 'should mark consumer as distributed')
     plan.equal(consumeTx.incomingCatId, null, 'should not set old CAT properties')


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

In [12.11.0](https://github.com/newrelic/node-newrelic/releases/tag/v12.11.0) we broke out segment tree from the actual segment.  Previously, it continued adding segments as children with a `_collect` property of false.  These got filtered out when we serialized the transaction trace.  When the segment tree was added it could crash with `RangeError: Maximum call stack size exceeded` when attempting to add a segment to a deeply nested tree.  In order to prevent this unnecessarily adding segments to the transaction trace tree after the `max_trace_segments` is exceeded, I updated the logic to only add segments to transaction trace when collect it true. 

## Related Links
Closes #3036


