### PR TITLE
feat: Disable timers instrumentation by default in the sample configuration

### DIFF
--- a/newrelic.js
+++ b/newrelic.js
@@ -23,6 +23,16 @@ exports.config = {
     level: 'info'
   },
   /**
+   * This provides instrumentation for `setTimeout` and `setInterval` calls.
+   * We recommend you disable this instrumentation as it does not not provide
+   * much value and creates a lot of unncessary TraceSegments/Span events.
+   */
+  instrumentation: {
+    timers: {
+      enabled: false
+    }
+  },
+  /**
    * When true, all request headers except for those listed in attributes.exclude
    * will be captured for all traces, unless otherwise specified in a destination's
    * attributes include/exclude lists.


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Since we didn't get approval to disable timers by default in 13.0.0, I want to at least disable it in the sample configuration file.  A lot of new customers use this when they first get started, it will be good to have timers off by default for them.
