### PR TITLE
ci: Change benchmark tests to use `TEST_LICENSE`

### DIFF
--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -28,7 +28,7 @@ jobs:
       run: npm install
     - name: Run Benchmark Tests
       env:
-        NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_API_KEY_PRODUCTION }}
+        NEW_RELIC_LICENSE_KEY: ${{ secrets.TEST_LICENSE }}
       run: node ./bin/run-bench.js --filename=${{ github.base_ref || 'main' }}_${{ matrix.node-version }}
     - name: Verify Benchmark Output
       run: ls benchmark_results

--- a/bin/otel-metrics-sender.js
+++ b/bin/otel-metrics-sender.js
@@ -7,7 +7,8 @@
 
 const NR_KEY = process.env.NEW_RELIC_LICENSE_KEY
 if (NR_KEY === null) {
-  console.warn('Missing required environment variable: NEW_RELIC_LICENSE_KEY. Will not send metrics.')
+  console.error('Missing required environment variable: NEW_RELIC_LICENSE_KEY.')
+  process.exit(1)
 }
 
 const { MeterProvider, PeriodicExportingMetricReader } = require('@opentelemetry/sdk-metrics')

--- a/bin/run-bench.js
+++ b/bin/run-bench.js
@@ -22,6 +22,9 @@ const globs = []
 const opts = Object.create(null)
 let hasFailures = false
 const SEND_METRICS = process.env.NEW_RELIC_LICENSE_KEY ? true : false
+if (SEND_METRICS === false) {
+  console.log('NEW_RELIC_LICENSE_KEY not set. Will not send metrics.')
+}
 
 process.argv.slice(2).forEach(function forEachFileArg(file) {
   if (/^--/.test(file) && file.indexOf('=') > -1) {


### PR DESCRIPTION
Benchmark tests are failing to send metrics because `NEW_RELIC_API_KEY_PRODUCTION` is a user key not an ingest license key. `TEST_LICENSE` should be the correct GH secret we need.