### PR TITLE
test: Add more cassandra-driver tests

### DIFF
--- a/test/versioned/cassandra-driver/query.test.js
+++ b/test/versioned/cassandra-driver/query.test.js
@@ -225,6 +225,7 @@ test('eachRow', (t, end) => {
         assert.ifError(err, 'should not get an error inserting data')
         verifyTrace(agent, transaction.trace, `${KS}.${FAM}`)
         transaction.end()
+        checkMetric(agent)
         end()
       })
     })
@@ -255,6 +256,7 @@ test('stream', (t, end) => {
           // Stream ended, there aren't any more rows
           verifyTrace(agent, transaction.trace, `${KS}.${FAM}`)
           transaction.end()
+          checkMetric(agent)
           end()
         })
         .on('error', function (err) {


### PR DESCRIPTION
I noticed while working on the `cassandra-driver` subscriber that we weren't testing some key methods of our cassandra instrumentation. This PR adds those missing tests.