### PR TITLE
test: fixed openai test after migration to tracing channel

### DIFF
--- a/test/versioned/openai/chat-completions.test.js
+++ b/test/versioned/openai/chat-completions.test.js
@@ -387,7 +387,7 @@ test('chat.completions.create', async (t) => {
         assertSegments(
           tx.trace,
           tx.trace.root,
-          ['timers.setTimeout', [`External/${host}:${port}/chat/completions`]],
+          ['timers.setTimeout', `External/${host}:${port}/chat/completions`],
           { exact: false }
         )
 


### PR DESCRIPTION
## Description

In #3331 I migrated `openai` instrumentation to tracing channel. I mistakenly changed the [one test](https://github.com/newrelic/node-newrelic/pull/3331/files#diff-b26d696faca54df9356be88d6e163ae836f075cae539b8da5937fc65fad52aecR390). It was never getting run on PRs because of the `--major` flag. This PR restores that so when the tests run on main it'll pass as expected

## How to Test
```sh
npm run versioned:internal openai
```