### PR TITLE
refactor: Updated elasticsearch instrumentation to subscribe to events emitted

### DIFF
--- a/lib/instrumentations.js
+++ b/lib/instrumentations.js
@@ -11,7 +11,6 @@ const InstrumentationDescriptor = require('./instrumentation-descriptor')
 module.exports = function instrumentations() {
   return {
     '@azure/functions': { type: InstrumentationDescriptor.TYPE_GENERIC },
-    '@elastic/elasticsearch': { type: InstrumentationDescriptor.TYPE_DATASTORE },
     '@opensearch-project/opensearch': { type: InstrumentationDescriptor.TYPE_DATASTORE },
     '@google/genai': { type: InstrumentationDescriptor.TYPE_GENERIC },
     '@grpc/grpc-js': { module: './instrumentation/grpc-js' },

--- a/lib/subscribers/db-operation.js
+++ b/lib/subscribers/db-operation.js
@@ -3,34 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const Subscriber = require('./base')
+const DbSubscriber = require('./db')
 const recordOperationMetrics = require('../metrics/recorders/database-operation')
-const urltils = require('../util/urltils')
-const { ALL, DB } = require('../metrics/names')
+const { DB } = require('../metrics/names')
 
-class DbOperationSubscriber extends Subscriber {
-  constructor(agent, id, system) {
-    super(agent, id)
-    this.system = system
-    this.config = agent.config
-    this._metrics = {
-      PREFIX: this.system,
-      ALL: `${DB.PREFIX}${this.system}/${ALL}`
-    }
-    this.instanceKeys = ['host', 'port_path_or_id']
-    this.hostKey = 'host'
-    this.dbNameKey = 'database_name'
-    this.requireActiveTx = true
-  }
-
-  get instanceReporting() {
-    return this._agent.config.datastore_tracer.instance_reporting.enabled
-  }
-
-  get dbNameReporting() {
-    return this._agent.config.datastore_tracer.database_name_reporting.enabled
-  }
-
+class DbOperationSubscriber extends DbSubscriber {
   handler(data, ctx) {
     const name = `${DB.OPERATION}/${this.system}/${this.operation}`
     const segment = this._agent.tracer.createSegment({
@@ -43,30 +20,6 @@ class DbOperationSubscriber extends Subscriber {
     this.addAttributes(segment)
     const newCtx = ctx.enterSegment({ segment })
     return newCtx
-  }
-
-  addAttributes(segment) {
-    for (let [key, value] of Object.entries(this.parameters)) {
-      if (this.instanceKeys.includes(key) && !this.instanceReporting) {
-        continue
-      }
-
-      if (key === this.dbNameKey && !this.dbNameReporting) {
-        continue
-      }
-
-      if (key === this.hostKey && urltils.isLocalhost(value)) {
-        // eslint-disable-next-line sonarjs/updated-loop-counter
-        value = this.config.getHostnameSafe()
-      }
-
-      if (key === this.dbNameKey && typeof value === 'number') {
-        // eslint-disable-next-line sonarjs/updated-loop-counter
-        value = String(value)
-      }
-
-      segment.addAttribute(key, value)
-    }
   }
 }
 

--- a/lib/subscribers/db-query.js
+++ b/lib/subscribers/db-query.js
@@ -16,11 +16,12 @@ class DbQuerySubscriber extends DbSubscriber {
     const name = `${DB.STATEMENT}/${this.system}/${parsed.collection}/${parsed.operation}`
     const segment = this._agent.tracer.createSegment({
       name,
-      opaque: this.opaque,
       parent: ctx.segment,
       recorder: recordQueryMetrics.bind(parsed),
       transaction: ctx.transaction
     })
+
+    segment.opaque = this.opaque
 
     this.addAttributes(segment)
     const newCtx = ctx.enterSegment({ segment })

--- a/lib/subscribers/db-query.js
+++ b/lib/subscribers/db-query.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const DbSubscriber = require('./db')
+const recordQueryMetrics = require('../metrics/recorders/database')
+const { DB } = require('../metrics/names')
+const ParsedStatement = require('../db/parsed-statement')
+const parseSql = require('../db/query-parsers/sql')
+
+class DbQuerySubscriber extends DbSubscriber {
+  handler(data, ctx) {
+    const queryString = this.queryString
+    const parsed = this.parseQueryString(queryString)
+    const name = `${DB.STATEMENT}/${this.system}/${parsed.collection}/${parsed.operation}`
+    const segment = this._agent.tracer.createSegment({
+      name,
+      opaque: this.opaque,
+      parent: ctx.segment,
+      recorder: recordQueryMetrics.bind(parsed),
+      transaction: ctx.transaction
+    })
+
+    this.addAttributes(segment)
+    const newCtx = ctx.enterSegment({ segment })
+    return newCtx
+  }
+
+  parseQueryString(queryString) {
+    const parsed = this.parseQuery(queryString)
+    let collection = parsed.collection
+    // strip enclosing special characters from collection (table) name
+    if (typeof collection === 'string' && collection.length > 2) {
+      if (/^[[{'"`]/.test(collection)) {
+        collection = collection.substring(1)
+      }
+      if (/[\]}'"`]$/.test(collection)) {
+        collection = collection.substring(0, collection.length - 1)
+      }
+    }
+
+    const queryRecorded =
+      this.config.transaction_tracer.record_sql === 'raw' ||
+      this.config.transaction_tracer.record_sql === 'obfuscated'
+
+    return new ParsedStatement(
+      this._metrics.PREFIX,
+      parsed.operation,
+      collection,
+      queryRecorded ? parsed.query : null
+    )
+  }
+
+  parseQuery(queryString) {
+    return parseSql(queryString)
+  }
+}
+
+module.exports = DbQuerySubscriber

--- a/lib/subscribers/db.js
+++ b/lib/subscribers/db.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const Subscriber = require('./base')
+const urltils = require('../util/urltils')
+const { ALL, DB } = require('../metrics/names')
+
+class DbSubscriber extends Subscriber {
+  constructor(agent, id, system) {
+    super(agent, id)
+    this.system = system
+    this.config = agent.config
+    this._metrics = {
+      PREFIX: this.system,
+      ALL: `${DB.PREFIX}${this.system}/${ALL}`
+    }
+    this.instanceKeys = ['host', 'port_path_or_id']
+    this.hostKey = 'host'
+    this.dbNameKey = 'database_name'
+    this.requireActiveTx = true
+  }
+
+  get instanceReporting() {
+    return this._agent.config.datastore_tracer.instance_reporting.enabled
+  }
+
+  get dbNameReporting() {
+    return this._agent.config.datastore_tracer.database_name_reporting.enabled
+  }
+
+  addAttributes(segment) {
+    for (let [key, value] of Object.entries(this.parameters)) {
+      if (this.instanceKeys.includes(key) && !this.instanceReporting) {
+        continue
+      }
+
+      if (key === this.dbNameKey && !this.dbNameReporting) {
+        continue
+      }
+
+      if (key === this.hostKey && urltils.isLocalhost(value)) {
+        // eslint-disable-next-line sonarjs/updated-loop-counter
+        value = this.config.getHostnameSafe()
+      }
+
+      if (key === this.dbNameKey && typeof value === 'number') {
+        // eslint-disable-next-line sonarjs/updated-loop-counter
+        value = String(value)
+      }
+
+      segment.addAttribute(key, value)
+    }
+  }
+}
+
+module.exports = DbSubscriber

--- a/lib/subscribers/elasticsearch.js
+++ b/lib/subscribers/elasticsearch.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const DbQuerySubscriber = require('./db-query')
+const stringify = require('json-stringify-safe')
+const { queryParser } = require('../db/query-parsers/elasticsearch')
+
+class ElasticSearchSubscriber extends DbQuerySubscriber {
+  constructor(agent, id) {
+    id = id || '@elastic/elasticsearch:nr_request'
+    super(agent, id, 'ElasticSearch')
+    this.events = ['asyncEnd']
+    this.opaque = true
+  }
+
+  handler(data, ctx) {
+    const { self, arguments: args } = data
+    this.queryString = stringify(args?.[0])
+    this.setParameters(self)
+    return super.handler(data, ctx)
+  }
+
+  setParameters(self) {
+    this.parameters = {}
+    this.parameters.product = this.system
+    const connectionPool = self?.connectionPool?.connections?.[0]
+    if (connectionPool) {
+      const host = connectionPool?.url?.host?.split(':')
+      const port = connectionPool?.url?.port || host?.[1]
+      this.parameters.host = host?.[0]
+      this.parameters.port_path_or_id = port
+    }
+  }
+
+  parseQuery(queryString) {
+    return queryParser(queryString)
+  }
+}
+
+class ElasticSearchTransportSubscriber extends ElasticSearchSubscriber {
+  constructor(agent) {
+    super(agent, '@elastic/transport:nr_request', 'ElasticSearch')
+  }
+}
+
+const elasticSearchConfig = {
+  package: '@elastic/elasticsearch',
+  instrumentations: [
+    {
+      channelName: 'nr_request',
+      module: { name: '@elastic/elasticsearch', versionRange: '>=7.16.0', filePath: 'lib/Transport.js' },
+      functionQuery: {
+        className: 'Transport',
+        methodName: 'request',
+        kind: 'Async'
+      }
+    },
+  ]
+}
+
+const elasticSearchTransportConfig = {
+  package: '@elastic/transport',
+  instrumentations: [
+    {
+      channelName: 'nr_request',
+      module: { name: '@elastic/transport', versionRange: '>=8', filePath: 'lib/Transport.js' },
+      functionQuery: {
+        className: 'Transport',
+        methodName: 'request',
+        kind: 'Async'
+      }
+    }
+  ]
+}
+
+module.exports = {
+  elasticSearchConfig,
+  elasticSearchTransportConfig,
+  ElasticSearchSubscriber,
+  ElasticSearchTransportSubscriber
+}

--- a/lib/subscribers/index.js
+++ b/lib/subscribers/index.js
@@ -6,13 +6,19 @@
 'use strict'
 const createSubscriptionConfig = require('./create-config')
 const { IoRedisSubscriber, ioRedisConfig } = require('./ioredis')
+const { ElasticSearchSubscriber, elasticSearchConfig, ElasticSearchTransportSubscriber, elasticSearchTransportConfig } = require('./elasticsearch')
+
 const subscriberConfigs = [
+  elasticSearchConfig,
+  elasticSearchTransportConfig,
   ioRedisConfig
 ]
 
 const config = createSubscriptionConfig(subscriberConfigs)
 
 const subscribers = {
+  ElasticSearchSubscriber,
+  ElasticSearchTransportSubscriber,
   IoRedisSubscriber
 }
 

--- a/test/versioned/elastic/elasticsearch.test.js
+++ b/test/versioned/elastic/elasticsearch.test.js
@@ -104,12 +104,44 @@ test('Elasticsearch instrumentation', async (t) => {
       assert.ok(transaction, 'transaction should be visible')
       await client.indices.create({ index })
       const trace = transaction.trace
+      // should only have two segments: the root and the index create, verifies opaque is working
+      assert.equal(transaction.numSegments, 2)
       const [firstChild] = trace.getChildren(trace.root.id)
       assert.equal(
         firstChild.name,
         `Datastore/statement/ElasticSearch/${index}/index.create`,
         'should record index PUT as create'
       )
+    })
+  })
+
+  await t.test('should be able to record creating an index(callback)', async (t) => {
+    const { agent, client, pkgVersion } = t.nr
+    if (semver.gte(pkgVersion, '8.0.0')) {
+      return
+    }
+
+    const index = `test-index-${randomString()}`
+    t.after(async () => {
+      await client.indices.delete({ index })
+    })
+    await helper.runInTransaction(agent, async function transactionInScope(transaction) {
+      assert.ok(transaction, 'transaction should be visible')
+      await new Promise((resolve) => {
+        client.indices.create({ index }, (err) => {
+          assert.ifError(err, 'should not error when creating index')
+          const trace = transaction.trace
+          // should only have two segments: the root and the index create, verifies opaque is working
+          assert.equal(transaction.numSegments, 2)
+          const [firstChild] = trace.getChildren(trace.root.id)
+          assert.equal(
+            firstChild.name,
+            `Datastore/statement/ElasticSearch/${index}/index.create`,
+            'should record index PUT as create'
+          )
+          resolve()
+        })
+      })
     })
   })
 

--- a/test/versioned/elastic/elasticsearch.test.js
+++ b/test/versioned/elastic/elasticsearch.test.js
@@ -211,8 +211,6 @@ test('Elasticsearch instrumentation', async (t) => {
       assert.equal(attrs.product, 'ElasticSearch')
       assert.equal(attrs.host, METRIC_HOST_NAME)
       assert.equal(attrs.port_path_or_id, `${params.elastic_port}`)
-      // TODO: update once instrumentation is properly setting database name
-      assert.equal(attrs.database_name, 'unknown')
       transaction.end()
       assert.ok(agent.queries.samples.size > 0, 'there should be a query sample')
       for (const query of agent.queries.samples.values()) {


### PR DESCRIPTION
## Description

This PR adds further abstractions on database subscribers.  It adds a new `db-query` subscriber but also an abstract db subscriber for handling of properties and assigning relevant db attributes to segment.  I removed the assertion for `unknown` as database_name for elasticsearch as there truly isn't a databse_name only indicies.

## How to Test

```sh
npm run versioned:internal elastic
```

## Related Issues

Closes #3055 