### PR TITLE
refactor: Update `fastify` instrumentation to subscribe to events emitted

### DIFF
--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -59,14 +59,11 @@ module.exports = function initialize(agent, fastify, moduleName, shim) {
     return
   }
 
-  // In 3.21.0+ fastify emits an event of diagnostics channel
-  // we are instrumented it in `lib/subscribers/fastify/index.js`
-  // this code is for any customers using <3.21.0, which hopefully should be very few.
+  // In 3.21.0+ fastify emits events via diagnostics channel.
+  // we are subscribing to one of those events in `lib/subscribers/fastify/index.js`.
+  // This code is for any customers using <3.21.0, which hopefully should be very few.
   // TODO: Remove <3.21.0 support in 14.0.0 of Node.js agent
   if (noDiagChannel) {
-    /**
-     * Fastify exports a function, so we need to use wrapExport
-     */
     const wrappedExport = shim.wrapExport(fastify, function wrapFastifyModule(shim, fn) {
       return function wrappedFastifyModule() {
         // call original function to get the fastify object (which is singleton-ish)

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -7,30 +7,8 @@
 
 const semver = require('semver')
 const {
-  buildMiddlewareSpecForRouteHandler,
-  buildMiddlewareSpecForMiddlewareFunction
+  buildMiddlewareSpecForRouteHandler
 } = require('./fastify/spec-builders')
-const { MiddlewareMounterSpec } = require('../shim/specs')
-
-/**
- * These are the events that occur during a fastify
- * request
- * see: https://www.fastify.io/docs/latest/Lifecycle/
- *
- * Note: preSerialization and onSend happen after the route handler
- * executes.  `onResponse` does not execute until after the client
- * sends the response so it'll never be in scope of the transaction
- */
-const REQUEST_HOOKS = [
-  'onRequest',
-  'preParsing',
-  'preValidation',
-  'preHandler',
-  'preSerialization',
-  'onSend',
-  'onResponse',
-  'onError'
-]
 
 /**
  * Sets up fastify route handler
@@ -47,11 +25,12 @@ const REQUEST_HOOKS = [
  * @param {WebFrameworkShim} shim instance
  * @param {object} fastify Fastify instance
  */
-const setupRouteHandler = (shim, fastify) => {
+function setupRouteHandler(shim, fastify) {
   fastify.addHook('onRoute', (routeOptions) => {
     if (!routeOptions.handler) {
       return
     }
+
     /**
      * recordMiddleware handler call
      *
@@ -66,88 +45,41 @@ const setupRouteHandler = (shim, fastify) => {
 
     routeOptions.handler = newRouteHandler
   })
-
-  shim.wrap(fastify, 'addHook', function addWrapHook(shim, fn) {
-    return function wrappedAddHook(...args) {
-      const hookName = args[0]
-      if (REQUEST_HOOKS.includes(hookName)) {
-        const middlewareFunction = args[1]
-        const name = `${hookName}/${shim.getName(middlewareFunction)}`
-        const middlewareSpec = buildMiddlewareSpecForMiddlewareFunction(shim, name)
-        const newMiddlewareFunction = shim.recordMiddleware(middlewareFunction, middlewareSpec)
-
-        args[1] = newMiddlewareFunction
-      }
-      return fn.apply(this, args)
-    }
-  })
 }
 
 module.exports = function initialize(agent, fastify, moduleName, shim) {
   shim.setFramework(shim.FASTIFY)
 
   const fastifyVersion = shim.pkgVersion
+  const noDiagChannel = semver.lt(fastifyVersion, '3.21.0')
   const isv3Plus = semver.satisfies(fastifyVersion, '>=3.0.0')
 
-  /**
-   * Fastify exports a function, so we need to use wrapExport
-   */
-  const wrappedExport = shim.wrapExport(fastify, function wrapFastifyModule(shim, fn) {
-    return function wrappedFastifyModule() {
-      // call original function to get the fastify object (which is singleton-ish)
-      const fastifyForWrapping = fn.apply(this, arguments)
-
-      setupRouteHandler(shim, fastifyForWrapping)
-
-      setupMiddlewareHandlers(shim, fastifyForWrapping, isv3Plus)
-
-      return fastifyForWrapping
-    }
-  })
-
-  if (isv3Plus) {
-    setupExports(fastify, wrappedExport)
+  if (!isv3Plus) {
+    shim.logger.warn('Fastify version: %s is unsupported, minimum supported version is `3.0.0`', fastifyVersion)
+    return
   }
-}
 
-function setupMiddlewareHandlers(shim, fastify, isv3Plus) {
-  const mounterSpec = new MiddlewareMounterSpec({
-    route: shim.FIRST,
-    wrapper: wrapMiddleware
-  })
+  // In 3.21.0+ fastify emits an event of diagnostics channel
+  // we are instrumented it in `lib/subscribers/fastify/index.js`
+  // this code is for any customers using <3.21.0, which hopefully should be very few.
+  // TODO: Remove <3.21.0 support in 14.0.0 of Node.js agent
+  if (noDiagChannel) {
+    /**
+     * Fastify exports a function, so we need to use wrapExport
+     */
+    const wrappedExport = shim.wrapExport(fastify, function wrapFastifyModule(shim, fn) {
+      return function wrappedFastifyModule() {
+        // call original function to get the fastify object (which is singleton-ish)
+        const fastifyForWrapping = fn.apply(this, arguments)
 
-  if (isv3Plus) {
-    // Fastify v3+ does not ship with traditional Node.js middleware mounting.
-    // This style is accomplished leveraging decorators. Both middie (which was built-in in v2)
-    // and fastify-express mount a 'use' function for mounting middleware.
-    shim.wrap(fastify, 'decorate', function wrapDecorate(shim, fn) {
-      return function wrappedDecorate(...args) {
-        const name = args[0]
-        if (name !== 'use') {
-          return fn.apply(this, args)
-        }
+        setupRouteHandler(shim, fastifyForWrapping)
 
-        args[1] = shim.wrapMiddlewareMounter(args[1], mounterSpec)
-
-        return fn.apply(this, args)
+        return fastifyForWrapping
       }
     })
-  } else {
-    shim.wrapMiddlewareMounter(fastify, 'use', mounterSpec)
+
+    setupExports(fastify, wrappedExport)
   }
-}
-
-function wrapMiddleware(shim, middleware, name, route) {
-  if (shim.isWrapped(middleware)) {
-    return middleware
-  }
-
-  // prefixing the segment name for middleware execution
-  // with the Fastify lifecycle hook
-  const segmentName = `onRequest/${name}`
-  const spec = buildMiddlewareSpecForMiddlewareFunction(shim, segmentName, route)
-
-  return shim.recordMiddleware(middleware, spec)
 }
 
 /**
@@ -155,8 +87,8 @@ function wrapMiddleware(shim, middleware, name, route) {
  * module.exports.fastify = fastify
  * module.exports.default = fastify
  *
- * @param {object} original original exports
- * @param {object} wrappedExport wrapped exports
+ * @param {object} original original fastify export
+ * @param {object} wrappedExport wrapped fastify export
  */
 function setupExports(original, wrappedExport) {
   wrappedExport.fastify = original.fastify

--- a/lib/instrumentation/fastify/spec-builders.js
+++ b/lib/instrumentation/fastify/spec-builders.js
@@ -98,26 +98,6 @@ function buildMiddlewareSpecForRouteHandler(shim, path) {
   })
 }
 
-/**
- * Spec for all Fastify middleware (excluding route handlers)
- *
- * @param {WebFrameworkShim} shim instance
- * @param {string} name metric name for middleware being executed
- * @param {number|string|null} route route
- * @returns {object} spec for Fastify middleware
- */
-function buildMiddlewareSpecForMiddlewareFunction(shim, name, route) {
-  return new MiddlewareSpec({
-    name,
-    route,
-    next: shim.LAST,
-    params: getParamsFromFastifyRequest,
-    req: getRequestFromFastify,
-    type: shim.MIDDLEWARE
-  })
-}
-
 module.exports = {
-  buildMiddlewareSpecForRouteHandler,
-  buildMiddlewareSpecForMiddlewareFunction
+  buildMiddlewareSpecForRouteHandler
 }

--- a/lib/instrumentation/nextjs/next-server.js
+++ b/lib/instrumentation/nextjs/next-server.js
@@ -124,12 +124,10 @@ module.exports = function initialize(shim, nextServer) {
 function assignParameters(shim, parameters) {
   const transaction = shim.tracer.getTransaction()
   if (transaction) {
-    const prefixedParameters = shim.prefixRouteParameters(parameters)
-
     // We have to add params because this framework doesn't
     // follow the traditional middleware/middleware mounter pattern
     // where we'd pull these from middleware.
-    transaction.nameState.appendPath('/', prefixedParameters)
+    transaction.nameState.appendPath('/', parameters)
   }
 }
 

--- a/lib/metrics/recorders/middleware.js
+++ b/lib/metrics/recorders/middleware.js
@@ -9,11 +9,10 @@
  * Creates a recorder for middleware metrics.
  *
  * @private
- * @param {object} _shim instance of shim
  * @param {string} metricName name of metric
  * @returns {Function} recorder for middleware
  */
-function makeMiddlewareRecorder(_shim, metricName) {
+function makeMiddlewareRecorder(metricName) {
   return function middlewareMetricRecorder(segment, scope, transaction) {
     const duration = segment.getDurationInMillis()
     const exclusive = segment.getExclusiveDurationInMillis(transaction.trace)

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -140,6 +140,7 @@ Shim.prototype.setDefaults = setDefaults
 Shim.prototype.proxy = proxy
 Shim.prototype.require = shimRequire
 Shim.prototype.copySegmentParameters = copySegmentParameters
+Shim.prototype.prefixRouteParameters = prefixRouteParameters
 Shim.prototype.interceptPromise = interceptPromise
 Shim.prototype.fixArity = arity.fixArity
 Shim.prototype.assignId = assignId
@@ -2157,4 +2158,17 @@ function _es5WrapClass(shim, Base, fnName, spec, args) {
   WrappedClass.prototype = Base.prototype
 
   return WrappedClass
+}
+
+/**
+ * This method is no longer in use. It still exists to avoid crashing
+ * applications.  The logic of this method has been integrated into
+ * finalizing a web transaction.
+ *
+ * @param {object} params - Object containing route/url parameter key/value pairs
+ * @returns {void} method is now stubbed and logic ported into `finalizeWebTransaction`
+ * @memberof Shim.prototype
+ */
+function prefixRouteParameters(params) {
+  logger.warnOnce('shim.prefixRouteParameters logic has been moved to when a web transaction ends.  This method will be removed in the next upcoming major version v14.0.0.')
 }

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -140,7 +140,6 @@ Shim.prototype.setDefaults = setDefaults
 Shim.prototype.proxy = proxy
 Shim.prototype.require = shimRequire
 Shim.prototype.copySegmentParameters = copySegmentParameters
-Shim.prototype.prefixRouteParameters = prefixRouteParameters
 Shim.prototype.interceptPromise = interceptPromise
 Shim.prototype.fixArity = arity.fixArity
 Shim.prototype.assignId = assignId
@@ -2158,31 +2157,4 @@ function _es5WrapClass(shim, Base, fnName, spec, args) {
   WrappedClass.prototype = Base.prototype
 
   return WrappedClass
-}
-
-/**
- * Method for prefixing Route (aka URL) parameters with `request.parameters.route`
- *
- * Many web frameworks support adding parameters to routes when defining your API structure, and this function
- * updates those parameters names to be prefixed by `request.parameters.route`. This is to avoid collision with reserved
- * attribute names, as parameters used to be blindly stored on router span attributes (see https://github.com/newrelic/node-newrelic/issues/1574)
- * in addition to being prefixed by `request.parameters`.
- *
- * Route parameters used to be stored under `request.parameters.*` just like query parameters pre v10, but we
- * now prefix with `request.parameter.route` to avoid collision in the event an application uses the same name for a query and route
- * parameter. Additionally, we now store the same key on the attributes of the base segment, trace, and router span.
- *
- * Exported on shim to be used in our Next.js instrumentation, as that instrumentation does not follow the same pattern as all the other
- * web frameworks we support.
- *
- * @param {object} params - Object containing route/url parameter key/value pairs
- * @returns {object|undefined} the updated object, `key` will now be `request.parameters.route.key`, value remains untouched
- * @memberof Shim.prototype
- */
-function prefixRouteParameters(params) {
-  if (params && isObject(params)) {
-    return Object.fromEntries(
-      Object.entries(params).map(([key, value]) => [`request.parameters.route.${key}`, value])
-    )
-  }
 }

--- a/lib/shim/webframework-shim/middleware.js
+++ b/lib/shim/webframework-shim/middleware.js
@@ -51,8 +51,10 @@ function getRoute(spec, shim) {
 }
 
 /**
- * Retrieves the parameters from the spec.params
- * and prefixes them all with `request.parameters.route`
+ * Retrieves the parameters from the spec.params.
+ * When a `transaction.finalizeNameFromWeb` is called, it takes these params
+ * and prefixes `request.parameters.route.` to every route param.
+ * Query params are handled in lib/transaction/index.js#initializeWeb
  *
  * @private
  * @param {object} params object passed to fn
@@ -66,12 +68,9 @@ function getRoute(spec, shim) {
  */
 function copyParams({ spec, shim, fn, fnName, args, req }) {
   // Copy over route parameters onto the transaction root.
-  const params = shim.agent.config.high_security
+  return shim.agent.config.high_security
     ? null
     : spec.params.call(this, shim, fn, fnName, args, req)
-
-  // Route parameters are handled here, query parameters are handled in lib/transaction/index.js#finalizeNameFromWeb as part of finalization
-  return shim.prefixRouteParameters(params)
 }
 
 /**
@@ -81,15 +80,14 @@ function copyParams({ spec, shim, fn, fnName, args, req }) {
  * @param {object} params object passed to fn
  * @param {object} params.txInfo transaction
  * @param {object} params.typeDetails metadata about the middleware type
- * @param {Shim} params.shim instance of shim
  * @param {string} params.metricName metric name for middleware function
  * @returns {Function} recorder for middleware type
  */
-function constructRecorder({ txInfo, typeDetails, shim, metricName }) {
+function constructRecorder({ txInfo, typeDetails, metricName }) {
   let recorder = null
   if (typeDetails.record) {
     const stackPath = txInfo.transaction.nameState.getPath() || ''
-    recorder = makeMiddlewareRecorder(shim, metricName + '/' + stackPath)
+    recorder = makeMiddlewareRecorder(metricName + '/' + stackPath)
   }
   return recorder
 }
@@ -166,7 +164,7 @@ function middlewareWithCallbackRecorder({ spec, typeDetails, metricName, isError
       txInfo.transaction.nameState.appendPath(route, params)
     }
 
-    const recorder = constructRecorder({ txInfo, typeDetails, shim, metricName })
+    const recorder = constructRecorder({ txInfo, typeDetails, metricName })
 
     const segmentName = getSegmentName(metricName, typeDetails, route)
 
@@ -176,7 +174,6 @@ function middlewareWithCallbackRecorder({ spec, typeDetails, metricName, isError
       callback: nextWrapper,
       parent: txInfo.segmentStack[txInfo.segmentStack.length - 1],
       recorder,
-      parameters: params,
       after: function afterExec({ shim, error }) {
         const errIsError = isError(shim, error)
         if (errIsError) {
@@ -224,7 +221,7 @@ function middlewareWithPromiseRecorder({ spec, typeDetails, metricName, isErrorW
       txInfo.transaction.nameState.appendPath(route, params)
     }
 
-    const recorder = constructRecorder({ txInfo, typeDetails, shim, metricName })
+    const recorder = constructRecorder({ txInfo, typeDetails, metricName })
     const nextWrapper = wrapNextHandler({
       shim,
       spec,
@@ -243,7 +240,6 @@ function middlewareWithPromiseRecorder({ spec, typeDetails, metricName, isErrorW
       promise: spec.promise,
       callback: nextWrapper,
       recorder,
-      parameters: params,
       after: function afterExec({ shim, error, result }) {
         if (shim._responsePredicate(args, result)) {
           txInfo.transaction.nameState.freeze()

--- a/lib/subscriber-configs.js
+++ b/lib/subscriber-configs.js
@@ -11,6 +11,7 @@ const subscribers = {
   ...require('./subscribers/amqplib/config'),
   ...require('./subscribers/cassandra-driver/config'),
   ...require('./subscribers/elasticsearch/config'),
+  ...require('./subscribers/fastify/config'),
   ...require('./subscribers/ioredis/config'),
   ...require('./subscribers/mcp-sdk/config'),
   ...require('./subscribers/openai/config'),

--- a/lib/subscribers/create-config.js
+++ b/lib/subscribers/create-config.js
@@ -6,7 +6,7 @@
 'use strict'
 
 /**
- * Builds a set of packages and instrumentaions from a list of subscriber configurations.
+ * Builds a set of packages and instrumentations from a list of subscriber configurations.
  *
  * @param {Array} subscribers - An array of subscriber objects, each containing a package name and an array of instrumentations.
  * @returns {object} An object containing a Set of unique package names and an array of instrumentations.

--- a/lib/subscribers/fastify/add-hook.js
+++ b/lib/subscribers/fastify/add-hook.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const Subscriber = require('../base')
+/**
+ * These are the events that occur during a fastify
+ * request
+ * see: https://www.fastify.io/docs/latest/Lifecycle/
+ *
+ * Note: preSerialization and onSend happen after the route handler
+ * executes.  `onResponse` does not execute until after the client
+ * sends the response so it'll never be in scope of the transaction
+ */
+const REQUEST_HOOKS = [
+  'onRequest',
+  'preParsing',
+  'preValidation',
+  'preHandler',
+  'preSerialization',
+  'onSend',
+  'onResponse',
+  'onError'
+]
+const { handlerWrapper } = require('./common')
+
+class FastifyAddHookSubscriber extends Subscriber {
+  constructor({ agent, logger }) {
+    super({ agent, logger, packageName: 'fastify', channelName: 'nr_addHook' })
+    this.requireActiveTx = false
+  }
+
+  handler(data) {
+    const { arguments: args } = data
+    const [hookName, fn] = args
+    if (REQUEST_HOOKS.includes(hookName)) {
+      const wrappedFn = handlerWrapper({ handler: fn, hookName, self: this })
+      data.arguments[1] = wrappedFn
+    }
+  }
+}
+
+module.exports = FastifyAddHookSubscriber

--- a/lib/subscribers/fastify/common.js
+++ b/lib/subscribers/fastify/common.js
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const { clm, transactionInfo } = require('#agentlib/symbols.js')
+const makeMiddlewareRecorder = require('#agentlib/metrics/recorders/middleware.js')
+const { addCLMAttributes } = require('#agentlib/util/code-level-metrics.js')
+const MW_PREFIX = 'Nodejs/Middleware/Fastify'
+
+function nameSegment({ hookName, handler, route }) {
+  let name = MW_PREFIX
+  const fnName = handler.name === '' ? '<anonymous>' : handler.name
+  if (hookName) {
+    name += `/${hookName}/${fnName}`
+    if (route) {
+      name += `/${route}`
+    }
+  } else if (route) {
+    name += `/${fnName}/${route}`
+  }
+  return name
+}
+
+/**
+ * Used to wrap all fastify handlers.  This checks if it is callback based,
+ * or promise based, and I _think_ propagates context accordingly
+ *
+ * @param {object} params to function
+ * @param {Function} params.handler the function getting wrapped
+ * @param {string} params.hookName value of fastify hook(not present if this is wrapping a route handler or middleware)
+ * @param {string} params.route route that is serving the handler
+ * @param {object} params.self instance that has agent/logger
+ * @returns {Function} a wrapped function used to record a segment and assign necessary transaction data
+ */
+function handlerWrapper({ handler, hookName, route, self }) {
+  const { agent, logger } = self
+  return function wrappedHandler (...args) {
+    const ctx = agent.tracer.getContext()
+    const transaction = ctx?.transaction
+    transaction.nameState.setPrefix('Fastify')
+    const [request] = args
+    const txInfo = request?.raw?.[transactionInfo] || request?.[transactionInfo]
+    if (route && !hookName) {
+      transaction.nameState.appendPath(route, request.params)
+    }
+
+    const parent = ctx?.segment
+    const name = nameSegment({ handler, hookName, route })
+    const segment = agent.tracer.createSegment({
+      name,
+      parent,
+      recorder: makeMiddlewareRecorder(name),
+      transaction
+    })
+
+    if (!segment) {
+      logger.trace('Failed to create new segment %s, calling original function', name)
+      return handler.apply(this, args)
+    }
+    logger.trace('Created segment %s, parent %s', segment?.name, parent?.name)
+
+    if (agent.config.code_level_metrics.enabled === true) {
+      handler[clm] = true
+      addCLMAttributes(handler, segment)
+    }
+    const newCtx = ctx.enterSegment({ segment })
+
+    const doneFn = args[args.length - 1]
+    const isSync = typeof doneFn === 'function' &&
+      handler.constructor.name !== 'AsyncFunction'
+    if (isSync) {
+      function wrappedDone(...doneArgs) {
+        const [err] = doneArgs
+        if (err) {
+          storeError(txInfo, err)
+        }
+        segment.touch()
+        return doneFn.apply(this, doneArgs)
+      }
+      // binding previous ctx as it should restore once this cb is executed
+      const bound = agent.tracer.bindFunction(wrappedDone, ctx, false)
+      args[args.length - 1] = bound
+    }
+    try {
+      const result = agent.tracer.bindFunction(handler, newCtx, true).apply(this, args)
+      if (result?.then) {
+        return result.then(function onThen(val) {
+          segment.touch()
+          return val
+        },
+        function onCatch(err) {
+          storeError(txInfo, err)
+          segment.touch()
+          throw err
+        })
+      }
+      return result
+    } catch (err) {
+      storeError(txInfo, err)
+      throw err
+    }
+  }
+}
+
+/**
+ * Errors are handled in `lib/instrumentation/core/http.js` when the
+ * http response is ended. This is because it has to check if the status
+ * code is being ignored via config
+ * @param {object} txInfo object storing transaction, error, segmentStack(not used in migrated subscribers)
+ * @param {Error} err error that occurred
+ */
+function storeError(txInfo, err) {
+  txInfo.error = err
+  txInfo.errorHandled = false
+}
+
+module.exports = {
+  handlerWrapper
+}

--- a/lib/subscribers/fastify/config.js
+++ b/lib/subscribers/fastify/config.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+module.exports = {
+  fastify: [
+    {
+      path: './fastify',
+      instrumentations: []
+    },
+    {
+      path: './fastify/add-hook',
+      instrumentations: [
+        {
+          channelName: 'nr_addHook',
+          module: { name: 'fastify', versionRange: '>=3.0.0', filePath: 'lib/hooks.js' },
+          functionQuery: {
+            expressionName: 'add',
+            kind: 'Sync'
+          }
+        }
+      ]
+    },
+    {
+      path: './fastify/decorate',
+      instrumentations: [
+        {
+          channelName: 'nr_decorate',
+          module: { name: 'fastify', versionRange: '>=3.0.0', filePath: 'lib/decorate.js' },
+          functionQuery: {
+            functionName: 'decorateFastify',
+            kind: 'Sync'
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/lib/subscribers/fastify/decorate.js
+++ b/lib/subscribers/fastify/decorate.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const Subscriber = require('../base')
+const { handlerWrapper } = require('./common')
+
+class FastifyDecorateSubscriber extends Subscriber {
+  constructor({ agent, logger }) {
+    super({ agent, logger, packageName: 'fastify', channelName: 'nr_decorate' })
+    this.requireActiveTx = false
+  }
+
+  handler(data) {
+    const self = this
+    const { arguments: args } = data
+    const [name, fn] = args
+    if (name === 'use') {
+      data.arguments[1] = function wrapUse(...useArgs) {
+        const [route, mwFn] = useArgs
+        if (typeof route === 'function') {
+          useArgs[0] = handlerWrapper({ handler: route, hookName: 'onRequest', self })
+        } else {
+          useArgs[1] = handlerWrapper({ handler: mwFn, hookName: 'onRequest', route, self })
+        }
+        return fn.apply(this, useArgs)
+      }
+    }
+  }
+}
+
+module.exports = FastifyDecorateSubscriber

--- a/lib/subscribers/fastify/index.js
+++ b/lib/subscribers/fastify/index.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const DcBase = require('../dc-base')
+const initChannel = 'fastify.initialization'
+const { handlerWrapper } = require('./common')
+
+class FastifyInitialization extends DcBase {
+  constructor({ agent, logger }) {
+    super({ agent, logger, packageName: 'fastify' })
+    this.channels = [
+      { channel: initChannel, hook: this.handler }
+    ]
+  }
+
+  handler({ fastify }) {
+    const self = this
+    fastify.addHook('onRoute', (routeOptions) => {
+      if (!routeOptions.handler) {
+        return
+      }
+
+      routeOptions.handler = handlerWrapper({ handler: routeOptions.handler, route: routeOptions.path, self })
+    })
+  }
+}
+
+module.exports = FastifyInitialization

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -11,7 +11,6 @@ const logger = require('../logger').child({ component: 'transaction' })
 const Metrics = require('../metrics')
 const NAMES = require('../metrics/names')
 const NameState = require('./name-state')
-const props = require('../util/properties')
 const Timer = require('../timer')
 const Trace = require('./trace')
 const synthetics = require('../synthetics')
@@ -23,7 +22,8 @@ const headerAttributes = require('../header-attributes')
 const headerProcessing = require('../header-processing')
 const DT_ACCEPT_PAYLOAD_EXCEPTION_METRIC = 'DistributedTrace/AcceptPayload/Exception'
 const DT_ACCEPT_PAYLOAD_PARSE_EXCEPTION_METRIC = 'DistributedTrace/AcceptPayload/ParseException'
-const REQUEST_PARAMS_PATH = 'request.parameters.'
+const QUERY_PARAMS_PATH = 'request.parameters.'
+const ROUTE_PARAMS_PREFIX = 'request.parameters.route.'
 
 /*
  *
@@ -464,7 +464,7 @@ function finalizeNameFromWeb(statusCode) {
   this.name = this.getFullName()
 
   // If a namestate stack exists, copy route parameters over to the trace.
-  if (!this.nameState.isEmpty() && this.baseSegment) {
+  if (!this.nameState.isEmpty() && this.baseSegment && this.agent.config.high_security === false) {
     this.nameState.forEachParams(forEachRouteParams, this)
   }
 
@@ -498,21 +498,25 @@ function finalizeNameFromWeb(statusCode) {
   }
 }
 
+/**
+ * Adds `request.parameters.route` to trace and segment for all the router params
+ * for a framework
+ *
+ * @param {object} params route params from given webframework
+ */
 function forEachRouteParams(params) {
-  for (const key in params) {
-    if (props.hasOwn(params, key)) {
-      this.trace.attributes.addAttribute(DESTS.NONE, key, params[key])
+  for (const [key, value] of Object.entries(params)) {
+    this.trace.attributes.addAttribute(DESTS.NONE, ROUTE_PARAMS_PREFIX + key, value)
 
-      const segment = this.agent.tracer.getSegment()
+    const segment = this.agent.tracer.getSegment()
 
-      if (!segment) {
-        logger.trace(
-          'Active segment not available, not adding request.parameters.route attribute for %s',
-          key
-        )
-      } else {
-        segment.attributes.addAttribute(DESTS.NONE, key, params[key])
-      }
+    if (!segment) {
+      logger.trace(
+        'Active segment not available, not adding request.parameters.route attribute for %s',
+        key
+      )
+    } else {
+      segment.attributes.addAttribute(DESTS.NONE, ROUTE_PARAMS_PREFIX + key, value)
     }
   }
 }
@@ -1456,13 +1460,13 @@ function addRequestParameters(requestParameters) {
   for (const [key, value] of Object.entries(requestParameters)) {
     this.trace.attributes.addAttribute(
       DESTS.NONE,
-      REQUEST_PARAMS_PATH + key,
+      QUERY_PARAMS_PATH + key,
       value
     )
 
     const segment = this.baseSegment
 
-    segment.attributes.addAttribute(DESTS.NONE, REQUEST_PARAMS_PATH + key, value)
+    segment.attributes.addAttribute(DESTS.NONE, QUERY_PARAMS_PATH + key, value)
   }
 }
 

--- a/test/unit/shim/shim.test.js
+++ b/test/unit/shim/shim.test.js
@@ -2951,29 +2951,6 @@ test('Shim', async function (t) {
     })
   })
 
-  await t.test('prefixRouteParameters', async (t) => {
-    t.beforeEach(beforeEach)
-    t.afterEach(afterEach)
-
-    await t.test('should not prefix parameters when given invalid input', (t) => {
-      const { shim } = t.nr
-      const resultNull = shim.prefixRouteParameters(null)
-      assert.equal(resultNull, undefined)
-
-      const resultString = shim.prefixRouteParameters('parameters')
-      assert.equal(resultString, undefined)
-    })
-
-    await t.test('should return the object with route param prefix applied to keys', (t) => {
-      const { shim } = t.nr
-      const result = shim.prefixRouteParameters({ id: '123abc', foo: 'bar' })
-      assert.deepEqual(result, {
-        'request.parameters.route.id': '123abc',
-        'request.parameters.route.foo': 'bar'
-      })
-    })
-  })
-
   await t.test('getOriginalOnce', async (t) => {
     t.beforeEach(beforeEach)
     t.afterEach(afterEach)

--- a/test/unit/transaction.test.js
+++ b/test/unit/transaction.test.js
@@ -1946,8 +1946,8 @@ test('when being named with finalizeNameFromWeb', async (t) => {
     const attrs = txn.trace.attributes.get(AttributeFilter.DESTINATIONS.TRANS_TRACE)
 
     assert.deepEqual(attrs, {
-      'request.parameters.foo': 'biz',
-      'request.parameters.bar': 'bang'
+      'request.parameters.route.foo': 'biz',
+      'request.parameters.route.bar': 'bang'
     })
   })
 
@@ -2032,8 +2032,8 @@ test('requestd', async (t) => {
     const segment = tracer.getSegment()
 
     assert.deepEqual(segment.attributes.get(AttributeFilter.DESTINATIONS.SPAN_EVENT), {
-      'request.parameters.foo': 'biz',
-      'request.parameters.bar': 'bang'
+      'request.parameters.route.foo': 'biz',
+      'request.parameters.route.bar': 'bang'
     })
   })
 })
@@ -2140,8 +2140,8 @@ function setupNameState(transaction) {
   transaction.nameState.setPrefix('Restify')
   transaction.nameState.setVerb('COOL')
   transaction.nameState.setDelimiter('/')
-  transaction.nameState.appendPath('/foo/:foo', { 'request.parameters.foo': 'biz' })
-  transaction.nameState.appendPath('/bar/:bar', { 'request.parameters.bar': 'bang' })
+  transaction.nameState.appendPath('/foo/:foo', { foo: 'biz' })
+  transaction.nameState.appendPath('/bar/:bar', { bar: 'bang' })
 }
 
 function setupHighSecurity(agent) {

--- a/test/versioned/fastify/errors.test.js
+++ b/test/versioned/fastify/errors.test.js
@@ -1,42 +1,84 @@
 /*
- * Copyright 2024 New Relic Corporation. All rights reserved.
+ * Copyright 2025 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict'
 
 const test = require('node:test')
-const assert = require('node:assert')
-const semver = require('semver')
-
+const { tspl } = require('@matteo.collina/tspl')
 const helper = require('../../lib/agent_helper')
-const { makeRequest } = require('./common')
+const { removeModules } = require('../../lib/cache-buster')
 
-test('Test Errors', async (t) => {
+test.beforeEach(async (ctx) => {
+  ctx.nr = {}
+
   const agent = helper.instrumentMockedAgent()
-  const fastify = require('fastify')()
-  const { version: pkgVersion } = require('fastify/package')
-
-  t.after(() => {
-    helper.unloadAgent(agent)
-    fastify.close()
+  const server = require('fastify')({
+    forceCloseConnections: true
   })
 
-  if (semver.major(pkgVersion) < 4) {
-    await fastify.register(require('middie'))
-  } else {
-    await fastify.register(require('@fastify/middie'))
-  }
-
-  fastify.use((req, res, next) => {
-    const err = new Error('Not found')
-
-    err.status = 404
-    next(err)
+  server.route({
+    method: 'GET',
+    path: '/async-handler',
+    async handler () {
+      throw Error('async function error')
+    }
   })
 
-  await fastify.listen({ port: 0 })
-  const address = fastify.server.address()
-  const res = await makeRequest(address, '/404-via-reply')
-  assert.equal(res.statusCode, 404)
+  server.route({
+    method: 'GET',
+    path: '/synchronous-handler',
+    handler () {
+      throw Error('synchronous function error')
+    }
+  })
+
+  const address = await server.listen({ host: '127.0.0.1', port: 0 })
+
+  ctx.nr.agent = agent
+  ctx.nr.server = server
+  ctx.nr.baseUrl = address
+})
+
+test.afterEach(async (ctx) => {
+  helper.unloadAgent(ctx.nr.agent)
+  await ctx.nr.server.close()
+  removeModules(['fastify'])
+})
+
+test('synchronous handler errors', async (t) => {
+  const plan = tspl(t, { plan: 3 })
+  const { agent, baseUrl } = t.nr
+  agent.on('transactionFinished', (tx) => {
+    plan.equal(tx.exceptions.length, 1)
+    plan.equal(tx.exceptions[0].error.message, 'synchronous function error')
+  })
+
+  const { body } = await helper.makeGetRequestAsync(`${baseUrl}/synchronous-handler`)
+  plan.deepEqual(body, {
+    error: 'Internal Server Error',
+    message: 'synchronous function error',
+    statusCode: 500
+  })
+
+  await plan.completed
+})
+
+test('asynchronous handler errors', async (t) => {
+  const plan = tspl(t, { plan: 3 })
+  const { agent, baseUrl } = t.nr
+  agent.on('transactionFinished', (tx) => {
+    plan.equal(tx.exceptions.length, 1)
+    plan.equal(tx.exceptions[0].error.message, 'async function error')
+  })
+
+  const { body } = await helper.makeGetRequestAsync(`${baseUrl}/async-handler`)
+  plan.deepEqual(body, {
+    error: 'Internal Server Error',
+    message: 'async function error',
+    statusCode: 500
+  })
+
+  await plan.completed
 })

--- a/test/versioned/fastify/express-compat-errors.test.js
+++ b/test/versioned/fastify/express-compat-errors.test.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const test = require('node:test')
+const semver = require('semver')
+const { tspl } = require('@matteo.collina/tspl')
+const helper = require('../../lib/agent_helper')
+const { makeRequest } = require('./common')
+
+test('Test Errors', async (t) => {
+  const plan = tspl(t, { plan: 3 })
+  const agent = helper.instrumentMockedAgent()
+  agent.on('transactionFinished', (tx) => {
+    plan.equal(tx.exceptions.length, 1)
+    plan.equal(tx.exceptions[0].error.message, 'Not found')
+  })
+
+  const fastify = require('fastify')()
+  const { version: pkgVersion } = require('fastify/package')
+
+  t.after(() => {
+    helper.unloadAgent(agent)
+    fastify.close()
+  })
+
+  if (semver.major(pkgVersion) < 4) {
+    await fastify.register(require('middie'))
+  } else {
+    await fastify.register(require('@fastify/middie'))
+  }
+
+  fastify.use((req, res, next) => {
+    const err = new Error('Not found')
+
+    err.status = 404
+    next(err)
+  })
+
+  await fastify.listen({ port: 0 })
+  const address = fastify.server.address()
+  const res = await makeRequest(address, '/404-via-reply')
+  plan.equal(res.statusCode, 404)
+})

--- a/test/versioned/fastify/fastify-gte3-naming.test.js
+++ b/test/versioned/fastify/fastify-gte3-naming.test.js
@@ -47,7 +47,12 @@ async function setupFastifyServer(fastify, calls) {
 test('standard export', async (t) => {
   test.beforeEach(async (ctx) => {
     ctx.nr = {}
-    ctx.nr.agent = helper.instrumentMockedAgent()
+    ctx.nr.agent = helper.instrumentMockedAgent({
+      attributes: {
+        enabled: true,
+        include: ['request.parameters.*']
+      }
+    })
 
     const calls = { test: 0, middleware: 0 }
     const fastify = require('fastify')()
@@ -71,7 +76,12 @@ test('standard export', async (t) => {
 test('fastify property', async (t) => {
   test.beforeEach(async (ctx) => {
     ctx.nr = {}
-    ctx.nr.agent = helper.instrumentMockedAgent()
+    ctx.nr.agent = helper.instrumentMockedAgent({
+      attributes: {
+        enabled: true,
+        include: ['request.parameters.*']
+      }
+    })
 
     const calls = { test: 0, middleware: 0 }
     const fastify = require('fastify').fastify()
@@ -95,7 +105,12 @@ test('fastify property', async (t) => {
 test('default property', async (t) => {
   test.beforeEach(async (ctx) => {
     ctx.nr = {}
-    ctx.nr.agent = helper.instrumentMockedAgent()
+    ctx.nr.agent = helper.instrumentMockedAgent({
+      attributes: {
+        enabled: true,
+        include: ['request.parameters.*']
+      }
+    })
 
     const calls = { test: 0, middleware: 0 }
     const fastify = require('fastify').default()

--- a/test/versioned/fastify/fastify-gte3.test.js
+++ b/test/versioned/fastify/fastify-gte3.test.js
@@ -10,13 +10,17 @@ const assert = require('node:assert')
 
 const helper = require('../../lib/agent_helper')
 const symbols = require('../../../lib/symbols')
+const semver = require('semver')
+const { version: pkgVersion } = require('fastify/package.json')
 
 /**
  * Fastify v3 has '.fastify' and '.default' properties attached to the exported
  * 'fastify' function. These are all the same original exported function, just
  * arranged to support a variety of import styles.
+ * This is only applicable to <3.21.0 as we instrument the instance of fastify over
+ * diagnostic channel in 3.21.0+
  */
-test('Should propagate fastify exports when instrumented', () => {
+test('Should propagate fastify exports when instrumented', { skip: semver.gte(pkgVersion, '3.21.0') }, () => {
   helper.instrumentMockedAgent()
   const Fastify = require('fastify')
   const original = Fastify[symbols.original]

--- a/test/versioned/fastify/package.json
+++ b/test/versioned/fastify/package.json
@@ -37,6 +37,7 @@
         "add-hook.test.js",
         "code-level-metrics-middleware.test.js",
         "code-level-metrics-hooks.test.js",
+        "express-compat-errors.test.js",
         "errors.test.js",
         "new-state-tracking.test.js"
       ]
@@ -56,6 +57,7 @@
         "add-hook.test.js",
         "code-level-metrics-middleware.test.js",
         "code-level-metrics-hooks.test.js",
+        "express-compat-errors.test.js",
         "errors.test.js",
         "new-state-tracking.test.js"
       ]


### PR DESCRIPTION
## Description

This PR is based off of #3408.  This migrates instrumentation for fastify to use a mix of diagnostics channel and tracing channel.

Fastify added support for emitting an event for the `fastify` export but it is only post 3.21.0+. We have to keep a little old instrumentation for those older versions for the time being around registering an app level `onRoute` hook to wrap the handlers.  

This also cleaned up some weirdness around tracking route parameters.  Route parameters are stored on the trace and the web segment as `request.parameters.route.<key>`.  Unlike query parameters that are also stored on trace and web segment as `request.parameters.<key>`, these were assigned through shim because we assigned them as `parameters` on the spec.  We also had some code in shim to prefix all of these as `requst.parameters.route.`. Instead of replicating that logic, I moved the prefixing when the transaction name is finalized and if route parameters are present.  You can see by this PR that next.js also had to call this `shim.prefixRoutParameters` method, but if it was done where I updated originally it would've just worked.  

This pattern for instrumenting webframeworks can probably be reused, and we will abstract later, within reason.  I want to avoid the middleware shim that had so much code that was very hard to follow.  

The overall gist is this:

 * wrap a middleware handler. it's either global(no route), or route based
 * Based on if the handler is from a hook or just a route handler, name it accordingly: `Nodejs/Middleware/Fastify/<hookName>/<fnName>`(global hook/middleware) or `Nodejs/Middleware/Fastify/<hookName>/<fnName>/<route>`(route based hook/middleware), `Nodejs/Middleware/Fastify/<fnName>/<route>`(route handler)
 * update the transaction name state with the routh path if present(this helps with finalizing the name as it hops through nested routers)
 * assign CLM attrs to segment
 * wrap the `done` function if the handler is not async and properly propagate the context
 * Run the handler in the context manager and propagate context in promise
 * Store error on txInfo symbol on request in sync, async or done handler. The error is stored because when the ServerResponse finishes(lib/instrumentation/core/http.js) it decides if it should log or ignore based on the status code


If you compare `lib/subscribers/fastify/common.js#handlerWrapper` with `lib/shim/webframework-shim/middleware.js` there's no more management of the segmentStack on the transactionInfo symbol on a given request.  This greatly simplified when segments should be pushed, popped and it just works.

This PR also fixes #3099 and adds the tests that @jsumners-nr wrote.


## How to Test

```sh
npm run versioned:internal fastify
```

## Related Issues
Closes #3099 
Closes #3194