### PR TITLE
chore: Pin prisma

### DIFF
--- a/test/versioned/prisma/package.json
+++ b/test/versioned/prisma/package.json
@@ -17,7 +17,7 @@
         "node": ">=20"
       },
       "dependencies": {
-        "@prisma/client": ">=5.0.0 <5.9.0 || >=5.9.1"
+        "@prisma/client": ">=5.0.0 <5.9.0 || >=5.9.1 <6.14.0"
       },
       "files": [
         "prisma.test.js"


### PR DESCRIPTION
This PR limits the versions of `prisma` we test against to be less than v6.14.0 (released on 2025-08-12). That version removes a long deprecated method that we rely upon in our testing. It will take some time (at least for me) to figure how to migrate the code to currently supported code. In order to unblock CI while that is figured out, this PR pins it.

RE: https://github.com/prisma/prisma/issues/27891

Code that we need to update:

https://github.com/newrelic/node-newrelic/blob/b61f6f76d68097b3f50575f6a7dfcb7ac5fe5010/test/versioned/prisma/app.js#L8-L14