### PR TITLE
test: Removed unnecessary `prisma.$use` in tests to unpin

### DIFF
--- a/test/versioned/prisma/app.js
+++ b/test/versioned/prisma/app.js
@@ -5,14 +5,6 @@
 
 'use strict'
 async function upsertUsers(prisma) {
-  prisma.$use(async function prismaMiddleware(params, next) {
-    if (params.action === 'update') {
-      params.args.data.updatedBy = 'Jessica Lopatta <jlopatta@newrelic.com>'
-    }
-
-    return next(params)
-  })
-
   const users = await prisma.user.findMany()
 
   const upserts = []

--- a/test/versioned/prisma/package.json
+++ b/test/versioned/prisma/package.json
@@ -17,7 +17,7 @@
         "node": ">=20"
       },
       "dependencies": {
-        "@prisma/client": ">=5.0.0 <5.9.0 || >=5.9.1 <6.14.0"
+        "@prisma/client": ">=5.0.0 <5.9.0 || >=5.9.1"
       },
       "files": [
         "prisma.test.js"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We had to pin prisma in #3297 because in 6.14.0 it removed `prisma.$use` which we had in our prisma test application.  It turns out this is not needed so I removed and unpinned the tests.

## How to Test

```sh
npm run versioned:internal prisma
```

## Related Issues
Closes #3298
