### PR TITLE
ci: Updated prepare release to exclude semver major copy for repos other than `node-newrelic`

### DIFF
--- a/bin/conventional-changelog.js
+++ b/bin/conventional-changelog.js
@@ -206,7 +206,8 @@ class ConventionalChangelog {
         owner: self.org,
         repository: self.repo,
         isPatch: false,
-        version: self.newVersion
+        version: self.newVersion,
+        includeSemverCopy: self.repo === 'node-newrelic'
       }
 
       const markdownFormatter = conventionalChangelogWriter(context, {

--- a/bin/templates/template.hbs
+++ b/bin/templates/template.hbs
@@ -4,7 +4,9 @@
 {{#each noteGroups}}
 #### ⚠ {{title}}
 
+{{#if @root.includeSemverCopy}}
 This version of the Node.js agent is a SemVer MAJOR update and contains the following breaking changes. MAJOR versions may drop support for language runtimes that have reached End-of-Life according to the maintainer. Additionally, MAJOR versions may drop support for and remove certain instrumentation. For more details on these changes please see the [migration guide](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent/).
+{{/if}}
 
 {{#each notes}}
 * {{#if commit.scope}}**{{commit.scope}}:** {{/if}}{{text}}

--- a/bin/test/conventional-changelog.test.js
+++ b/bin/test/conventional-changelog.test.js
@@ -52,6 +52,18 @@ const exampleCommit = {
   }
 }
 
+const exampleMarkdownNoSemverMajorCopy = `### v1.0.0 (2020-04-03)
+#### ⚠ BREAKING CHANGES
+
+
+* **thing:** updated Thing to prevent modifications to inputs
+
+#### Bug fixes
+
+* **thing:** updated Thing to prevent modifications to inputs ([#123](https://github.com/newrelic/node-newrelic/pull/123)), closes [1234](https://github.com/newrelic/testRepo/issues/1234)
+    * Thing no longer mutates provided inputs, but instead clones inputs before performing modifications. Thing will now always return an entirely new output
+`
+
 const exampleMarkdown = `### v1.0.0 (2020-04-03)
 #### ⚠ BREAKING CHANGES
 
@@ -202,6 +214,16 @@ test('Conventional Changelog Class', async (t) => {
       const changelog = new ConventionalChangelog({ newVersion: '1.0.0', previousVersion: '0.9.0' })
       const markdown = await changelog.generateMarkdownChangelog([exampleCommit])
       assert.equal(markdown, exampleMarkdown)
+    }
+  )
+
+  await t.test(
+    'generateMarkdownChangelog - should create the new Markdown changelog entry, skip semver major copy',
+    async (t) => {
+      const { ConventionalChangelog } = t.nr
+      const changelog = new ConventionalChangelog({ newVersion: '1.0.0', previousVersion: '0.9.0', repo: 'testRepo' })
+      const markdown = await changelog.generateMarkdownChangelog([exampleCommit])
+      assert.equal(markdown, exampleMarkdownNoSemverMajorCopy)
     }
   )
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

The semver major copy is only needed on releases from agent(node-newrelic). Since this file is shared, this PR updates it to only include the copy for agent releases.
