### PR TITLE
ci: Updated the `GH_RELEASE_TOKEN` to point to our bot user PAT instead of python agent

### DIFF
--- a/.github/workflows/release-lambda-init-containers.yml
+++ b/.github/workflows/release-lambda-init-containers.yml
@@ -29,4 +29,4 @@ jobs:
           echo "newrelic/newrelic-agent-init-container - Releasing \"${RELEASE_TITLE}\" with tag ${RELEASE_TAG}"
           gh release create "${RELEASE_TAG}" --title="${RELEASE_TITLE}" --repo=newrelic/newrelic-agent-init-container --notes="${RELEASE_NOTES}"
         env:
-          GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+          GH_RELEASE_TOKEN: ${{ secrets.NODE_AGENT_GH_TOKEN }}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

When the python agent team moved creation of releases for newrelic-lambda-layers and newrelic-agent-init-container [here](https://github.com/newrelic/node-newrelic/pull/2848) to our repo, we relied on a repo secret that was a PAT for the newrelic-python-agent-team machine user.  This will be difficult to rotate and since we already have a machine user that has access to those repos, this PR updates the value of that env var.

