### PR TITLE
fix: Default `transaction.addRequestParameters` to an object to avoid crash

### DIFF
--- a/lib/serverless/api-gateway.js
+++ b/lib/serverless/api-gateway.js
@@ -62,7 +62,7 @@ function normalizeQueryStringParameters(event) {
     !event.multiValueQueryStringParameters ||
     Object.keys(event.multiValueQueryStringParameters).length === 0
   ) {
-    return event.queryStringParameters
+    return event.queryStringParameters ?? {}
   }
   return Object.fromEntries(
     Object.entries(event.multiValueQueryStringParameters).map(([param, value]) => {

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -1452,6 +1452,7 @@ Transaction.prototype.addRequestParameters = addRequestParameters
  * @param {Object<string, string>} requestParameters of the request object
  */
 function addRequestParameters(requestParameters) {
+  requestParameters ??= {}
   for (const [key, value] of Object.entries(requestParameters)) {
     this.trace.attributes.addAttribute(
       DESTS.NONE,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

In [url.parse refactor](https://github.com/newrelic/node-newrelic/pull/3340/files#diff-465a59f09f8e16dc024f585318b4796c5c8860f553b89254081ce1bd4c35cf8fR1454) `tx.addRequestParameters` was updated to modern syntax.  There were missing tests for passing in `undefined`, `null` values instead of an object.  This PR adds more tests both in transaction and a lambda scenario to assert the bug is fixed.


## Related Issues
Closes #3360
