### PR TITLE
fix: Google Cloud Run hostname issue

### DIFF
--- a/lib/collector/facts.js
+++ b/lib/collector/facts.js
@@ -32,8 +32,8 @@ async function facts(agent, callback, { logger = defaultLogger } = {}) {
   systemInfo = systemInfo || Object.create(null)
   environment = environment || []
 
-  console.debug(systemInfo.vendors.gcp)
-  const hostname = systemInfo.vendors.gcp.id //agent.config.getHostnameSafe()
+  console.debug('systemInfo.vendors.gcp: ', systemInfo.vendors.gcp)
+  const hostname = systemInfo.vendors?.gcp?.id || agent.config.getHostnameSafe()
   const results = {
     utilization: {
       metadata_version: 5,

--- a/lib/collector/facts.js
+++ b/lib/collector/facts.js
@@ -23,9 +23,8 @@ async function facts(agent, callback, { logger = defaultLogger } = {}) {
 
   const environmentPromise = agent.environment.getJSON()
   let [systemInfo, environment] = await Promise.all([systemInfoPromise, environmentPromise])
-  console.log('environment: ', environment)
-  console.log('systemInfo: ', systemInfo)
   logger.trace('Facts gathering finished in %dms', Date.now() - startTime)
+  console.log('systemInfo: ', systemInfo)
 
   if (environment.failed) {
     logger.debug(environment.err, 'Failed to load system facts!')
@@ -60,6 +59,7 @@ async function facts(agent, callback, { logger = defaultLogger } = {}) {
     }, {})
   }
 
+  console.log('facts host: ', results.host)
   logger.debug('New Relic metadata %o', results.metadata)
 
   /**

--- a/lib/collector/facts.js
+++ b/lib/collector/facts.js
@@ -5,7 +5,6 @@
 
 'use strict'
 
-const { env } = require('process')
 const fetchSystemInfo = require('../system-info')
 const defaultLogger = require('../logger').child({ component: 'facts' })
 const os = require('os')
@@ -32,7 +31,10 @@ async function facts(agent, callback, { logger = defaultLogger } = {}) {
   systemInfo = systemInfo || Object.create(null)
   environment = environment || []
 
-  const hostname = systemInfo.vendors?.gcp?.id || agent.config.getHostnameSafe()
+  let hostname = agent.config.getHostnameSafe()
+  if (agent.config.gcp_cloud_run.use_instance_as_host && process.env.K_SERVICE) {
+    hostname = systemInfo.vendors?.gcp?.id
+  }
   const results = {
     utilization: {
       metadata_version: 5,

--- a/lib/collector/facts.js
+++ b/lib/collector/facts.js
@@ -32,7 +32,6 @@ async function facts(agent, callback, { logger = defaultLogger } = {}) {
   systemInfo = systemInfo || Object.create(null)
   environment = environment || []
 
-  console.debug('systemInfo.vendors.gcp: ', systemInfo.vendors.gcp)
   const hostname = systemInfo.vendors?.gcp?.id || agent.config.getHostnameSafe()
   const results = {
     utilization: {
@@ -59,7 +58,6 @@ async function facts(agent, callback, { logger = defaultLogger } = {}) {
     }, {})
   }
 
-  console.log('facts host: ', results.host) // is localhost here
   logger.debug('New Relic metadata %o', results.metadata)
 
   /**

--- a/lib/collector/facts.js
+++ b/lib/collector/facts.js
@@ -5,6 +5,7 @@
 
 'use strict'
 
+const { env } = require('process')
 const fetchSystemInfo = require('../system-info')
 const defaultLogger = require('../logger').child({ component: 'facts' })
 const os = require('os')
@@ -22,6 +23,8 @@ async function facts(agent, callback, { logger = defaultLogger } = {}) {
 
   const environmentPromise = agent.environment.getJSON()
   let [systemInfo, environment] = await Promise.all([systemInfoPromise, environmentPromise])
+  console.log('environment: ', environment)
+  console.log('systemInfo: ', systemInfo)
   logger.trace('Facts gathering finished in %dms', Date.now() - startTime)
 
   if (environment.failed) {

--- a/lib/collector/facts.js
+++ b/lib/collector/facts.js
@@ -32,7 +32,8 @@ async function facts(agent, callback, { logger = defaultLogger } = {}) {
   systemInfo = systemInfo || Object.create(null)
   environment = environment || []
 
-  const hostname = agent.config.getHostnameSafe()
+  console.debug(systemInfo.vendors.gcp)
+  const hostname = systemInfo.vendors.gcp.id //agent.config.getHostnameSafe()
   const results = {
     utilization: {
       metadata_version: 5,

--- a/lib/collector/facts.js
+++ b/lib/collector/facts.js
@@ -24,7 +24,6 @@ async function facts(agent, callback, { logger = defaultLogger } = {}) {
   const environmentPromise = agent.environment.getJSON()
   let [systemInfo, environment] = await Promise.all([systemInfoPromise, environmentPromise])
   logger.trace('Facts gathering finished in %dms', Date.now() - startTime)
-  console.log('systemInfo: ', systemInfo)
 
   if (environment.failed) {
     logger.debug(environment.err, 'Failed to load system facts!')
@@ -59,7 +58,7 @@ async function facts(agent, callback, { logger = defaultLogger } = {}) {
     }, {})
   }
 
-  console.log('facts host: ', results.host)
+  console.log('facts host: ', results.host) // is localhost here
   logger.debug('New Relic metadata %o', results.metadata)
 
   /**

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1596,6 +1596,17 @@ defaultConfig.definition = () => ({
   },
 
   /**
+   * When enabled, it will use GCP metadata id 
+   * to set the hostname of the running application
+   */
+  gcp_cloud_run:{
+    use_instance_as_host: {
+      default: true,
+      formatter: boolean
+    }
+  },
+
+  /**
    * When enabled, it will allow loading of the agent
    * in worker threads.
    *

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -42,6 +42,7 @@ function fetchGCPInfo(agent, callback) {
         return callback(err)
       }
       try {
+        console.log('data before parse: ', data) 
         data = JSONbig.parse(data)
         if (typeof data.id !== 'string') {
           data.id = data.id.toString()

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -27,7 +27,6 @@ function fetchGCPInfo(agent, callback) {
     return setImmediate(callback, null, resultDict)
   }
 
-  // TODO: Explore /computeMetadata/v1/project/project-id ?
   common.request(
     {
       host: 'metadata.google.internal',
@@ -53,16 +52,19 @@ function fetchGCPInfo(agent, callback) {
       }
 
       console.log('getMetadata data: ', data) 
-      const results = common.getKeys(data, ['id', 'machineType', 'name', 'zone'])
-      console.log('getKeys result: ', results)
+      const results = common.getKeys(data, ['id', 'zone'])
+      console.log('id: ', data.id)
+      console.log('machineType: ', data.machineType)
+      console.log('name: ', data.name)
+      console.log('zone: ', data.zone)
       if (results == null) {
         logger.debug({ utilization: 'gcp' }, 'GCP metadata was invalid.')
         agent.metrics.getOrCreateMetric(NAMES.UTILIZATION.GCP_ERROR).incrementCallCount()
       } else {
         // normalize
-        results.machineType = results.machineType.substring(
-          results.machineType.lastIndexOf('/') + 1
-        )
+        // results.machineType = results.machineType.substring(
+        //   results.machineType.lastIndexOf('/') + 1
+        // )
         results.zone = results.zone.substring(results.zone.lastIndexOf('/') + 1)
 
         resultDict = results

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -42,6 +42,7 @@ function fetchGCPInfo(agent, callback) {
         return callback(err)
       }
       try {
+        console.debug('metadata before parse: ', data)  
         data = JSONbig.parse(data)
         if (typeof data.id !== 'string') {
           data.id = data.id.toString()

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -27,6 +27,7 @@ function fetchGCPInfo(agent, callback) {
     return setImmediate(callback, null, resultDict)
   }
 
+  // TODO: Explore /computeMetadata/v1/project/project-id ?
   common.request(
     {
       host: 'metadata.google.internal',

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -53,9 +53,13 @@ async function fetchGCPInfo(agent, callback) {
   }
 
   const isAvail = gcpMetadata.isAvailable()
+  let hostname
+  let instanceId
   if (await isAvail) {
-    console.debug('hostname: ', _getHostname(isAvail))
-    console.debug('instanceId: ', _getInstanceId(isAvail))
+    hostname = await _getHostname(isAvail)
+    instanceId = await _getInstanceId(isAvail)
+    console.debug('hostname: ', hostname)
+    console.debug('instanceId: ', instanceId)
   }
 
   common.request(
@@ -89,6 +93,7 @@ async function fetchGCPInfo(agent, callback) {
         logger.debug({ utilization: 'gcp' }, 'GCP metadata was invalid.')
         agent.metrics.getOrCreateMetric(NAMES.UTILIZATION.GCP_ERROR).incrementCallCount()
       } else {
+        console.debug('ids matched: ', results.id===instanceId)
         if (data.machineType) {
           results.machineType = data.machineType
           // normalize

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -1,12 +1,9 @@
-/*
- * Copyright 2020 New Relic Corporation. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 'use strict'
 
-const gcpMetadata = require('gcp-metadata')
 const logger = require('../logger.js').child({ component: 'gcp-info' })
+const common = require('./common')
+const NAMES = require('../metrics/names.js')
+const JSONbig = require('json-bigint')({ useNativeBigInt: true })
 let resultDict = null
 
 module.exports = fetchGCPInfo
@@ -14,55 +11,54 @@ module.exports.clearCache = function clearGCPCache() {
   resultDict = null
 }
 
-async function fetchGCPInfo(agent, callback) {
+function fetchGCPInfo(agent, callback) {
   if (!agent.config.utilization || !agent.config.utilization.detect_gcp) {
     logger.trace({ utilization: 'gcp' }, 'Skipping GCP due to being disabled via config.')
     return setImmediate(callback, null)
   }
-
   if (resultDict) {
     logger.trace({ utilization: 'gcp' }, 'Returning previously found results.')
     return setImmediate(callback, null, resultDict)
   }
 
-  const isAvail = gcpMetadata.isAvailable()
-  if (!(await isAvail)) {
-    logger.debug({ utilization: 'gcp' }, 'GCP metadata is not available.')
-    return callback(err)
-  }
+  common.request(
+    {
+      host: 'metadata.google.internal',
+      path: '/computeMetadata/v1/instance/?recursive=true',
+      headers: {
+        'Metadata-Flavor': 'Google'
+      }
+    },
+    agent,
+    function getMetadata(err, data) {
+      if (err) {
+        logger.trace({ utilization: 'gcp', error: err }, 'Failed to communicate with metadata endpoint.')
+        return callback(err)
+      }
+      try {
+        data = JSONbig.parse(data)
+        if (typeof data.id !== 'string') {
+          data.id = data.id.toString()
+        }
+      } catch (e) {
+        logger.debug({ utilization: 'gcp', error: e }, 'Failed to parse GCP metadata.')
+        data = null
+      }
 
-  // Grab relevant metadata
-  const attributes = ['id', 'machineType', 'name', 'zone']
-  const values = await Promise.all(attributes.map(attr => getMetadataAttribute(isAvail, attr)))
-  const [id, machineType, name, zone] = values
+      // GCP cloud run metadata only has id and zone
+      // other GCP services have id, zone, machineType, name
+      const results = common.getKeys(data, ['id', 'zone'])
+      if (!results) {
+        logger.debug({ utilization: 'gcp' }, 'GCP metadata was invalid.')
+        agent.metrics.getOrCreateMetric(NAMES.UTILIZATION.GCP_ERROR).incrementCallCount()
+      } else {
+        results.machineType = data.machineType?.split('/').pop()
+        results.name = data.name
+        results.zone = results.zone.split('/').pop()
 
-  const results = {
-    id,
-    name,
-    machineType: machineType ? machineType.substring(machineType.lastIndexOf('/') + 1) : undefined,
-    zone: zone ? zone.substring(zone.lastIndexOf('/') + 1) : undefined
-  }
-
-  resultDict = results
-  callback(null, results)
-}
-
-/**
- * Get the metadata attribute from gcp-metadata
- * @param {*} isAvail gcpMetadata.isAvailable()
- * @param {*} attribute The attribute to get from the metadata e.g. id
- * @returns The value of the attribute or null if not available
- */
-async function getMetadataAttribute(isAvail, attribute) {
-  if (!(await isAvail)) {
-    logger.debug({ utilization: 'gcp' }, 'GCP metadata is not available.')
-    return undefined
-  }
-  try {
-    const value = await gcpMetadata.instance(attribute)
-    return value.toString()
-  } catch (e) {
-    logger.debug({ utilization: 'gcp', error: e }, `Failed to get GCP attribute '${attribute}'.`)
-    return undefined
-  }
+        resultDict = results
+      }
+      callback(null, results)
+    }
+  )
 }

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -51,6 +51,7 @@ function fetchGCPInfo(agent, callback) {
         data = null
       }
 
