### PR TITLE
fix: Updated `openai` instrumentation to properly return APIPromise to avoid crashing when using `completions.parse` or `responses.parse`

### DIFF
--- a/lib/subscribers/openai/chat.js
+++ b/lib/subscribers/openai/chat.js
@@ -23,6 +23,7 @@ const MIN_STREAM_VERSION = '4.12.2'
 class OpenAIChatCompletions extends OpenAISubscriber {
   constructor({ agent, logger, channelName = 'nr_completionsCreate' }) {
     super({ agent, logger, channelName })
+    this.events = ['asyncEnd', 'end']
   }
 
   handler(data, ctx) {
@@ -40,6 +41,32 @@ class OpenAIChatCompletions extends OpenAISubscriber {
     })
     const newCtx = ctx.enterSegment({ segment })
     return newCtx
+  }
+
+  /**
+   * Temporary fix as `tracePromise` wraps the promise in a native one.
+   * We are now wrapping `openai.chat.completions.parse` in a traceSync call
+   * and then wrapping the promise here so it returns the custom promise.
+   * OpenAI has a [custom promise](https://github.com/openai/openai-node/blob/master/src/core/api-promise.ts) that crashes applications using `openai.chat.completions.parse`
+   * see: https://github.com/newrelic/node-newrelic/issues/3379
+   * see: https://github.com/nodejs/node/issues/59936
+   * @param data
+   */
+  end(data) {
+    const promise = data?.result
+    if (!promise.then) {
+      return promise
+    }
+
+    return promise.then((result) => {
+      data.result = result
+      this.channel.asyncEnd.publish(data)
+      return result
+    }).catch((err) => {
+      data.error = err
+      this.channel.asyncEnd.publish(data)
+      return err
+    })
   }
 
   asyncEnd(data) {

--- a/lib/subscribers/openai/config.js
+++ b/lib/subscribers/openai/config.js
@@ -16,7 +16,7 @@ module.exports = {
           functionQuery: {
             className: 'Completions',
             methodName: 'create',
-            kind: 'Async'
+            kind: 'Sync'
           }
         },
         {
@@ -25,7 +25,7 @@ module.exports = {
           functionQuery: {
             className: 'Completions',
             methodName: 'create',
-            kind: 'Async'
+            kind: 'Sync'
           }
         }
       ]
@@ -39,7 +39,7 @@ module.exports = {
           functionQuery: {
             className: 'Responses',
             methodName: 'create',
-            kind: 'Async'
+            kind: 'Sync'
           }
         }
       ]


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
The linked bug found an issue with how we're now instrumenting `openai` with the tracing channel.  I determined this is actually a bug in [Node.js](https://github.com/nodejs/node/issues/59936).  In the meantime, we can work around it by wrapping the functions we need in `traceSync` and propagating and emitting the results in the resolve/reject blocks of the promise.

**Note**: I added a test to prove this no longer crashes, but I can't seem to get it to succeed with our mock server. I want to test with a live openai instance to ensure there aren't more issues, but I don't expect there to be.

## How to Test

```sh
npm run versioned:internal openai
```

## Related Issues
Fixes #3379
