### PR TITLE
chore: Add guardrail for OTEL bridge

### DIFF
--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -184,7 +184,8 @@ test('index tests', async (t) => {
       logging: {},
       feature_flag: { flag_1: true, flag_2: false },
       security: { agent: { enabled: false } },
-      worker_threads: { enabled: false }
+      worker_threads: { enabled: false },
+      opentelemetry_bridge: { enabled: false }
     }
     const configMock = {
       getOrCreateInstance: sandbox.stub().returns(mockConfig)

--- a/test/unit/otel-bridge.test.js
+++ b/test/unit/otel-bridge.test.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+// The purpose of this test is to verify that the agent will refuse to start
+// when any required Open Telemetry packages are not available and the bridge
+// is supposed to be enabled. The idea being, we can remove the OTEL packages
+// and start the agent with the bridge disabled in order to trim the size of
+// AWS Lambda Layers.
+
+const test = require('node:test')
+const assert = require('node:assert')
+const Module = require('node:module')
+const proxyquire = require('proxyquire')
+
+test('logs warning when missing otel packages', () => {
+  process.env.NEW_RELIC_OPENTELEMETRY_BRIDGE_ENABLED = true
+
+  require.resolve = function resolve (...args) {
+    if (args[0].startsWith('@opentelemetry') === true) {
+      const error = Error('boom')
+      error.code = 'ERR_MODULE_NOT_FOUND'
+      throw error
+    }
+    return require.resolve.apply(require, args)
+  }
+  Module.createRequire = function () {
+    return require
+  }
+
+  const logs = []
+  const agent = proxyquire('../../index.js', {
+    './lib/logger': {
+      info() {},
+      debug() {},
+      warn(...args) {
+        logs.push(args)
+      }
+    }
+  })
+  assert.ok(agent)
+  agent.shutdown()
+  assert.deepEqual(logs, [['OpenTelemetry bridge enabled, but packages are missing. Not starting!']])
+})


### PR DESCRIPTION
This PR resolves #3278.

This implementation should allow the Lambda team to remove the Open Telemetry packages when creating a new Lambda layer. The steps to do so should be:

1. Install with nested dependencies: `npm --install-strategy=nested newrelic`
2. Remove packages: `rm -rf ./node_modules/newrelic/node_modules/@opentelemetry`
3. Proceed with building layer

-----

<details>
<summary>Example:</summary>

```
/tmp/07/foo
❯ npm i --install-strategy=nested ../newrelic-13.0.0.tgz

added 221 packages, and audited 222 packages in 7s

20 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

/tmp/07/foo took 7.2s
❯ ls node_modules
newrelic

/tmp/07/foo
❯ ls node_modules/newrelic
api.js                 index.js               load-externals.js      node_modules           stub_api.js
bin                    lib                    newrelic.js            package.json           THIRD_PARTY_NOTICES.md
esm-loader.mjs         LICENSE                NEWS.md                README.md

/tmp/07/foo
❯ ls node_modules/newrelic/node_modules
@grpc                    @prisma                  https-proxy-agent        json-stringify-safe      require-in-the-middle
@newrelic                @tyriar                  import-in-the-middle     module-details-from-path semver
@opentelemetry           concat-stream            json-bigint              readable-stream          winston-transport

/tmp/07/foo
❯ ls node_modules/newrelic/node_modules/@opentelemetry
api                         core                        resources                   sdk-metrics
api-logs                    exporter-metrics-otlp-proto sdk-logs                    sdk-trace-base

/tmp/07/foo
❯ du -sh node_modules/newrelic/
 99M    node_modules/newrelic/

/tmp/07/foo
❯ du -sh node_modules/newrelic/node_modules
 96M    node_modules/newrelic/node_modules

/tmp/07/foo
❯ du -sh node_modules/newrelic/node_modules/@opentelemetry
 56M    node_modules/newrelic/node_modules/@opentelemetry
```

</details>

The result, as of 2025-08-07, would be a reduction of about 56MiB for a total `newrelic` size impact of about 43MiB.