### PR TITLE
chore: Restored reliance on `@contrast/fn-inspect` instead of fork `@newrelic/fn-inspect` as original package now supports Node 24

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -85,7 +85,7 @@ code, the source code can be found at [https://github.com/newrelic/node-newrelic
 
 **[optionalDependencies](#optionalDependencies)**
 
-* [@newrelic/fn-inspect](#newrelicfn-inspect)
+* [@contrast/fn-inspect](#contrastfn-inspect)
 * [@newrelic/native-metrics](#newrelicnative-metrics)
 * [@prisma/prisma-fmt-wasm](#prismaprisma-fmt-wasm)
 
@@ -1190,7 +1190,7 @@ This product includes source derived from [@opentelemetry/api](https://github.co
 
 ### @opentelemetry/core
 
-This product includes source derived from [@opentelemetry/core](https://github.com/open-telemetry/opentelemetry-js) ([v2.0.1](https://github.com/open-telemetry/opentelemetry-js/tree/v2.0.1)), distributed under the [Apache-2.0 License](https://github.com/open-telemetry/opentelemetry-js/blob/v2.0.1/LICENSE):
+This product includes source derived from [@opentelemetry/core](https://github.com/open-telemetry/opentelemetry-js) ([v2.1.0](https://github.com/open-telemetry/opentelemetry-js/tree/v2.1.0)), distributed under the [Apache-2.0 License](https://github.com/open-telemetry/opentelemetry-js/blob/v2.1.0/LICENSE):
 
 ```
                                  Apache License
@@ -1608,7 +1608,7 @@ This product includes source derived from [@opentelemetry/exporter-metrics-otlp-
 
 ### @opentelemetry/resources
 
-This product includes source derived from [@opentelemetry/resources](https://github.com/open-telemetry/opentelemetry-js) ([v2.0.1](https://github.com/open-telemetry/opentelemetry-js/tree/v2.0.1)), distributed under the [Apache-2.0 License](https://github.com/open-telemetry/opentelemetry-js/blob/v2.0.1/LICENSE):
+This product includes source derived from [@opentelemetry/resources](https://github.com/open-telemetry/opentelemetry-js) ([v2.1.0](https://github.com/open-telemetry/opentelemetry-js/tree/v2.1.0)), distributed under the [Apache-2.0 License](https://github.com/open-telemetry/opentelemetry-js/blob/v2.1.0/LICENSE):
 
 ```
                                  Apache License
@@ -2026,7 +2026,7 @@ This product includes source derived from [@opentelemetry/sdk-logs](https://gith
 
 ### @opentelemetry/sdk-metrics
 
-This product includes source derived from [@opentelemetry/sdk-metrics](https://github.com/open-telemetry/opentelemetry-js) ([v2.0.1](https://github.com/open-telemetry/opentelemetry-js/tree/v2.0.1)), distributed under the [Apache-2.0 License](https://github.com/open-telemetry/opentelemetry-js/blob/v2.0.1/LICENSE):
+This product includes source derived from [@opentelemetry/sdk-metrics](https://github.com/open-telemetry/opentelemetry-js) ([v2.1.0](https://github.com/open-telemetry/opentelemetry-js/tree/v2.1.0)), distributed under the [Apache-2.0 License](https://github.com/open-telemetry/opentelemetry-js/blob/v2.1.0/LICENSE):
 
 ```
                                  Apache License
@@ -2235,7 +2235,7 @@ This product includes source derived from [@opentelemetry/sdk-metrics](https://g
 
 ### @opentelemetry/sdk-trace-base
 
-This product includes source derived from [@opentelemetry/sdk-trace-base](https://github.com/open-telemetry/opentelemetry-js) ([v2.0.1](https://github.com/open-telemetry/opentelemetry-js/tree/v2.0.1)), distributed under the [Apache-2.0 License](https://github.com/open-telemetry/opentelemetry-js/blob/v2.0.1/LICENSE):
+This product includes source derived from [@opentelemetry/sdk-trace-base](https://github.com/open-telemetry/opentelemetry-js) ([v2.1.0](https://github.com/open-telemetry/opentelemetry-js/tree/v2.1.0)), distributed under the [Apache-2.0 License](https://github.com/open-telemetry/opentelemetry-js/blob/v2.1.0/LICENSE):
 
 ```
                                  Apache License
@@ -2964,7 +2964,7 @@ SOFTWARE.
 
 ### @aws-sdk/client-s3
 
-This product includes source derived from [@aws-sdk/client-s3](https://github.com/aws/aws-sdk-js-v3) ([v3.872.0](https://github.com/aws/aws-sdk-js-v3/tree/v3.872.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.872.0/LICENSE):
+This product includes source derived from [@aws-sdk/client-s3](https://github.com/aws/aws-sdk-js-v3) ([v3.879.0](https://github.com/aws/aws-sdk-js-v3/tree/v3.879.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.879.0/LICENSE):
 
 ```
                                 Apache License
@@ -3173,7 +3173,7 @@ This product includes source derived from [@aws-sdk/client-s3](https://github.co
 
 ### @aws-sdk/s3-request-presigner
 
-This product includes source derived from [@aws-sdk/s3-request-presigner](https://github.com/aws/aws-sdk-js-v3) ([v3.872.0](https://github.com/aws/aws-sdk-js-v3/tree/v3.872.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.872.0/LICENSE):
+This product includes source derived from [@aws-sdk/s3-request-presigner](https://github.com/aws/aws-sdk-js-v3) ([v3.879.0](https://github.com/aws/aws-sdk-js-v3/tree/v3.879.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js-v3/blob/v3.879.0/LICENSE):
 
 ```
                                 Apache License
@@ -5033,7 +5033,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ### eslint
 
-This product includes source derived from [eslint](https://github.com/eslint/eslint) ([v9.33.0](https://github.com/eslint/eslint/tree/v9.33.0)), distributed under the [MIT License](https://github.com/eslint/eslint/blob/v9.33.0/LICENSE):
+This product includes source derived from [eslint](https://github.com/eslint/eslint) ([v9.34.0](https://github.com/eslint/eslint/tree/v9.34.0)), distributed under the [MIT License](https://github.com/eslint/eslint/blob/v9.34.0/LICENSE):
 
 ```
 Copyright OpenJS Foundation and other contributors, <www.openjsf.org>
@@ -5866,9 +5866,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ## optionalDependencies
 
-### @newrelic/fn-inspect
+### @contrast/fn-inspect
 
-This product includes source derived from [@newrelic/fn-inspect](https://github.com/newrelic-forks/node-fn-inspect) ([v4.4.0](https://github.com/newrelic-forks/node-fn-inspect/tree/v4.4.0)), distributed under the [MIT License](https://github.com/newrelic-forks/node-fn-inspect/blob/v4.4.0/LICENSE):
+This product includes source derived from [@contrast/fn-inspect](https://github.com/Contrast-Security-Inc/node-fn-inspect) ([v5.0.2](https://github.com/Contrast-Security-Inc/node-fn-inspect/tree/v5.0.2)), distributed under the [MIT License](https://github.com/Contrast-Security-Inc/node-fn-inspect/blob/v5.0.2/LICENSE):
 
 ```
 Copyright 2022 Contrast Security, Inc

--- a/lib/util/code-level-metrics.js
+++ b/lib/util/code-level-metrics.js
@@ -52,7 +52,7 @@ clmUtils.addCLMAttributes = function addCLMAttributes(fn, segment) {
   }
 
   try {
-    const { funcInfo } = require('@newrelic/fn-inspect')
+    const { funcInfo } = require('@contrast/fn-inspect')
     const { lineNumber, method, file: filePath, column } = funcInfo(fn)
     const fnName = setFunctionName(method)
 

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "winston-transport": "^4.5.0"
   },
   "optionalDependencies": {
-    "@newrelic/fn-inspect": "^4.4.0",
+    "@contrast/fn-inspect": "^5.0.0",
     "@newrelic/native-metrics": "^12.0.0",
     "@prisma/prisma-fmt-wasm": "^4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085"
   },

--- a/test/unit/util/code-level-metrics.test.js
+++ b/test/unit/util/code-level-metrics.test.js
@@ -127,7 +127,7 @@ test('failure cases', async (t) => {
     ctx.nr.segmentStub = {
       addAttribute: sinon.stub()
     }
-    const fnInspector = require('@newrelic/fn-inspect')
+    const fnInspector = require('@contrast/fn-inspect')
     sinon.stub(fnInspector, 'funcInfo')
     ctx.nr.fnInspector = fnInspector
   })

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,18 +1,18 @@
 {
-  "lastUpdated": "Thu Aug 21 2025 11:37:45 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Thu Sep 04 2025 13:26:00 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
   "optionalDependencies": {
-    "@newrelic/fn-inspect@4.4.0": {
-      "name": "@newrelic/fn-inspect",
-      "version": "4.4.0",
-      "range": "^4.4.0",
+    "@contrast/fn-inspect@5.0.2": {
+      "name": "@contrast/fn-inspect",
+      "version": "5.0.2",
+      "range": "^5.0.0",
       "licenses": "MIT",
-      "repoUrl": "https://github.com/newrelic-forks/node-fn-inspect",
-      "versionedRepoUrl": "https://github.com/newrelic-forks/node-fn-inspect/tree/v4.4.0",
-      "licenseFile": "node_modules/@newrelic/fn-inspect/LICENSE",
-      "licenseUrl": "https://github.com/newrelic-forks/node-fn-inspect/blob/v4.4.0/LICENSE",
+      "repoUrl": "https://github.com/Contrast-Security-Inc/node-fn-inspect",
+      "versionedRepoUrl": "https://github.com/Contrast-Security-Inc/node-fn-inspect/tree/v5.0.2",
+      "licenseFile": "node_modules/@contrast/fn-inspect/LICENSE",
+      "licenseUrl": "https://github.com/Contrast-Security-Inc/node-fn-inspect/blob/v5.0.2/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Contrast Security"
     },
@@ -115,15 +115,15 @@
       "licenseTextSource": "file",
       "publisher": "OpenTelemetry Authors"
     },
-    "@opentelemetry/core@2.0.1": {
+    "@opentelemetry/core@2.1.0": {
       "name": "@opentelemetry/core",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "range": "^2.0.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/open-telemetry/opentelemetry-js",
-      "versionedRepoUrl": "https://github.com/open-telemetry/opentelemetry-js/tree/v2.0.1",
+      "versionedRepoUrl": "https://github.com/open-telemetry/opentelemetry-js/tree/v2.1.0",
       "licenseFile": "node_modules/@opentelemetry/core/LICENSE",
-      "licenseUrl": "https://github.com/open-telemetry/opentelemetry-js/blob/v2.0.1/LICENSE",
+      "licenseUrl": "https://github.com/open-telemetry/opentelemetry-js/blob/v2.1.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "OpenTelemetry Authors"
     },
@@ -139,15 +139,15 @@
       "licenseTextSource": "file",
       "publisher": "OpenTelemetry Authors"
     },
-    "@opentelemetry/resources@2.0.1": {
+    "@opentelemetry/resources@2.1.0": {
       "name": "@opentelemetry/resources",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "range": "^2.0.1",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/open-telemetry/opentelemetry-js",
-      "versionedRepoUrl": "https://github.com/open-telemetry/opentelemetry-js/tree/v2.0.1",
+      "versionedRepoUrl": "https://github.com/open-telemetry/opentelemetry-js/tree/v2.1.0",
       "licenseFile": "node_modules/@opentelemetry/resources/LICENSE",
-      "licenseUrl": "https://github.com/open-telemetry/opentelemetry-js/blob/v2.0.1/LICENSE",
+      "licenseUrl": "https://github.com/open-telemetry/opentelemetry-js/blob/v2.1.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "OpenTelemetry Authors"
     },
@@ -163,27 +163,27 @@
       "licenseTextSource": "file",
       "publisher": "OpenTelemetry Authors"
     },
-    "@opentelemetry/sdk-metrics@2.0.1": {
+    "@opentelemetry/sdk-metrics@2.1.0": {
       "name": "@opentelemetry/sdk-metrics",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "range": "^2.0.1",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/open-telemetry/opentelemetry-js",
-      "versionedRepoUrl": "https://github.com/open-telemetry/opentelemetry-js/tree/v2.0.1",
+      "versionedRepoUrl": "https://github.com/open-telemetry/opentelemetry-js/tree/v2.1.0",
       "licenseFile": "node_modules/@opentelemetry/sdk-metrics/LICENSE",
-      "licenseUrl": "https://github.com/open-telemetry/opentelemetry-js/blob/v2.0.1/LICENSE",
+      "licenseUrl": "https://github.com/open-telemetry/opentelemetry-js/blob/v2.1.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "OpenTelemetry Authors"
     },
-    "@opentelemetry/sdk-trace-base@2.0.1": {
+    "@opentelemetry/sdk-trace-base@2.1.0": {
       "name": "@opentelemetry/sdk-trace-base",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "range": "^2.0.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/open-telemetry/opentelemetry-js",
-      "versionedRepoUrl": "https://github.com/open-telemetry/opentelemetry-js/tree/v2.0.1",
+      "versionedRepoUrl": "https://github.com/open-telemetry/opentelemetry-js/tree/v2.1.0",
       "licenseFile": "node_modules/@opentelemetry/sdk-trace-base/LICENSE",
-      "licenseUrl": "https://github.com/open-telemetry/opentelemetry-js/blob/v2.0.1/LICENSE",
+      "licenseUrl": "https://github.com/open-telemetry/opentelemetry-js/blob/v2.1.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "OpenTelemetry Authors"
     },
@@ -333,28 +333,28 @@
     }
   },
   "devDependencies": {
-    "@aws-sdk/client-s3@3.872.0": {
+    "@aws-sdk/client-s3@3.879.0": {
       "name": "@aws-sdk/client-s3",
-      "version": "3.872.0",
+      "version": "3.879.0",
       "range": "^3.556.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/aws/aws-sdk-js-v3",
-      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.872.0",
+      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.879.0",
       "licenseFile": "node_modules/@aws-sdk/client-s3/LICENSE",
-      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.872.0/LICENSE",
+      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.879.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "AWS SDK for JavaScript Team",
       "url": "https://aws.amazon.com/javascript/"
     },
-    "@aws-sdk/s3-request-presigner@3.872.0": {
+    "@aws-sdk/s3-request-presigner@3.879.0": {
       "name": "@aws-sdk/s3-request-presigner",
-      "version": "3.872.0",
+      "version": "3.879.0",
       "range": "^3.556.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/aws/aws-sdk-js-v3",
-      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.872.0",
+      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js-v3/tree/v3.879.0",
       "licenseFile": "node_modules/@aws-sdk/s3-request-presigner/LICENSE",
-      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.872.0/LICENSE",
+      "licenseUrl": "https://github.com/aws/aws-sdk-js-v3/blob/v3.879.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "AWS SDK for JavaScript Team",
       "url": "https://aws.amazon.com/javascript/"
@@ -614,15 +614,15 @@
       "email": "gajus@gajus.com",
       "url": "http://gajus.com"
     },
-    "eslint@9.33.0": {
+    "eslint@9.34.0": {
       "name": "eslint",
-      "version": "9.33.0",
+      "version": "9.34.0",
       "range": "^9.17.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/eslint/eslint",
-      "versionedRepoUrl": "https://github.com/eslint/eslint/tree/v9.33.0",
+      "versionedRepoUrl": "https://github.com/eslint/eslint/tree/v9.34.0",
       "licenseFile": "node_modules/eslint/LICENSE",
-      "licenseUrl": "https://github.com/eslint/eslint/blob/v9.33.0/LICENSE",
+      "licenseUrl": "https://github.com/eslint/eslint/blob/v9.34.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Nicholas C. Zakas",
       "email": "nicholas+npm@nczconsulting.com"


### PR DESCRIPTION
…<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

I noticed the original package we were using was finally released to support Node 24. This PR updates to use the non-forked version