### PR TITLE
chore: Replaced `openAIApiKey` with `apiKey`

### DIFF
--- a/test/versioned/langchain/runnables-streaming.test.js
+++ b/test/versioned/langchain/runnables-streaming.test.js
@@ -44,7 +44,7 @@ async function beforeEach({ enabled, ctx }) {
 
   ctx.nr.prompt = ChatPromptTemplate.fromMessages([['assistant', '{topic} response']])
   ctx.nr.model = new ChatOpenAI({
-    openAIApiKey: 'fake-key',
+    apiKey: 'fake-key',
     maxRetries: 0,
     configuration: {
       baseURL: `http://${host}:${port}`

--- a/test/versioned/langchain/runnables.test.js
+++ b/test/versioned/langchain/runnables.test.js
@@ -38,7 +38,7 @@ test.beforeEach(async (ctx) => {
 
   ctx.nr.prompt = ChatPromptTemplate.fromMessages([['assistant', 'You are a {topic}.']])
   ctx.nr.model = new ChatOpenAI({
-    openAIApiKey: 'fake-key',
+    apiKey: 'fake-key',
     maxRetries: 0,
     configuration: {
       baseURL: `http://${host}:${port}`

--- a/test/versioned/langchain/vectorstore.test.js
+++ b/test/versioned/langchain/vectorstore.test.js
@@ -45,7 +45,7 @@ test.beforeEach(async (ctx) => {
   const { ElasticVectorSearch } = require('@langchain/community/vectorstores/elasticsearch')
 
   ctx.nr.embedding = new OpenAIEmbeddings({
-    openAIApiKey: 'fake-key',
+    apiKey: 'fake-key',
     configuration: {
       baseURL: `http://${host}:${port}`
     }


### PR DESCRIPTION
Tests were failing.  Replaced `openAIApiKey` with `apiKey`