### PR TITLE
fix: Updated `shimmer.setupSubscribers` to properly setup and skip subscribers that are disabled

### DIFF
--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -395,7 +395,7 @@ const shimmer = (module.exports = {
             'Skipping subscriber %s because it is disabled in the config',
             subscriber.id
           )
-          return
+          continue
         }
 
         subscriber.enable()

--- a/lib/subscribers/base.js
+++ b/lib/subscribers/base.js
@@ -18,7 +18,8 @@ class Subscriber {
     this.opaque = false
     this.prefix = 'orchestrion:'
     this.requireActiveTx = true
-    this.channel = tracingChannel(`${this.prefix}${this.packageName}:${this.channelName}`)
+    this.id = `${this.prefix}${this.packageName}:${this.channelName}`
+    this.channel = tracingChannel(this.id)
     this.store = agent.tracer._contextManager._asyncLocalStorage
   }
 

--- a/test/unit/shimmer.test.js
+++ b/test/unit/shimmer.test.js
@@ -842,6 +842,51 @@ test('Shimmer with logger mock', async (t) => {
   )
 })
 
+test('Shimmer subscriber setup/teardown', async (t) => {
+  t.beforeEach((ctx) => {
+    ctx.nr = {}
+    const sandbox = sinon.createSandbox()
+    const loggerMock = require('./mocks/logger')(sandbox)
+    const shimmer = proxyquire('../../lib/shimmer', {
+      './logger': {
+        child: sandbox.stub().callsFake(() => loggerMock)
+      }
+    })
+    const agent = helper.loadMockedAgent({}, true)
+    agent.config.instrumentation.pino.enabled = false
+    agent.config.instrumentation.ioredis.enabled = true
+    ctx.nr = {
+      agent,
+      sandbox,
+      shimmer,
+      loggerMock
+    }
+  })
+
+  t.afterEach((ctx) => {
+    const { agent, sandbox, shimmer } = ctx.nr
+    sandbox.restore()
+    clearCachedModules([TEST_MODULE_RELATIVE_PATH])
+    helper.unloadAgent(agent, shimmer)
+  })
+
+  await t.test('should setup subscribers that are enabled', (t) => {
+    const { agent, shimmer } = t.nr
+    assert.ok(!shimmer._subscribers, 'should not have subscribers before setup')
+    shimmer.setupSubscribers(agent)
+    assert.ok(!shimmer._subscribers['orchestrion:pino:nr_asJson'])
+    assert.ok(shimmer._subscribers['orchestrion:ioredis:nr_sendCommand'])
+  })
+
+  await t.test('should teardown subscribers that are enabled', (t) => {
+    const { agent, shimmer } = t.nr
+    assert.ok(!shimmer._subscribers, 'should not have subscribers before setup')
+    shimmer.setupSubscribers(agent)
+    shimmer.teardownSubscribers()
+    assert.deepEqual(shimmer._subscribers, {}, 'should not have subscribers after teardown')
+  })
+})
+
 function clearCachedModules(modules) {
   modules.forEach((moduleName) => {
     try {


### PR DESCRIPTION

## Description

I noticed after #3247 that any subscribers listed after a disabled one weren't getting registered. It was because the inner for loop had to be properly exited. This PR fixes this and adds some basic tests to ensure it's working.

## How to Test

```sh
node test/unit/shimmer.test.js
```
