### PR TITLE
chore: Tweaked redis pin

### DIFF
--- a/test/versioned/redis/package.json
+++ b/test/versioned/redis/package.json
@@ -23,8 +23,18 @@
         "redis": ">=4.0.0 < 5.0.0"
       },
       "files": [
+        "redis-v4-legacy-mode.test.js"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=18"
+      },
+      "dependencies": {
+        "redis": ">=4.0.0"
+      },
+      "files": [
         "redis-v4.test.js",
-        "redis-v4-legacy-mode.test.js",
         "tls.test.js"
       ]
     }


### PR DESCRIPTION
Allows `redis@5` to be tested against the suites that should work until we get an answer on https://github.com/redis/node-redis/issues/2934.