### PR TITLE
test: fixed a failing span-event benchmark test

### DIFF
--- a/test/benchmark/events/span-event.bench.js
+++ b/test/benchmark/events/span-event.bench.js
@@ -21,7 +21,7 @@ suite.add({
     segment.name = 'some random segment'
   },
   fn: () => {
-    return SpanEvent.fromSegment(segment, transaction)
+    return SpanEvent.fromSegment({ segment, transaction })
   }
 })
 
@@ -33,7 +33,7 @@ suite.add({
     segment.name = 'External/www.foobar.com/'
   },
   fn: () => {
-    return SpanEvent.fromSegment(segment, transaction)
+    return SpanEvent.fromSegment({ segment, transaction })
   }
 })
 
@@ -45,7 +45,7 @@ suite.add({
     segment.name = 'Datastore/statement/SELECT'
   },
   fn: () => {
-    return SpanEvent.fromSegment(segment, transaction)
+    return SpanEvent.fromSegment({ segment, transaction })
   }
 })
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
I was showing Amy how they benchmark tests are run and realized we had a failing test for several weeks.  In #3184 the signature for `fromSegment` was changed. This PR updates the test to match the new signature. 

## How to test
```sh
npm run bench
```
