### PR TITLE
ci: Updated the redis container to use the official `redis` image as `bitnami/redis` is moving and no reason to use a 3rd party image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,18 +116,17 @@ services:
 
   redis:
     container_name: nr_node_redis
-    image: bitnami/redis
+    image: redis
     ports:
       - "6379:6379"
       - "6380:6380"
-    environment:
-      - ALLOW_EMPTY_PASSWORD=yes
-      - REDIS_TLS_ENABLED=yes
-      - REDIS_TLS_PORT=6380
-      - REDIS_TLS_CERT_FILE=/tls/redis.crt
-      - REDIS_TLS_KEY_FILE=/tls/redis.key
-      - REDIS_TLS_CA_FILE=/tls/ca.crt
-      - REDIS_TLS_AUTH_CLIENTS=no
+    command: >
+      redis-server
+      --tls-port 6380
+      --tls-auth-clients no
+      --tls-cert-file /tls/redis.crt
+      --tls-key-file /tls/redis.key
+      --tls-ca-cert-file /tls/ca.crt
     volumes:
       - "./docker/redis:/tls"
     healthcheck:


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This PR updates our container for redis to use the official image. I had to change it slightly to configure TLS.

## How to Test


```sh
docker stop nr_node_redis
npm run services
npm run versioned:internal redis
npm run versioned:internal ioredis
```

## Related Issues
Today, bitnami is moving their image, [see](https://hub.docker.com/r/bitnami/redis)

