### PR TITLE
fix: Fixed logic around detecting OTEL packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -293,7 +293,7 @@ function otelBridgeAvailable() {
     try {
       otelRequire.resolve(p)
     } catch (error) {
-      if (error.code === 'ERR_MODULE_NOT_FOUND') {
+      if (error.code.includes('MODULE_NOT_FOUND')) {
         return false
       }
     }

--- a/lib/shimmer.js
+++ b/lib/shimmer.js
@@ -23,7 +23,6 @@ let pkgsToHook = []
 const NAMES = require('./metrics/names')
 const symbols = require('./symbols')
 const { unsubscribe } = require('./instrumentation/undici')
-const { setupOtel, teardownOtel } = require('./otel/setup')
 const subscriptions = require('./subscriber-configs')
 const createSubscriberConfigs = require('./subscribers/create-config')
 const ModulePatch = require('./patch-module')
@@ -332,7 +331,11 @@ const shimmer = (module.exports = {
     }
 
     pkgsToHook = []
-    teardownOtel(agent)
+    if (agent.config.opentelemetry_bridge.enabled === true) {
+      // We must lazy load the method in order to support stripping of the
+      // `@opentelemetry` packages for slim builds.
+      require('./otel/setup').teardownOtel(agent)
+    }
     unsubscribe()
     if (this._subscribers) {
       shimmer.teardownSubscribers()
@@ -349,7 +352,11 @@ const shimmer = (module.exports = {
     shimmer.registerCoreInstrumentation(agent)
     shimmer.registerThirdPartyInstrumentation(agent)
     shimmer.setupSubscribers(agent)
-    setupOtel(agent)
+    if (agent.config.opentelemetry_bridge.enabled === true) {
+      // We must lazy load the method in order to support stripping of the
+      // `@opentelemetry` packages for slim builds.
+      require('./otel/setup').setupOtel(agent)
+    }
   },
 
   registerInstrumentation: function registerInstrumentation(opts) {


### PR DESCRIPTION
This PR resolves a problem with the OTEL brige guardrail introduced in #3283. Basically, we forgot that `shimmer.js` would still try to transitively import the `@opentelemetry` packages due to its usage of the setup and teardown functions. This PR adds in the missing bits.