### PR TITLE
chore: Fix issues on Node 24

### DIFF
--- a/test/versioned/express-esm/package.json
+++ b/test/versioned/express-esm/package.json
@@ -11,7 +11,7 @@
       },
       "dependencies": {
         "express": {
-          "versions": ">=4.6.0",
+          "versions": ">=4.15.0",
           "samples": 5
         }
       },

--- a/test/versioned/express/package.json
+++ b/test/versioned/express/package.json
@@ -15,7 +15,7 @@
       },
       "dependencies": {
         "express": {
-          "versions": ">=4.6.0",
+          "versions": ">=4.15.0",
           "samples": 5
         },
         "express-enrouten": "1.1",

--- a/test/versioned/mysql/package.json
+++ b/test/versioned/mysql/package.json
@@ -9,7 +9,7 @@
         "node": ">=18"
       },
       "dependencies": {
-        "mysql": ">=2.2.0",
+        "mysql": ">=2.16.0",
         "generic-pool": "2.4"
       },
       "files": [


### PR DESCRIPTION
This PR resolves #3180.

1. `express` minimum version is bumped due to prior versions utilizing an internal `_headers` being removed. See:
    + https://github.com/nodejs/node/blob/dbd24b165128affb7468ca42f69edaf7e0d85a9a/doc/api/deprecations.md?plain=1#L1554-L1556
    + https://github.com/expressjs/express/commit/f87abb34934c21926f0315162159e4acf7d7dae8
3. `mysql` minimum version is bumped due to prior versions utilizing `Timers.enroll` which has been removed in Node 24. See:
    + https://github.com/nodejs/node/blob/dbd24b165128affb7468ca42f69edaf7e0d85a9a/doc/api/deprecations.md?plain=1#L2088-L2104
    + https://github.com/mysqljs/mysql/commit/55265b8126d66793033ce9ee34982dee30c85486