### PR TITLE
refactor: Updated transformation rules to remove the bespoke rule to appease `@google-cloud/pubsub` < 5.1.0

### DIFF
--- a/lib/otel/transformation-rules.json
+++ b/lib/otel/transformation-rules.json
@@ -973,39 +973,6 @@
     }
   },
   {
-    "name": "Producer_1_24_GCP",
-    "type": "producer",
-    "matcher": {
-      "required_span_kinds": [
-        "producer"
-      ],
-      "required_attribute_keys": [
-        "messaging.system",
-        "messaging.destination.name"
-      ],
-      "attribute_conditions": {
-        "messaging.system": ["gcp_pubsub"]
-      }
-    },
-    "attributes": [
-      {
-        "key": "server.address",
-        "target": "segment",
-        "name": "host"
-      },
-      {
-        "key": "server.port",
-        "target": "segment", 
-        "name": "port"
-      }
-    ],
-    "segment": {
-      "name": {
-        "template": "MessageBroker/${messaging.system}/${messaging.operation}/Produce/Named/${messaging.destination.name}"
-      }
-    }
-  },
-  {
     "name": "Producer_1_30",
     "type": "producer",
     "matcher": {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We had a rule that was for `gcp_pubsub` because it was not adding `message.operation` to producer spans.  This [PR](https://github.com/googleapis/nodejs-pubsub/pull/2030) fixed that and it was released as part of [5.1.0](https://github.com/googleapis/nodejs-pubsub/blob/main/CHANGELOG.md#510-2025-06-04)
