### PR TITLE
chore: Removed force labels on main CI workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     types:
       - edited
-      - labeled
       - opened
       - reopened
       - synchronize
@@ -50,7 +49,6 @@ jobs:
     needs:
       - should_run
     if: github.event_name == 'workflow_dispatch' ||
-      github.event.label.name == 'force-lint' ||
       (needs.should_run.outputs.javascript_changed == 'true' ||
       needs.should_run.outputs.deps_changed == 'true')
     runs-on: ubuntu-latest
@@ -98,7 +96,6 @@ jobs:
     needs:
       - should_run
     if: github.event_name == 'workflow_dispatch' ||
-      github.event.label.name == 'force-unit' ||
       (needs.should_run.outputs.javascript_changed == 'true' ||
       needs.should_run.outputs.deps_changed == 'true')
     runs-on: ubuntu-latest
@@ -128,7 +125,6 @@ jobs:
     needs:
       - should_run
     if: github.event_name == 'workflow_dispatch' ||
-      github.event.label.name == 'force-integration' ||
       (needs.should_run.outputs.javascript_changed == 'true' ||
       needs.should_run.outputs.deps_changed == 'true')
     runs-on: ubuntu-latest
@@ -168,7 +164,6 @@ jobs:
     needs:
       - should_run
     if: github.event_name == 'workflow_dispatch' ||
-      github.event.label.name == 'force-versioned' ||
       (needs.should_run.outputs.javascript_changed == 'true' ||
       needs.should_run.outputs.deps_changed == 'true')
     runs-on: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER || 'ubuntu-latest' }}
@@ -220,7 +215,6 @@ jobs:
     needs:
       - should_run
     if: github.event_name == 'workflow_dispatch' ||
-      github.event.label.name == 'force-versioned' ||
       (needs.should_run.outputs.javascript_changed == 'true' ||
       needs.should_run.outputs.deps_changed == 'true')
     runs-on: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER || 'ubuntu-latest' }}


### PR DESCRIPTION
This PR removes support for the set of "force" labels in the main CI workflow. The logic was incorrect, and fixing it would be more trouble than it is worth. If we decide we want to be able to force a run of the main CI workflow on a PR (which could be handy on a PR that doesn't change any JavaScript code) then we can add a singular label and some short circuit logic on the `should_run` job.