### PR TITLE
fix: Updated rules to work with 1.17.0 and 1.24.0 for consumer and producer span kind

### DIFF
--- a/lib/otel/transformation-rules.json
+++ b/lib/otel/transformation-rules.json
@@ -188,7 +188,9 @@
         "consumer"
       ],
       "required_attribute_keys": [
-        "messaging.operation.name"
+        "messaging.system",
+        "messaging.operation.name",
+        "messaging.destination.name"
       ]
     },
     "attributes": [
@@ -243,7 +245,9 @@
         "consumer"
       ],
       "required_attribute_keys": [
-        "messaging.operation"
+        "messaging.system",
+        "messaging.operation",
+        "messaging.destination.name"
       ]
     },
     "attributes": [
@@ -969,6 +973,39 @@
     }
   },
   {
+    "name": "Producer_1_24_GCP",
+    "type": "producer",
+    "matcher": {
+      "required_span_kinds": [
+        "producer"
+      ],
+      "required_attribute_keys": [
+        "messaging.system",
+        "messaging.destination.name"
+      ],
+      "attribute_conditions": {
+        "messaging.system": ["gcp_pubsub"]
+      }
+    },
+    "attributes": [
+      {
+        "key": "server.address",
+        "target": "segment",
+        "name": "host"
+      },
+      {
+        "key": "server.port",
+        "target": "segment", 
+        "name": "port"
+      }
+    ],
+    "segment": {
+      "name": {
+        "template": "MessageBroker/${messaging.system}/${messaging.operation}/Produce/Named/${messaging.destination.name}"
+      }
+    }
+  },
+  {
     "name": "Producer_1_30",
     "type": "producer",
     "matcher": {
@@ -977,6 +1014,7 @@
       ],
       "required_attribute_keys": [
         "messaging.system",
+        "messaging.operation.name",
         "messaging.destination.name"
       ]
     },
@@ -1010,6 +1048,52 @@
     "segment": {
       "name": {
         "template": "MessageBroker/${messaging.system}/${messaging.operation.name}/Produce/Named/${messaging.destination.name}"
+      }
+    }
+  },
+  {
+    "name": "Producer_1_24",
+    "type": "producer",
+    "matcher": {
+      "required_span_kinds": [
+        "producer"
+      ],
+      "required_attribute_keys": [
+        "messaging.system",
+        "messaging.operation",
+        "messaging.destination.name"
+      ]
+    },
+    "attributes": [
+      {
+        "key": "server.address",
+        "target": "segment",
+        "name": "host"
+      },
+      {
+        "key": "server.port",
+        "target": "segment", 
+        "name": "port"
+      },
+      {
+        "key": "messaging.kafka.message.key",
+        "target": "segment",
+        "name": "routing_key"
+      },
+      {
+        "key": "messaging.rabbitmq.destination.routing_key",
+        "target": "segment",
+        "name": "routing_key"
+      },
+      {
+        "key": "messaging.message.conversation_id",
+        "target": "segment",
+        "name": "correlation_id"
+      }
+    ],
+    "segment": {
+      "name": {
+        "template": "MessageBroker/${messaging.system}/${messaging.operation}/Produce/Named/${messaging.destination.name}"
       }
     }
   },
@@ -1083,7 +1167,7 @@
       ],
       "required_attribute_keys": [
         "messaging.system",
-        "messaging.destination"
+        "messaging.destination_kind"
       ]
     },
     "attributes": [
@@ -1110,7 +1194,7 @@
     ],
     "segment": {
       "name": {
-        "template": "MessageBroker/${messaging.system}/${messaging.operation}/Produce/Named/${messaging.destination}"
+        "template": "MessageBroker/${messaging.system}/${messaging.destination_kind}/Produce/Named/${messaging.destination}"
       }
     }
   },

