### PR TITLE
fix: Added defensive code for obtaining `protocol` in outbound http calls

### DIFF
--- a/lib/instrumentation/core/http-outbound.js
+++ b/lib/instrumentation/core/http-outbound.js
@@ -269,7 +269,7 @@ function applySegment({ opts, makeRequest, host, port, hostname, segment, config
     obfuscatedPath = request.path
   }
 
-  const proto = parsed.protocol || opts.protocol || 'http:'
+  const proto = parsed?.protocol || opts.protocol || 'http:'
 
   segment.captureExternalAttributes({
     protocol: proto,

--- a/test/unit/instrumentation/http/outbound.test.js
+++ b/test/unit/instrumentation/http/outbound.test.js
@@ -160,22 +160,6 @@ test('instrumentOutbound', async (t) => {
     })
   })
 
-  await t.test('should not accept an undefined path', (t, end) => {
-    const { agent } = t.nr
-    const req = new events.EventEmitter()
-    helper.runInTransaction(agent, function () {
-      assert.throws(
-        () => instrumentOutbound(agent, { host: HOSTNAME, port: PORT }, makeFakeRequest),
-        Error
-      )
-      end()
-    })
-
-    function makeFakeRequest() {
-      return req
-    }
-  })
-
   await t.test('should accept a simple path with no parameters', (t, end) => {
     const { agent } = t.nr
     const req = new events.EventEmitter()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Regression from #2209.


## Related Issues
Closes #3366
