### PR TITLE
test: Silenced agent logs in benchmark tests

### DIFF
--- a/bin/run-bench.js
+++ b/bin/run-bench.js
@@ -145,6 +145,8 @@ async function run() {
 
   const runBenchmarks = async () => {
     tests.sort()
+    // silence agent logs during these tests
+    process.env.NEW_RELIC_LOG_LEVEL = 'error'
     for await (const file of tests) {
       await spawnEachFile(file)
     }


### PR DESCRIPTION
## Description

Benchmark tests use stdout to collect JSON test results from spawned processes. Agent logs (`info` by default) are also written to stdout, and interfere with this process. Until we alter the benchmark behavior, this simple change fixes the problem.

## How to Test
`npm run bench` should result in benchmark test results written to `./benchmark_results`. There should be no errors written to the console showing that JSON output is unparseable. 