### PR TITLE
test: Hardened `batch-span-streamer.test.js` to avoid random failures in CI

### DIFF
--- a/test/unit/spans/batch-span-streamer.test.js
+++ b/test/unit/spans/batch-span-streamer.test.js
@@ -225,6 +225,6 @@ test('BatchSpanStreamer', async (t) => {
         `SENT metric incremented to ${SPANS + 1}`
       )
       end()
-    }, spanStreamer.queueInterval)
+    }, spanStreamer.queueInterval + 10) // delay a bit more than queueInterval to avoid clock skew
   })
 })


### PR DESCRIPTION
## Description

We saw this batch streamer test fail at times in CI. It wasn't flushing the queue after the queueInterval was exceeded:

```sh
Error: Error [ERR_TEST_FAILURE]: SENT metric incremented to 10000
    at process.emit (node:events:507:28) {
  code: 'ERR_TEST_FAILURE',
  failureType: 'uncaughtException',
  cause: AssertionError [ERR_ASSERTION]: SENT metric incremented to 10000
      at Timeout._onTimeout (/home/runner/work/node-newrelic/node-newrelic/test/unit/spans/batch-span-streamer.test.js:222:14)
      at listOnTimeout (node:internal/timers:608:17)
      at process.processTimers (node:internal/timers:543:7) {
    generatedMessage: false,
    code: 'ERR_ASSERTION',
    actual: 9750,
    expected: 10000,
    operator: '=='
  }
}
```

I cannot reproduce but my guess is that it was a timing problem. I increased the timeout for the last message being sent to ensure the queueInterval has been exceeded

## Related Issues
Closes #3300 