### PR TITLE
fix: Defensive `addAttribute` code

### DIFF
--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -2030,7 +2030,7 @@ function wrapStreamEmit({ stream, shim, segment, specEvent, shouldCreateSegment,
           const newContext = context.enterSegment({ segment: eventSegment })
           eventBoundEmit = shim.bindContext({ nodule: emit, full: true, context: newContext })
         }
-        eventSegment.addAttribute('count', ++emitCount)
+        if (eventSegment) eventSegment.addAttribute('count', ++emitCount)
         emitToCall = eventBoundEmit
       }
       if (evnt === 'end' || evnt === 'error') {


### PR DESCRIPTION
This resolves #3202 by asserting that `eventSegment` exists before attempting to `addAttribute`. However, this does not resolve the root issue of why `eventSegment` could be null/undefined.