### PR TITLE
chore: Updated supportability metric names for OTel Bridge enablement…

### DIFF
--- a/lib/otel/metrics/index.js
+++ b/lib/otel/metrics/index.js
@@ -42,7 +42,7 @@ class SetupMetrics extends SetupSignal {
     const getMeter = provider.getMeter
     provider.getMeter = function nrGetMeter(...args) {
       agent.metrics
-        .getOrCreateMetric('Supportability/Nodejs/OpenTelemetryBridge/Metrics/getMeter')
+        .getOrCreateMetric('Supportability/Metrics/Nodejs/OpenTelemetryBridge/getMeter')
         .incrementCallCount()
 
       const meter = getMeter.apply(provider, args)
@@ -61,7 +61,7 @@ class SetupMetrics extends SetupSignal {
         // + createObservableUpDownCounter
         meter[method] = function nrWrappedMethod(...args) {
           agent.metrics
-            .getOrCreateMetric(`Supportability/Nodejs/OpenTelemetryBridge/Metrics/meter/${method}`)
+            .getOrCreateMetric(`Supportability/Metrics/Nodejs/OpenTelemetryBridge/meter/${method}`)
             .incrementCallCount()
           return originals[method].apply(meter, args)
         }
@@ -73,7 +73,7 @@ class SetupMetrics extends SetupSignal {
     this.coreApi.metrics.setGlobalMeterProvider(provider)
 
     agent.metrics
-      .getOrCreateMetric('Supportability/Nodejs/OpenTelemetryBridge/Metrics')
+      .getOrCreateMetric('Supportability/Metrics/Nodejs/OpenTelemetryBridge/enabled')
       .incrementCallCount()
 
     // We need access to `agent.config.entity_guid` in order to attach metrics

--- a/lib/otel/setup.js
+++ b/lib/otel/setup.js
@@ -23,12 +23,6 @@ function setupOtel(agent, logger = defaultLogger) {
     logger.warn(
       '`opentelemetry_bridge` is not enabled, skipping setup of opentelemetry-bridge'
     )
-    agent.metrics
-      .getOrCreateMetric('Supportability/Metrics/Nodejs/OpenTelemetryBridge/disabled')
-      .incrementCallCount()
-    agent.metrics
-      .getOrCreateMetric('Supportability/Tracing/Nodejs/OpenTelemetryBridge/disabled')
-      .incrementCallCount()
     return
   }
 

--- a/lib/otel/setup.js
+++ b/lib/otel/setup.js
@@ -24,6 +24,9 @@ function setupOtel(agent, logger = defaultLogger) {
       '`opentelemetry_bridge` is not enabled, skipping setup of opentelemetry-bridge'
     )
     agent.metrics
+      .getOrCreateMetric('Supportability/Metrics/Nodejs/OpenTelemetryBridge/disabled')
+      .incrementCallCount()
+    agent.metrics
       .getOrCreateMetric('Supportability/Tracing/Nodejs/OpenTelemetryBridge/disabled')
       .incrementCallCount()
     return
@@ -44,6 +47,9 @@ function setupOtel(agent, logger = defaultLogger) {
     signals.push(signal)
   } else {
     logger.debug('`opentelemetry_bridge.traces` is not enabled, skipping')
+    agent.metrics
+      .getOrCreateMetric('Supportability/Tracing/Nodejs/OpenTelemetryBridge/disabled')
+      .incrementCallCount()
   }
 
   if (agent.config.opentelemetry_bridge.metrics.enabled === true) {
@@ -51,6 +57,9 @@ function setupOtel(agent, logger = defaultLogger) {
     signals.push(signal)
   } else {
     logger.debug('`opentelemetry_bridge.metrics` is not enabled, skipping')
+    agent.metrics
+      .getOrCreateMetric('Supportability/Metrics/Nodejs/OpenTelemetryBridge/disabled')
+      .incrementCallCount()
   }
 
   if (agent.config.opentelemetry_bridge.logs.enabled === true) {

--- a/test/integration/otel/metrics.test.js
+++ b/test/integration/otel/metrics.test.js
@@ -139,9 +139,9 @@ test('sends metrics', { timeout: 5_000 }, async (t) => {
   const supportMetrics = agent.metrics._metrics.unscoped
   const expectedMetricNames = [
     'Supportability/Nodejs/OpenTelemetryBridge/Setup',
-    'Supportability/Nodejs/OpenTelemetryBridge/Metrics',
-    'Supportability/Nodejs/OpenTelemetryBridge/Metrics/getMeter',
-    'Supportability/Nodejs/OpenTelemetryBridge/Metrics/meter/createCounter'
+    'Supportability/Metrics/Nodejs/OpenTelemetryBridge',
+    'Supportability/Metrics/Nodejs/OpenTelemetryBridge/getMeter',
+    'Supportability/Metrics/Nodejs/OpenTelemetryBridge/meter/createCounter'
   ]
   for (const expectedMetricName of expectedMetricNames) {
     assert.equal(supportMetrics[expectedMetricName].callCount, 1)

--- a/test/integration/otel/metrics.test.js
+++ b/test/integration/otel/metrics.test.js
@@ -139,7 +139,7 @@ test('sends metrics', { timeout: 5_000 }, async (t) => {
   const supportMetrics = agent.metrics._metrics.unscoped
   const expectedMetricNames = [
     'Supportability/Nodejs/OpenTelemetryBridge/Setup',
-    'Supportability/Metrics/Nodejs/OpenTelemetryBridge',
+    'Supportability/Metrics/Nodejs/OpenTelemetryBridge/enabled',
     'Supportability/Metrics/Nodejs/OpenTelemetryBridge/getMeter',
     'Supportability/Metrics/Nodejs/OpenTelemetryBridge/meter/createCounter'
   ]

--- a/test/unit/lib/otel/metrics/index.test.js
+++ b/test/unit/lib/otel/metrics/index.test.js
@@ -30,7 +30,7 @@ test('configures global provider after agent start', async (t) => {
     },
     metrics: {
       getOrCreateMetric(name) {
-        plan.equal(name, 'Supportability/Nodejs/OpenTelemetryBridge/Metrics')
+        plan.equal(name, 'Supportability/Metrics/Nodejs/OpenTelemetryBridge/enabled')
         return this
       },
       incrementCallCount() {


### PR DESCRIPTION
## Description

The standard for supportability metric names has changed to a different format. This PR focuses on Metrics. See https://github.com/newrelic/node-newrelic/issues/3375

Also included is a change to OTel Setup to make sure that when Tracing is disabled individually, that is recorded. 

## Related Issues

#3375 