### PR TITLE
fix: http.route is empty in Apollo OTel spans which leads to an incomplete txn name

### DIFF
--- a/lib/otel/attr-mapping/http.js
+++ b/lib/otel/attr-mapping/http.js
@@ -14,19 +14,19 @@ const attrMappings = {
   clientHost: {
     attrs: [constants.ATTR_SERVER_ADDRESS, constants.ATTR_NET_PEER_NAME],
     mapping() {
-      return () => {}
+      return () => { }
     }
   },
   clientPort: {
     attrs: [constants.ATTR_SERVER_PORT, constants.ATTR_NETWORK_PEER_PORT, constants.ATTR_NET_PEER_PORT],
     mapping() {
-      return () => {}
+      return () => { }
     }
   },
   clientUrl: {
     attrs: [constants.ATTR_FULL_URL, constants.ATTR_HTTP_URL],
     mapping() {
-      return () => {}
+      return () => { }
     }
   },
   grpcStatusCode: {
@@ -83,8 +83,16 @@ const attrMappings = {
     attrs: [constants.ATTR_HTTP_ROUTE],
     mapping({ segment, transaction }) {
       return (value) => {
-        transaction.nameState.appendPath(value)
-        segment.addAttribute('http.route', value)
+        if (value.length > 0) {
+          transaction.nameState.appendPath(value)
+          segment.addAttribute('http.route', value)
+        }
+        // Some spans e.g. Apollo Server do not have the http.route
+        // attribute and therefore will not have not a correct transaction
+        // name, so this is a work around.
+        else if (segment.attributes['http.target']) {
+          transaction.nameState.appendPath(segment.attributes['http.target'])
+        }
       }
     }
   },

--- a/lib/otel/attr-mapping/http.js
+++ b/lib/otel/attr-mapping/http.js
@@ -14,19 +14,19 @@ const attrMappings = {
   clientHost: {
     attrs: [constants.ATTR_SERVER_ADDRESS, constants.ATTR_NET_PEER_NAME],
     mapping() {
-      return () => { }
+      return () => {}
     }
   },
   clientPort: {
     attrs: [constants.ATTR_SERVER_PORT, constants.ATTR_NETWORK_PEER_PORT, constants.ATTR_NET_PEER_PORT],
     mapping() {
-      return () => { }
+      return () => {}
     }
   },
   clientUrl: {
     attrs: [constants.ATTR_FULL_URL, constants.ATTR_HTTP_URL],
     mapping() {
-      return () => { }
+      return () => {}
     }
   },
   grpcStatusCode: {
@@ -86,11 +86,10 @@ const attrMappings = {
         if (value.length > 0) {
           transaction.nameState.appendPath(value)
           segment.addAttribute('http.route', value)
-        }
-        // Some spans e.g. Apollo Server do not have the http.route
-        // attribute and therefore will not have not a correct transaction
-        // name, so this is a work around.
-        else if (segment.attributes['http.target']) {
+        } else if (segment.attributes['http.target']) {
+          // Some spans e.g. Apollo Server do not have the http.route
+          // attribute and therefore will not have not a correct transaction
+          // name, so this is a work around.
           transaction.nameState.appendPath(segment.attributes['http.target'])
         }
       }


### PR DESCRIPTION
While working on [node-examples PR #324](https://github.com/newrelic/newrelic-node-examples/issues/324), I noticed that running the [example app](https://github.com/newrelic/newrelic-node-examples/pull/325) with an Apollo Server produced incomplete transaction names. An Express server returned the expected `/POST/graphql` but Apollo returned `/POST//`.

This is because `http.route` is not set (or is `''`) in Apollo http OTel spans, and thus an incomplete transaction name is created (see lib/otel/attr-mapping/http.js:82). However, `http.target` is defined and is set to `/graphql`, so I figured we could just use that instead. 