### PR TITLE
refactor: Removed `id` parameter from `opensearch` class

### DIFF
--- a/lib/subscribers/elasticsearch.js
+++ b/lib/subscribers/elasticsearch.js
@@ -9,12 +9,13 @@ const stringify = require('json-stringify-safe')
 const { queryParser } = require('../db/query-parsers/elasticsearch')
 
 class ElasticSearchSubscriber extends DbQuerySubscriber {
-  constructor(agent, id) {
+  constructor(agent, id, system) {
     // elasticsearch has a different id for the same file
     // in different versions so we have a default id and
     // can pass in another id
     id = id || '@elastic/elasticsearch:nr_request'
-    super(agent, id, 'ElasticSearch')
+    system = system || 'ElasticSearch'
+    super(agent, id, system)
     this.events = ['asyncEnd']
     this.opaque = true
   }

--- a/lib/subscribers/elasticsearch.js
+++ b/lib/subscribers/elasticsearch.js
@@ -10,6 +10,9 @@ const { queryParser } = require('../db/query-parsers/elasticsearch')
 
 class ElasticSearchSubscriber extends DbQuerySubscriber {
   constructor(agent, id) {
+    // elasticsearch has a different id for the same file
+    // in different versions so we have a default id and
+    // can pass in another id
     id = id || '@elastic/elasticsearch:nr_request'
     super(agent, id, 'ElasticSearch')
     this.events = ['asyncEnd']

--- a/lib/subscribers/opensearch.js
+++ b/lib/subscribers/opensearch.js
@@ -10,9 +10,8 @@ const stringify = require('json-stringify-safe')
 const { queryParser } = require('../db/query-parsers/elasticsearch')
 
 class OpenSearchSubscriber extends DbQuerySubscriber {
-  constructor(agent, id) {
-    id = id || '@opensearch-project/opensearch:nr_request'
-    super(agent, id, 'OpenSearch')
+  constructor(agent) {
+    super(agent, '@opensearch-project/opensearch:nr_request', 'OpenSearch')
     this.events = ['asyncEnd']
     this.opaque = true
   }

--- a/lib/subscribers/opensearch.js
+++ b/lib/subscribers/opensearch.js
@@ -5,38 +5,10 @@
 
 'use strict'
 
-const DbQuerySubscriber = require('./db-query')
-const stringify = require('json-stringify-safe')
-const { queryParser } = require('../db/query-parsers/elasticsearch')
-
-class OpenSearchSubscriber extends DbQuerySubscriber {
+const { ElasticSearchSubscriber } = require('./elasticsearch')
+class OpenSearchSubscriber extends ElasticSearchSubscriber {
   constructor(agent) {
     super(agent, '@opensearch-project/opensearch:nr_request', 'OpenSearch')
-    this.events = ['asyncEnd']
-    this.opaque = true
-  }
-
-  handler(data, ctx) {
-    const { self, arguments: args } = data
-    this.queryString = stringify(args?.[0])
-    this.setParameters(self)
-    return super.handler(data, ctx)
-  }
-
-  setParameters(self) {
-    this.parameters = {}
-    this.parameters.product = this.system
-    const connectionPool = self?.connectionPool?.connections?.[0]
-    if (connectionPool) {
-      const host = connectionPool?.url?.host?.split(':')
-      const port = connectionPool?.url?.port || host?.[1]
-      this.parameters.host = host?.[0]
-      this.parameters.port_path_or_id = port
-    }
-  }
-
-  parseQuery(queryString) {
-    return queryParser(queryString)
   }
 }
 


### PR DESCRIPTION
Removed `id` parameter from `opensearch` class because they are not needed in `opensearch`. And added a comment to `elasticsearch` explaining why we need `id` parameter there. 