--- a/test/unit/lib/otel/fixtures/producer.js
+++ b/test/unit/lib/otel/fixtures/producer.js
@@ -9,7 +9,7 @@ const { SpanKind } = require('@opentelemetry/api')
 const createSpan = require('./span')
 
 const {
-  ATTR_MESSAGING_DESTINATION,
+  ATTR_MESSAGING_DESTINATION_NAME,
   ATTR_MESSAGING_SYSTEM,
   ATTR_MESSAGING_OPERATION,
 } = require('#agentlib/otel/constants.js')
@@ -18,7 +18,7 @@ function createProducerSpan({ tracer, name = 'test-span' }) {
   const span = createSpan({ name, kind: SpanKind.PRODUCER, tracer })
   span.setAttribute(ATTR_MESSAGING_SYSTEM, 'messaging-lib')
   span.setAttribute(ATTR_MESSAGING_OPERATION, 'send')
-  span.setAttribute(ATTR_MESSAGING_DESTINATION, 'test-topic')
+  span.setAttribute(ATTR_MESSAGING_DESTINATION_NAME, 'test-topic')
   return span
 }
 

--- a/test/unit/lib/otel/rules.test.js
+++ b/test/unit/lib/otel/rules.test.js
@@ -31,6 +31,8 @@ test('consumer does not match fallback rule', () => {
   const engine = new RulesEngine()
   const span = tracer.startSpan('test-span', { kind: SpanKind.CONSUMER }, ROOT_CONTEXT)
   span.setAttribute('messaging.operation', 'create')
+  span.setAttribute('messaging.system', 'rabbitmq')
+  span.setAttribute('messaging.destination.name', 'test-queue')
   span.end()
 
   const rule = engine.test(span)

--- a/test/versioned/otel-bridge/span.test.js
+++ b/test/versioned/otel-bridge/span.test.js
@@ -35,6 +35,7 @@ const {
   ATTR_HTTP_STATUS_TEXT,
   ATTR_HTTP_URL,
   ATTR_MESSAGING_DESTINATION,
+  ATTR_MESSAGING_DESTINATION_KIND,
   ATTR_MESSAGING_DESTINATION_NAME,
   ATTR_MESSAGING_MESSAGE_CONVERSATION_ID,
   ATTR_MESSAGING_OPERATION,
@@ -815,7 +816,7 @@ test('producer span is bridged accordingly', (t, end) => {
   const { agent, tracer } = t.nr
   const attributes = {
     [ATTR_MESSAGING_SYSTEM]: 'messaging-lib',
-    [ATTR_MESSAGING_OPERATION]: MESSAGING_SYSTEM_KIND_VALUES.QUEUE,
+    [ATTR_MESSAGING_DESTINATION_KIND]: MESSAGING_SYSTEM_KIND_VALUES.QUEUE,
     [ATTR_MESSAGING_DESTINATION]: 'test-queue',
     [ATTR_NET_PEER_NAME]: 'localhost',
     [ATTR_NET_PEER_PORT]: 5672,
@@ -852,7 +853,7 @@ test('producer span is bridged accordingly', (t, end) => {
       assert.equal(attrs.routing_key, 'myKey')
       assert.equal(attrs[ATTR_MESSAGING_SYSTEM], 'messaging-lib')
       assert.equal(attrs[ATTR_MESSAGING_DESTINATION], 'test-queue')
-      assert.equal(attrs[ATTR_MESSAGING_OPERATION], MESSAGING_SYSTEM_KIND_VALUES.QUEUE)
+      assert.equal(attrs[ATTR_MESSAGING_DESTINATION_KIND], MESSAGING_SYSTEM_KIND_VALUES.QUEUE)
       end()
     })
   })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
I tested all of our example apps. I misconfiugred the producers in the rules json.  I also had to add a specific `gcp_pubsub` producer rule for now.  Until [5.1.0](https://github.com/googleapis/nodejs-pubsub/pull/2039) is released naming will be off. Once they ship this I can remove `Producer_1_24_GCP` rule as it'll match on `Producer_1_24`.  
