### PR TITLE
fix: getHostnameSafe rewrite

### DIFF
--- a/lib/collector/facts.js
+++ b/lib/collector/facts.js
@@ -31,11 +31,7 @@ async function facts(agent, callback, { logger = defaultLogger } = {}) {
   systemInfo = systemInfo || Object.create(null)
   environment = environment || []
 
-  let hostname = agent.config.getHostnameSafe()
-  if (agent.config.gcp_cloud_run.use_instance_as_host && process.env.K_SERVICE) {
-    // K_SERVICE is the name of the service in GCP Cloud Run
-    hostname = systemInfo.vendors?.gcp?.id
-  }
+  const hostname = agent.config.getHostnameSafe(systemInfo?.vendors?.gcp?.id)
   const results = {
     utilization: {
       metadata_version: 5,

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -972,16 +972,25 @@ Config.prototype.getIPAddresses = function getIPAddresses() {
   return addresses
 }
 
-function getHostnameSafe() {
+/**
+ * Gets the system's host name. If that fails, it just returns ipv4/6
+ * based on the user's process_host.ipv_preference setting.
+ * @param {string} gcpId GCP metadata ID
+ * @returns {string} host name
+ */
+function getHostnameSafe(gcpId = null) {
   let _hostname
   const config = this
   this.getHostnameSafe = function getCachedHostname() {
     return _hostname
   }
   try {
-    if (config.heroku.use_dyno_names) {
-      const dynoName = process.env.DYNO
-      _hostname = dynoName || os.hostname()
+    // Check for any special hostname scenarios.
+    // If not applicable, use the os.hostname()
+    if (config.heroku.use_dyno_names && process.env.DYNO) {
+      _hostname = process.env.DYNO || os.hostname()
+    } else if (config.gcp_cloud_run.use_instance_as_host && process.env.K_SERVICE && gcpId) {
+      _hostname = gcpId
     } else {
       _hostname = os.hostname()
     }

--- a/lib/otel/attr-reconciler.js
+++ b/lib/otel/attr-reconciler.js
@@ -23,7 +23,7 @@ class AttributeReconciler {
 
   resolveHost(hostname) {
     if (urltils.isLocalhost(hostname)) {
-      return this.#agent.config.getHostnameSafe(hostname)
+      return this.#agent.config.getHostnameSafe()
     }
     return hostname
   }

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -696,7 +696,7 @@ function _normalizeInstanceInformation(parameters, dsTracerConf, config) {
     }
     if (hasOwnProperty(parameters, 'host')) {
       if (parameters.host && urltils.isLocalhost(parameters.host)) {
-        parameters.host = config.getHostnameSafe(parameters.host)
+        parameters.host = config.getHostnameSafe()
       }
 
       // Config's default name of a host is `UNKNOWN_BOX`.

--- a/test/unit/collector/facts.test.js
+++ b/test/unit/collector/facts.test.js
@@ -872,7 +872,7 @@ test('host facts', async (t) => {
     agent.config.gcp_cloud_run = { use_instance_as_host: true }
 
     facts(agent, (result) => {
-      assert.notEqual(result.host, 'mock-gcp-instance-id', 'Hostname should not be set to GCP instance ID')
+      assert.equal(result.host, os.hostname(), 'Hostname should not be set to GCP instance ID')
       end()
     })
   })
@@ -884,7 +884,7 @@ test('host facts', async (t) => {
     process.env.K_SERVICE = 'mock-service'
 
     facts(agent, (result) => {
-      assert.notEqual(result.host, 'mock-gcp-instance-id', 'Hostname should not be set to GCP instance ID')
+      assert.equal(result.host, os.hostname(), 'Hostname should not be set to GCP instance ID')
       end()
     })
   })

--- a/test/unit/collector/facts.test.js
+++ b/test/unit/collector/facts.test.js
@@ -829,7 +829,12 @@ test('host facts', async (t) => {
 
     ctx.nr.agent = helper.loadMockedAgent(structuredClone(DISABLE_ALL_DETECTIONS))
     ctx.nr.agent.config.utilization = null
-    ctx.nr.agent.config.getHostnameSafe = () => 'localhost'
+    ctx.nr.agent.config.getHostnameSafe = (gcpId) => {
+      if (ctx.nr.agent.config.gcp_cloud_run.use_instance_as_host && process.env.K_SERVICE && gcpId) {
+        return gcpId
+      }
+      return 'localhost'
+    }
   })
 
   t.afterEach((ctx) => {
@@ -873,7 +878,7 @@ test('host facts', async (t) => {
     agent.config.gcp_cloud_run = { use_instance_as_host: true }
 
     facts(agent, (result) => {
-      assert.equal(result.host, 'localhost', 'Hostname should be set to GCP instance ID')
+      assert.equal(result.host, 'localhost', 'Hostname should still be localhost')
       end()
     })
   })
@@ -885,7 +890,7 @@ test('host facts', async (t) => {
     process.env.K_SERVICE = 'mock-service'
 
     facts(agent, (result) => {
-      assert.equal(result.host, 'localhost', 'Hostname should be set to GCP instance ID')
+      assert.equal(result.host, 'localhost', 'Hostname should still be localhost')
       end()
     })
   })

--- a/test/unit/collector/facts.test.js
+++ b/test/unit/collector/facts.test.js
@@ -829,12 +829,6 @@ test('host facts', async (t) => {
 
     ctx.nr.agent = helper.loadMockedAgent(structuredClone(DISABLE_ALL_DETECTIONS))
     ctx.nr.agent.config.utilization = null
-    ctx.nr.agent.config.getHostnameSafe = (gcpId) => {
-      if (ctx.nr.agent.config.gcp_cloud_run.use_instance_as_host && process.env.K_SERVICE && gcpId) {
-        return gcpId
-      }
-      return 'localhost'
-    }
   })
 
   t.afterEach((ctx) => {
@@ -860,7 +854,7 @@ test('host facts', async (t) => {
     }
   })
 
-  await t.test('should use GCP instance ID as hostname when K_SERVICE is set', (t, end) => {
+  await t.test('should be GCP id when K_SERVICE is set', (t, end) => {
     const { agent, facts } = t.nr
 
     agent.config.gcp_cloud_run = { use_instance_as_host: true }
@@ -872,25 +866,25 @@ test('host facts', async (t) => {
     })
   })
 
-  await t.test('should use getHostnameSafe as hostname when K_SERVICE is not present', (t, end) => {
+  await t.test('should not be GCP id when K_SERVICE is not present', (t, end) => {
     const { agent, facts } = t.nr
 
     agent.config.gcp_cloud_run = { use_instance_as_host: true }
 
     facts(agent, (result) => {
-      assert.equal(result.host, 'localhost', 'Hostname should still be localhost')
+      assert.notEqual(result.host, 'mock-gcp-instance-id', 'Hostname should not be set to GCP instance ID')
       end()
     })
   })
 
-  await t.test('should use getHostnameSafe when K_SERVICE is set but gcp_cloud_run.use_instance_as_host is false', (t, end) => {
+  await t.test('should not be GCP id when K_SERVICE is set but gcp_cloud_run.use_instance_as_host is false', (t, end) => {
     const { agent, facts } = t.nr
 
     agent.config.gcp_cloud_run = { use_instance_as_host: false }
     process.env.K_SERVICE = 'mock-service'
 
     facts(agent, (result) => {
-      assert.equal(result.host, 'localhost', 'Hostname should still be localhost')
+      assert.notEqual(result.host, 'mock-gcp-instance-id', 'Hostname should not be set to GCP instance ID')
       end()
     })
   })

--- a/test/versioned/otel-bridge/span.test.js
+++ b/test/versioned/otel-bridge/span.test.js
@@ -405,7 +405,7 @@ test('client span(db) is bridge accordingly(statement test)', (t, end) => {
     [ATTR_SERVER_PORT]: 5436,
     [ATTR_SERVER_ADDRESS]: '127.0.0.1'
   }
-  const expectedHost = agent.config.getHostnameSafe('127.0.0.1')
+  const expectedHost = agent.config.getHostnameSafe()
   helper.runInTransaction(agent, (tx) => {
     tx.name = 'db-test'
     tracer.startActiveSpan('db-test', { kind: otel.SpanKind.CLIENT, attributes }, (span) => {
@@ -456,7 +456,7 @@ test('client span(db) is bridged accordingly(operation test)', (t, end) => {
     [ATTR_SERVER_PORT]: 5436,
     [ATTR_SERVER_ADDRESS]: '127.0.0.1'
   }
-  const expectedHost = agent.config.getHostnameSafe('127.0.0.1')
+  const expectedHost = agent.config.getHostnameSafe()
   helper.runInTransaction(agent, (tx) => {
     tx.name = 'db-test'
     tracer.startActiveSpan('db-test', { kind: otel.SpanKind.CLIENT, attributes }, (span) => {
@@ -504,7 +504,7 @@ test('client span(db) 1.17 is bridged accordingly(operation test)', (t, end) => 
     [ATTR_NET_PEER_PORT]: 5436,
     [ATTR_NET_PEER_NAME]: '127.0.0.1'
   }
-  const expectedHost = agent.config.getHostnameSafe('127.0.0.1')
+  const expectedHost = agent.config.getHostnameSafe()
   helper.runInTransaction(agent, (tx) => {
     tx.name = 'db-test'
     tracer.startActiveSpan('db-test', { kind: otel.SpanKind.CLIENT, attributes }, (span) => {
@@ -555,7 +555,7 @@ test('client span(db) 1.17 mongodb is bridged accordingly(operation test)', (t, 
     [ATTR_NET_PEER_PORT]: 5436,
     [ATTR_NET_PEER_NAME]: '127.0.0.1'
   }
-  const expectedHost = agent.config.getHostnameSafe('127.0.0.1')
+  const expectedHost = agent.config.getHostnameSafe()
   helper.runInTransaction(agent, (tx) => {
     tx.name = 'db-test'
     tracer.startActiveSpan('db-test', { kind: otel.SpanKind.CLIENT, attributes }, (span) => {
@@ -779,7 +779,7 @@ test('producer span(legacy) is bridged accordingly', (t, end) => {
   helper.runInTransaction(agent, (tx) => {
     tx.name = 'prod-test'
 
-    const expectedHost = agent.config.getHostnameSafe('localhost')
+    const expectedHost = agent.config.getHostnameSafe()
     tracer.startActiveSpan('prod-test', { kind: otel.SpanKind.PRODUCER, attributes }, (span) => {
       const segment = agent.tracer.getSegment()
       assert.equal(tx.traceId, span.spanContext().traceId)
@@ -826,7 +826,7 @@ test('producer span is bridged accordingly', (t, end) => {
   helper.runInTransaction(agent, (tx) => {
     tx.name = 'prod-test'
 
-    const expectedHost = agent.config.getHostnameSafe('localhost')
+    const expectedHost = agent.config.getHostnameSafe()
     tracer.startActiveSpan('prod-test', { kind: otel.SpanKind.PRODUCER, attributes }, (span) => {
       const segment = agent.tracer.getSegment()
       assert.equal(tx.traceId, span.spanContext().traceId)
@@ -861,7 +861,7 @@ test('producer span is bridged accordingly', (t, end) => {
 
 test('consumer span is bridged correctly', (t, end) => {
   const { agent, tracer } = t.nr
-  const expectedHost = agent.config.getHostnameSafe('localhost')
+  const expectedHost = agent.config.getHostnameSafe()
   const attributes = {
     [ATTR_MESSAGING_SYSTEM]: 'kafka',
     [ATTR_SERVER_ADDRESS]: '127.0.0.1',
@@ -914,7 +914,7 @@ test('consumer span is bridged correctly', (t, end) => {
 
 test('messaging consumer skips high security attributes', (t, end) => {
   const { agent, tracer } = t.nr
-  const expectedHost = agent.config.getHostnameSafe('localhost')
+  const expectedHost = agent.config.getHostnameSafe()
   const attributes = {
     [ATTR_MESSAGING_SYSTEM]: 'kafka',
     [ATTR_SERVER_ADDRESS]: '127.0.0.1',


### PR DESCRIPTION
Addendum to #3111. The GCP cloud run hostname was not preserved across our agent because of caching which might have resulted in some UI funkiness. This fixes that.