### PR TITLE
chore: Improved output of pending prs script

### DIFF
--- a/.github/workflows/compatibility-report.yml
+++ b/.github/workflows/compatibility-report.yml
@@ -66,7 +66,7 @@ jobs:
           branch: "compatibility-report/auto-update"
           delete-branch: true
           base: main
-          labels: "documentation"
+          labels: "documentation,dev:repo_maintenance"
 
   docs:
     runs-on: ubuntu-latest

--- a/bin/pending-prs.js
+++ b/bin/pending-prs.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /*
  * Copyright 2021 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
@@ -46,8 +47,8 @@ function unreleasedPRs() {
       stopOnError()
     }
 
-    const repos = opts.repos.split(',')
-    const ignoredLabels = opts.ignoreLabels.split(',')
+    const repos = opts.repos?.split(',') ?? []
+    const ignoredLabels = opts.ignoreLabels?.split(',') ?? []
 
     repos.forEach(async (repo) => {
       const { prs, latestRelease } = await findMergedPRs(repo, ignoredLabels)
@@ -141,7 +142,13 @@ async function findMergedPRs(repo, ignoredLabels) {
   })
 
   console.log(`Found ${filteredPullRequests.length} PRs not yet released.`)
-  const prs = filteredPullRequests.map((pr) => pr.html_url)
+  const prs = filteredPullRequests
+    .sort((a, b) => {
+      if (a.number > b.number) return 1
+      if (a.number < b.number) return -1
+      return 0
+    })
+    .map((pr) => `<${pr.html_url} | (${pr.number}) ${pr.title}>`)
   return {
     prs,
     latestRelease


### PR DESCRIPTION
This PR improves the output of the pending prs script by formatting the links to PRs with the number and title instead of just the URL.

<details>
<summary>Before this change:</summary>

```
    *node-newrelic*

  There have been 17 PRs merged since `v12.21.0` on *2025-06-04T17:47:36Z*.

  :waiting: *PRs not yet released*:

 - https://github.com/newrelic/node-newrelic/pull/3155
 - https://github.com/newrelic/node-newrelic/pull/3158
 - https://github.com/newrelic/node-newrelic/pull/3148
 - https://github.com/newrelic/node-newrelic/pull/3154
 - https://github.com/newrelic/node-newrelic/pull/3150
 - https://github.com/newrelic/node-newrelic/pull/3152
 - https://github.com/newrelic/node-newrelic/pull/3151
 - https://github.com/newrelic/node-newrelic/pull/3149
 - https://github.com/newrelic/node-newrelic/pull/3147
 - https://github.com/newrelic/node-newrelic/pull/3139
 - https://github.com/newrelic/node-newrelic/pull/3145
 - https://github.com/newrelic/node-newrelic/pull/3141
 - https://github.com/newrelic/node-newrelic/pull/3138
 - https://github.com/newrelic/node-newrelic/pull/3127
 - https://github.com/newrelic/node-newrelic/pull/3134
 - https://github.com/newrelic/node-newrelic/pull/3136
 - https://github.com/newrelic/node-newrelic/pull/3131

    Do you want to <https://github.com/newrelic/node-newrelic/actions/workflows/prepare-release.yml | prepare a release>?
```

</details>

<details>
<summary>After this change:</summary>

```
    *node-newrelic*

  There have been 17 PRs merged since `v12.21.0` on *2025-06-04T17:47:36Z*.

  :waiting: *PRs not yet released*:

 - <https://github.com/newrelic/node-newrelic/pull/3127 | (3127) test: Added JSDoc annotation for benchmark interface>
 - <https://github.com/newrelic/node-newrelic/pull/3131 | (3131) docs: Updated compatibility report>
 - <https://github.com/newrelic/node-newrelic/pull/3134 | (3134) docs: Gemini compatibility>
 - <https://github.com/newrelic/node-newrelic/pull/3136 | (3136) docs: Updated compatibility report>
 - <https://github.com/newrelic/node-newrelic/pull/3138 | (3138) chore: Improved setup of OpenTelemetry metrics API>
 - <https://github.com/newrelic/node-newrelic/pull/3139 | (3139) feat: Support `openai.responses.create` api>
 - <https://github.com/newrelic/node-newrelic/pull/3141 | (3141) chore: Removed usage of `shim.argsToArray` in favor of rest parameters>
 - <https://github.com/newrelic/node-newrelic/pull/3145 | (3145) chore: Added logging of used New Relic environment variables>
 - <https://github.com/newrelic/node-newrelic/pull/3147 | (3147) docs: Updated compatibility report>
 - <https://github.com/newrelic/node-newrelic/pull/3148 | (3148) feat: `openai` v5 streaming support>
 - <https://github.com/newrelic/node-newrelic/pull/3149 | (3149) test: Skips running nest 11+ on node 18 due to dropping support>
 - <https://github.com/newrelic/node-newrelic/pull/3150 | (3150) docs: Updated compatibility report>
 - <https://github.com/newrelic/node-newrelic/pull/3151 | (3151) refactor: Updated transformation rules to remove the bespoke rule to appease `@google-cloud/pubsub` < 5.1.0>
 - <https://github.com/newrelic/node-newrelic/pull/3152 | (3152) chore: Tweak nestjs test manifest>
 - <https://github.com/newrelic/node-newrelic/pull/3154 | (3154) chore: Pin google/genai to <1.5.0>
 - <https://github.com/newrelic/node-newrelic/pull/3155 | (3155) docs: Updated compatibility report>
 - <https://github.com/newrelic/node-newrelic/pull/3158 | (3158) chore: Remove discontinued Bedrock models>

    Do you want to <https://github.com/newrelic/node-newrelic/actions/workflows/prepare-release.yml | prepare a release>?
```

</details>