### PR TITLE
refactor: Updated undici instrumentation to remove its reliance on shm. Also updating storing the relevant segments on context instead of symbols on the request object

### DIFF
--- a/lib/instrumentation/undici.js
+++ b/lib/instrumentation/undici.js
@@ -9,7 +9,6 @@ const cat = require('../util/cat')
 const recordExternal = require('../metrics/recorders/http_external')
 const logger = require('../logger').child({ component: 'undici' })
 const NAMES = require('../metrics/names')
-const symbols = require('../symbols')
 // eslint-disable-next-line n/no-unsupported-features/node-builtins
 const diagnosticsChannel = require('diagnostics_channel')
 const synthetics = require('../synthetics')
@@ -27,13 +26,10 @@ const channels = [
  * See: https://github.com/nodejs/undici/blob/main/docs/api/DiagnosticsChannel.md
  *
  * @param agent
- * @param _undici
- * @param _modName
- * @param shim
  */
-module.exports = function addUndiciChannels(agent, _undici, _modName, shim) {
+module.exports = function addUndiciChannels(agent) {
   channels.forEach(({ channel, hook }, index) => {
-    const boundHook = hook.bind(null, shim)
+    const boundHook = hook.bind(null, agent)
     diagnosticsChannel.subscribe(channel, boundHook)
     // store the bound hook for unsubscription later
     channels[index].boundHook = boundHook
@@ -75,18 +71,25 @@ function addDTHeaders({ transaction, config, request }) {
  * Creates the external segment with url, procedure and request.parameters attributes
  *
  * @param {object} params object to fn
- * @param {Shim} params.shim instance of shim
- * @param {object} params.request undici request object
- * @param {TraceSegment} params.segment current active, about to be parent of external segment
+ * @param {Agent} params.agent NR agent instance
+ * @param {object} params.context active context
+ * @param params.request
  */
-function createExternalSegment({ shim, request, segment }) {
+function createExternalSegment({ agent, request, context }) {
   const url = new URL(request.origin + request.path)
-  const obfuscatedPath = urltils.obfuscatePath(shim.agent.config, url.pathname)
+  const obfuscatedPath = urltils.obfuscatePath(agent.config, url.pathname)
   const name = NAMES.EXTERNAL.PREFIX + url.host + obfuscatedPath
+  const transaction = context?.transaction
+  const parent = context?.extras?.undiciParent
   // Metrics for `External/<host>` will have a suffix of undici
   // We will have to see if this matters for people only using fetch
   // It's undici under the hood so ¯\_(ツ)_/¯
-  const externalSegment = shim.createSegment(name, recordExternal(url.host, 'undici'), segment)
+  const externalSegment = agent.tracer.createSegment({
+    name,
+    recorder: recordExternal(url.host, 'undici'),
+    parent,
+    transaction
+  })
 
   // the captureExternalAttributes expects queryParams to be an object, do conversion
   // to object see:  https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
@@ -94,7 +97,11 @@ function createExternalSegment({ shim, request, segment }) {
 
   if (externalSegment) {
     externalSegment.start()
-    shim.setActiveSegment(externalSegment)
+    // storing the undici external segment in the context extras
+    // this has to be done because the various hook points produce different segments
+    // and we need to be able to access the segment later
+    context.extras = { undiciSegment: externalSegment }
+    agent.tracer.setSegment({ segment: externalSegment, transaction })
     externalSegment.captureExternalAttributes({
       protocol: url.protocol,
       hostname: url.hostname,
@@ -104,8 +111,6 @@ function createExternalSegment({ shim, request, segment }) {
       path: obfuscatedPath,
       queryParams
     })
-
-    request[symbols.segment] = externalSegment
   }
 }
 
@@ -115,15 +120,18 @@ function createExternalSegment({ shim, request, segment }) {
  * external segment with the standard url/procedure/request.parameters
  * attributes.  We will also attach relevant DT headers to outgoing http request.
  *
- * @param {Shim} shim instance of shim
+ * @param {Agent} agent NR agent instance
  * @param {object} params object from undici hook
  * @param {object} params.request undici request object
  */
-function requestCreateHook(shim, { request }) {
-  const { config } = shim.agent
-  const { transaction, segment } = shim.tracer.getContext()
-  request[symbols.parentSegment] = segment
-  request[symbols.transaction] = transaction
+function requestCreateHook(agent, { request }) {
+  const { config } = agent
+  const context = agent.tracer.getContext()
+  const { segment, transaction } = context
+  // storing the parent of the undici external segment in the context extras
+  // this has to be done because the various hook points produce different segments
+  // and we need to be able to access the segment later
+  context.extras = { undiciParent: segment }
   if (!(segment || transaction) || segment?.opaque) {
     logger.trace(
       'Not capturing data for outbound request (%s) because parent segment opaque (%s)',
@@ -135,7 +143,7 @@ function requestCreateHook(shim, { request }) {
   }
 
   try {
-    createExternalSegment({ shim, request, segment })
+    createExternalSegment({ agent, request, context })
     addDTHeaders({ transaction, config, request })
   } catch (err) {
     logger.warn(err, 'Unable to create external segment')
@@ -147,15 +155,15 @@ function requestCreateHook(shim, { request }) {
  * We will add the relevant http response attributes to active segment.
  * Also add CAT specific keys to active segment.
  *
- * @param {Shim} shim instance of shim
+ * @param {object} agent
  * @param {object} params object from undici hook
- * @param {object} params.request undici request object
  * @param {object} params.response { statusCode, headers, statusText }
  */
-function requestHeadersHook(shim, { request, response }) {
-  const { config } = shim.agent
-  const activeSegment = request[symbols.segment]
-  const transaction = request[symbols.transaction]
+function requestHeadersHook(agent, { response }) {
+  const { config } = agent
+  const context = agent.tracer.getContext()
+  const activeSegment = context?.extras?.undiciSegment
+  const transaction = context?.transaction
   if (!activeSegment) {
     return
   }
@@ -185,37 +193,37 @@ function requestHeadersHook(shim, { request, response }) {
  * Gets the active segment, parent segment and transaction from given ctx(request, client connector)
  * and ends segment and sets the previous parent segment as the active segment.  If an error exists it will add the error to the transaction
  *
- * @param {Shim} shim instance of shim
+ * @param {Agent} agent NR agent instance
  * @param {object} params object from undici hook
- * @param {object} params.request or client connector
  * @param {Error} params.error error from undici request
  */
-function endAndRestoreSegment(shim, { request, error }) {
-  const { config } = shim.agent
-  const activeSegment = request[symbols.segment]
-  const parentSegment = request[symbols.parentSegment]
-  const tx = request[symbols.transaction]
+function endAndRestoreSegment(agent, { error }) {
+  const { config } = agent
+  const context = agent.tracer.getContext()
+  const activeSegment = context?.extras?.undiciSegment
+  const parentSegment = context?.extras?.undiciParent
+  const tx = context?.transaction
   if (activeSegment) {
     activeSegment.end()
   }
 
   if (error && tx && config.feature_flag.undici_error_tracking === true) {
-    handleError(shim, tx, error)
+    handleError(agent, tx, error)
   }
 
   if (parentSegment) {
-    shim.setActiveSegment(parentSegment)
+    agent.tracer.setSegment({ segment: parentSegment, transaction: tx })
   }
 }
 
 /**
  * Adds the error to the active transaction
  *
- * @param {Shim} shim instance of shim
+ * @param {Agent} agent NR agent instance
  * @param {Transaction} tx active transaction
  * @param {Error} error error from undici request
  */
-function handleError(shim, tx, error) {
+function handleError(agent, tx, error) {
   logger.trace(error, 'Captured outbound error on behalf of the user.')
-  shim.agent.errors.add(tx, error)
+  agent.errors.add(tx, error)
 }


### PR DESCRIPTION

## Description

There was no reason to refactor the undici code to rely on the tracing channel.  Undici natively emits events over diagnostics channel.  This PR refactors the undici instrumentation to remove its reliance on shim, which is another goal of the migration of instrumentation to tracing channel.  It also removes storing of the relevant parent and active external segments on the undici request and instead stores them on the context.extras property.

## How to Test

```sh
npm run versioned:internal undici
```

## Related Issues
Closes #3197 