### PR TITLE
test: Pinned @aws-sdk/client-bedrock-runtime to <3.798.0

### DIFF
--- a/test/versioned/aws-sdk-v3/package.json
+++ b/test/versioned/aws-sdk-v3/package.json
@@ -202,7 +202,7 @@
         "node": ">=18.0"
       },
       "dependencies": {
-        "@aws-sdk/client-bedrock-runtime": ">=3.474.0"
+        "@aws-sdk/client-bedrock-runtime": ">=3.474.0 <3.798.0"
       },
       "files": [
         "bedrock-chat-completions.test.js",


### PR DESCRIPTION
The AWS SDK client-bedrock-runtime v3.798.0 replaces NodeHttpHandler with NodeHttp2Handler. This fails version testing, so this pins the version to a compatible range while we work on support. 