### PR TITLE
refactor: Added check to only set a FakeSpan if `transaction.agent.otelSpanKey` exists

### DIFF
--- a/lib/context-manager/context.js
+++ b/lib/context-manager/context.js
@@ -40,6 +40,6 @@ module.exports = class Context {
    * @returns {Context} a newly constructed context
    */
   enterTransaction(transaction) {
-    return new this.constructor(transaction, transaction.trace.root)
+    return new this.constructor(transaction, transaction?.trace?.root)
   }
 }

--- a/lib/otel/context.js
+++ b/lib/otel/context.js
@@ -24,7 +24,9 @@ module.exports = class OtelContext extends Context {
    * @returns {OtelContext} a newly constructed context
    */
   enterSegment({ segment, transaction = this._transaction }) {
-    this._otelCtx.set(transaction.agent.otelSpanKey, new FakeSpan(segment, transaction))
+    if (transaction?.agent?.otelSpanKey) {
+      this._otelCtx.set(transaction.agent.otelSpanKey, new FakeSpan(segment, transaction))
+    }
     return new this.constructor(transaction, segment, this._otelCtx)
   }
 
@@ -36,8 +38,10 @@ module.exports = class OtelContext extends Context {
    * @returns {OtelContext} a newly constructed context
    */
   enterTransaction(transaction) {
-    this._otelCtx.set(transaction.agent.otelSpanKey, new FakeSpan(transaction.trace.root, transaction))
-    return new this.constructor(transaction, transaction.trace.root, this._otelCtx)
+    if (transaction?.agent?.otelSpanKey) {
+      this._otelCtx.set(transaction.agent.otelSpanKey, new FakeSpan(transaction.trace.root, transaction))
+    }
+    return new this.constructor(transaction, transaction?.trace?.root, this._otelCtx)
   }
 
   /**

--- a/test/unit/lib/otel/context.test.js
+++ b/test/unit/lib/otel/context.test.js
@@ -85,6 +85,14 @@ test('should add transaction and trace root to otel ctx', (t) => {
   })
 })
 
+test('should not add transaction and trace root to otel ctx when undefined', (t) => {
+  const { agent } = t.nr
+  const ctx = otel.context.active()
+  const newContext = ctx.enterTransaction()
+  const fakeSpan = newContext.getValue(agent.otelSpanKey)
+  assert.equal(fakeSpan, undefined)
+})
+
 test('should add segment to otel ctx', (t) => {
   const { agent } = t.nr
   const ctx = otel.context.active()
@@ -96,4 +104,26 @@ test('should add segment to otel ctx', (t) => {
     segmentId: segment.id,
     traceId: newContext.transaction.traceId
   })
+})
+
+test('should add segment to otel when both segment and transaction are passed in', (t) => {
+  const { agent } = t.nr
+  const ctx = otel.context.active()
+  const transaction = { agent, traceId: 'traceId' }
+  const segment = { id: 'segmentId' }
+  const newContext = ctx.enterSegment({ segment, transaction })
+  const fakeSpan = newContext.getValue(agent.otelSpanKey)
+  assert.deepEqual(fakeSpan, {
+    segmentId: segment.id,
+    traceId: newContext.transaction.traceId
+  })
+})
+
+test('should not set fake span if transaction.agent.otelSpanKey is null', (t) => {
+  const { agent } = t.nr
+  const ctx = otel.context.active()
+  const segment = { id: 'segmentId' }
+  const newContext = ctx.enterSegment({ segment })
+  const fakeSpan = newContext.getValue(agent.otelSpanKey)
+  assert.equal(fakeSpan, undefined)
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
This is defensive code to prevent obscuring errors.  We have found that if you have an uncaught exception, it tries to enter the segment with a null value.  If the otel bridge is enabled this crashes becaue of some assumptions in the context that transaction always exists when entering a segment.
