### PR TITLE
test: force install of peer deps on nestjs test app

### DIFF
--- a/test/versioned/nestjs/setup.js
+++ b/test/versioned/nestjs/setup.js
@@ -22,7 +22,10 @@ async function initNestApp() {
     // out so badly that they can't clean up.
     await deleteNestApp()
   }
-  await exec('npx nest new --package-manager npm --skip-git test-app')
+  // skip install of deps because we will install them later to force peer dep failures on nest 10.x
+  await exec('npx nest new --package-manager npm --skip-git --skip-install test-app')
+  // on versions of nest 10.x peer dep issues exist, ignore them and force install
+  await exec('npm install --prefix test-app --force', { cwd: __dirname })
   // We patch the default Nest app with some of our own functions.
   for (const fname of ['main.ts', 'app.controller.ts']) {
     await fsPromises.copyFile(`${PATCH_DIR}/${fname}`, `${APP_DIR}/src/${fname}`)


### PR DESCRIPTION
## Description

I noticed nestjs versioned tests started failing on an older version 10.4.9:

```sh
Error: Command failed: npx nest build
  src/app.controller.ts:1:38 - error TS2307: Cannot find module '@nestjs/common' or its corresponding type declarations.

  1 import { Controller, Get, Req } from '@nestjs/common';
                                         ~~~~~~~~~~~~~~~~
  src/app.module.ts:1:24 - error TS2307: Cannot find module '@nestjs/common' or its corresponding type declarations.

  1 import { Module } from '@nestjs/common';
                           ~~~~~~~~~~~~~~~~
  src/app.service.ts:1:28 - error TS2307: Cannot find module '@nestjs/common' or its corresponding type declarations.

  1 import { Injectable } from '@nestjs/common';
                               ~~~~~~~~~~~~~~~~
  src/main.ts:1:29 - error TS2307: Cannot find module '@nestjs/core' or its corresponding type declarations.

  1 import { NestFactory } from '@nestjs/core';
                                ~~~~~~~~~~~~~~


      at genericNodeError (node:internal/errors:983:15)
      at wrappedFn (node:internal/errors:537:14)
      at ChildProcess.exithandler (node:child_process:415:12)
      at ChildProcess.emit (node:events:507:28)
      at maybeClose (node:internal/child_process:1101:16)
      at Socket.<anonymous> (node:internal/child_process:457:11)
      at Socket.emit (node:events:507:28)
      at Pipe.<anonymous> (node:net:346:12) {
    code: 1,
    killed: false,
    signal: null,
    cmd: 'npx nest build',
    stdout: 'Found 4 error(s).\n\n',
    stderr: "\x1B[96msrc/app.controller.ts\x1B[0m:\x1B[93m1\x1B[0m:\x1B[93m38\x1B[0m - \x1B[91merror\x1B[0m\x1B[90m TS2307: \x1B[0mCannot find module '@nestjs/common' or its corresponding type declarations.\n\n\x1B[7m1\x1B[0m import { Controller, Get, Req } from '@nestjs/common';\n\x1B[7m \x1B[0m \x1B[91m                                     ~~~~~~~~~~~~~~~~\x1B[0m\n\x1B[96msrc/app.module.ts\x1B[0m:\x1B[93m1\x1B[0m:\x1B[93m24\x1B[0m - \x1B[91merror\x1B[0m\x1B[90m TS2307: \x1B[0mCannot find module '@nestjs/common' or its corresponding type declarations.\n\n\x1B[7m1\x1B[0m import { Module } from '@nestjs/common';\n\x1B[7m \x1B[0m \x1B[91m                       ~~~~~~~~~~~~~~~~\x1B[0m\n\x1B[96msrc/app.service.ts\x1B[0m:\x1B[93m1\x1B[0m:\x1B[93m28\x1B[0m - \x1B[91merror\x1B[0m\x1B[90m TS2307: \x1B[0mCannot find module '@nestjs/common' or its corresponding type declarations.\n\n\x1B[7m1\x1B[0m import { Injectable } from '@nestjs/common';\n\x1B[7m \x1B[0m \x1B[91m                           ~~~~~~~~~~~~~~~~\x1B[0m\n\x1B[96msrc/main.ts\x1B[0m:\x1B[93m1\x1B[0m:\x1B[93m29\x1B[0m - \x1B[91merror\x1B[0m\x1B[90m TS2307: \x1B[0mCannot find module '@nestjs/core' or its corresponding type declarations.\n\n\x1B[7m1\x1B[0m import { NestFactory } from '@nestjs/core';\n\x1B[7m \x1B[0m \x1B[91m                            ~~~~~~~~~~~~~~\x1B[0m\n\n"
  }
```

Digging more into it, it was because of an peer dep conflict:
```sh
npm error code ERESOLVE
npm error ERESOLVE could not resolve
npm error
npm error While resolving: test-app@0.0.1
npm error Found: typescript@5.9.2
npm error node_modules/typescript
npm error   dev typescript@"^5.1.3" from the root project
npm error   peer typescript@">=4.8.2" from @nestjs/schematics@10.2.3
npm error   node_modules/@nestjs/schematics
npm error     dev @nestjs/schematics@"^10.0.0" from the root project
npm error     @nestjs/schematics@"^10.0.1" from @nestjs/cli@10.4.9
npm error     node_modules/@nestjs/cli
npm error       dev @nestjs/cli@"^10.0.0" from the root project
npm error
npm error Could not resolve dependency:
npm error dev @typescript-eslint/eslint-plugin@"^8.0.0" from the root project
npm error
npm error Conflicting peer dependency: typescript@5.8.3
npm error node_modules/typescript
npm error   peer typescript@">=4.8.4 <5.9.0" from @typescript-eslint/eslint-plugin@8.38.0
npm error   node_modules/@typescript-eslint/eslint-plugin
npm error     dev @typescript-eslint/eslint-plugin@"^8.0.0" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
```

This PR updates the setup of test-app by skipping install in nest cli and running npm install manually and forcing peer dep resolution