### PR TITLE
chore: Pinned openai due to new major

### DIFF
--- a/lib/instrumentation/openai.js
+++ b/lib/instrumentation/openai.js
@@ -25,7 +25,7 @@ let TRACKING_METRIC = OPENAI.TRACKING_PREFIX
 
 /**
  * Checks if we should skip instrumentation.
- * Currently it checks if `ai_monitoring.enabled` is true
+ * Currently, it checks if `ai_monitoring.enabled` is true
  * and the package version >= 4.0.0
  *
  * @param {object} config agent config

--- a/test/versioned/openai/package.json
+++ b/test/versioned/openai/package.json
@@ -12,7 +12,7 @@
         "node": ">=18"
       },
       "dependencies": {
-        "openai": ">=4.0.0"
+        "openai": ">=4.0.0 <5.0.0"
       },
       "files": [
         "chat-completions.test.js",


### PR DESCRIPTION
This PR pins the `openai` module to the v4 range. The newly released v5 will require more work.