### PR TITLE
ci: Reverted value of GH_RELEASE_TOKEN to the previous classic token

### DIFF
--- a/.github/workflows/release-lambda-init-containers.yml
+++ b/.github/workflows/release-lambda-init-containers.yml
@@ -29,4 +29,4 @@ jobs:
           echo "newrelic/newrelic-agent-init-container - Releasing \"${RELEASE_TITLE}\" with tag ${RELEASE_TAG}"
           gh release create "${RELEASE_TAG}" --title="${RELEASE_TITLE}" --repo=newrelic/newrelic-agent-init-container --notes="${RELEASE_NOTES}"
         env:
-          GH_RELEASE_TOKEN: ${{ secrets.NODE_AGENT_GH_TOKEN }}
+          GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}


### PR DESCRIPTION
## Description

https://github.com/newrelic/node-newrelic/commit/06eb5c1be0da5ffea4853e521223a711cc7b1805 Changed the value of the credential used in querying the Layers repo API. The token to which this changed does not have permission to access other repositories' APIs. This reverts the change.

## How to Test

GHA workflows aren't testable outside of the GitHub environment, but we know the previous value was working.

## Related Issues

Closes #3388