### PR TITLE
chore: Added support for running jobs on label

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -3,6 +3,8 @@ name: Node Agent CI
 on:
   push:
   pull_request:
+    types:
+      - labeled
   workflow_dispatch:
 
 env:
@@ -44,6 +46,7 @@ jobs:
     needs:
       - should_run
     if: github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'force-lint' ||
       (needs.should_run.outputs.javascript_changed == 'true' ||
       needs.should_run.outputs.deps_changed == 'true')
     runs-on: ubuntu-latest
@@ -53,15 +56,15 @@ jobs:
         node-version: [lts/*]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install Dependencies
-      run: npm install
-    - name: Run Linting
-      run: npm run lint
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Dependencies
+        run: npm install
+      - name: Run Linting
+        run: npm run lint
 
   ci:
     needs:
@@ -77,20 +80,21 @@ jobs:
         node-version: [lts/*]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install Dependencies
-      run: npm install
-    - name: Run CI Script Unit Tests
-      run: npm run unit:scripts
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Dependencies
+        run: npm install
+      - name: Run CI Script Unit Tests
+        run: npm run unit:scripts
 
   unit:
     needs:
       - should_run
     if: github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'force-unit' ||
       (needs.should_run.outputs.javascript_changed == 'true' ||
       needs.should_run.outputs.deps_changed == 'true')
     runs-on: ubuntu-latest
@@ -101,25 +105,26 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install Dependencies
-      run: npm install
-    - name: Run Unit Tests
-      run: npm run unit
-    - name: Archive Unit Test Coverage
-      uses: actions/upload-artifact@v4
-      with:
-        name: unit-tests-${{ matrix.node-version }}
-        path: ./coverage/unit/lcov.info
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Dependencies
+        run: npm install
+      - name: Run Unit Tests
+        run: npm run unit
+      - name: Archive Unit Test Coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-tests-${{ matrix.node-version }}
+          path: ./coverage/unit/lcov.info
 
   integration:
     needs:
       - should_run
     if: github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'force-integration' ||
       (needs.should_run.outputs.javascript_changed == 'true' ||
       needs.should_run.outputs.deps_changed == 'true')
     runs-on: ubuntu-latest
@@ -133,32 +138,33 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install Dependencies
-      run: npm install
-    - name: Run Integration Tests
-      run: npm run integration
-    - name: Run ESM Integration Tests
-      run: npm run integration:esm
-    - name: Archive Integration Test Coverage
-      uses: actions/upload-artifact@v4
-      with:
-        name: integration-tests-cjs-${{ matrix.node-version }}
-        path: ./coverage/integration/lcov.info
-    - name: Archive Integration (ESM) Test Coverage
-      uses: actions/upload-artifact@v4
-      with:
-        name: integration-tests-esm-${{ matrix.node-version }}
-        path: ./coverage/integration-esm/lcov.info
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Dependencies
+        run: npm install
+      - name: Run Integration Tests
+        run: npm run integration
+      - name: Run ESM Integration Tests
+        run: npm run integration:esm
+      - name: Archive Integration Test Coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-tests-cjs-${{ matrix.node-version }}
+          path: ./coverage/integration/lcov.info
+      - name: Archive Integration (ESM) Test Coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-tests-esm-${{ matrix.node-version }}
+          path: ./coverage/integration-esm/lcov.info
 
   versioned-internal:
     needs:
       - should_run
     if: github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'force-versioned' ||
       (needs.should_run.outputs.javascript_changed == 'true' ||
       needs.should_run.outputs.deps_changed == 'true')
     runs-on: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER || 'ubuntu-latest' }}
@@ -169,47 +175,48 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install Dependencies
-      run: npm install
-    - name: Run Docker Services
-      run: npm run services
-    - name: Run Versioned Tests
-      run: TEST_CHILD_TIMEOUT=600000 npm run versioned:internal
-      env:
-        VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}
-        # Run more jobs when using larger runner, otherwise 2 per CPU seems to be the sweet spot in GHA default runners(July 2022)
-        JOBS: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER && 16 ||  4 }}
-        C8_REPORTER: lcovonly
-    - name: Archive Versioned Test Coverage
-      uses: actions/upload-artifact@v4
-      with:
-        name: versioned-tests-${{ matrix.node-version }}
-        path: ./coverage/versioned/lcov.info
-    - name: Collect docker logs on failure
-      if: failure()
-      uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e
-      with:
-        dest: ./logs-${{ matrix.node-version }}
-    - name: Tar logs
-      if: failure()
-      run: tar cvzf ./logs-${{ matrix.node-version }}.tgz ./logs-${{ matrix.node-version }}
-    - name: Upload logs to GitHub
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: logs-${{ matrix.node-version }}.tgz
-        path: ./logs-${{ matrix.node-version }}.tgz
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Dependencies
+        run: npm install
+      - name: Run Docker Services
+        run: npm run services
+      - name: Run Versioned Tests
+        run: TEST_CHILD_TIMEOUT=600000 npm run versioned:internal
+        env:
+          VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}
+          # Run more jobs when using larger runner, otherwise 2 per CPU seems to be the sweet spot in GHA default runners(July 2022)
+          JOBS: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER && 16 ||  4 }}
+          C8_REPORTER: lcovonly
+      - name: Archive Versioned Test Coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: versioned-tests-${{ matrix.node-version }}
+          path: ./coverage/versioned/lcov.info
+      - name: Collect docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e
+        with:
+          dest: ./logs-${{ matrix.node-version }}
+      - name: Tar logs
+        if: failure()
+        run: tar cvzf ./logs-${{ matrix.node-version }}.tgz ./logs-${{ matrix.node-version }}
+      - name: Upload logs to GitHub
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-${{ matrix.node-version }}.tgz
+          path: ./logs-${{ matrix.node-version }}.tgz
 
   # There is no coverage for external as that's tracked in their respective repos
   versioned-external:
     needs:
       - should_run
     if: github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'force-versioned' ||
       (needs.should_run.outputs.javascript_changed == 'true' ||
       needs.should_run.outputs.deps_changed == 'true')
     runs-on: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER || 'ubuntu-latest' }}
@@ -220,19 +227,19 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install Dependencies
-      run: npm install
-    - name: Run Versioned Tests
-      run: TEST_CHILD_TIMEOUT=600000 npm run versioned:external
-      env:
-        VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}
-        # Run more jobs when using larger runner, otherwise 2 per CPU seems to be the sweet spot in GHA default runners(July 2022)
-        JOBS: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER && 16 ||  4 }}
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Dependencies
+        run: npm install
+      - name: Run Versioned Tests
+        run: TEST_CHILD_TIMEOUT=600000 npm run versioned:external
+        env:
+          VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}
+          # Run more jobs when using larger runner, otherwise 2 per CPU seems to be the sweet spot in GHA default runners(July 2022)
+          JOBS: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER && 16 ||  4 }}
 
   codecov:
     needs: [unit, integration, versioned-internal]

--- a/.github/workflows/smoke-test-workflow.yml
+++ b/.github/workflows/smoke-test-workflow.yml
@@ -1,7 +1,10 @@
 name: Server Smoke Tests
 
 on:
-    # Run on pushes to any branch. Not triggered for forked repo PRs.
+  pull_request:
+    types:
+      - labeled
+  # Run on pushes to any branch. Not triggered for forked repo PRs.
   push:
   schedule:
     # Run once a day at 9AM PDT (16 UTC) on week days (1-5).
@@ -12,6 +15,10 @@ on:
 
 jobs:
   smoke:
+    if: github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      github.event.label.name == 'force-smoke'
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/smoke-test-workflow.yml
+++ b/.github/workflows/smoke-test-workflow.yml
@@ -1,7 +1,7 @@
 name: Server Smoke Tests
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - labeled
   # Run on pushes to any branch. Not triggered for forked repo PRs.
@@ -19,6 +19,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       github.event.label.name == 'force-smoke'
+    permissions: read-all
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/versioned-security-agent.yml
+++ b/.github/workflows/versioned-security-agent.yml
@@ -24,6 +24,8 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - labeled
 
 env:
   # Enable versioned runner quiet mode to make CI output easier to read:
@@ -56,6 +58,7 @@ jobs:
     needs: [should_run]
     if: github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule' ||
+      github.event.label.name == 'force-security' ||
       needs.should_run.outputs.sec_agent_did_change == 'true'
 
     runs-on: ${{ vars.NR_RUNNER || 'ubuntu-latest' }}


### PR DESCRIPTION
This PR resolves #3083 by adding configuration to our GHA workflows to force running of desired jobs by adding a label to a PR.

Supported labels are:

- `force-integration` -- runs integration tests
- `force-lint` -- runs linter
- `force-unit` -- runs unit tests
- `force-smoke` -- runs smoke test
- `force-security` -- runs security agent tests
- `force-versioned` -- runs versioned tests