### PR TITLE
chore: Updated security agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.13.2",
     "@grpc/proto-loader": "^0.7.5",
-    "@newrelic/security-agent": "2.4.0",
+    "@newrelic/security-agent": "^2.4.2",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Tue May 13 2025 08:48:02 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Wed May 14 2025 07:35:45 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,


### PR DESCRIPTION
This unpins the security agent and bumps it to the version that is not broken.