### PR TITLE
test: cleaned up engines and version ranges in versioned tests

### DIFF
--- a/test/versioned/aws-sdk-v3/package.json
+++ b/test/versioned/aws-sdk-v3/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-sdk-v3-tests",
   "engines": {
-    "node": ">=20.0"
+    "node": ">=20"
   },
   "targets": [
     {"name": "@aws-sdk/client-sqs", "minAgentVersion": "8.7.1"},
@@ -17,7 +17,7 @@
   "tests": [
     {
       "engines": {
-        "node": ">=20.0"
+        "node": ">=20"
       },
       "dependencies": {
         "@aws-sdk/client-api-gateway": {
@@ -31,7 +31,7 @@
     },
     {
       "engines": {
-        "node": ">=20.0"
+        "node": ">=20"
       },
       "dependencies": {
         "@aws-sdk/client-elasticache": {
@@ -45,7 +45,7 @@
     },
     {
       "engines": {
-        "node": ">=20.0"
+        "node": ">=20"
       },
       "dependencies": {
         "@aws-sdk/client-elastic-load-balancing": {
@@ -59,7 +59,7 @@
     },
     {
       "engines": {
-        "node": ">=20.0"
+        "node": ">=20"
       },
       "dependencies": {
         "@aws-sdk/client-lambda": {
@@ -73,7 +73,7 @@
     },
     {
       "engines": {
-        "node": ">=20.0"
+        "node": ">=20"
       },
       "dependencies": {
         "@aws-sdk/client-rds": {
@@ -87,7 +87,7 @@
     },
     {
       "engines": {
-        "node": ">=20.0"
+        "node": ">=20"
       },
       "dependencies": {
         "@aws-sdk/client-redshift": {
@@ -101,7 +101,7 @@
     },
     {
       "engines": {
-        "node": ">=20.0"
+        "node": ">=20"
       },
       "dependencies": {
         "@aws-sdk/client-rekognition": {
@@ -115,7 +115,7 @@
     },
     {
       "engines": {
-        "node": ">=20.0"
+        "node": ">=20"
       },
       "dependencies": {
         "@aws-sdk/client-s3": {
@@ -129,7 +129,7 @@
     },
     {
       "engines": {
-        "node": ">=20.0"
+        "node": ">=20"
       },
       "dependencies": {
         "@aws-sdk/client-ses": {
@@ -143,7 +143,7 @@
     },
     {
       "engines": {
-        "node": ">=20.0"
+        "node": ">=20"
       },
       "dependencies": {
         "@aws-sdk/client-sns": {
@@ -157,7 +157,7 @@
     },
     {
       "engines": {
-        "node": ">=20.0"
+        "node": ">=20"
       },
       "dependencies": {
         "@aws-sdk/client-sqs": {
@@ -171,7 +171,7 @@
     },
     {
       "engines": {
-        "node": ">=20.0"
+        "node": ">=20"
       },
       "dependencies": {
         "@aws-sdk/client-dynamodb": {
@@ -185,7 +185,7 @@
     },
     {
       "engines": {
-        "node": ">=20.0"
+        "node": ">=20"
       },
       "dependencies": {
         "@aws-sdk/lib-dynamodb": {
@@ -199,7 +199,7 @@
     },
     {
       "engines": {
-        "node": ">=20.0"
+        "node": ">=20"
       },
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": ">=3.474.0 <3.798.0"
@@ -212,7 +212,7 @@
     },
       {
       "engines": {
-        "node": ">=18.0"
+        "node": ">=20"
       },
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": ">=3.587.0 <3.798.0"

--- a/test/versioned/google-genai/package.json
+++ b/test/versioned/google-genai/package.json
@@ -9,12 +9,12 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "tests": [
     {
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "dependencies": {
         "@google/genai": ">=1.1.0 <1.5.0 || >=1.5.1"

--- a/test/versioned/mongodb-esm/package.json
+++ b/test/versioned/mongodb-esm/package.json
@@ -9,7 +9,7 @@
         "node": ">=20"
       },
       "dependencies": {
-        "mongodb": ">= 4.1.4"
+        "mongodb": ">=4.1.4 < 5"
       },
       "files": [
         "bulk.test.mjs",

--- a/test/versioned/mongodb-esm/package.json
+++ b/test/versioned/mongodb-esm/package.json
@@ -9,7 +9,7 @@
         "node": ">=20"
       },
       "dependencies": {
-        "mongodb": ">= 4.1.4 < 5"
+        "mongodb": ">= 4.1.4"
       },
       "files": [
         "bulk.test.mjs",

--- a/test/versioned/pg-esm/package.json
+++ b/test/versioned/pg-esm/package.json
@@ -18,7 +18,7 @@
     },
     {
       "engines": {
-        "node": ">=18 <24"
+        "node": ">=20 <24"
       },
       "dependencies": {
         "pg": ">=8.2.0",

--- a/test/versioned/pg/package.json
+++ b/test/versioned/pg/package.json
@@ -17,7 +17,7 @@
     },
     {
       "engines": {
-        "node": ">=18 <24"
+        "node": ">=20 <24"
       },
       "dependencies": {
         "pg": ">=8.2.0",

--- a/test/versioned/undici/package.json
+++ b/test/versioned/undici/package.json
@@ -9,19 +9,7 @@
         "node": ">=20"
       },
       "dependencies": {
-        "undici": ">=5.0.0 <7.11.0"
-      },
-      "files": [
-        "requests.test.js"
-      ]
-    },
-
-    {
-      "engines": {
-        "node": ">=20"
-      },
-      "dependencies": {
-        "undici": ">=7.11.0"
+        "undici": ">=5.0.0"
       },
       "files": [
         "requests.test.js"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
I noticed we still had some engines with `18` in them. Also I'm going to assume when we dropped 18 we had some test stanzas that were split for 18 but are no longer necessary. This PR cleans up all of those issues
