### PR TITLE
test: Fixed tests that assumed timers instrumentation was always enabled

### DIFF
--- a/test/integration/core/net.test.js
+++ b/test/integration/core/net.test.js
@@ -60,12 +60,7 @@ test('createServer', function createServerTest(t, end) {
       const childChildren = transaction.trace.getChildren(child.id)
       assert.equal(child.name, 'net.Server.onconnection', 'child segment should have correct name')
       assert.ok(child.timer.touched, 'child should started and ended')
-      assert.equal(childChildren.length, 1, 'child should have a single child segment')
-      const timeout = childChildren[0]
-      const timeoutChildren = transaction.trace.getChildren(timeout.id)
-      assert.equal(timeout.name, 'timers.setTimeout', 'timeout segment should have correct name')
-      assert.ok(timeout.timer.touched, 'timeout should started and ended')
-      assert.equal(timeoutChildren.length, 1, 'timeout should have a single callback segment')
+      assert.equal(childChildren.length, 0)
       end()
     }
   })
@@ -129,21 +124,13 @@ test('connect', function connectTest(t, end) {
       }
       connectChildren = transaction.trace.getChildren(connectSegment.id)
 
-      assert.equal(connectChildren.length, 2, 'connect should have a two child segment')
-      const [dnsSegment, timeoutSegment] = connectChildren
+      assert.equal(connectChildren.length, 1, 'connect should have a two child segment')
+      const [dnsSegment] = connectChildren
 
       assert.equal(dnsSegment.name, 'dns.lookup', 'dns segment should have correct name')
       assert.ok(dnsSegment.timer.touched, 'dns segment should started and ended')
       const dnsChildren = transaction.trace.getChildren(dnsSegment.id)
       assert.equal(dnsChildren.length, 1, 'dns should have a single callback segment')
-      assert.equal(
-        timeoutSegment.name,
-        'timers.setTimeout',
-        'timeout segment should have correct name'
-      )
-      assert.ok(timeoutSegment.timer.touched, 'timeout should started and ended')
-      const timeoutChildren = transaction.trace.getChildren(timeoutSegment.id)
-      assert.equal(timeoutChildren.length, 1, 'timeout should have a single callback segment')
       end()
     }
   }

--- a/test/integration/core/timers.test.js
+++ b/test/integration/core/timers.test.js
@@ -14,7 +14,13 @@ const verifySegments = require('./verify')
 
 test.beforeEach((ctx) => {
   ctx.nr = {}
-  ctx.nr.agent = helper.instrumentMockedAgent()
+  ctx.nr.agent = helper.instrumentMockedAgent({
+    instrumentation: {
+      timers: {
+        enabled: true
+      }
+    }
+  })
 })
 
 test.afterEach((ctx) => {

--- a/test/integration/instrumentation/http-outbound.test.js
+++ b/test/integration/instrumentation/http-outbound.test.js
@@ -112,9 +112,6 @@ test('external requests', async function (t) {
       const dnsLookup = connectChildren[0]
       assert.equal(dnsLookup.name, 'dns.lookup', 'should be dns.lookup segment')
 
-      const callback = externalChildren[externalChildren.length - 1]
-      assert.equal(callback.name, 'timers.setTimeout', 'should have timeout segment')
-
       end()
     }
   })

--- a/test/integration/transaction/tracer.test.js
+++ b/test/integration/transaction/tracer.test.js
@@ -14,7 +14,13 @@ const tempRemoveListeners = require('../../lib/temp-remove-listeners')
 const Context = require('../../../lib/context-manager/context')
 
 test.beforeEach((ctx) => {
-  const agent = helper.instrumentMockedAgent()
+  const agent = helper.instrumentMockedAgent({
+    instrumentation: {
+      timers: {
+        enabled: true
+      }
+    }
+  })
   const tracer = helper.getTracer()
   ctx.nr = {
     agent,

--- a/test/smoke/client-s3.test.js
+++ b/test/smoke/client-s3.test.js
@@ -41,7 +41,7 @@ test('@aws-sdk/client-s3 functionality', async (t) => {
 
     transaction.end()
 
-    const [, child] = transaction.trace.getChildren(transaction.trace.root.id)
+    const [child] = transaction.trace.getChildren(transaction.trace.root.id)
     const { url, procedure, ...awsAttributes } = child.attributes.get(TRANS_SEGMENT)
 
     delete awsAttributes.nr_exclusive_duration_millis


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

In #3253, we disabled timers instrumentation in the sample config.  It turns out this config is being used for tests and we had some tests that assumed timers instrumentation was enabled.  This PR fixes the assertions in those tests to account for the fact that timers instrumentation is now disabled by default.
