### PR TITLE
chore: Updated undici tests to unblock CI

### DIFF
--- a/test/versioned/undici/package.json
+++ b/test/versioned/undici/package.json
@@ -9,14 +9,23 @@
         "node": ">=18"
       },
       "dependencies": {
-        "undici": ">=5.0.0"
+        "undici": ">=5.0.0 <7.11.0"
+      },
+      "files": [
+        "requests.test.js"
+      ]
+    },
+
+    {
+      "engines": {
+        "node": ">=20"
+      },
+      "dependencies": {
+        "undici": ">=7.11.0"
       },
       "files": [
         "requests.test.js"
       ]
     }
-  ],
-  "engines": {
-    "node": ">=18"
-  }
+  ]
 }


### PR DESCRIPTION
The `undici` v7 line targets Node.js >=20. We've just been lucky so far that it hasn't relied on v20 features. As of 7.11.0, that is no longer the case. https://github.com/nodejs/undici/commit/ccf385ad87c86e582c2fda69dd1eda5057d0ed5d removed a backward compatibility feature. [`toWellFormed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toWellFormed) is only supported in >=20.