### PR TITLE
test: Skips running nest 11+ on node 18 due to dropping support

### DIFF
--- a/test/versioned/nestjs/package.json
+++ b/test/versioned/nestjs/package.json
@@ -20,7 +20,7 @@
         "node": ">=20"
       },
       "dependencies": {
-        "@nestjs/cli": ">11"
+        "@nestjs/cli": ">=11"
       },
       "files": [
         "nest.test.js"

--- a/test/versioned/nestjs/package.json
+++ b/test/versioned/nestjs/package.json
@@ -9,7 +9,18 @@
         "node": ">=18"
       },
       "dependencies": {
-        "@nestjs/cli": ">=9.0.0"
+        "@nestjs/cli": ">=9.0.0 <11"
+      },
+      "files": [
+        "nest.test.js"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=20"
+      },
+      "dependencies": {
+        "@nestjs/cli": ">11"
       },
       "files": [
         "nest.test.js"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Apparently Nest dropped support for Node 18, last [November](https://github.com/nestjs/nest/commit/74789282d1dda112571628fe5b87c453553c940f).  It was still working for us, but we are now seeing errors like this:

```sh
error: |-
    Command failed: npx nest new --package-manager npm --skip-git test-app
    /home/runner/work/node-newrelic/node-newrelic/test/versioned/nestjs/node_modules/glob/node_modules/minimatch/dist/commonjs/index.js:7
    const brace_expansion_1 = __importDefault(require("brace-expansion"));
                                              ^
    
    Error [ERR_REQUIRE_ESM]: require() of ES Module /home/runner/work/node-newrelic/node-newrelic/test/versioned/nestjs/node_modules/glob/node_modules/brace-expansion/index.js from /home/runner/work/node-newrelic/node-newrelic/test/versioned/nestjs/node_modules/glob/node_modules/minimatch/dist/commonjs/index.js not supported.
    Instead change the require of /home/runner/work/node-newrelic/node-newrelic/test/versioned/nestjs/node_modules/glob/node_modules/brace-expansion/index.js in /home/runner/work/node-newrelic/node-newrelic/test/versioned/nestjs/node_modules/glob/node_modules/minimatch/dist/commonjs/index.js to a dynamic import() which is available in all CommonJS modules.
        at Object.<anonymous> (/home/runner/work/node-newrelic/node-newrelic/test/versioned/nestjs/node_modules/glob/node_modules/minimatch/dist/commonjs/index.js:7:43)
        at Object.<anonymous> (/home/runner/work/node-newrelic/node-newrelic/test/versioned/nestjs/node_modules/glob/dist/commonjs/index.js:9:21)
        at Object.<anonymous> (/home/runner/work/node-newrelic/node-newrelic/test/versioned/nestjs/node_modules/@nestjs/cli/lib/compiler/assets-manager.js:6:16)
        at Object.<anonymous> (/home/runner/work/node-newrelic/node-newrelic/test/versioned/nestjs/node_modules/@nestjs/cli/actions/build.action.js:6:26)
        at Object.<anonymous> (/home/runner/work/node-newrelic/node-newrelic/test/versioned/nestjs/node_modules/@nestjs/cli/actions/index.js:18:14)
        at Object.<anonymous> (/home/runner/work/node-newrelic/node-newrelic/test/versioned/nestjs/node_modules/@nestjs/cli/commands/command.loader.js:5:19)
        at Object.<anonymous> (/home/runner/work/node-newrelic/node-newrelic/test/versioned/nestjs/node_modules/@nestjs/cli/commands/index.js:17:14)
        at Object.<anonymous> (/home/runner/work/node-newrelic/node-newrelic/test/versioned/nestjs/node_modules/@nestjs/cli/bin/nest.js:5:20) {
      code: 'ERR_REQUIRE_ESM'
    }
    
    Node.js v18.20.8
```

This is actually due to [minmatch](https://github.com/isaacs/minimatch/issues/257) issuing a breaking change in a patch.  However, since Nest's engines is >=20 in 11, we will stop testing on 18.