+      console.log('getMetadata data: ', data) 
       const results = common.getKeys(data, ['id', 'machineType', 'name', 'zone'])
       console.log('getKeys result: ', results)
       if (results == null) {

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -38,11 +38,12 @@ function fetchGCPInfo(agent, callback) {
     agent,
     function getMetadata(err, data) {
       if (err) {
+        console.debug('error with metadata endpoint')
         logger.trace({ utilization: 'gcp', error: err }, 'Failed to communicate with metadata endpoint.')
         return callback(err)
       }
       try {
-        console.log('data before parse: ', data)
+        console.debug('data before parse: ', data)
         data = JSONbig.parse(data)
         if (typeof data.id !== 'string') {
           data.id = data.id.toString()

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -30,7 +30,7 @@ function fetchGCPInfo(agent, callback) {
   common.request(
     {
       host: 'metadata.google.internal',
-      path: '/computeMetadata/v1/instance',
+      path: '/computeMetadata/v1/instance/?recursive=true',
       headers: {
         'Metadata-Flavor': 'Google'
       }
@@ -38,12 +38,10 @@ function fetchGCPInfo(agent, callback) {
     agent,
     function getMetadata(err, data) {
       if (err) {
-        console.debug('error with metadata endpoint')
         logger.trace({ utilization: 'gcp', error: err }, 'Failed to communicate with metadata endpoint.')
         return callback(err)
       }
       try {
-        console.debug('data before parse: ', data)
         data = JSONbig.parse(data)
         if (typeof data.id !== 'string') {
           data.id = data.id.toString()

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -17,6 +17,29 @@ module.exports.clearCache = function clearGCPCache() {
   resultDict = null
 }
 
+ /** Gets hostname from GCP instance metadata. */
+async function _getHostname(isAvail) {
+  if (!(await isAvail)) {
+    return undefined;
+  }
+  try {
+    return await gcpMetadata.instance('hostname');
+  } catch {
+    return '';
+  }
+}
+
+ /** Gets instance id from GCP instance metadata. */
+async function _getInstanceId(isAvail) {
+  if (!(await isAvail)) {
+    return undefined;
+  }
+  try {
+    return await gcpMetadata.instance('id');
+  } catch {
+    return '';
+  }
+}
 
 async function fetchGCPInfo(agent, callback) {
   if (!agent.config.utilization || !agent.config.utilization.detect_gcp) {
@@ -29,10 +52,10 @@ async function fetchGCPInfo(agent, callback) {
     return setImmediate(callback, null, resultDict)
   }
 
-  const isAvail = await gcpMetadata.isAvailable()
-  if (isAvail) {
-    console.debug('hostname: ', await gcpMetadata.instance('hostname'))
-    console.debug('instanceId: ', await gcpMetadata.instance('id'))
+  const isAvail = gcpMetadata.isAvailable()
+  if (await isAvail) {
+    console.debug('hostname: ', _getHostname(isAvail))
+    console.debug('instanceId: ', _getInstanceId(isAvail))
   }
 
   common.request(

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -42,7 +42,7 @@ function fetchGCPInfo(agent, callback) {
         return callback(err)
       }
       try {
-        console.debug('metadata before parse: ', data)  
+        console.debug('metadata before parse: ', data)
         data = JSONbig.parse(data)
         if (typeof data.id !== 'string') {
           data.id = data.id.toString()
@@ -52,6 +52,7 @@ function fetchGCPInfo(agent, callback) {
         data = null
       }
 
+      // Pull out the id, zone, zone, and machineType from the metadata
       const results = common.getKeys(data, ['id', 'zone'])
       if (results == null) {
         logger.debug({ utilization: 'gcp' }, 'GCP metadata was invalid.')
@@ -65,6 +66,13 @@ function fetchGCPInfo(agent, callback) {
           )
         }
         results.zone = results.zone.substring(results.zone.lastIndexOf('/') + 1)
+
+        // Add resource attributes for Cloud Run
+        if (process.env.K_SERVICE) {
+          results.faas_name = process.env.K_SERVICE
+          results.faas_version = process.env.K_REVISION
+          results.faas_instance = results.id
+        }
 
         resultDict = results
       }

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -17,7 +17,8 @@ module.exports.clearCache = function clearGCPCache() {
   resultDict = null
 }
 
-function fetchGCPInfo(agent, callback) {
+
+async function fetchGCPInfo(agent, callback) {
   if (!agent.config.utilization || !agent.config.utilization.detect_gcp) {
     logger.trace({ utilization: 'gcp' }, 'Skipping GCP due to being disabled via config.')
     return setImmediate(callback, null)
@@ -28,10 +29,10 @@ function fetchGCPInfo(agent, callback) {
     return setImmediate(callback, null, resultDict)
   }
 
-  const isAvail = gcpMetadata.isAvailable()
+  const isAvail = await gcpMetadata.isAvailable()
   if (isAvail) {
-    console.debug('hostname: ', gcpMetadata.instance('hostname'))
-    console.debug('instanceId: ', gcpMetadata.instance('id'))
+    console.debug('hostname: ', await gcpMetadata.instance('hostname'))
+    console.debug('instanceId: ', await gcpMetadata.instance('id'))
   }
 
   common.request(

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -5,6 +5,7 @@
 
 'use strict'
 
+const gcpMetadata = require('gcp-metadata')
 const logger = require('../logger.js').child({ component: 'gcp-info' })
 const common = require('./common')
 const NAMES = require('../metrics/names.js')
@@ -25,6 +26,12 @@ function fetchGCPInfo(agent, callback) {
   if (resultDict) {
     logger.trace({ utilization: 'gcp' }, 'Returning previously found results.')
     return setImmediate(callback, null, resultDict)
+  }
+
+  const isAvail = gcpMetadata.isAvailable()
+  if (isAvail) {
+    console.debug('hostname: ', gcpMetadata.instance('hostname'))
+    console.debug('instanceId: ', gcpMetadata.instance('id'))
   }
 
   common.request(
@@ -66,13 +73,6 @@ function fetchGCPInfo(agent, callback) {
           )
         }
         results.zone = results.zone.substring(results.zone.lastIndexOf('/') + 1)
-
-        // Add resource attributes for Cloud Run
-        if (process.env.K_SERVICE) {
-          results.faas_name = process.env.K_SERVICE
-          results.faas_version = process.env.K_REVISION
-          results.faas_instance = results.id
-        }
 
         resultDict = results
       }

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -7,38 +7,11 @@
 
 const gcpMetadata = require('gcp-metadata')
 const logger = require('../logger.js').child({ component: 'gcp-info' })
-const common = require('./common')
-const NAMES = require('../metrics/names.js')
-const JSONbig = require('json-bigint')({ useNativeBigInt: true })
 let resultDict = null
 
 module.exports = fetchGCPInfo
 module.exports.clearCache = function clearGCPCache() {
   resultDict = null
-}
-
- /** Gets hostname from GCP instance metadata. */
-async function _getHostname(isAvail) {
-  if (!(await isAvail)) {
-    return undefined;
-  }
-  try {
-    return await gcpMetadata.instance('hostname');
-  } catch {
-    return '';
-  }
-}
-
- /** Gets instance id from GCP instance metadata. */
-async function _getInstanceId(isAvail) {
-  if (!(await isAvail)) {
-    return undefined;
-  }
-  try {
-    return await gcpMetadata.instance('id');
-  } catch {
-    return '';
-  }
 }
 
 async function fetchGCPInfo(agent, callback) {
@@ -53,59 +26,43 @@ async function fetchGCPInfo(agent, callback) {
   }
 
   const isAvail = gcpMetadata.isAvailable()
-  let hostname
-  let instanceId
-  if (await isAvail) {
-    hostname = await _getHostname(isAvail)
-    instanceId = await _getInstanceId(isAvail)
-    console.debug('hostname: ', hostname)
-    console.debug('instanceId: ', instanceId)
+  if (!(await isAvail)) {
+    logger.debug({ utilization: 'gcp' }, 'GCP metadata is not available.')
+    return callback(err)
   }
 
-  common.request(
-    {
-      host: 'metadata.google.internal',
-      path: '/computeMetadata/v1/instance/?recursive=true',
-      headers: {
-        'Metadata-Flavor': 'Google'
-      }
-    },
-    agent,
-    function getMetadata(err, data) {
-      if (err) {
-        logger.trace({ utilization: 'gcp', error: err }, 'Failed to communicate with metadata endpoint.')
-        return callback(err)
-      }
-      try {
-        console.debug('metadata before parse: ', data)
-        data = JSONbig.parse(data)
-        if (typeof data.id !== 'string') {
-          data.id = data.id.toString()
-        }
-      } catch (e) {
-        logger.debug({ utilization: 'gcp', error: e }, 'Failed to parse GCP metadata.')
-        data = null
-      }
+  // Grab relevant metadata
+  const attributes = ['id', 'machineType', 'name', 'zone']
+  const values = await Promise.all(attributes.map(attr => getMetadataAttribute(isAvail, attr)))
+  const [id, machineType, name, zone] = values
 
-      // Pull out the id, zone, zone, and machineType from the metadata
-      const results = common.getKeys(data, ['id', 'zone'])
-      if (results == null) {
-        logger.debug({ utilization: 'gcp' }, 'GCP metadata was invalid.')
-        agent.metrics.getOrCreateMetric(NAMES.UTILIZATION.GCP_ERROR).incrementCallCount()
-      } else {
-        console.debug('ids matched: ', results.id===instanceId)
-        if (data.machineType) {
-          results.machineType = data.machineType
-          // normalize
-          results.machineType = results.machineType.substring(
-            results.machineType.lastIndexOf('/') + 1
-          )
-        }
-        results.zone = results.zone.substring(results.zone.lastIndexOf('/') + 1)
+  const results = {
+    id,
+    name,
+    machineType: machineType ? machineType.substring(machineType.lastIndexOf('/') + 1) : undefined,
+    zone: zone ? zone.substring(zone.lastIndexOf('/') + 1) : undefined
+  }
 
-        resultDict = results
-      }
-      callback(null, results)
-    }
-  )
+  resultDict = results
+  callback(null, results)
+}
+
+/**
+ * Get the metadata attribute from gcp-metadata
+ * @param {*} isAvail gcpMetadata.isAvailable()
+ * @param {*} attribute The attribute to get from the metadata e.g. id
+ * @returns The value of the attribute or null if not available
+ */
+async function getMetadataAttribute(isAvail, attribute) {
+  if (!(await isAvail)) {
+    logger.debug({ utilization: 'gcp' }, 'GCP metadata is not available.')
+    return undefined
+  }
+  try {
+    const value = await gcpMetadata.instance(attribute)
+    return value.toString()
+  } catch (e) {
+    logger.debug({ utilization: 'gcp', error: e }, `Failed to get GCP attribute '${attribute}'.`)
+    return undefined
+  }
 }

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -30,7 +30,7 @@ function fetchGCPInfo(agent, callback) {
   common.request(
     {
       host: 'metadata.google.internal',
-      path: '/computeMetadata/v1/instance/?recursive=true',
+      path: '/computeMetadata/v1/instance',
       headers: {
         'Metadata-Flavor': 'Google'
       }
@@ -42,7 +42,7 @@ function fetchGCPInfo(agent, callback) {
         return callback(err)
       }
       try {
-        console.log('data before parse: ', data) 
+        console.log('data before parse: ', data)
         data = JSONbig.parse(data)
         if (typeof data.id !== 'string') {
           data.id = data.id.toString()
@@ -52,20 +52,18 @@ function fetchGCPInfo(agent, callback) {
         data = null
       }
 
-      console.log('getMetadata data: ', data) 
       const results = common.getKeys(data, ['id', 'zone'])
-      console.log('id: ', data.id)
-      console.log('machineType: ', data.machineType)
-      console.log('name: ', data.name)
-      console.log('zone: ', data.zone)
       if (results == null) {
         logger.debug({ utilization: 'gcp' }, 'GCP metadata was invalid.')
         agent.metrics.getOrCreateMetric(NAMES.UTILIZATION.GCP_ERROR).incrementCallCount()
       } else {
-        // normalize
-        // results.machineType = results.machineType.substring(
-        //   results.machineType.lastIndexOf('/') + 1
-        // )
+        if (data.machineType) {
+          results.machineType = data.machineType
+          // normalize
+          results.machineType = results.machineType.substring(
+            results.machineType.lastIndexOf('/') + 1
+          )
+        }
         results.zone = results.zone.substring(results.zone.lastIndexOf('/') + 1)
 
         resultDict = results

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -52,6 +52,7 @@ function fetchGCPInfo(agent, callback) {
       }
 
       const results = common.getKeys(data, ['id', 'machineType', 'name', 'zone'])
+      console.log('getKeys result: ', results)
       if (results == null) {
         logger.debug({ utilization: 'gcp' }, 'GCP metadata was invalid.')
         agent.metrics.getOrCreateMetric(NAMES.UTILIZATION.GCP_ERROR).incrementCallCount()

--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@tyriar/fibonacci-heap": "^2.0.7",
     "concat-stream": "^2.0.0",
+    "gcp-metadata": "^6.1.1",
     "https-proxy-agent": "^7.0.1",
     "import-in-the-middle": "^1.13.0",
     "json-bigint": "^1.0.0",

--- a/test/lib/cross_agent_tests/utilization/utilization_json.json
+++ b/test/lib/cross_agent_tests/utilization/utilization_json.json
@@ -211,7 +211,7 @@
     "input_hostname": "myotherhost",
     "input_full_hostname": "myotherhost.com",
     "input_ip_address": ["1.2.3.4"],
-    "input_gcp_id": "3161347020215157123",
+    "input_gcp_id": null,
     "input_gcp_type": "projects/492690098729/machineTypes/custom-1-1024",
     "input_gcp_name": null,
     "input_gcp_zone": "projects/492690098729/zones/us-central1-c",


### PR DESCRIPTION
This PR resolves #3093 (also resolves #1339). The solution is to set `hostname` to GCP metadata `id` when a GCP Cloud Run specific environment variable (`K_SERVICE`) exists and when the new feature flag `gcp_cloud_run.use_instance_as_host` is true (default).