### PR TITLE
style: Require jsdoc `require-returns-check` and `require-property-*`

### DIFF
--- a/dashboards/utils.js
+++ b/dashboards/utils.js
@@ -8,25 +8,25 @@ const utils = module.exports
 
 /**
  * @typedef {object} Page
- * @property {string} name
- * @property {description} description
- * @property {Widget[]} widgets
+ * @property {string} name the name of the Page
+ * @property {string} description the description of the Page
+ * @property {Widget[]} widgets an array of widgets
  */
 
 /**
  * @typedef {object} Dashboard
- * @property {string} name
- * @property {Page[]} pages
+ * @property {string} name the name of the Dashboard
+ * @property {Page[]} pages an array of pages
  */
 
 /**
  * @typedef {object} Widget
- * @property {string} title
- * @property {number} column
- * @property {number} row
- * @property {number} width
- * @property {number} height
- * @property {string} query
+ * @property {string} title widget title
+ * @property {number} column column number
+ * @property {number} row row number
+ * @property {number} width widget width
+ * @property {number} height widget height
+ * @property {string} query nrql query
  */
 
 /**

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -86,9 +86,9 @@ const jsdocConfig = {
     'jsdoc/require-returns-check': 'error',
     'jsdoc/require-returns-type': 'error',
     // Property rules
-    // 'jsdoc/require-property-description': 'error',
-    // 'jsdoc/require-property-name': 'error',
-    // 'jsdoc/require-property-type': 'error',
+    'jsdoc/require-property-description': 'error',
+    'jsdoc/require-property-name': 'error',
+    'jsdoc/require-property-type': 'error',
   }
 }
 const jsdocOverrides = {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,9 +53,12 @@ const jsdocConfig = {
   },
   plugins: { jsdoc },
   rules: {
+    // General rules
     'jsdoc/require-jsdoc': 'off',
     'jsdoc/tag-lines': 'off',
+    // Types rules
     'jsdoc/check-types': 'error',
+    'jsdoc/valid-types': 'error',
     'jsdoc/no-undefined-types': [
       'warn',
       {
@@ -75,11 +78,17 @@ const jsdocConfig = {
         ]
       }
     ],
-    'jsdoc/valid-types': 'error',
-    'jsdoc/check-param-names': 'error',
+    // Parameter rules
     'jsdoc/require-param-description': 'error',
+    'jsdoc/check-param-names': 'error',
     'jsdoc/require-param-type': 'error',
-    'jsdoc/require-returns-type': 'error'
+    // Returns rules
+    'jsdoc/require-returns-check': 'error',
+    'jsdoc/require-returns-type': 'error',
+    // Property rules
+    // 'jsdoc/require-property-description': 'error',
+    // 'jsdoc/require-property-name': 'error',
+    // 'jsdoc/require-property-type': 'error',
   }
 }
 const jsdocOverrides = {

--- a/lib/aggregators/event-aggregator.js
+++ b/lib/aggregators/event-aggregator.js
@@ -85,8 +85,6 @@ class EventAggregator extends Aggregator {
 
   /**
    * Resets the contents of the aggregator and all counters.
-   *
-   * @returns {PriorityQueue} The old collection of aggregated events.
    */
   clearEvents() {
     // ???: might be more efficient to clear here and come up with an efficient way to

--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -176,8 +176,8 @@ class Attributes {
  * Creates a filter function for the given scope.
  *
  * @param {string} scope - The scope of the filter to make.
- * @returns {Function} A function that performs attribute filtering for the given
- *  scope.
+ * @returns {Function|undefined} A function that performs attribute filtering for the given
+ *  scope, or undefined if the scope is not recognized.
  */
 function makeFilter(scope) {
   const { attributeFilter } = Config.getInstance()

--- a/lib/collector/serverless.js
+++ b/lib/collector/serverless.js
@@ -110,7 +110,7 @@ class ServerlessCollector {
    * Constructs, serializes, and prints the final consolidated payload to stdout.
    *
    * @param {Function} cb The callback to invoke when finished.
-   * @returns {boolean} indicating if callback was defined and successfully executed
+   * @returns {boolean|undefined} indicating if callback was defined and successfully executed
    */
   flushPayload(cb) {
     if (!this.enabled) {

--- a/lib/config/formatters.js
+++ b/lib/config/formatters.js
@@ -67,7 +67,7 @@ formatters.boolean = function boolean(setting) {
  *
  * @param {string} val config setting
  * @param {logger} logger agent logger instance
- * @returns {object}
+ * @returns {object|undefined} the parsed value, or undefined if an error occurred
  */
 formatters.object = function object(val, logger) {
   try {
@@ -83,7 +83,7 @@ formatters.object = function object(val, logger) {
  *
  * @param {string} val config setting
  * @param {logger} logger agent logger instance
- * @returns {Array}
+ * @returns {Array|undefined} The parsed array of objects, or undefined if an error occurred
  */
 formatters.objectList = function objectList(val, logger) {
   try {
@@ -111,7 +111,7 @@ formatters.allowList = function allowList(list, val) {
  *
  * @param {string} val valid regex
  * @param {logger} logger agent logger instance
- * @returns {RegExp} regex
+ * @returns {RegExp|undefined} regex, or undefined if an error occurred
  */
 formatters.regex = function regex(val, logger) {
   try {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1670,7 +1670,7 @@ function redactValue(value) {
  * Get a JSONifiable object containing all settings we want to report to the
  * collector and store in the environment_values table.
  *
- * @returns {object} containing simple key-value pairs of settings
+ * @returns {object|undefined} containing simple key-value pairs of settings, or undefined if an error occurred
  */
 Config.prototype.publicSettings = function publicSettings() {
   let settings = Object.create(null)

--- a/lib/instrumentation/@prisma/client.js
+++ b/lib/instrumentation/@prisma/client.js
@@ -75,7 +75,7 @@ function extractQueryArgs(args, pkgVersion) {
  *
  * @param {Array} args arguments to a prisma operation
  * @param {string} pkgVersion prisma version
- * @returns {string} query raw query string or model call <collection>.<operation>
+ * @returns {string|undefined} query raw query string or model call <collection>.<operation>
  */
 function retrieveQuery(args, pkgVersion) {
   if (Array.isArray(args)) {

--- a/lib/instrumentation/when/contextualizer.js
+++ b/lib/instrumentation/when/contextualizer.js
@@ -160,7 +160,7 @@ Contextualizer.prototype.setSegment = function setSegment(segment) {
  * Propagates the segment to the finally function
  *
  * @param {Function} prom current promise
- * @returns {Function} current promise or wrapped finally that will propagate the segment
+ * @returns {Function|undefined} current promise or wrapped finally that will propagate the segment
  */
 Contextualizer.prototype.continue = function continueContext(prom) {
   const self = this

--- a/lib/llm-events/aws-bedrock/chat-completion-summary.js
+++ b/lib/llm-events/aws-bedrock/chat-completion-summary.js
@@ -10,7 +10,8 @@ const LlmEvent = require('./event')
 /**
  * @typedef {object} LlmChatCompletionSummaryParams
  * @augments LlmEventParams
- * @property
+ * @property {string} segment the segment associated with this LlmChatCompletionSummary
+ * @property {boolean} isError whether this event represents an error
  */
 /**
  * @type {LlmChatCompletionSummaryParams}

--- a/lib/spans/streaming-span-event-aggregator.js
+++ b/lib/spans/streaming-span-event-aggregator.js
@@ -109,14 +109,17 @@ class StreamingSpanEventAggregator extends Aggregator {
   addSegment({ segment, transaction, parentId, isRoot }) {
     if (!this.started) {
       logger.trace('Aggregator has not yet started, dropping span (%s).', segment.name)
-      return
+      return false
     }
 
     const span = StreamingSpanEvent.fromSegment({ segment, transaction, parentId, isRoot, inProcessSpans: this.inProcessSpans })
 
     if (span) {
       this.stream.write(span)
+      return true
     }
+
+    return false
   }
 
   reconfigure(config) {

--- a/lib/subscribers/base.js
+++ b/lib/subscribers/base.js
@@ -217,10 +217,15 @@ class Subscriber {
   /**
    * Enables the subscriber by binding the store to the channel and setting up the handler.
    * If the subscriber requires an active transaction, it will check the context before passing the event to the handler.
-   * @returns {Context} - The context after processing the event
+   * @returns {void} The `bindStore` function with our handler.
    */
   enable() {
-    this.channel.start.bindStore(this.store, (data) => {
+    /**
+     * Event handler for processing incoming events.
+     * @param {object} data Event data
+     * @returns {Context} The context after processing the event
+     */
+    function handler(data) {
       // only wrap the callback if a subscriber has a callback property defined
       if (this.callback !== null) {
         this.traceCallback(this.callback, data)
@@ -246,7 +251,9 @@ class Subscriber {
         data.transaction = result?.transaction
       }
       return result
-    })
+    }
+
+    this.channel.start.bindStore(this.store, handler)
   }
 
   /**

--- a/lib/subscribers/base.js
+++ b/lib/subscribers/base.js
@@ -225,7 +225,7 @@ class Subscriber {
      * @param {object} data Event data
      * @returns {Context} The context after processing the event
      */
-    function handler(data) {
+    const handler = (data) => {
       // only wrap the callback if a subscriber has a callback property defined
       if (this.callback !== null) {
         this.traceCallback(this.callback, data)

--- a/lib/subscribers/openai/utils.js
+++ b/lib/subscribers/openai/utils.js
@@ -200,6 +200,7 @@ function shouldSkipInstrumentation(config, logger) {
     logger.debug('config.ai_monitoring.enabled is set to false.')
     return true
   }
+  return false
 }
 
 /**

--- a/lib/subscribers/pino/index.js
+++ b/lib/subscribers/pino/index.js
@@ -72,7 +72,7 @@ class PinoSubscriber extends ApplicationLogsSubscriber {
      * A function that gets executed in `_toPayloadSync` of log aggregator.
      * This will parse the serialized log line and then add the relevant NR
      * context metadata and rename the time/msg keys to timestamp/message
-     * @returns {object} formatted log line
+     * @returns {object|undefined} formatted log line, or undefined if an error occurred
      */
     return function formatLogLine() {
       let formattedLog

--- a/lib/synthetics.js
+++ b/lib/synthetics.js
@@ -85,8 +85,8 @@ function assignSyntheticsInfoHeader(header, encKey, transaction) {
  *
  * @param {string} header - The raw X-NewRelic-Synthetics-Info header
  * @param {string} encKey - Encoding key handed down from the server
- * @returns {object | null} - On successful parse and verification an object of
- *                            synthetics info data is returned, otherwise null is
+ * @returns {object | undefined} - On successful parse and verification an object of
+ *                            synthetics info data is returned, otherwise undefined is
  *                            returned.
  */
 function parseSyntheticsInfoHeader(header, encKey) {
@@ -120,8 +120,8 @@ function parseSyntheticsInfoHeader(header, encKey) {
  * @param {string} header - The raw X-NewRelic-Synthetics header
  * @param {string} encKey - Encoding key handed down from the server
  * @param {Array.<number>} trustedIds - Array of accounts to trust the header from.
- * @returns {object | null} - On successful parse and verification an object of
- *                            synthetics data is returned, otherwise null is
+ * @returns {object | undefined} - On successful parse and verification an object of
+ *                            synthetics data is returned, otherwise undefined is
  *                            returned.
  */
 function parseSyntheticsHeader(header, encKey, trustedIds) {

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -186,7 +186,7 @@ Transaction.prototype.isActive = function isActive() {
  * Close out the current transaction and its associated trace. Remove any
  * instances of this transaction annotated onto the call stack.
  *
- * @returns {(Transaction|undefined)} this transaction, or undefined
+ * @returns {Transaction|undefined} this transaction, or undefined
  *
  * @fires Agent#transactionFinished
  */

--- a/lib/util/cat.js
+++ b/lib/util/cat.js
@@ -112,7 +112,7 @@ cat.assignCatToTransaction = function assignCatToTransaction(
  * @param {Transaction} transaction current transaction
  * @param {string} contentLength length of content
  * @param {boolean} useMqHeaders flag to return proper headers for MQ compliance
- * @returns {object} { key, data } to add as header
+ * @returns {object|undefined} { key, data } to add as header, or undefined if an error occurred
  */
 cat.encodeAppData = function encodeAppData(config, transaction, contentLength, useMqHeaders) {
   let appData = null
@@ -240,7 +240,7 @@ cat.isTrustedAccountId = function isTrustedAccountId(data, trustedAccounts) {
  * @param {object} config agent config
  * @param {string} obfAppData encoded app data to parse and use
  *
- * @returns {Array} decoded app data header
+ * @returns {Array|undefined} decoded app data header
  */
 cat.parseAppData = function parseAppData(config, obfAppData) {
   if (!config.encoding_key) {

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -265,7 +265,7 @@ Logger.prototype._read = function _read() {
 Logger.prototype.write = function write(level, args, extra) {
   if (this._nestedLog) {
     // This log is downstream of another log call and should be ignored
-    return
+    return false
   }
   this._nestedLog = true
   for (let i = 0, l = args.length; i < l; ++i) {

--- a/test/lib/proxy-server.js
+++ b/test/lib/proxy-server.js
@@ -22,7 +22,7 @@ const connectResponse = [
  *
  * @augments http.Server
  * @typedef {object} ProxyServer
- * @property
+ * @property {boolean} proxyUsed indicates if the proxy has serviced any connections
  */
 
 /**

--- a/test/lib/test-collector.js
+++ b/test/lib/test-collector.js
@@ -18,13 +18,15 @@ const CollectorValidators = require('./test-collector-validators')
 /**
  * Extends {@link http.IncomingMessage} with convenience properties and methods.
  * @typedef {object} CollectorIncomingRequest
- * @property
+ * @property {object} query The parsed query string.
+ * @property {Function} body A function that returns a promise resolving to the request body.
+ * @property {Function} getHeader A function that returns the value of a specific header.
  */
 
 /**
  * Extends {@link http.OutgoingMessage} with convenience properties and methods.
  * @typedef {object} CollectorOutgoingResponse
- * @property
+ * @property {Function} json A function that sends a JSON response.
  */
 
 /**

--- a/test/versioned/restify/common.js
+++ b/test/versioned/restify/common.js
@@ -8,15 +8,22 @@ const common = module.exports
 const helper = require('../../lib/agent_helper')
 
 /**
- * @param {object} cfg config
- * @property {object} cfg.t
- * @property {string} cfg.endpoint
- * @property {string} [cfg.prefix='Restify']
- * @property {string} cfg.expectedName
- * @property {Function} [cfg.cb=t.end]
- * @property {object} [cfg.requestOpts=null]
- * @property {object} cfg.agent
- * @property {object} cfg.server
+ * Defines the configuration for the Restify test utility.
+ * @typedef {object} TestConfig
+ * @property {object} t test context
+ * @property {object} [assert=require('node:assert')] the assert library to use
+ * @property {string} endpoint url endpoint
+ * @property {string} [prefix='Restify'] prefix for the transaction name
+ * @property {string} expectedName expected transaction name
+ * @property {Function} [cb=t.end] callback function
+ * @property {object} [requestOpts=null] request options
+ * @property {object} agent New Relic agent instance
+ * @property {object} server Restify server instance
+ */
+
+/**
+ * Runs the Restify test.
+ * @param {TestConfig} cfg The Restify test configuration object.
  */
 common.runTest = function runTest(cfg) {
   const {


### PR DESCRIPTION
This PR relates to #2503. This changes the following eslint jsdoc rules:

- `jsdoc/require-returns-check`: warn -> error
- `jsdoc/require-property-description`: warn- > error
- `jsdoc/require-property-name`:  warn -> error
- `jsdoc/require-property-type`: warn -> error