### PR TITLE
chore: Added event source type to  txn name for Lambda APM Mode

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1231,6 +1231,9 @@ defaultConfig.definition = () => ({
       default: true
     }
   },
+  /**
+   * Specifies whether AWS Lambda telemetry is going to be compatible with the APM UI.
+   */
   lambda: {
     apm_mode: {
       default: false,

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1231,13 +1231,16 @@ defaultConfig.definition = () => ({
       default: true
     }
   },
+
   /**
-   * Specifies whether AWS Lambda telemetry is going to be compatible with the APM UI.
+   * When `true`, the AWS Lambda instrumentation will add the necessary
+   * data to support the new (as of 2025) unified APM UI.
    */
   apm_lambda_mode: {
     default: false,
     formatter: boolean
   },
+
   /**
    * Specifies whether the agent will be used to monitor serverless functions.
    * For example: AWS Lambda

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1234,11 +1234,9 @@ defaultConfig.definition = () => ({
   /**
    * Specifies whether AWS Lambda telemetry is going to be compatible with the APM UI.
    */
-  lambda: {
-    apm_mode: {
-      default: false,
-      formatter: boolean
-    }
+  apm_lambda_mode: {
+    default: false,
+    formatter: boolean
   },
   /**
    * Specifies whether the agent will be used to monitor serverless functions.

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1231,6 +1231,12 @@ defaultConfig.definition = () => ({
       default: true
     }
   },
+  lambda: {
+    apm_mode: {
+      default: false,
+      formatter: boolean
+    }
+  },
   /**
    * Specifies whether the agent will be used to monitor serverless functions.
    * For example: AWS Lambda

--- a/lib/serverless/aws-lambda.js
+++ b/lib/serverless/aws-lambda.js
@@ -125,7 +125,7 @@ class AwsLambda {
     const awsAttributes = this._getAwsAgentAttributes(event, context)
     let trigger = ''
     // Lambda environment variables are passed as strings, so a simple truthiness check could be misleading
-    if (this.agent.config.lambda?.apm_mode === true &&
+    if (this.agent.config.apm_lambda_mode === true &&
         awsAttributes &&
         typeof awsAttributes['aws.lambda.eventSource.eventType'] === 'string') {
       // In Lambda APM mode, we prepend the event type (if present) in upper case to

--- a/lib/serverless/aws-lambda.js
+++ b/lib/serverless/aws-lambda.js
@@ -466,7 +466,7 @@ function lowercaseObjectKeys(original) {
   }, {})
 }
 
-function endTransaction(transaction, enderIndex, eventType) {
+function endTransaction(transaction, enderIndex) {
   if (transactionEnders.length === 0 || transactionEnders[enderIndex] === cleanClosure) {
     // In the case where we have already been called, we return early. There may be a
     // case where this is called more than once, given the lambda is left in a dirty

--- a/lib/serverless/aws-lambda.js
+++ b/lib/serverless/aws-lambda.js
@@ -125,7 +125,7 @@ class AwsLambda {
     const awsAttributes = this._getAwsAgentAttributes(event, context)
     let trigger = ''
     // Lambda environment variables are passed as strings, so a simple truthiness check could be misleading
-    if (process.env.NEW_RELIC_APM_LAMBDA_MODE === 'true' &&
+    if (this.agent.config.lambda?.apm_mode === true &&
         awsAttributes &&
         typeof awsAttributes['aws.lambda.eventSource.eventType'] === 'string') {
       // In Lambda APM mode, we prepend the event type (if present) in upper case to

--- a/lib/serverless/aws-lambda.js
+++ b/lib/serverless/aws-lambda.js
@@ -121,7 +121,21 @@ class AwsLambda {
 
   createSegment({ event, context, transaction, recorder }) {
     const shim = this.shim
-    const functionName = context.functionName
+
+    const awsAttributes = this._getAwsAgentAttributes(event, context)
+    let trigger = ''
+    // Lambda environment variables are passed as strings, so a simple truthiness check could be misleading
+    if (process.env.NEW_RELIC_APM_LAMBDA_MODE === 'true' &&
+        awsAttributes &&
+        awsAttributes['aws.lambda.eventSource.eventType']) {
+      // In Lambda APM mode, we prepend the event type (if present) in upper case to
+      // the function name segment of the transaction name, so the event type can be
+      // displayed properly in the unified APM UI. b
+
+      trigger = awsAttributes['aws.lambda.eventSource.eventType'].toUpperCase() + ' '
+    }
+
+    const functionName = trigger + context.functionName
     const group = NAMES.FUNCTION.PREFIX
     const transactionName = group + functionName
 
@@ -133,7 +147,6 @@ class AwsLambda {
     transactionEnders.push(txnEnder)
     const segment = shim.createSegment(functionName, recorder, activeSegment)
     transaction.baseSegment = segment
-    const awsAttributes = this._getAwsAgentAttributes(event, context)
     transaction.trace.attributes.addAttributes(ATTR_DEST.TRANS_COMMON, awsAttributes)
 
     shim.agent.setLambdaArn(context.invokedFunctionArn)
@@ -453,7 +466,7 @@ function lowercaseObjectKeys(original) {
   }, {})
 }
 
-function endTransaction(transaction, enderIndex) {
+function endTransaction(transaction, enderIndex, eventType) {
   if (transactionEnders.length === 0 || transactionEnders[enderIndex] === cleanClosure) {
     // In the case where we have already been called, we return early. There may be a
     // case where this is called more than once, given the lambda is left in a dirty

--- a/lib/serverless/aws-lambda.js
+++ b/lib/serverless/aws-lambda.js
@@ -130,7 +130,7 @@ class AwsLambda {
         awsAttributes['aws.lambda.eventSource.eventType']) {
       // In Lambda APM mode, we prepend the event type (if present) in upper case to
       // the function name segment of the transaction name, so the event type can be
-      // displayed properly in the unified APM UI. b
+      // displayed properly in the unified APM UI.
 
       trigger = awsAttributes['aws.lambda.eventSource.eventType'].toUpperCase() + ' '
     }

--- a/lib/serverless/aws-lambda.js
+++ b/lib/serverless/aws-lambda.js
@@ -127,7 +127,7 @@ class AwsLambda {
     // Lambda environment variables are passed as strings, so a simple truthiness check could be misleading
     if (process.env.NEW_RELIC_APM_LAMBDA_MODE === 'true' &&
         awsAttributes &&
-        awsAttributes['aws.lambda.eventSource.eventType']) {
+        typeof awsAttributes['aws.lambda.eventSource.eventType'] === 'string') {
       // In Lambda APM mode, we prepend the event type (if present) in upper case to
       // the function name segment of the transaction name, so the event type can be
       // displayed properly in the unified APM UI.

--- a/test/unit/serverless/aws-lambda-stream-response.test.js
+++ b/test/unit/serverless/aws-lambda-stream-response.test.js
@@ -43,7 +43,7 @@ const defaultConfig = {
   serverless_mode: { enabled: true }
 }
 
-const lambdaApmConfig = { lambda: { apm_mode: true }, ...defaultConfig }
+// const lambdaApmConfig = { apm: { lambda_mode: true }, ...defaultConfig }
 
 async function beforeEach(ctx, agentConfig = defaultConfig) {
   ctx.nr = {}
@@ -404,11 +404,11 @@ test('should record standard background metrics', async (t) => {
 
 test('should name transaction correctly in Lambda APM Mode', async (t) => {
   helper.unloadAgent(t.nr.agent)
-  await beforeEach(t, lambdaApmConfig)
+  process.env.NEW_RELIC_APM_LAMBDA_MODE = 'true'
+  await beforeEach(t)
   const plan = tspl(t, { plan: 2 })
   const { agent, awsLambda, responseStream, context, responseDone } = t.nr
   const event = lambdaSampleEvents.cloudwatchScheduled
-  process.env.NEW_RELIC_APM_LAMBDA_MODE = 'true'
 
   agent.on('transactionFinished', (tx) => {
     const agentAttributes = tx.trace.attributes.get(ATTR_DEST.TRANS_EVENT)

--- a/test/unit/serverless/aws-lambda-stream-response.test.js
+++ b/test/unit/serverless/aws-lambda-stream-response.test.js
@@ -279,7 +279,8 @@ test('should name transaction correctly in Lambda APM Mode', async (t) => {
 
   agent.on('transactionFinished', (tx) => {
     const agentAttributes = tx.trace.attributes.get(ATTR_DEST.TRANS_EVENT)
-    const expectedApmTxnName = `OtherTransaction/Function/${agentAttributes[EVENTSOURCE_TYPE].toUpperCase()} ${context.functionName}`
+    const trigger = agentAttributes[EVENTSOURCE_TYPE].toUpperCase()
+    const expectedApmTxnName = `OtherTransaction/Function/${trigger} ${context.functionName}`
     plan.equal(tx.type, 'bg')
     plan.equal(tx.getFullName(), expectedApmTxnName)
 

--- a/test/unit/serverless/aws-lambda-stream-response.test.js
+++ b/test/unit/serverless/aws-lambda-stream-response.test.js
@@ -43,8 +43,6 @@ const defaultConfig = {
   serverless_mode: { enabled: true }
 }
 
-// const lambdaApmConfig = { apm: { lambda_mode: true }, ...defaultConfig }
-
 async function beforeEach(ctx, agentConfig = defaultConfig) {
   ctx.nr = {}
   ctx.nr.agent = helper.loadMockedAgent(agentConfig)

--- a/test/unit/serverless/aws-lambda.test.js
+++ b/test/unit/serverless/aws-lambda.test.js
@@ -560,7 +560,8 @@ test('AwsLambda.patchLambdaHandler', async (t) => {
 
       function confirmAgentAttributeAndReset(transaction) {
         const agentAttributes = transaction.trace.attributes.get(ATTR_DEST.TRANS_EVENT)
-        const expectedApmTxnName = `WebTransaction/Function/${agentAttributes[EVENTSOURCE_TYPE].toUpperCase()} ${functionName}`
+        const trigger = agentAttributes[EVENTSOURCE_TYPE].toUpperCase()
+        const expectedApmTxnName = `WebTransaction/Function/${trigger} ${functionName}`
 
         assert.equal(agentAttributes[EVENTSOURCE_TYPE], 'apiGateway')
         assert.ok(transaction)

--- a/test/unit/serverless/aws-lambda.test.js
+++ b/test/unit/serverless/aws-lambda.test.js
@@ -1570,6 +1570,7 @@ test('AwsLambda.patchLambdaHandler', async (t) => {
 test('APM Mode transaction name should include event type', async (t) => {
   process.env.NEW_RELIC_APM_LAMBDA_MODE = 'true'
   await beforeTests(t)
+  t.after(async () => { await afterTests(t) })
   const { agent, awsLambda, stubContext, stubCallback } = t.nr
   let transaction
 
@@ -1589,6 +1590,4 @@ test('APM Mode transaction name should include event type', async (t) => {
   assert.ok(transaction)
   assert.equal(transaction.type, 'web')
   assert.equal(transaction.getFullName(), expectedApmTxnName)
-
-  await afterTests(t)
 })

--- a/test/unit/serverless/aws-lambda.test.js
+++ b/test/unit/serverless/aws-lambda.test.js
@@ -49,7 +49,7 @@ const defaultAgentConfig = {
   serverless_mode: { enabled: true }
 }
 
-const apmLambdaConfig = { lambda: { apm_mode: true }, ...defaultAgentConfig }
+// const apmLambdaConfig = { apm: { lambda_mode: true }, ...defaultAgentConfig }
 
 function beforeTests(ctx, agentConfig = defaultAgentConfig) {
   ctx.nr = {}
@@ -1568,7 +1568,8 @@ test('AwsLambda.patchLambdaHandler', async (t) => {
 })
 
 test('APM Mode transaction name should include event type', async (t) => {
-  await beforeTests(t, apmLambdaConfig)
+  process.env.NEW_RELIC_APM_LAMBDA_MODE = 'true'
+  await beforeTests(t)
   const { agent, awsLambda, stubContext, stubCallback } = t.nr
   let transaction
 

--- a/test/unit/serverless/aws-lambda.test.js
+++ b/test/unit/serverless/aws-lambda.test.js
@@ -1568,7 +1568,10 @@ test('AwsLambda.patchLambdaHandler', async (t) => {
 test('APM Mode transaction name should include event type', async (t) => {
   process.env.NEW_RELIC_APM_LAMBDA_MODE = 'true'
   await beforeTests(t)
-  t.after(async () => { await afterTests(t) })
+  t.after(async () => {
+    await afterTests(t)
+    delete process.env.NEW_RELIC_APM_LAMBDA_MODE
+  })
   const { agent, awsLambda, stubContext, stubCallback } = t.nr
   let transaction
 

--- a/test/unit/serverless/aws-lambda.test.js
+++ b/test/unit/serverless/aws-lambda.test.js
@@ -49,8 +49,6 @@ const defaultAgentConfig = {
   serverless_mode: { enabled: true }
 }
 
-// const apmLambdaConfig = { apm: { lambda_mode: true }, ...defaultAgentConfig }
-
 function beforeTests(ctx, agentConfig = defaultAgentConfig) {
   ctx.nr = {}
   ctx.nr.agent = helper.loadMockedAgent(agentConfig)


### PR DESCRIPTION
Lambda APM Mode will support Lambda telemetry in the same UI as the one used by APM. To support this unified view, agent teams will need to inject an all-uppercase event source type in the function name segment of the transaction name. 

If `NEW_RELIC_APM_LAMBDA_MODE` is not enabled, or if there is no event source, the transaction name is unchanged. 

## How to Test

One test has been added to each of `aws-lambda.test.js` and `aws-lambda-stream-response.test.js`. In the latter case, the test uses a `cloudwatchScheduled` test event, as response streaming Lambda functions don't support API Gateway. Presumably any response streaming Lambda function using `NEW_RELIC_APM_LAMBDA_MODE` will be triggered by some background event, if any.

## Related Issues

Closes #3104 
Closes NR-416510