### PR TITLE
chore: Remove diacritical grave encoding

### DIFF
--- a/bin/pending-prs.js
+++ b/bin/pending-prs.js
@@ -153,7 +153,6 @@ async function findMergedPRs(repo, ignoredLabels) {
         .replaceAll('&', '&amp;')
         .replaceAll('<', '&lt;')
         .replaceAll('>', '&gt;')
-        .replaceAll('`', '&DiacriticalGrave;')
         .replaceAll('|', '&mid;')
       return `<${pr.html_url} | (${pr.number}) ${slackifiedTitle}>`
     })


### PR DESCRIPTION
This encoding was not helping the Slack notifications. It was was just printing `&DiacriticalGrave;` in the titles being displayed in the channel.