### PR TITLE
refactor: Added ability to prevent creation of segments in subscriber based instrumentation when parent is marked as internal and of the same package

### DIFF
--- a/lib/subscribers/base.js
+++ b/lib/subscribers/base.js
@@ -8,10 +8,40 @@
 const { tracingChannel } = require('node:diagnostics_channel')
 
 /**
- * Base class for defining a subscriber.
- * events property is an array with the following possible event names:
- *  `start`, `end`, `asyncStart`, `asyncEnd`, `error`
- *  @link https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel
+ * The baseline parameters available to all subscribers.
+ *
+ * @typedef {object} SubscriberParams
+ * @property {object} agent A New Relic Node.js agent instance.
+ * @property {object} logger An agent logger instance.
+ * @property {string} packageName The npm installable name for the package
+ * being instrumented. This is what a developer would provide to the `require`
+ * function.
+ * @property {string} channelName A unique name for the diagnostics channel
+ * that will be created and monitored.
+ */
+
+/**
+ * @property {object} agent A New Relic Node.js agent instance.
+ * @property {object} logger An agent logger instance.
+ * @property {object} config The agent configuration object.
+ * @property {string} packageName The name of the module being instrumented.
+ * This is the same string one would pass to the `require` function.
+ * @property {string} channelName A unique name for the diagnostics channel
+ * that will be registered.
+ * @property {string[]} [events=[]] Set of tracing channel event names to
+ * register handlers for. For any name in the set, a corresponding method
+ * must exist on the subscriber instance. The method will be passed the
+ * event object. Possible event names are `start`, `end`, `asyncStart`,
+ * `asyncEnd`, and `error`. @link https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel
+ * @property {boolean} [opaque=false] If true, any children segments will not be created
+ * @property {boolean} [internal=false] If true, any children segments from the same library will not be created
+ * @property {string} [prefix='orchestrion:'] String to prepend to diagnostics
+ * channel event names. This provides a namespace for the events we are
+ * injecting into a module.
+ * @property {boolean} [requireActiveTx=true] If true, the subscriber will only handle events when there is an active transaction.
+ * @property {string} id A unique identifier for the subscriber, combining the prefix, package name, and channel name.
+ * @property {TracingChannel} channel The tracing channel instance this subscriber will be monitoring.
+ * @property {AsyncLocalStorage} store The async local storage instance used for context management.
  */
 class Subscriber {
   constructor({ agent, logger, packageName, channelName }) {
@@ -22,11 +52,18 @@ class Subscriber {
     this.channelName = channelName
     this.events = []
     this.opaque = false
+    this.internal = false
     this.prefix = 'orchestrion:'
     this.requireActiveTx = true
     this.id = `${this.prefix}${this.packageName}:${this.channelName}`
     this.channel = tracingChannel(this.id)
     this.store = agent.tracer._contextManager._asyncLocalStorage
+  }
+
+  shouldCreateSegment(parent) {
+    return !(parent?.opaque ||
+    (this.internal && this.packageName === parent?.shimId)
+    )
   }
 
   /**
@@ -39,15 +76,23 @@ class Subscriber {
    * @returns {Context} - The updated context with the new segment or existing context if segment creation fails
    */
   createSegment({ name, recorder, ctx }) {
+    const parent = ctx?.segment
+
+    if (this.shouldCreateSegment(parent) === false) {
+      this.logger.trace('Skipping segment creation for %s, %s(parent) is of the same package: %s and incoming segment is marked as internal', name, parent?.name, this.packageName)
+      return ctx
+    }
+
     const segment = this.agent.tracer.createSegment({
       name,
-      parent: ctx?.segment,
+      parent,
       recorder,
       transaction: ctx?.transaction,
     })
 
     if (segment) {
       segment.opaque = this.opaque
+      segment.shimId = this.packageName
       segment.start()
       this.logger.trace('Created segment %s', name)
       this.addAttributes(segment)

--- a/test/unit/lib/subscribers/base.test.js
+++ b/test/unit/lib/subscribers/base.test.js
@@ -95,6 +95,37 @@ test('should not create segment if no active tx', (t) => {
   assert.ok(!newCtx.segment)
 })
 
+test('should not create segment if parent is opaque', async (t) => {
+  const { agent, subscriber } = t.nr
+  await helper.runInTransaction(agent, async () => {
+    const ctx = agent.tracer.getContext()
+    ctx.segment.opaque = true
+    const newCtx = subscriber.createSegment({
+      name: 'test-segment',
+      ctx,
+    })
+
+    assert.deepEqual(newCtx, ctx)
+    assert.equal(newCtx.segment.name, ctx.segment.name)
+  })
+})
+
+test('should not create segment if parent is of same package and subscriber is internal', async (t) => {
+  const { agent, subscriber } = t.nr
+  await helper.runInTransaction(agent, async () => {
+    const ctx = agent.tracer.getContext()
+    ctx.segment.shimId = 'test-package'
+    subscriber.internal = true
+    const newCtx = subscriber.createSegment({
+      name: 'test-segment',
+      ctx,
+    })
+
+    assert.deepEqual(newCtx, ctx)
+    assert.equal(newCtx.segment.name, ctx.segment.name)
+  })
+})
+
 test('should touch segment when asyncEnd is called', (t, end) => {
   const { agent, subscriber } = t.nr
   helper.runInTransaction(agent, () => {


### PR DESCRIPTION
## Description

This adds support for defining a subscriber to the current `internal` shim behavior. It will skip the creation of the segment if the current segment is from the same package.  This should rarely be used but its intent is when we instrument internal methods on package that get called by other methods we instrument. The behavior is dfif from that of https://github.com/newrelic/node-newrelic/blob/aa3f8d936aa9fd7ffdad1f771dc16da8782ad917/lib/shim/shim.js#L700-L702

This is because this logic will no longer work.  Previously all database segments were marked as internal unless explicitly set to false.  For libraries that were callback based, we would create a segment for the db query/operation and another for the callback. If I assigned the `db` subscriber to `internal: true`, it would prevent creation from consecutive segments in databases because we are no longer creating the useless callback segment.  So the intent of this will be to explicitly set subscribers to `internal: true`. The immediate known one, is the `connect` method on cassandra driver. That's because older versions of `execute` which we instrument immediately call `connect`. In that scenario, we want to ignore the creation of the `connect` because it's indirectly being called in execute.  I could make the case that it doesn't matter, but I want to maintain as much parity as possible when we migrate libraries to the tracing channel.  

## Related Issues
Closes #3321