### PR TITLE
chore: Fixed formatting in Slack PR titles

### DIFF
--- a/bin/pending-prs.js
+++ b/bin/pending-prs.js
@@ -148,7 +148,13 @@ async function findMergedPRs(repo, ignoredLabels) {
       if (a.number < b.number) return -1
       return 0
     })
-    .map((pr) => `<${pr.html_url} | (${pr.number}) ${pr.title}>`)
+    .map((pr) => {
+      const slackifiedTitle = pr.title
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+      return `<${pr.html_url} | (${pr.number}) ${slackifiedTitle}>`
+    })
   return {
     prs,
     latestRelease


### PR DESCRIPTION
According to https://github.com/slackhq/slack-api-docs/blob/4ddb64b6efd5124cd99f0af0fbd66a6e4feb44ac/page_formatting.md#how-to-escape-characters, we have to escape `&`, `<`, and `>` because Slack refuses to support actual Markdown like everyone else in the known universe.