### PR TITLE
test: Fixed assertSegments to insert all expected segments

### DIFF
--- a/test/lib/custom-assertions/assert-segments.js
+++ b/test/lib/custom-assertions/assert-segments.js
@@ -78,6 +78,10 @@
  *                                  directly under test.  Only used when `exact` is true.
  * @param {object} [deps] Injected dependencies.
  * @param {object} [deps.assert] Assertion library to use.
+ * @param options
+ * @param root0
+ * @param root0.assert
+ * @param options.assert
  */
 module.exports = function assertSegments( // eslint-disable-line sonarjs/cognitive-complexity
   trace,
@@ -145,12 +149,7 @@ module.exports = function assertSegments( // eslint-disable-line sonarjs/cogniti
       const sequenceItem = expected[i]
 
       if (typeof sequenceItem === 'string') {
-        // find corresponding child in parent
-        for (let j = 0; j < children.length; j++) {
-          if (children[j].name === sequenceItem) {
-            child = children[j]
-          }
-        }
+        const child = children.find((segment) => segment.name === sequenceItem)
         assert.ok(child, 'segment "' + parent.name + '" should have child "' + sequenceItem + '"')
         if (typeof expected[i + 1] === 'object') {
           assertSegments(trace, child, expected[i + 1], { exact }, { assert })

--- a/test/versioned/google-genai/chat-completions.test.js
+++ b/test/versioned/google-genai/chat-completions.test.js
@@ -27,13 +27,15 @@ const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
 const responses = require('./mock-responses')
 const TRACKING_METRIC = `Supportability/Nodejs/ML/Gemini/${pkgVersion}`
 
-test.beforeEach(async (ctx) => {
-  ctx.nr = {}
+/**
+ * DISCLAIMER:
+ * This test suite is registering all instrumentation once and then cleaning up what is needed after each test.
+ * If you do not do it this way, undici does not play nice with our context manager. This leads to every test,
+ * after the first one not having the appropriate context for the outgoing call to the mock server.
+ */
+test('Google GenAI Chat Completion tests', async (t) => {
   const { host, port, server } = await GoogleGenAIMockServer()
-  ctx.nr.host = host
-  ctx.nr.port = port
-  ctx.nr.server = server
-  ctx.nr.agent = helper.instrumentMockedAgent({
+  const agent = helper.instrumentMockedAgent({
     ai_monitoring: {
       enabled: true
     },
@@ -43,7 +45,7 @@ test.beforeEach(async (ctx) => {
   })
   const { GoogleGenAI } = require('@google/genai')
 
-  ctx.nr.client = new GoogleGenAI({
+  const client = new GoogleGenAI({
     apiKey: 'fake-versioned-test-key',
     vertexai: false,
     httpOptions: {
@@ -51,425 +53,414 @@ test.beforeEach(async (ctx) => {
     },
     httpMethod: 'GET'
   })
-})
 
-test.afterEach((ctx) => {
-  helper.unloadAgent(ctx.nr.agent)
-  ctx.nr.server?.close()
-  removeModules('@google/genai')
-})
-
-test('should create span on successful models generateContent', (t, end) => {
-  const { client, agent, host, port } = t.nr
-  helper.runInTransaction(agent, async (tx) => {
-    const model = 'gemini-2.0-flash'
-    const result = await client.models.generateContent({
-      model,
-      contents: 'You are a mathematician.'
-    })
-
-    assert.equal(result.headers, undefined, 'should remove response headers from user result')
-    assert.equal(result.candidates[0].content.parts[0].text, '1 plus 2 is 3.')
-
-    const name = `External/${host}:${port}/v1beta/models/${model}:generateContent`
-    assertSegments(
-      tx.trace,
-      tx.trace.root,
-      [GEMINI.COMPLETION, [name]],
-      { exact: false }
-    )
-
-    tx.end()
-    assertSpanKind({
-      agent,
-      segments: [
-        { name: GEMINI.COMPLETION, kind: 'internal' }
-      ]
-    })
-    end()
+  t.after(() => {
+    helper.unloadAgent(agent)
+    server?.close()
+    removeModules('@google/genai')
   })
-})
 
-test('should increment tracking metric for each chat completion event', (t, end) => {
-  const { client, agent } = t.nr
-  helper.runInTransaction(agent, async (tx) => {
-    await client.models.generateContent({
-      model: 'gemini-2.0-flash',
-      contents: 'You are a mathematician.'
-    })
-
-    const metrics = agent.metrics.getOrCreateMetric(TRACKING_METRIC)
-    assert.equal(metrics.callCount > 0, true)
-
-    tx.end()
-    end()
+  t.afterEach(() => {
+    agent.customEventAggregator.clear()
+    agent.llm.tokenCountCallback = null
+    agent.config.ai_monitoring.streaming.enabled = true
   })
-})
 
-test('should create chat completion message and summary for every message sent', (t, end) => {
-  const { client, agent } = t.nr
-  helper.runInTransaction(agent, async (tx) => {
-    const model = 'gemini-2.0-flash'
-    const content = 'You are a mathematician.'
-    await client.models.generateContent({
-      model,
-      contents: [content, 'What does 1 plus 1 equal?'],
-      config: {
-        maxOutputTokens: 100,
-        temperature: 0.5
-      }
-    })
-
-    const events = agent.customEventAggregator.events.toArray()
-    assert.equal(events.length, 4, 'should create a chat completion message and summary event')
-    const chatMsgs = events.filter(([{ type }]) => type === 'LlmChatCompletionMessage')
-    assertChatCompletionMessages({
-      tx,
-      chatMsgs,
-      model,
-      resContent: '1 plus 2 is 3.',
-      reqContent: content
-    })
-
-    const chatSummary = events.filter(([{ type }]) => type === 'LlmChatCompletionSummary')[0]
-    assertChatCompletionSummary({ tx, model, chatSummary, tokenUsage: true })
-
-    tx.end()
-    end()
-  })
-})
-
-// Streaming tests
-// TODO: this test is not creating an external segment properly,
-// keep previous code for reference, but commented out
-test('should create span on successful models generateContentStream', (t, end) => {
-  // const { client, agent, host, port } = t.nr
-  const { client, agent } = t.nr
-  helper.runInTransaction(agent, async (tx) => {
-    const content = 'Streamed response'
-    const model = 'gemini-2.0-flash'
-    const stream = await client.models.generateContentStream({
-      model,
-      contents: content
-    })
-
-    let chunk = {}
-    let res = ''
-    for await (chunk of stream) {
-      assert.ok(chunk.text, 'should have text in chunk')
-      res += chunk.text
-    }
-
-    assert.equal(chunk.headers, undefined, 'should remove response headers from user result')
-    assert.equal(chunk.candidates[0].content.role, 'model')
-    const expectedRes = responses.get(content)
-    assert.equal(chunk.candidates[0].content.parts[0].text, expectedRes.body.candidates[0].content.parts[0].text)
-    assert.equal(chunk.candidates[0].content.parts[0].text, res)
-
-    // const name = `External/${host}:${port}/v1beta/models/${model}:generateContentStream`
-    assertSegments(
-      tx.trace,
-      tx.trace.root,
-      // [GEMINI.COMPLETION, [name]],
-      [GEMINI.COMPLETION],
-      { exact: false }
-    )
-
-    tx.end()
-    end()
-  })
-})
-
-test('should create chat completion message and summary for every message sent in stream', (t, end) => {
-  const { client, agent } = t.nr
-  helper.runInTransaction(agent, async (tx) => {
-    const content = 'Streamed response'
-    const model = 'gemini-2.0-flash'
-    const stream = await client.models.generateContentStream({
-      config: {
-        maxOutputTokens: 100,
-        temperature: 0.5
-      },
-      model,
-      contents: [content, 'What does 1 plus 1 equal?']
-    })
-
-    let res = ''
-    for await (const chunk of stream) {
-      assert.ok(chunk.text, 'should have text in chunk')
-      res += chunk.text
-    }
-
-    const events = agent.customEventAggregator.events.toArray()
-    assert.equal(events.length, 4, 'should create a chat completion message and summary event')
-    const chatMsgs = events.filter(([{ type }]) => type === 'LlmChatCompletionMessage')
-    assertChatCompletionMessages({
-      tx,
-      chatMsgs,
-      id: '0e7e48f05cf962e1692113a49b276e8bb1bc',
-      model,
-      resContent: res,
-      reqContent: content
-    })
-
-    const chatSummary = events.filter(([{ type }]) => type === 'LlmChatCompletionSummary')[0]
-    assertChatCompletionSummary({ tx, model, chatSummary })
-
-    tx.end()
-    end()
-  })
-})
-
-test('should call the tokenCountCallback in streaming', (t, end) => {
-  const { client, agent } = t.nr
-  const promptContent = 'Streamed response'
-  const promptContent2 = 'What does 1 plus 1 equal?'
-  let res = ''
-  const expectedModel = 'gemini-2.0-flash'
-  const api = helper.getAgentApi()
-  let cbCalled = false
-  function cb(model, content) {
-    assert.equal(model, expectedModel)
-    cbCalled = true
-    if (content === promptContent || content === promptContent2) {
-      return 53
-    } else if (content === res) {
-      return 11
-    }
-  }
-  api.setLlmTokenCountCallback(cb)
-
-  helper.runInTransaction(agent, async (tx) => {
-    const stream = await client.models.generateContentStream({
-      config: {
-        maxOutputTokens: 100,
-        temperature: 0.5
-      },
-      model: expectedModel,
-      contents: [promptContent, promptContent2]
-    })
-
-    for await (const chunk of stream) {
-      assert.ok(chunk.text, 'should have text in chunk')
-      res += chunk.text
-    }
-
-    assert.equal(cbCalled, true, 'should call the token count callback')
-    const events = agent.customEventAggregator.events.toArray()
-    const chatMsgs = events.filter(([{ type }]) => type === 'LlmChatCompletionMessage')
-    assertChatCompletionMessages({
-      tokenUsage: true,
-      tx,
-      chatMsgs,
-      id: '"0e7e48f05cf962e1692113a49b276e8bb1bc"',
-      model: expectedModel,
-      resContent: res,
-      reqContent: promptContent
-    })
-
-    tx.end()
-    end()
-  })
-})
-
-test('handles error in stream', (t, end) => {
-  const { client, agent } = t.nr
-  helper.runInTransaction(agent, async (tx) => {
-    const content = 'bad stream'
-    const model = 'gemini-2.0-flash'
-
-    try {
-      const stream = await client.models.generateContentStream({
+  await t.test('should create span on successful models generateContent', (t, end) => {
+    helper.runInTransaction(agent, async (tx) => {
+      const model = 'gemini-2.0-flash'
+      const result = await client.models.generateContent({
         model,
-        contents: [content, content, content],
+        contents: 'You are a mathematician.'
+      })
+
+      assert.equal(result.headers, undefined, 'should remove response headers from user result')
+      assert.equal(result.candidates[0].content.parts[0].text, '1 plus 2 is 3.')
+
+      const name = `External/${host}:${port}/v1beta/models/${model}:generateContent`
+      assertSegments(
+        tx.trace,
+        tx.trace.root,
+        [GEMINI.COMPLETION, [name]],
+        { exact: false }
+      )
+
+      tx.end()
+      assertSpanKind({
+        agent,
+        segments: [
+          { name: GEMINI.COMPLETION, kind: 'internal' }
+        ]
+      })
+      end()
+    })
+  })
+
+  await t.test('should increment tracking metric for each chat completion event', (t, end) => {
+    helper.runInTransaction(agent, async (tx) => {
+      await client.models.generateContent({
+        model: 'gemini-2.0-flash',
+        contents: 'You are a mathematician.'
+      })
+
+      const metrics = agent.metrics.getOrCreateMetric(TRACKING_METRIC)
+      assert.equal(metrics.callCount > 0, true)
+
+      tx.end()
+      end()
+    })
+  })
+
+  await t.test('should create chat completion message and summary for every message sent', (t, end) => {
+    helper.runInTransaction(agent, async (tx) => {
+      const model = 'gemini-2.0-flash'
+      const content = 'You are a mathematician.'
+      await client.models.generateContent({
+        model,
+        contents: [content, 'What does 1 plus 1 equal?'],
         config: {
           maxOutputTokens: 100,
           temperature: 0.5
         }
       })
 
-      for await (const chunk of stream) {
-        // No-op to trigger the error
-        assert.ok(chunk)
-      }
-    } catch {
       const events = agent.customEventAggregator.events.toArray()
-      assert.equal(events.length, 4)
+      assert.equal(events.length, 4, 'should create a chat completion message and summary event')
+      const chatMsgs = events.filter(([{ type }]) => type === 'LlmChatCompletionMessage')
+      assertChatCompletionMessages({
+        tx,
+        chatMsgs,
+        model,
+        resContent: '1 plus 2 is 3.',
+        reqContent: content
+      })
+
       const chatSummary = events.filter(([{ type }]) => type === 'LlmChatCompletionSummary')[0]
-      assertChatCompletionSummary({ tx, model, chatSummary, error: true })
-      assert.equal(tx.exceptions.length, 1)
-      // only asserting message and completion_id as the rest of the attrs
-      // are asserted in other tests
-      match(tx.exceptions[0], {
-        customAttributes: {
-          'error.message': /.*bad stream.*/,
-          completion_id: /\w{32}/
-        }
+      assertChatCompletionSummary({ tx, model, chatSummary, tokenUsage: true })
+
+      tx.end()
+      end()
+    })
+  })
+
+  await t.test('should create span on successful models generateContentStream', (t, end) => {
+    helper.runInTransaction(agent, async (tx) => {
+      const content = 'Streamed response'
+      const model = 'gemini-2.0-flash'
+      const stream = await client.models.generateContentStream({
+        model,
+        contents: content
+      })
+
+      let chunk = {}
+      let res = ''
+      for await (chunk of stream) {
+        assert.ok(chunk.text, 'should have text in chunk')
+        res += chunk.text
+      }
+
+      assert.equal(chunk.headers, undefined, 'should remove response headers from user result')
+      assert.equal(chunk.candidates[0].content.role, 'model')
+      const expectedRes = responses.get(content)
+      assert.equal(chunk.candidates[0].content.parts[0].text, expectedRes.body.candidates[0].content.parts[0].text)
+      assert.equal(chunk.candidates[0].content.parts[0].text, res)
+
+      const name = `External/${host}:${port}/v1beta/models/${model}:streamGenerateContent`
+      assertSegments(
+        tx.trace,
+        tx.trace.root,
+        [GEMINI.COMPLETION, [name]],
+        { exact: false }
+      )
+
+      tx.end()
+      end()
+    })
+  })
+
+  await t.test('should create chat completion message and summary for every message sent in stream', (t, end) => {
+    helper.runInTransaction(agent, async (tx) => {
+      const content = 'Streamed response'
+      const model = 'gemini-2.0-flash'
+      const stream = await client.models.generateContentStream({
+        config: {
+          maxOutputTokens: 100,
+          temperature: 0.5
+        },
+        model,
+        contents: [content, 'What does 1 plus 1 equal?']
+      })
+
+      let res = ''
+      for await (const chunk of stream) {
+        assert.ok(chunk.text, 'should have text in chunk')
+        res += chunk.text
+      }
+
+      const events = agent.customEventAggregator.events.toArray()
+      assert.equal(events.length, 4, 'should create a chat completion message and summary event')
+      const chatMsgs = events.filter(([{ type }]) => type === 'LlmChatCompletionMessage')
+      assertChatCompletionMessages({
+        tx,
+        chatMsgs,
+        id: '0e7e48f05cf962e1692113a49b276e8bb1bc',
+        model,
+        resContent: res,
+        reqContent: content
+      })
+
+      const chatSummary = events.filter(([{ type }]) => type === 'LlmChatCompletionSummary')[0]
+      assertChatCompletionSummary({ tx, model, chatSummary })
+
+      tx.end()
+      end()
+    })
+  })
+
+  await t.test('should call the tokenCountCallback in streaming', (t, end) => {
+    const promptContent = 'Streamed response'
+    const promptContent2 = 'What does 1 plus 1 equal?'
+    let res = ''
+    const expectedModel = 'gemini-2.0-flash'
+    const api = helper.getAgentApi()
+    let cbCalled = false
+    function cb(model, content) {
+      assert.equal(model, expectedModel)
+      cbCalled = true
+      if (content === promptContent || content === promptContent2) {
+        return 53
+      } else if (content === res) {
+        return 11
+      }
+    }
+    api.setLlmTokenCountCallback(cb)
+
+    helper.runInTransaction(agent, async (tx) => {
+      const stream = await client.models.generateContentStream({
+        config: {
+          maxOutputTokens: 100,
+          temperature: 0.5
+        },
+        model: expectedModel,
+        contents: [promptContent, promptContent2]
+      })
+
+      for await (const chunk of stream) {
+        assert.ok(chunk.text, 'should have text in chunk')
+        res += chunk.text
+      }
+
+      assert.equal(cbCalled, true, 'should call the token count callback')
+      const events = agent.customEventAggregator.events.toArray()
+      const chatMsgs = events.filter(([{ type }]) => type === 'LlmChatCompletionMessage')
+      assertChatCompletionMessages({
+        tokenUsage: true,
+        tx,
+        chatMsgs,
+        id: '"0e7e48f05cf962e1692113a49b276e8bb1bc"',
+        model: expectedModel,
+        resContent: res,
+        reqContent: promptContent
       })
 
       tx.end()
       end()
-    }
-  })
-})
-
-// Other tests
-test('should not create llm events when ai_monitoring.streaming.enabled is false', (t, end) => {
-  const { client, agent } = t.nr
-  agent.config.ai_monitoring.streaming.enabled = false
-  helper.runInTransaction(agent, async (tx) => {
-    const content = 'Streamed response'
-    const model = 'gemini-2.0-flash'
-    const stream = await client.models.generateContentStream({
-      config: {
-        maxOutputTokens: 100,
-        temperature: 0.5
-      },
-      model,
-      contents: content
     })
-
-    let res = ''
-    let chunk = {}
-
-    for await (chunk of stream) {
-      assert.ok(chunk.text, 'should have text in chunk')
-      res += chunk.text
-    }
-    const expectedRes = responses.get(content)
-    assert.equal(res, expectedRes.body.candidates[0].content.parts[0].text)
-
-    const events = agent.customEventAggregator.events.toArray()
-    assert.equal(events.length, 0, 'should not llm events when streaming is disabled')
-    const streamingDisabled = agent.metrics.getOrCreateMetric(
-      'Supportability/Nodejs/ML/Streaming/Disabled'
-    )
-    assert.equal(streamingDisabled.callCount > 0, true)
-
-    tx.end()
-    end()
-  })
-})
-
-test('should not create llm events when not in a transaction', async (t) => {
-  const { client, agent } = t.nr
-  await client.models.generateContent({
-    model: 'gemini-2.0-flash',
-    contents: 'You are a mathematician.'
   })
 
-  const events = agent.customEventAggregator.events.toArray()
-  assert.equal(events.length, 0, 'should not create llm events')
-})
+  await t.test('handles error in stream', (t, end) => {
+    helper.runInTransaction(agent, async (tx) => {
+      const content = 'bad stream'
+      const model = 'gemini-2.0-flash'
 
-test('auth errors should be tracked', (t, end) => {
-  const { client, agent } = t.nr
-  helper.runInTransaction(agent, async (tx) => {
-    try {
-      await client.models.generateContent({
-        model: 'gemini-2.0-flash',
-        contents: 'Invalid API key.'
-      })
-    } catch {}
+      try {
+        const stream = await client.models.generateContentStream({
+          model,
+          contents: [content, content, content],
+          config: {
+            maxOutputTokens: 100,
+            temperature: 0.5
+          }
+        })
 
-    assert.equal(tx.exceptions.length, 1)
-    match(tx.exceptions[0], {
-      error: {
-        message: /.*API key not valid. Please pass a valid API key.*/
-      },
-      customAttributes: {
-        'http.statusCode': 400,
-        'error.message': /.*API key not valid. Please pass a valid API key..*/,
-        'error.code': 400,
-        'error.param': undefined,
-        completion_id: /\w{32}/
-      },
-      agentAttributes: {
-        spanId: /\w+/
+        for await (const chunk of stream) {
+          // No-op to trigger the error
+          assert.ok(chunk)
+        }
+      } catch {
+        const events = agent.customEventAggregator.events.toArray()
+        assert.equal(events.length, 4)
+        const chatSummary = events.filter(([{ type }]) => type === 'LlmChatCompletionSummary')[0]
+        assertChatCompletionSummary({ tx, model, chatSummary, error: true })
+        assert.equal(tx.exceptions.length, 1)
+        // only asserting message and completion_id as the rest of the attrs
+        // are asserted in other tests
+        match(tx.exceptions[0], {
+          customAttributes: {
+            'error.message': /.*bad stream.*/,
+            completion_id: /\w{32}/
+          }
+        })
+
+        tx.end()
+        end()
       }
     })
-
-    const summary = agent.customEventAggregator.events.toArray().find((e) => {
-      return e[0].type === 'LlmChatCompletionSummary'
-    })
-    assert.ok(summary)
-    assert.equal(summary[1].error, true)
-
-    tx.end()
-    end()
   })
-})
 
-test('should add llm attribute to transaction', (t, end) => {
-  const { client, agent } = t.nr
-  helper.runInTransaction(agent, async (tx) => {
+  // Other tests
+  await t.test('should not create llm events when ai_monitoring.streaming.enabled is false', (t, end) => {
+    agent.config.ai_monitoring.streaming.enabled = false
+    helper.runInTransaction(agent, async (tx) => {
+      const content = 'Streamed response'
+      const model = 'gemini-2.0-flash'
+      const stream = await client.models.generateContentStream({
+        config: {
+          maxOutputTokens: 100,
+          temperature: 0.5
+        },
+        model,
+        contents: content
+      })
+
+      let res = ''
+      let chunk = {}
+
+      for await (chunk of stream) {
+        assert.ok(chunk.text, 'should have text in chunk')
+        res += chunk.text
+      }
+      const expectedRes = responses.get(content)
+      assert.equal(res, expectedRes.body.candidates[0].content.parts[0].text)
+
+      const events = agent.customEventAggregator.events.toArray()
+      assert.equal(events.length, 0, 'should not llm events when streaming is disabled')
+      const streamingDisabled = agent.metrics.getOrCreateMetric(
+        'Supportability/Nodejs/ML/Streaming/Disabled'
+      )
+      assert.equal(streamingDisabled.callCount > 0, true)
+
+      tx.end()
+      end()
+    })
+  })
+
+  await t.test('should not create llm events when not in a transaction', async (t) => {
     await client.models.generateContent({
       model: 'gemini-2.0-flash',
       contents: 'You are a mathematician.'
     })
 
-    const attributes = tx.trace.attributes.get(DESTINATIONS.TRANS_EVENT)
-    assert.equal(attributes.llm, true)
-
-    tx.end()
-    end()
+    const events = agent.customEventAggregator.events.toArray()
+    assert.equal(events.length, 0, 'should not create llm events')
   })
-})
 
-test('should record LLM custom events with attributes', (t, end) => {
-  const { client, agent } = t.nr
-  const api = helper.getAgentApi()
+  await t.test('auth errors should be tracked', (t, end) => {
+    helper.runInTransaction(agent, async (tx) => {
+      try {
+        await client.models.generateContent({
+          model: 'gemini-2.0-flash',
+          contents: 'Invalid API key.'
+        })
+      } catch {}
 
-  helper.runInTransaction(agent, () => {
-    api.withLlmCustomAttributes({ 'llm.shared': true, 'llm.path': 'root/' }, async () => {
-      await api.withLlmCustomAttributes(
-        { 'llm.path': 'root/branch1', 'llm.attr1': true },
-        async () => {
-          agent.config.ai_monitoring.streaming.enabled = true
-          const model = 'gemini-2.0-flash'
-          const content = 'You are a mathematician.'
-          await client.models.generateContent({
-            config: {
-              max_tokens: 100,
-              temperature: 0.5
-            },
-            model,
-            contents: [content, 'What does 1 plus 1 equal?']
-          })
-        }
-      )
-
-      await api.withLlmCustomAttributes(
-        { 'llm.path': 'root/branch2', 'llm.attr2': true },
-        async () => {
-          agent.config.ai_monitoring.streaming.enabled = true
-          const model = 'gemini-2.0-flash'
-          const content = 'You are a mathematician.'
-          await client.models.generateContent({
-            config: {
-              max_tokens: 100,
-              temperature: 0.5
-            },
-            model,
-            contents: [content, 'What does 1 plus 2 equal?']
-          })
-        }
-      )
-
-      const events = agent.customEventAggregator.events.toArray().map((event) => event[1])
-
-      events.forEach((event) => {
-        assert.ok(event['llm.shared'])
-        if (event['llm.path'] === 'root/branch1') {
-          assert.ok(event['llm.attr1'])
-          assert.equal(event['llm.attr2'], undefined)
-        } else {
-          assert.ok(event['llm.attr2'])
-          assert.equal(event['llm.attr1'], undefined)
+      assert.equal(tx.exceptions.length, 1)
+      match(tx.exceptions[0], {
+        error: {
+          message: /.*API key not valid. Please pass a valid API key.*/
+        },
+        customAttributes: {
+          'http.statusCode': 400,
+          'error.message': /.*API key not valid. Please pass a valid API key..*/,
+          'error.code': 400,
+          'error.param': undefined,
+          completion_id: /\w{32}/
+        },
+        agentAttributes: {
+          spanId: /\w+/
         }
       })
 
+      const summary = agent.customEventAggregator.events.toArray().find((e) => {
+        return e[0].type === 'LlmChatCompletionSummary'
+      })
+      assert.ok(summary)
+      assert.equal(summary[1].error, true)
+
+      tx.end()
       end()
+    })
+  })
+
+  await t.test('should add llm attribute to transaction', (t, end) => {
+    helper.runInTransaction(agent, async (tx) => {
+      await client.models.generateContent({
+        model: 'gemini-2.0-flash',
+        contents: 'You are a mathematician.'
+      })
+
+      const attributes = tx.trace.attributes.get(DESTINATIONS.TRANS_EVENT)
+      assert.equal(attributes.llm, true)
+
+      tx.end()
+      end()
+    })
+  })
+
+  await t.test('should record LLM custom events with attributes', (t, end) => {
+    const api = helper.getAgentApi()
+
+    helper.runInTransaction(agent, () => {
+      api.withLlmCustomAttributes({ 'llm.shared': true, 'llm.path': 'root/' }, async () => {
+        await api.withLlmCustomAttributes(
+          { 'llm.path': 'root/branch1', 'llm.attr1': true },
+          async () => {
+            agent.config.ai_monitoring.streaming.enabled = true
+            const model = 'gemini-2.0-flash'
+            const content = 'You are a mathematician.'
+            await client.models.generateContent({
+              config: {
+                max_tokens: 100,
+                temperature: 0.5
+              },
+              model,
+              contents: [content, 'What does 1 plus 1 equal?']
+            })
+          }
+        )
+
+        await api.withLlmCustomAttributes(
+          { 'llm.path': 'root/branch2', 'llm.attr2': true },
+          async () => {
+            agent.config.ai_monitoring.streaming.enabled = true
+            const model = 'gemini-2.0-flash'
+            const content = 'You are a mathematician.'
+            await client.models.generateContent({
+              config: {
+                max_tokens: 100,
+                temperature: 0.5
+              },
+              model,
+              contents: [content, 'What does 1 plus 2 equal?']
+            })
+          }
+        )
+
+        const events = agent.customEventAggregator.events.toArray().map((event) => event[1])
+
+        events.forEach((event) => {
+          assert.ok(event['llm.shared'])
+          if (event['llm.path'] === 'root/branch1') {
+            assert.ok(event['llm.attr1'])
+            assert.equal(event['llm.attr2'], undefined)
+          } else {
+            assert.ok(event['llm.attr2'])
+            assert.equal(event['llm.attr1'], undefined)
+          }
+        })
+
+        end()
+      })
     })
   })
 })

--- a/test/versioned/google-genai/chat-completions.test.js
+++ b/test/versioned/google-genai/chat-completions.test.js
@@ -62,19 +62,20 @@ test.afterEach((ctx) => {
 test('should create span on successful models generateContent', (t, end) => {
   const { client, agent, host, port } = t.nr
   helper.runInTransaction(agent, async (tx) => {
+    const model = 'gemini-2.0-flash'
     const result = await client.models.generateContent({
-      model: 'gemini-2.0-flash',
+      model,
       contents: 'You are a mathematician.'
     })
 
     assert.equal(result.headers, undefined, 'should remove response headers from user result')
     assert.equal(result.candidates[0].content.parts[0].text, '1 plus 2 is 3.')
 
-    const name = `External/${host}:${port}/generate_content`
+    const name = `External/${host}:${port}/v1beta/models/${model}:generateContent`
     assertSegments(
       tx.trace,
       tx.trace.root,
-      [GEMINI.COMPLETION, name],
+      [GEMINI.COMPLETION, [name]],
       { exact: false }
     )
 
@@ -139,12 +140,16 @@ test('should create chat completion message and summary for every message sent',
 })
 
 // Streaming tests
+// TODO: this test is not creating an external segment properly,
+// keep previous code for reference, but commented out
 test('should create span on successful models generateContentStream', (t, end) => {
-  const { client, agent, host, port } = t.nr
+  // const { client, agent, host, port } = t.nr
+  const { client, agent } = t.nr
   helper.runInTransaction(agent, async (tx) => {
     const content = 'Streamed response'
+    const model = 'gemini-2.0-flash'
     const stream = await client.models.generateContentStream({
-      model: 'gemini-2.0-flash',
+      model,
       contents: content
     })
 
@@ -161,11 +166,12 @@ test('should create span on successful models generateContentStream', (t, end) =
     assert.equal(chunk.candidates[0].content.parts[0].text, expectedRes.body.candidates[0].content.parts[0].text)
     assert.equal(chunk.candidates[0].content.parts[0].text, res)
 
-    const name = `External/${host}:${port}/generate_content`
+    // const name = `External/${host}:${port}/v1beta/models/${model}:generateContentStream`
     assertSegments(
       tx.trace,
       tx.trace.root,
-      [GEMINI.COMPLETION, name],
+      // [GEMINI.COMPLETION, [name]],
+      [GEMINI.COMPLETION],
       { exact: false }
     )
 

--- a/test/versioned/google-genai/embeddings.test.js
+++ b/test/versioned/google-genai/embeddings.test.js
@@ -58,18 +58,19 @@ test.afterEach((ctx) => {
 test('should create span on successful embedding create', (t, end) => {
   const { client, agent, host, port } = t.nr
   helper.runInTransaction(agent, async (tx) => {
+    const model = 'text-embedding-004'
     const results = await client.models.embedContent({
       contents: 'This is an embedding test.',
-      model: 'text-embedding-004'
+      model
     })
 
     assert.equal(results.headers, undefined, 'should remove response headers from user result')
 
-    const name = `External/${host}:${port}/embed`
+    const name = `External/${host}:${port}/v1beta/models/${model}:batchEmbedContents`
     assertSegments(
       tx.trace,
       tx.trace.root,
-      [GEMINI.EMBEDDING, name],
+      [GEMINI.EMBEDDING, [name]],
       {
         exact: false
       }

--- a/test/versioned/openai/chat-completions-res-api.test.js
+++ b/test/versioned/openai/chat-completions-res-api.test.js
@@ -28,36 +28,41 @@ const TRACKING_METRIC = `Supportability/Nodejs/ML/OpenAI/${pkgVersion}`
 const responses = require('./mock-responses-api-responses')
 const { assertChatCompletionMessages, assertChatCompletionSummary } = require('./common-responses-api')
 
+/**
+ * DISCLAIMER:
+ * This test suite is registering all instrumentation once and then cleaning up what is needed after each test.
+ * If you do not do it this way, undici does not play nice with our context manager, which is the default client in openai >= 5.0.0. This leads to every test,
+ * after the first one not having the appropriate context for the outgoing call to the mock server.
+ */
 test('responses.create', async (t) => {
-  t.beforeEach(async (ctx) => {
-    ctx.nr = {}
-    const { host, port, server } = await createOpenAIMockServer(responses)
-    ctx.nr.host = host
-    ctx.nr.port = port
-    ctx.nr.server = server
-    ctx.nr.agent = helper.instrumentMockedAgent({
-      ai_monitoring: {
-        enabled: true
-      },
-      streaming: {
-        enabled: true
-      }
-    })
-    const OpenAI = require('openai')
-    ctx.nr.client = new OpenAI({
-      apiKey: 'fake-versioned-test-key',
-      baseURL: `http://${host}:${port}`
-    })
+  const { host, port, server } = await createOpenAIMockServer(responses)
+  const agent = helper.instrumentMockedAgent({
+    ai_monitoring: {
+      enabled: true
+    },
+    streaming: {
+      enabled: true
+    }
+  })
+  const OpenAI = require('openai')
+  const client = new OpenAI({
+    apiKey: 'fake-versioned-test-key',
+    baseURL: `http://${host}:${port}`
   })
 
-  t.afterEach((ctx) => {
-    helper.unloadAgent(ctx.nr.agent)
-    ctx.nr.server?.close()
+  t.after(() => {
+    helper.unloadAgent(agent)
+    server?.close()
     removeModules('openai')
   })
 
+  t.afterEach(() => {
+    agent.customEventAggregator.clear()
+    agent.llm.tokenCountCallback = null
+    agent.config.ai_monitoring.streaming.enabled = true
+  })
+
   await t.test('should create span on successful chat completion create', (t, end) => {
-    const { client, agent, host, port } = t.nr
     helper.runInTransaction(agent, async (tx) => {
       const results = await client.responses.create({
         input: [{ role: 'user', content: 'You are a mathematician.' }]
@@ -87,7 +92,6 @@ test('responses.create', async (t) => {
   })
 
   await t.test('should increment tracking metric for each chat completion event', (t, end) => {
-    const { client, agent } = t.nr
     helper.runInTransaction(agent, async (tx) => {
       await client.responses.create({
         input: [{ role: 'user', content: 'You are a mathematician.' }]
@@ -102,7 +106,6 @@ test('responses.create', async (t) => {
   })
 
   await t.test('should create chat completion message and summary for every message sent', (t, end) => {
-    const { client, agent } = t.nr
     helper.runInTransaction(agent, async (tx) => {
       const model = 'gpt-4'
       const content = 'You are a mathematician.'
@@ -135,7 +138,6 @@ test('responses.create', async (t) => {
   })
 
   await t.test('should create chat completion message and summary when input is a single string', (t, end) => {
-    const { client, agent } = t.nr
     helper.runInTransaction(agent, async (tx) => {
       const model = 'gpt-4'
       const content = 'You are a mathematician.'
@@ -166,7 +168,6 @@ test('responses.create', async (t) => {
   })
 
   await t.test('should not create llm events when not in a transaction', async (t) => {
-    const { client, agent } = t.nr
     await client.responses.create({
       input: [{ role: 'user', content: 'You are a mathematician.' }]
     })
@@ -176,7 +177,6 @@ test('responses.create', async (t) => {
   })
 
   await t.test('auth errors should be tracked', (t, end) => {
-    const { client, agent } = t.nr
     helper.runInTransaction(agent, async (tx) => {
       try {
         await client.responses.create({
@@ -215,7 +215,6 @@ test('responses.create', async (t) => {
   })
 
   await t.test('bad input error should be tracked', (t, end) => {
-    const { client, agent } = t.nr
     helper.runInTransaction(agent, async (tx) => {
       const model = 'gpt-4'
       try {
@@ -250,7 +249,6 @@ test('responses.create', async (t) => {
   })
 
   await t.test('invalid role error should be tracked', (t, end) => {
-    const { client, agent } = t.nr
     helper.runInTransaction(agent, async (tx) => {
       try {
         await client.responses.create({
@@ -283,7 +281,6 @@ test('responses.create', async (t) => {
   })
 
   await t.test('should add llm attribute to transaction', (t, end) => {
-    const { client, agent } = t.nr
     helper.runInTransaction(agent, async (tx) => {
       await client.responses.create({
         input: [{ role: 'user', content: 'You are a mathematician.' }]
@@ -298,7 +295,6 @@ test('responses.create', async (t) => {
   })
 
   await t.test('should create span on successful responses stream create', (t, end) => {
-    const { client, agent, host, port } = t.nr
     helper.runInTransaction(agent, async (tx) => {
       const content = 'Streamed response'
       const stream = await client.responses.create({
@@ -319,7 +315,7 @@ test('responses.create', async (t) => {
       assertSegments(
         tx.trace,
         tx.trace.root,
-        [OPENAI.COMPLETION, `External/${host}:${port}/responses`],
+        [OPENAI.COMPLETION, [`External/${host}:${port}/responses`]],
         { exact: false }
       )
 
@@ -329,7 +325,6 @@ test('responses.create', async (t) => {
   })
 
   await t.test('should create chat completion message and summary for every message sent in stream', (t, end) => {
-    const { client, agent } = t.nr
     helper.runInTransaction(agent, async (tx) => {
       const content = 'Streamed response'
       const stream = await client.responses.create({
@@ -361,7 +356,6 @@ test('responses.create', async (t) => {
   })
 
   await t.test('should call the tokenCountCallback in streaming', (t, end) => {
-    const { client, agent } = t.nr
     const promptContent = 'Streamed response'
     const promptContent2 = 'What does 1 plus 1 equal?'
     const res = 'Test stream'
@@ -409,7 +403,6 @@ test('responses.create', async (t) => {
   })
 
   await t.test('handles error in stream', (t, end) => {
-    const { client, agent } = t.nr
     helper.runInTransaction(agent, async (tx) => {
       const content = 'bad stream'
       const model = 'gpt-4'
@@ -446,7 +439,6 @@ test('responses.create', async (t) => {
   })
 
   await t.test('should not create llm events when ai_monitoring.streaming.enabled is false', (t, end) => {
-    const { client, agent } = t.nr
     agent.config.ai_monitoring.streaming.enabled = false
     helper.runInTransaction(agent, async (tx) => {
       const content = 'Streamed response'

--- a/test/versioned/openai/chat-completions.test.js
+++ b/test/versioned/openai/chat-completions.test.js
@@ -161,7 +161,7 @@ test('chat.completions.create', async (t) => {
         assertSegments(
           tx.trace,
           tx.trace.root,
-          [OPENAI.COMPLETION, `External/${host}:${port}/chat/completions`],
+          [OPENAI.COMPLETION, [`External/${host}:${port}/chat/completions`]],
           { exact: false }
         )
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This is the same PR as https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/358.  This unmasked some fun nuances with google genai and openai.  Since they rely on undici to make client calls, the test suites cannot be designed to spin up agent and tear down between tests due to context issues with undici in this manner.
