### PR TITLE
style: Require `jsdoc/valid-types` and `jsdoc/check-param-names`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,7 +66,9 @@ const jsdocConfig = {
           'EventEmitter'
         ]
       }
-    ]
+    ],
+    'jsdoc/valid-types': 'error',
+    'jsdoc/check-param-names': 'error'
   }
 }
 const jsdocOverrides = {

--- a/lib/collector/parse-response.js
+++ b/lib/collector/parse-response.js
@@ -16,18 +16,15 @@ const logger = require('../logger').child({ component: 'new_relic_response' })
  * about errors as possible, and to parse out the return value as often
  * as possible.
  *
- * @param string         name     Remote method name that was invoked.
- * @param ServerResponse response HTTP response stream
- * @param Function       callback Function that will be called with any
- *                                error, the value returned by the server
- *                                (if any), and the raw JSON of the
- *                                server's response.
- * @param name
- * @param response
- * @param callback
- * @returns Function Another callback that is meant to be invoked with
- *                   any errors from reading the response stream, as
- *                   well as a string containing the full response.
+ * @param {string}         name     Remote method name that was invoked.
+ * @param {ServerResponse} response HTTP response stream
+ * @param {Function}       callback Function that will be called with any
+ *                                  error, the value returned by the server
+ *                                  (if any), and the raw JSON of the
+ *                                  server's response.
+ * @returns {Function} Another callback that is meant to be invoked with
+ *                     any errors from reading the response stream, as
+ *                     well as a string containing the full response.
  */
 module.exports = function parse(name, response, callback) {
   if (!callback) {

--- a/lib/collector/remote-method.js
+++ b/lib/collector/remote-method.js
@@ -128,9 +128,8 @@ RemoteMethod.prototype.invoke = function invoke(payload, nrHeaders, callback) {
  * Take a serialized payload and create a response wrapper for it before
  * invoking the method on the collector.
  *
- * @param {string}   methodName Name of method to invoke on collector.
  * @param {string}   data       Serialized payload.
- * @param {?object}  nrHeaders  NR request headers from connect response.
+ * @param {object}  nrHeaders  NR request headers from connect response.
  * @param {Function} callback   What to do next. Gets passed any error.
  */
 RemoteMethod.prototype._post = function _post(data, nrHeaders, callback) {
@@ -282,6 +281,7 @@ RemoteMethod.prototype._safeRequest = function _safeRequest(options) {
  * Generate the request headers and wire up the request. There are many
  * parameters used to make a request:
  *
+ * @param options
  * @param {string}   options.host       Hostname (or proxy hostname) for collector.
  * @param {string}   options.port       Port (or proxy port) for collector.
  * @param {string}   options.path       URL path for method being invoked on collector.
@@ -292,7 +292,6 @@ RemoteMethod.prototype._safeRequest = function _safeRequest(options) {
  *                                      original callback given to .send).
  * @param {Function} options.onResponse Response handler for this request (created by
  *                                      ._post).
- * @param options
  */
 RemoteMethod.prototype._request = function _request(options) {
   const requestOptions = {

--- a/lib/config/formatters.js
+++ b/lib/config/formatters.js
@@ -10,7 +10,7 @@ const formatters = module.exports
  * Splits a string by a ',' and trims whitespace
  *
  * @param {string} val config setting
- * @param {Array}
+ * @returns {Array}
  */
 formatters.array = function array(val) {
   return val.split(',').map((k) => k.trim())
@@ -39,8 +39,7 @@ formatters.float = function float(val) {
 /**
  * Parses a config setting as a boolean
  *
- * @param {string} val config setting
- * @param setting
+ * @param {string} setting value of config setting
  * @returns {boolean}
  */
 formatters.boolean = function boolean(setting) {

--- a/lib/instrumentation/core/http-outbound.js
+++ b/lib/instrumentation/core/http-outbound.js
@@ -289,8 +289,7 @@ function applySegment({ opts, makeRequest, host, port, hostname, segment, config
  * events.
  *
  * @param {Agent} agent New Relic agent
- * @param {string} hostname host of outbound request
- * @param host
+ * @param {string} host host of outbound request
  * @param {TraceSegment} segment outbound http segment
  * @param {http.IncomingMessage} request actual http outbound request
  */

--- a/lib/metrics/normalizer.js
+++ b/lib/metrics/normalizer.js
@@ -88,9 +88,8 @@ util.inherits(MetricNormalizer, EventEmitter)
  * Convert the raw, de-serialized JSON response into a set of
  * NormalizationRules.
  *
- * @param object json The de-serialized JSON response sent on collector
+ * @param {object} json The de-serialized JSON response sent on collector
  *                    connection.
- * @param json
  */
 MetricNormalizer.prototype.load = function load(json) {
   if (json) {

--- a/lib/metrics/recorders/database-operation.js
+++ b/lib/metrics/recorders/database-operation.js
@@ -13,7 +13,7 @@ const metrics = require('../names')
  * - `recordOperationMetrics(segment [, scope])`
  *
  * @private
- * @this DatastoreShim
+ * @memberof DatastoreShim.prototype
  * @implements {MetricFunction}
  * @param {TraceSegment}  segment - The segment being recorded.
  * @param {string}        [scope] - The scope of the segment.

--- a/lib/metrics/recorders/database.js
+++ b/lib/metrics/recorders/database.js
@@ -9,7 +9,7 @@ const { DB, ALL } = require('../names')
 const { DESTINATIONS } = require('../../config/attribute-filter')
 
 /**
- * @this ParsedStatement
+ * @memberof ParsedStatement.prototype
  * @param {TraceSegment}  segment - The segment being recorded.
  * @param {string}        [scope] - The scope of the segment.
  */

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -521,7 +521,7 @@ function getDatabaseNameFromUseQuery(query) {
  * `STATEMENT` metric.
  *
  * @private
- * @this DatastoreShim
+ * @memberof DatastoreShim.prototype
  * @param {string} suffix
  *  Suffix to be added to the segment name.
  * @param {object | Function} nodule
@@ -606,7 +606,7 @@ function _getSpec({ spec, shim, fn, fnName, args }) {
  * - `_extractQueryStr(fn, fnName, spec, ctx, args)`
  *
  * @private
- * @this DatastoreShim
+ * @memberof DatastoreShim.prototype
  * @param {Function}  fn      - The query function to be executed.
  * @param {string}    fnName  - The name of the query function.
  * @param {QuerySpec} spec    - The query spec.
@@ -639,7 +639,7 @@ function _extractQueryStr(fn, fnName, spec, ctx, args) {
  * from `localhost` to the actual host name.
  *
  * @private
- * @this DatastoreShim
+ * @memberof DatastoreShim.prototype
  * @param {object} [parameters] - The segment parameters to clean up.
  * @returns {object} - The normalized segment parameters.
  */

--- a/lib/shim/message-shim/subscribe-consume.js
+++ b/lib/shim/message-shim/subscribe-consume.js
@@ -38,7 +38,6 @@ function _nameMessageTransaction(shim, msgDesc) {
  * @param {Function} params.fn subscriber function
  * @param {specs.MessageSubscribeSpec} params.spec spec for subscriber
  * @param params.name
- * @param {boolean} params.destNameIsArg flag to state if destination is an argument
  * @returns {Function} wrapped subscribe function
  */
 function createSubscriberWrapper({ shim, fn, spec, name }) {

--- a/lib/shim/promise-shim.js
+++ b/lib/shim/promise-shim.js
@@ -366,9 +366,7 @@ function _wrapExecutorContext(shim, args) {
 
   /**
    *
-   * @param {Function} resolve function of promise
-   * @param {Function} reject function of promise
-   * @param {...any} args
+   * @param {Object} args contains the `resolve` and `reject` functions of a promise
    */
   function contextExporter(...args) {
     const [resolve, reject] = args

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -1453,8 +1453,7 @@ function isPromise(obj) {
  * promise or async function
  *
  * @memberof Shim.prototype
- * @param fn
- * @param (function) function to test if async
+ * @param {function} fn function to test if async
  * @returns {boolean} True if the function is an async function
  */
 function isAsyncFunction(fn) {
@@ -1871,7 +1870,6 @@ function _makeBindWrapper(shim, func, context, full) {
  * (i.e. `bindRowCallbackSegment` for `rowCallback`), but will fall back to the
  * generic callback binding method, `bindCallbackSegment`, otherwise.
  *
- * @this *
  * @private
  * @param {Shim} shim
  *  The shim performing this binding.

--- a/lib/shim/transaction-shim.js
+++ b/lib/shim/transaction-shim.js
@@ -19,7 +19,6 @@ const TRANSACTION_TYPES_SET = Transaction.TYPES_SET
  * @class
  * @augments Shim
  * @classdesc
- * @param shimName
  *  A helper class for working with transactions.
  * @param {Agent}   agent         - The agent the shim will use.
  * @param {string}  moduleName    - The name of the module being instrumented.

--- a/lib/shim/webframework-shim/common.js
+++ b/lib/shim/webframework-shim/common.js
@@ -46,8 +46,6 @@ common.getTransactionInfo = function getTransactionInfo(shim, req) {
  * Adds the given error to the transaction information if it is actually an error.
  *
  * @private
- * @param {WebFrameworkShim} shim
- *  The shim used for this web framework.
  * @param {TransactionInfo} txInfo
  *  The transaction context information for the request.
  * @param {*} err

--- a/lib/spans/span-event.js
+++ b/lib/spans/span-event.js
@@ -89,11 +89,12 @@ class SpanEvent {
    * The constructed span event will contain extra data depending on the
    * category of the segment.
    *
-   * @param {TraceSegment} segment segment to turn into a span event.
-   * @param {Transaction} transaction active transaction
-   * @param {?string} [parentId] ID of the segment's parent.
-   * @param {boolean} isRoot if segment is root segment
-   * @param {boolean} inProcessSpans if the segment is in-process, create span
+   * @param {Object} params
+   * @param {TraceSegment} params.segment segment to turn into a span event.
+   * @param {Transaction} params.transaction active transaction
+   * @param {?string} [params.parentId] ID of the segment's parent.
+   * @param {boolean} [params.isRoot] if segment is root segment; defaults to `false`
+   * @param {boolean} params.inProcessSpans if the segment is in-process, create span
    * @returns {SpanEvent} The constructed event.
    */
   static fromSegment({ segment, transaction, parentId = null, isRoot = false, inProcessSpans }) {

--- a/lib/spans/streaming-span-event-aggregator.js
+++ b/lib/spans/streaming-span-event-aggregator.js
@@ -101,10 +101,9 @@ class StreamingSpanEventAggregator extends Aggregator {
    *
    * @param {object} params to function
    * @param {TraceSegment} params.segment segment to add.
-   * @param {string} [parms.parentId] GUID of the parent span.
    * @param {Transaction} params.transaction active transaction
+   * @param {string} [params.parentId] GUID of the parent span.
    * @param {boolean} params.isRoot is segment root segment
-   * @param params.parentId
    * @returns {boolean} True if the segment was added, or false if it was discarded.
    */
   addSegment({ segment, transaction, parentId, isRoot }) {

--- a/lib/subscribers/openai/utils.js
+++ b/lib/subscribers/openai/utils.js
@@ -212,14 +212,13 @@ function shouldSkipInstrumentation(config, logger) {
  * messages.
  * @param {object} params input params
  * @param {Agent} params.agent NR agent instance
- * @param {Shim} params.shim the current shim instance
+ * @param {object} params.headers request headers
+ * @param {object} params.logger logger instance
  * @param {object} params.request chat completion params
  * @param {object} params.response chat completion response
  * @param {TraceSegment} params.segment active segment from chat completion
  * @param {Transaction} params.transaction active transaction
- * @param {Error} params.err error if it exists
- * @param params.headers
- * @param params.logger
+ * @param {Error} [params.err] error if it exists
  */
 function instrumentStream({ agent, headers, logger, request, response, segment, transaction, err = null }) {
   if (!agent.config.ai_monitoring.streaming.enabled) {

--- a/lib/transaction/handle.js
+++ b/lib/transaction/handle.js
@@ -57,11 +57,10 @@ class TransactionHandle {
    * W3C TraceContext format is preferred over the NewRelic DT format.
    * NewRelic DT format will be used if no `traceparent` header is found.
    *
-   * @param @param {string} [transportType='Unknown'] - The transport type that delivered the trace.
-   * @param transportType
+   * @param {string} [transportType] - The transport type that delivered the trace; defaults to 'Unknown'.
    * @param {object} headers - Headers to search for supported formats. Keys must be lowercase.
    */
-  acceptDistributedTraceHeaders(transportType, headers) {
+  acceptDistributedTraceHeaders(transportType = 'Unknown', headers) {
     incrementApiSupportMetric(this._metrics, 'acceptDistributedTraceHeaders')
     return this._transaction.acceptDistributedTraceHeaders(transportType, headers)
   }

--- a/lib/transaction/trace/segment.js
+++ b/lib/transaction/trace/segment.js
@@ -270,11 +270,10 @@ function getExclusiveDurationInMillis(trace) {
  * @param {string} params.protocol protocol of request(i.e. `http:`, `grpc:`)
  * @param {string} params.hostname hostname of request(no port)
  * @param {string} params.host host of request(hostname + port)
- * @param [string] params.port port of request if applicable
+ * @param {string} params.port port of request if applicable
  * @param {string} params.path uri of request
  * @param {string} [params.method] method of request
  * @param {object} [params.queryParams] query parameters of request
- * @param params.port
  */
 TraceSegment.prototype.captureExternalAttributes = function captureExternalAttributes({
   protocol,

--- a/lib/util/cat.js
+++ b/lib/util/cat.js
@@ -32,11 +32,11 @@ const MATCH_CAT_APP_DATA_HEADER = new RegExp(
 /**
  * Decodes the CAT id and transaction headers from incoming request
  *
- * @param {object} headers incoming headers
  * @param id
  * @param transactionId
  * @param {string} encKey config.encoding_key used to decode CAT headers
- * @param {object} { externalId, externalTransaction }
+ *
+ * @returns {object} { externalId, externalTransaction }
  */
 cat.parseCatData = function parseCatData(id, transactionId, encKey) {
   if (!encKey) {
@@ -220,8 +220,7 @@ cat.extractCatHeaders = function extractCatHeaders(headers) {
  * Extracts the account Id from CAT data and verifies if it is
  * a trusted account id
  *
- * @param {object} CAT data
- * @param data
+ * @param {object} data CAT data
  * @param {Array} trustedAccounts from config
  * @returns {boolean}
  */
@@ -240,7 +239,8 @@ cat.isTrustedAccountId = function isTrustedAccountId(data, trustedAccounts) {
  *
  * @param {object} config agent config
  * @param {string} obfAppData encoded app data to parse and use
- * @param {Array} decoded app data header
+ *
+ * @returns {Array} decoded app data header
  */
 cat.parseAppData = function parseAppData(config, obfAppData) {
   if (!config.encoding_key) {

--- a/lib/util/flatten.js
+++ b/lib/util/flatten.js
@@ -16,8 +16,8 @@ exports.keys = flatKeys
  * @private
  * @param {object} result Object to place key-value pairs into, normally called with `{}`.
  * @param {string} prefix Prefix for keys, normally called with `''`.
- * @param seen
  * @param {object} obj    Object to be flattened.
+ * @param {Array} seen    Array of seen objects to prevent circular references.
  * @returns {object} Object with flattened key-value pairs
  */
 function flatten(result, prefix, obj, seen) {
@@ -45,8 +45,7 @@ function flatten(result, prefix, obj, seen) {
  * @private
  * @param {object}  obj       - The object to get the flat keys of.
  * @param {string}  prefix    - A prefix for the keys, usually `''`.
- * @param arrayIdxs
- * @param {boolean}    arrayIdx  - Flag indicating if array indexes should be iterated.
+ * @param {boolean}    arrayIdxs  - Flag indicating if array indexes should be iterated.
  * @returns {Array.<string>} An array of keys names.
  */
 function flatKeys(obj, prefix, arrayIdxs) {

--- a/lib/util/is-absolute-path.js
+++ b/lib/util/is-absolute-path.js
@@ -19,7 +19,7 @@ module.exports = function isAbsolutePath(target) {
   }
 
   const suffix = target.slice(-4)
-  /* eslint-disable-next-line */
+
   if (suffix.slice(-3) !== '.js' && suffix !== '.cjs' && suffix !== '.mjs') {
     return false
   }

--- a/lib/utilization/docker-info.js
+++ b/lib/utilization/docker-info.js
@@ -58,9 +58,10 @@ function recordBootIdError(agent) {
 /**
  * Utility function to parse a Docker boot id from a cgroup proc file.
  *
- * @param {Buffer} data The information from the proc file.
- * @param {object} agent Newrelic agent instance.
- * @param {Function} callback Typical error first callback. Second parameter
+ * @param {Object} params
+ * @param {Buffer} params.data The information from the proc file.
+ * @param {Agent} params.agent Newrelic agent instance.
+ * @param {Function} params.callback Typical error first callback. Second parameter
  * is the boot id as a string.
  *
  * @returns {*}

--- a/test/lib/agent_helper.js
+++ b/test/lib/agent_helper.js
@@ -129,10 +129,8 @@ helper.getAgentApi = function getAgentApi() {
  * specific format. Useful with nock.
  *
  * @param {String} method The method being invoked on the collector.
- * @param number runID  Agent run ID (optional).
- *
- * @param runID
- * @param protocolVersion
+ * @param {number} runID  Agent run ID (optional).
+ * @param {number} [protocolVersion] defaults to 17
  * @returns {String} URL path for the collector.
  */
 helper.generateCollectorPath = function generateCollectorPath(method, runID, protocolVersion) {
@@ -197,8 +195,7 @@ helper.instrumentMockedAgent = (conf, setState = true, shimmer = require('../../
 /**
  * Helper to check if security agent should be loaded
  *
- * @param {Agent} Agent with a stubbed configuration
- * @param agent
+ * @param {Agent} agent with a stubbed configuration
  * @returns {boolean}
  */
 helper.isSecurityAgentEnabled = function isSecurityAgentEnabled(agent) {
@@ -209,8 +206,7 @@ helper.isSecurityAgentEnabled = function isSecurityAgentEnabled(agent) {
  * Checks if security agent _should_ be loaded
  * and requires it and calls start
  *
- * @param {Agent} Agent with a stubbed configuration
- * @param agent
+ * @param {Agent} agent with a stubbed configuration
  */
 helper.maybeLoadSecurityAgent = function maybeLoadSecurityAgent(agent) {
   if (helper.isSecurityAgentEnabled(agent)) {
@@ -224,8 +220,7 @@ helper.maybeLoadSecurityAgent = function maybeLoadSecurityAgent(agent) {
  * Checks if security agent is loaded and deletes all
  * files in its require cache so it can be re-loaded
  *
- * @param {Agent} Agent with a stubbed configuration
- * @param agent
+ * @param {Agent} agent with a stubbed configuration
  */
 helper.maybeUnloadSecurityAgent = function maybeUnloadSecurityAgent(agent) {
   if (helper.isSecurityAgentEnabled(agent)) {
@@ -237,9 +232,8 @@ helper.maybeUnloadSecurityAgent = function maybeUnloadSecurityAgent(agent) {
  * Shut down the agent, ensuring that any instrumentation scaffolding
  * is shut down.
  *
- * @param Agent agent The agent to shut down.
- * @param agent
- * @param shimmer
+ * @param {Agent} agent The agent to shut down.
+ * @param {object} [shimmer] The shimmer to use.
  */
 helper.unloadAgent = (agent, shimmer = require('../../lib/shimmer')) => {
   agent.emit('unload')
@@ -336,10 +330,8 @@ helper.runInSegment = (agent, name, callback) => {
 /**
  * Select Redis DB index and flush entries in it.
  *
- * @param {redis} [redis]
- * @param client
+ * @param {redis} client
  * @param {number} dbIndex
- * @param {function} callback
  *  The operations to be performed while the server is running.
  */
 helper.flushRedisDb = (client, dbIndex) => new Promise((resolve, reject) => {
@@ -533,8 +525,7 @@ helper.getMetrics = function getMetrics(agent) {
  * It also verifies it does not throw an error
  *
  * @param {object} shim shim lib
- * @param {Function} original callback
- * @param cb
+ * @param {Function} cb original callback
  */
 helper.checkWrappedCb = function checkWrappedCb(shim, cb) {
   // The wrapped calledback is always the last argument

--- a/test/lib/custom-assertions/assert-segments.js
+++ b/test/lib/custom-assertions/assert-segments.js
@@ -68,6 +68,7 @@
  * @param {Array} expected          Array of strings that represent segment names.
  *                                  If an item in the array is another array, it
  *                                  represents children of the previous item.
+ * @param {object} [options]        Options object
  * @param {boolean} options.exact   If true, then the expected segments must match
  *                                  exactly, including their position and children on all
  *                                  levels.  When false, then only check that each child
@@ -78,10 +79,6 @@
  *                                  directly under test.  Only used when `exact` is true.
  * @param {object} [deps] Injected dependencies.
  * @param {object} [deps.assert] Assertion library to use.
- * @param options
- * @param root0
- * @param root0.assert
- * @param options.assert
  */
 module.exports = function assertSegments( // eslint-disable-line sonarjs/cognitive-complexity
   trace,

--- a/test/lib/custom-assertions/not-has.js
+++ b/test/lib/custom-assertions/not-has.js
@@ -12,17 +12,12 @@ const get = require('../../../lib/util/get')
  * by `doNotWant`.
  *
  * @param {object} params Input parameters
- * @param params.found
- * @param {object} found The object to test for absence.
- * @param {string} doNotWant Dot separated path to a field that should not
+ * @param {object} params.found The object to test for absence.
+ * @param {string} params.doNotWant Dot separated path to a field that should not
  * have a value.
- * @param {string} [msg] Assertion message to include.
+ * @param {string} [params.msg] Assertion message to include.
  * @param {object} [deps] Injected dependencies.
  * @param {object} [deps.assert] Assertion library to use.
- *
- * @param params.doNotWant
- * @param params.msg
- * @param found.assert
  * @throws {Error} When the `found` object contains a value at the specified
  * `doNotWant` path.
  */

--- a/test/lib/logging-helper.js
+++ b/test/lib/logging-helper.js
@@ -13,10 +13,9 @@ const CONTEXT_KEYS = ['trace.id', 'span.id']
  * Validates context about a given log line
  *
  * @param {object} params to fn
- * @param {object} params.log log line
+ * @param {object} params.line log line
  * @param {string} params.message message in log line
  * @param {number} params.level log level
- * @param params.line
  */
 function validateLogLine({ line: logLine, message, level }) {
   assert.equal(/\d{10}/.test(logLine.timestamp), true, 'should have proper unix timestamp')

--- a/test/lib/temp-override-uncaught.js
+++ b/test/lib/temp-override-uncaught.js
@@ -21,14 +21,11 @@ const oldListeners = {
  * restoring the original listeners upon test completion.
  *
  * @param {object} params
- * @param params.t
- * @param {TestContext} t A `node:test` context object.
- * @param {function} handler An error handler function that will replace all
+ * @param {TestContext} params.t A `node:test` context object.
+ * @param {function} params.handler An error handler function that will replace all
  * current listeners.
- * @param {string} [type] The kind of uncaught event to
+ * @param {string} [params.type] The kind of uncaught event to
  * override.
- * @param params.handler
- * @param params.type
  * @property {string} EXCEPTION Constant value usable for `type`.
  * @property {string} REJECTION Constant value usable for `type`.
  */

--- a/test/lib/temp-remove-listeners.js
+++ b/test/lib/temp-remove-listeners.js
@@ -10,12 +10,9 @@
  * and re-adds them subsequent to a test completing.
  *
  * @param {object} params
- * @param params.t
- * @param {TestContext} t A `node:test` test context.
- * @param {EventEmitter} emitter The emitter to manipulate.
- * @param {string} event The event name to target.
- * @param params.emitter
- * @param params.event
+ * @param {TestContext} params.t A `node:test` test context.
+ * @param {EventEmitter} params.emitter The emitter to manipulate.
+ * @param {string} params.event The event name to target.
  */
 module.exports = function tempRemoveListeners({ t, emitter, event }) {
   if (!emitter) {

--- a/test/versioned/connect/route.test.js
+++ b/test/versioned/connect/route.test.js
@@ -105,11 +105,9 @@ test('should default to `/` when no route is specified', async (t) => {
  * @param {Object} params
  * @param {string} params.url url to make request
  * @param {string} params.expectedData expected response data
- * @param {Object} app connect app
- *
- * @param params.plan
- * @param params.app
- * @param params.pkgVersion
+ * @param {Object} params.plan
+ * @param {Object} params.app connect app
+ * @param {string} params.pkgVersion
  * @returns {http.Server}
  */
 function createServerAndMakeRequest({ url, expectedData, plan, app, pkgVersion }) {

--- a/test/versioned/express-esm/helpers.mjs
+++ b/test/versioned/express-esm/helpers.mjs
@@ -9,7 +9,7 @@ const helpers = Object.create(null)
 
 /**
  * Imports express, creates an express app and returns both as an object
- * @returns { app, express }
+ * @returns { Object } object containing `app` and `express`
  */
 helpers.setup = async function setup() {
   const { default: express } = await import('express')

--- a/test/versioned/fastify/common.js
+++ b/test/versioned/fastify/common.js
@@ -110,11 +110,11 @@ common.registerMiddlewares = ({ fastify, calls }) => {
 /**
  * Helper to make a request and parse the json body
  *
- * @param address.address
  * @param {Object} address fastify address contains address/port/family
- * @param address.port
+ * @param {string} address.address
+ * @param {number} address.port
+ * @param {string} address.family
  * @param {string} uri to make request to
- * @param address.family
  * @returns {Object} parsed json body
  */
 common.makeRequest = async ({ address, port, family }, uri) => {

--- a/test/versioned/grpc/util.cjs
+++ b/test/versioned/grpc/util.cjs
@@ -180,13 +180,12 @@ util.assertExternalSegment = function assertExternalSegment(
  * Asserts the gRPC server segment and its relevant attributes: response.status
  * request.method, request.uri
  *
- * @param {Object} params
- * @param {Object} params.tx transaction under test
- * @param {string} params.fnName gRPC method name
- * @param {number} [params.expectedStatusCode] expected status code for test
- * @param params.transaction
- * @param root1
- * @param root1.assert
+ * @param {Object} params1
+ * @param {Object} params1.transaction transaction under test
+ * @param {string} params1.fnName gRPC method name
+ * @param {number} [params1.expectedStatusCode] expected status code for test
+ * @param {Object} params2
+ * @param {Object} params2.assert assert library to use
  */
 util.assertServerTransaction = function assertServerTransaction(
   { transaction, fnName, expectedStatusCode = 0 },

--- a/test/versioned/mongodb-esm/collection-update.test.mjs
+++ b/test/versioned/mongodb-esm/collection-update.test.mjs
@@ -19,10 +19,9 @@ const { STATEMENT_PREFIX } = ESM
  *
  * @param {Object} params
  * @param {Object} params.data result from callback used to assert
- * @param {Number} params.count, optional
+ * @param {Number} [params.count] optional count
  * @param {string} params.keyPrefix prefix where the count exists
  * @param {Object} params.extraValues extra fields to assert on >=4.0.0 version of module
- * @param params.count
  */
 function assertExpectedResult({ data, count, keyPrefix, extraValues }) {
   const expectedResult = { acknowledged: true, ...extraValues }

--- a/test/versioned/mongodb/collection-update.test.js
+++ b/test/versioned/mongodb/collection-update.test.js
@@ -23,10 +23,9 @@ const { STATEMENT_PREFIX } = require('./common')
  *
  * @param {Object} params
  * @param {Object} params.data result from callback used to assert
- * @param {Number} params.count, optional
+ * @param {Number} [params.count] optional count
  * @param {string} params.keyPrefix prefix where the count exists
  * @param {Object} params.extraValues extra fields to assert on >=4.0.0 version of module
- * @param params.count
  */
 function assertExpectedResult({ data, count, keyPrefix, extraValues }) {
   const expectedResult = { acknowledged: true, ...extraValues }

--- a/test/versioned/pino/helpers.js
+++ b/test/versioned/pino/helpers.js
@@ -15,10 +15,9 @@ const { CONTEXT_KEYS } = require('../../lib/logging-helper')
  *
  * @param {Object} opts
  * @param {boolean} [opts.includeLocalDecorating] is local log decoration enabled
- * @param {boolean} [opts.timestamp] does timestamp exist on original message
  * @param {string} [opts.level] level to assert is on message
- * @param opts.logLine
- * @param opts.hostname
+ * @param {Object} opts.logLine
+ * @param {string} opts.hostname
  */
 helpers.originalMsgAssertion = function originalMsgAssertion({
   includeLocalDecorating = false,

--- a/test/versioned/prisma/utils.js
+++ b/test/versioned/prisma/utils.js
@@ -93,8 +93,7 @@ function verifyTraces(agent, transaction) {
  * associative datastore attributes + backtrace.
  *
  * @param {Object} agent mocked NR agent
- * @param {Number} [count] number of queries it expects in aggregator
- * @param queries
+ * @param {Number} [queries] queries it expects in aggregator
  */
 utils.verifySlowQueries = function verifySlowQueries(agent, queries = []) {
   const metricHostName = getMetricHostName(agent, params.postgres_host)

--- a/test/versioned/when/when.test.js
+++ b/test/versioned/when/when.test.js
@@ -869,16 +869,13 @@ test('node.apply', (t, end) => {
 /**
  * Tests a `when` library method outside of an agent transaction.
  *
- * @param {object} params
- * @param params.plan
- * @param {object} plan The assertion library that expects a set number of
+ * @param {object} params The params object
+ * @param {object} params.plan The assertion library that expects a set number of
  * assertions to be completed during the test.
- * @param {object} agent A mocked agent instance.
- * @param {function} testFunc A function that accepts a "name" parameter and
+ * @param {object} params.agent A mocked agent instance.
+ * @param {function} params.testFunc A function that accepts a "name" parameter and
  * returns a promise. The parameter is a string for identifying the test and
  * values used within the test.
- * @param params.agent
- * @param params.testFunc
  * @returns {Promise<void>}
  */
 async function testThrowOutsideTransaction({ plan, agent, testFunc }) {
@@ -904,16 +901,13 @@ async function testThrowOutsideTransaction({ plan, agent, testFunc }) {
 /**
  * Tests a `when` library method inside of an agent transaction.
  *
- * @param {object} params
- * @param params.plan
- * @param {object} plan The assertion library that expects a set number of
+ * @param {object} params The params object
+ * @param {object} params.plan The assertion library that expects a set number of
  * assertions to be completed during the test.
- * @param {object} agent A mocked agent instance.
- * @param {function} testFunc A function that accepts a "name" parameter and
+ * @param {object} params.agent A mocked agent instance.
+ * @param {function} params.testFunc A function that accepts a "name" parameter and
  * returns a promise. The parameter is a string for identifying the test and
  * values used within the test.
- * @param params.agent
- * @param params.testFunc
  * @returns {Promise<void>}
  */
 async function testInsideTransaction({ plan, agent, testFunc }) {


### PR DESCRIPTION
This PR relates to #2503. `jsdoc/valid-types` and `jsdoc/check-param-names` are now errors in our eslint config. I will do the rest of the `jsdoc/*` rules in separate PRs.