### PR TITLE
chore: Pin google/genai to <1.5.0

### DIFF
--- a/test/versioned/google-genai/package.json
+++ b/test/versioned/google-genai/package.json
@@ -17,7 +17,7 @@
         "node": ">=18"
       },
       "dependencies": {
-        "@google/genai": "^1.1.0"
+        "@google/genai": ">=1.1.0 <1.5.0"
       },
       "files": [
         "chat-completions.test.js",


### PR DESCRIPTION
Version 1.5.0 of `@google/genai` introduced a change that, as of writing, requires a manual dependency install, so it breaks our tests: https://github.com/googleapis/js-genai/issues/684. For now, we'll pin to below 1.5.0.