### PR TITLE
fix: Fixed logic around static values in OTEL rules

### DIFF
--- a/lib/otel/rules.js
+++ b/lib/otel/rules.js
@@ -116,7 +116,7 @@ class Rule {
   }
 
   /**
-   * Determines if the given span satifies this rule's requirements.
+   * Determines if the given span satisfies this rule's requirements.
    *
    * @param {object} span An OTEL span instance.
    *
@@ -147,6 +147,12 @@ class Rule {
   }
 }
 
+/**
+ * `RulesEngine` parses a set of transformation rules into {@link Rule}
+ * instances and stores them according to rule types (e.g. "server" or "client").
+ * A `RulesEngine` instance is used to inspect an unknown OTEL span instance
+ * in order to determine which transformation rule it matches, if any.
+ */
 class RulesEngine {
   #serverRules = new Map()
   #consumerRules = new Map()
@@ -158,8 +164,14 @@ class RulesEngine {
   #fallbackInternalRules = new Map()
   #fallbackProducerRules = new Map()
 
-  constructor() {
-    for (const inputRule of srcJson) {
+  /**
+   * Create a new {@link RulesEngine} instance.
+   *
+   * @param {object[]} [rulesJson] Set of transformation rules that map OTEL
+   * spans to New Relic spans.
+   */
+  constructor({ rulesJson = srcJson } = {}) {
+    for (const inputRule of rulesJson) {
       const rule = new Rule(inputRule)
 
       if (/fallback/i.test(rule.name) === true) {

--- a/lib/otel/span-processor.js
+++ b/lib/otel/span-processor.js
@@ -139,6 +139,12 @@ module.exports = class NrSpanProcessor {
         continue
       }
 
+      if (Object.prototype.hasOwnProperty.call(attribute, 'value') === true) {
+        // The transformation rule is specifying a static value for the
+        // attribute. So we need to use that instead of whatever was found.
+        value = attribute.value
+      }
+
       assignToTarget({ target, name, value, segment, transaction, span })
     }
 

--- a/test/unit/lib/otel/rules.test.js
+++ b/test/unit/lib/otel/rules.test.js
@@ -12,7 +12,7 @@ const assert = require('node:assert')
 
 const { ROOT_CONTEXT, SpanKind } = require('@opentelemetry/api')
 const { BasicTracerProvider } = require('@opentelemetry/sdk-trace-base')
-const { RulesEngine } = require('../../../../lib/otel/rules.js')
+const { RulesEngine } = require('#agentlib/otel/rules.js')
 
 const tracer = new BasicTracerProvider().getTracer('default')
 

--- a/test/unit/lib/otel/span-processor.test.js
+++ b/test/unit/lib/otel/span-processor.test.js
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert')
+
+const helper = require('#testlib/agent_helper.js')
+const { ROOT_CONTEXT, SpanKind } = require('@opentelemetry/api')
+const { BasicTracerProvider } = require('@opentelemetry/sdk-trace-base')
+const { RulesEngine } = require('#agentlib/otel/rules.js')
+const SegmentSynthesizer = require('#agentlib/otel/segment-synthesis.js')
+const SpanProcessor = require('#agentlib/otel/span-processor.js')
+
+const tracer = new BasicTracerProvider().getTracer('default')
+
+const ruleWithStaticAttributesJson = {
+  name: 'StaticAttributes',
+  type: 'db',
+  matcher: {
+    required_span_kinds: [
+      'client'
+    ],
+    required_attribute_keys: [
+      'db.system'
+    ],
+    attribute_conditions: {
+      'db.system': ['test-db']
+    }
+  },
+  attributes: [
+    {
+      key: 'db.system',
+      target: 'segment',
+      name: 'product'
+    },
+    {
+      key: 'db.name',
+      target: 'segment',
+      name: 'database_name'
+    },
+    {
+      key: 'server.address',
+      target: 'segment',
+      name: 'host',
+      value: 'localhost'
+    },
+    {
+      key: 'server.port',
+      target: 'segment',
+      name: 'port_path_or_id',
+      value: '0'
+    }
+  ],
+  segment: {
+    collection: 'db.sql.table',
+    operation: 'db.operation',
+    statement: 'db.statement',
+    type: 'db.system',
+    name: {
+      // eslint-disable-next-line no-template-curly-in-string
+      template: 'Datastore/statement/${type}/${collection}/${operation}'
+    }
+  }
+}
+
+test.beforeEach(ctx => {
+  ctx.nr = {}
+  ctx.nr.agent = helper.loadMockedAgent()
+
+  ctx.nr.logs = {
+    debug: []
+  }
+  ctx.nr.logger = {
+    debug(...args) {
+      ctx.nr.logs.debug.push(args)
+    }
+  }
+
+  ctx.nr.synthesizer = new SegmentSynthesizer(ctx.nr.agent, { logger: ctx.nr.logger })
+  ctx.nr.processor = new SpanProcessor(ctx.nr.agent, { logger: ctx.nr.logger })
+})
+
+test.afterEach(ctx => [
+  helper.unloadAgent(ctx.nr.agent)
+])
+
+test('maps static attributes', (t, end) => {
+  const { agent, processor, synthesizer } = t.nr
+
+  helper.runInTransaction(agent, tx => {
+    const span = tracer.startSpan('test-span', { kind: SpanKind.CLIENT }, ROOT_CONTEXT)
+    span.setAttribute('db.system', 'test-db')
+    span.setAttribute('db.name', 'foo')
+    span.setAttribute('db.sql.table', 'table1')
+    span.setAttribute('db.operation', 'select')
+    span.setAttribute('db.statement', 'select * from table1')
+    span.end()
+
+    synthesizer.engine = new RulesEngine({ rulesJson: [ruleWithStaticAttributesJson] })
+    const { segment, rule } = synthesizer.synthesize(span)
+    processor.mapAttributes({ segment, span, rule, transaction: tx })
+
+    tx.end()
+    assert.ok(tx)
+
+    const augmentedSegment = tx.trace.segments.root.children[0]?.segment
+    const attrs = augmentedSegment.attributes.attributes
+    assert.ok(augmentedSegment)
+    assert.equal(augmentedSegment.name, 'Datastore/statement/test-db/table1/select')
+    assert.equal(attrs.database_name.value, 'foo')
+    assert.equal(attrs['db.operation'].value, 'select')
+    assert.equal(attrs['db.sql.table'].value, 'table1')
+    assert.equal(attrs['db.statement'].value, 'select * from table1')
+    assert.equal(attrs.product.value, 'test-db')
+
+    const metrics = tx.metrics.unscoped
+    const expectedMetrics = [
+      'Datastore/operation/test-db/select',
+      'Datastore/statement/test-db/table1/select',
+      'Datastore/instance/test-db/localhost/0'
+    ]
+    for (const expectedMetric of expectedMetrics) {
+      assert.equal(metrics[expectedMetric]?.callCount, 1, `should have ${expectedMetric} metric`)
+    }
+
+    end()
+  })
+})


### PR DESCRIPTION
I discovered that we don't actually support the static value feature of an OTEL transformation rule. This PR resolves that problem.