### PR TITLE
chore: Updated local TLS cert size

### DIFF
--- a/test/lib/fake-cert.js
+++ b/test/lib/fake-cert.js
@@ -32,11 +32,11 @@ const selfCert = require('self-cert')
  */
 module.exports = function fakeCert({ commonName = null } = {}) {
   const cert = selfCert({
-    // We set the certificate bits to 1,024 because we don't need 4,096 bit
+    // We set the certificate bits to 2,048 because we don't need 4,096 bit
     // certificates for tests. This speeds up certificate generation time by
     // a significant amount, and thus speeds up tests that rely on these
     // certificates.
-    bits: 1_024,
+    bits: 2_048,
     attrs: {
       commonName,
       stateName: 'Georgia',


### PR DESCRIPTION
It seems that at some point in the Node.s 24 line the requirement for TLS certificate key size has increased from a minimum of 1,024 to a minimum of 2,048. This PR corrects our size to match.