### PR TITLE
test: Fixed obtaining opensearch package version for older versions we instrument

### DIFF
--- a/test/versioned/opensearch/opensearch.test.js
+++ b/test/versioned/opensearch/opensearch.test.js
@@ -6,6 +6,8 @@
 'use strict'
 const test = require('node:test')
 const assert = require('node:assert')
+const { readFile } = require('node:fs/promises')
+const path = require('node:path')
 const helper = require('../../lib/agent_helper')
 const params = require('../../lib/params')
 const urltils = require('../../../lib/util/urltils')
@@ -48,7 +50,8 @@ test('opensearch instrumentation', async (t) => {
     const client = new Client({
       node: `http://${params.opensearch_host}:${params.opensearch_port}`
     })
-    const { version: pkgVersion } = require('@opensearch-project/opensearch/package.json')
+    const pkg = await readFile(path.join(__dirname, '/node_modules/@opensearch-project/opensearch/package.json'))
+    const { version: pkgVersion } = JSON.parse(pkg.toString())
 
     ctx.nr = {
       agent,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

When the assertions were added to assert the on require metrics, it was on the `next` branch which never ran the full suite of tests, even on merge. In older versions of opensearch, the package.json wasn't defined in the exports. This PR resolve it by just reading the package.json instead of requiring it.

## How to Test

```sh
npm run versioned:internal opensearch
```
