### PR TITLE
ci: Updated release-lambda-init-containers.yml to use shared machine user token

### DIFF
--- a/.github/workflows/release-lambda-init-containers.yml
+++ b/.github/workflows/release-lambda-init-containers.yml
@@ -30,4 +30,4 @@ jobs:
           echo "newrelic/newrelic-agent-init-container - Releasing \"${RELEASE_TITLE}\" with tag ${RELEASE_TAG}"
           gh release create "${RELEASE_TAG}" --title="${RELEASE_TITLE}" --repo=newrelic/newrelic-agent-init-container --notes="${RELEASE_NOTES}"
         env:
-          GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+          GH_RELEASE_TOKEN: ${{ secrets.NODE_AGENT_GH_TOKEN }}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
In #3363 I edited this workflow and assign our shared github machine user token.  It was reverted because I forgot it was a fine grained token and it lacks permissions to the `newrelic-lambda-layers` and `newrelic-agent-init-container` repos.  I've since added those repos and it got approved by our internal teams managing github.  This PR restores my original PR.
