### PR TITLE
chore: Reduced redis range to unblock CI

### DIFF
--- a/test/versioned/redis/package.json
+++ b/test/versioned/redis/package.json
@@ -20,7 +20,7 @@
         "node": ">=18"
       },
       "dependencies": {
-        "redis": ">=4.0.0"
+        "redis": ">=4.0.0 < 5.0.0"
       },
       "files": [
         "redis-v4.test.js",


### PR DESCRIPTION
https://github.com/redis/node-redis/releases/tag/redis%405.0.0 was released yesterday and is not compatible in some way with our tests. Omitting it for now to unblock CI while we work on a proper fix.