### PR TITLE
test: Fixed langchain openai streaming tests by explicitly passing `streaming: true` to chat model

### DIFF
--- a/test/versioned/langchain/runnables-streaming.test.js
+++ b/test/versioned/langchain/runnables-streaming.test.js
@@ -44,6 +44,7 @@ async function beforeEach({ enabled, ctx }) {
 
   ctx.nr.prompt = ChatPromptTemplate.fromMessages([['assistant', '{topic} response']])
   ctx.nr.model = new ChatOpenAI({
+    streaming: true,
     apiKey: 'fake-key',
     maxRetries: 0,
     configuration: {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We were inproperly initializing streaming chat models with langchain openai.  This PR fixes it by passing in `streaming: true`.  This started breaking in 0.6.10 of @langchain/openai because of https://github.com/langchain-ai/langchainjs/pull/8807
