### PR TITLE
test: Fixed CI issues with latest 24

### DIFF
--- a/test/integration/instrumentation/http-outbound.test.js
+++ b/test/integration/instrumentation/http-outbound.test.js
@@ -112,9 +112,6 @@ test('external requests', async function (t) {
         connect = connectChildren[0]
       }
 
-      if (connectChildren[0].name === 'net.createConnection') {
-        connectChildren = tx.trace.getChildren(connectChildren[0].id)
-      }
       connectChildren = tx.trace.getChildren(connect.id)
 
       const dnsLookup = connectChildren[0]

--- a/test/integration/instrumentation/http-outbound.test.js
+++ b/test/integration/instrumentation/http-outbound.test.js
@@ -103,9 +103,17 @@ test('external requests', async function (t) {
       let connectChildren = tx.trace.getChildren(connect.id)
       assert.equal(connectChildren.length, 1, 'connect should have 1 child')
 
+      // as of Node 24.5.0 there's yet another layer of net segments
+      if (connectChildren[0].name === 'net.createConnection') {
+        connectChildren = tx.trace.getChildren(connectChildren[0].id)
+      }
       // There is potentially an extra layer of create/connect segments.
       if (connectChildren[0].name === 'net.Socket.connect') {
         connect = connectChildren[0]
+      }
+
+      if (connectChildren[0].name === 'net.createConnection') {
+        connectChildren = tx.trace.getChildren(connectChildren[0].id)
       }
       connectChildren = tx.trace.getChildren(connect.id)
 

--- a/test/lib/fake-cert.js
+++ b/test/lib/fake-cert.js
@@ -32,11 +32,11 @@ const selfCert = require('self-cert')
  */
 module.exports = function fakeCert({ commonName = null } = {}) {
   const cert = selfCert({
-    // We set the certificate bits to 1,024 because we don't need 4,096 bit
+    // We set the certificate bits to 2,048 because we don't need 4,096 bit
     // certificates for tests. This speeds up certificate generation time by
     // a significant amount, and thus speeds up tests that rely on these
     // certificates.
-    bits: 1_024,
+    bits: 2_048,
     attrs: {
       commonName,
       stateName: 'Georgia',

--- a/test/versioned/prisma/setup.js
+++ b/test/versioned/prisma/setup.js
@@ -20,11 +20,12 @@ function getPostgresUrl() {
 }
 async function initPrismaApp() {
   process.env.DATABASE_URL = getPostgresUrl()
-  const infoOut = await exec('npm info @prisma/client version')
-  const clientVersion = infoOut.stdout.trim()
-  await exec(`npm install prisma@${clientVersion}`)
-  await exec('node ./node_modules/prisma/build/index.js generate')
-  await exec('node ./node_modules/prisma/build/index.js migrate reset --force')
+  const { version } = require('@prisma/client/package.json')
+  // install CLI globally with proper version so the client package can be generated and setup accordingly
+  // If this was locally installed, it would get stomped on.
+  await exec(`npm install -g prisma@${version}`)
+  await exec('prisma generate')
+  await exec('prisma migrate reset --force')
   delete process.env.DATABASE_URL
 }
 


### PR DESCRIPTION

## Description

This is 3 separate issues happening on 8/3/25:
 * node 24.5.0 causing integration failure in http-outbound
 * node 24.5.0 requires cert to be of a certain min size now
 * prisma 6.13.0 broke our existing setup of tests(turns out we weren't installed the proper CLI to build the prisma client)