### PR TITLE
test: Added helper to get version of package when package.json not exported, and updated tests that need it

### DIFF
--- a/test/lib/agent_helper.js
+++ b/test/lib/agent_helper.js
@@ -21,6 +21,8 @@ const semver = require('semver')
 const crypto = require('crypto')
 const util = require('util')
 const cp = require('child_process')
+const fs = require('node:fs')
+const path = require('node:path')
 
 let _agent = null
 let _agentApi = null
@@ -617,4 +619,20 @@ helper.execSync = function execSync({ cwd, script }) {
   } catch (err) {
     throw err.stderr
   }
+}
+
+/**
+ * Used to get version from package.json.
+ * Some packages define exports and omit `package.json` so `require` or `import`
+ * will fail when trying to read package.json. This instead just reads file and parses to json
+ *
+ * @param {string} dirname value of `__dirname` in caller
+ * @param {string} pkg name of package
+ * @returns {string} package version
+ */
+helper.readPackageVersion = function readPackageVersion(dirname, pkg) {
+  const parsedPath = path.join(dirname, 'node_modules', pkg, 'package.json')
+  const packageFile = fs.readFileSync(parsedPath)
+  const { version } = JSON.parse(packageFile)
+  return version
 }

--- a/test/versioned/elastic/elasticsearch.test.js
+++ b/test/versioned/elastic/elasticsearch.test.js
@@ -6,13 +6,11 @@
 'use strict'
 const test = require('node:test')
 const assert = require('node:assert')
-const path = require('node:path')
 const helper = require('../../lib/agent_helper')
 const params = require('../../lib/params')
 const urltils = require('../../../lib/util/urltils')
 const crypto = require('crypto')
 const { assertPackageMetrics } = require('../../lib/custom-assertions')
-const { readFile } = require('fs/promises')
 const semver = require('semver')
 const DB_INDEX = `test-${randomString()}`
 const DB_INDEX_2 = `test2-${randomString()}`
@@ -52,10 +50,7 @@ function setMsearch(body, version) {
 
 test('Elasticsearch instrumentation', async (t) => {
   t.beforeEach(async (ctx) => {
-    // Determine version. ElasticSearch v7 did not export package, so we have to read the file
-    // instead of requiring it, as we can with 8+.
-    const pkg = await readFile(path.join(__dirname, '/node_modules/@elastic/elasticsearch/package.json'))
-    const { version: pkgVersion } = JSON.parse(pkg.toString())
+    const pkgVersion = helper.readPackageVersion(__dirname, '@elastic/elasticsearch')
 
     const agent = helper.instrumentMockedAgent()
 

--- a/test/versioned/google-genai/chat-completions.test.js
+++ b/test/versioned/google-genai/chat-completions.test.js
@@ -7,9 +7,6 @@
 
 const test = require('node:test')
 const assert = require('node:assert')
-const fs = require('node:fs')
-const path = require('node:path')
-
 const { removeModules } = require('../../lib/cache-buster')
 const { assertPackageMetrics, assertSegments, assertSpanKind, match } = require('../../lib/custom-assertions')
 const { assertChatCompletionMessages, assertChatCompletionSummary } = require('./common')
@@ -19,10 +16,7 @@ const helper = require('../../lib/agent_helper')
 const {
   AI: { GEMINI }
 } = require('../../../lib/metrics/names')
-// have to read and not require because @google/genai does not export the package.json
-const { version: pkgVersion } = JSON.parse(
-  fs.readFileSync(path.join(__dirname, '/node_modules/@google/genai/package.json'))
-)
+const pkgVersion = helper.readPackageVersion(__dirname, '@google/genai')
 const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
 const responses = require('./mock-responses')
 const TRACKING_METRIC = `Supportability/Nodejs/ML/Gemini/${pkgVersion}`

--- a/test/versioned/google-genai/embeddings.test.js
+++ b/test/versioned/google-genai/embeddings.test.js
@@ -7,9 +7,6 @@
 
 const test = require('node:test')
 const assert = require('node:assert')
-const fs = require('node:fs')
-const path = require('node:path')
-
 const { removeModules } = require('../../lib/cache-buster')
 const { assertSegments, assertSpanKind, match } = require('../../lib/custom-assertions')
 const GoogleGenAIMockServer = require('./mock-server')
@@ -18,10 +15,7 @@ const helper = require('../../lib/agent_helper')
 const {
   AI: { GEMINI }
 } = require('../../../lib/metrics/names')
-// have to read and not require because @google/genai does not export the package.json
-const { version: pkgVersion } = JSON.parse(
-  fs.readFileSync(path.join(__dirname, '/node_modules/@google/genai/package.json'))
-)
+const pkgVersion = helper.readPackageVersion(__dirname, '@google/genai')
 const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
 
 test.beforeEach(async (ctx) => {

--- a/test/versioned/mcp-sdk/client-stdio.test.js
+++ b/test/versioned/mcp-sdk/client-stdio.test.js
@@ -11,9 +11,6 @@ const assert = require('node:assert')
 const { removeModules } = require('../../lib/cache-buster')
 const helper = require('../../lib/agent_helper')
 const { assertPackageMetrics, assertSegments, assertSpanKind } = require('../../lib/custom-assertions')
-const { readFile } = require('node:fs/promises')
-const path = require('node:path')
-
 const {
   MCP
 } = require('../../../lib/metrics/names')
@@ -28,8 +25,7 @@ test.beforeEach(async (ctx) => {
 
   const { Client } = require('@modelcontextprotocol/sdk/client/index.js')
   const { StdioClientTransport } = require('@modelcontextprotocol/sdk/client/stdio.js')
-  const pkg = await readFile(path.join(__dirname, '/node_modules/@modelcontextprotocol/sdk/package.json'))
-  const { version: pkgVersion } = JSON.parse(pkg.toString())
+  const pkgVersion = helper.readPackageVersion(__dirname, '@modelcontextprotocol/sdk')
   ctx.nr.pkgVersion = pkgVersion
 
   ctx.nr.transport = new StdioClientTransport({

--- a/test/versioned/mysql2/basic-pool.test.js
+++ b/test/versioned/mysql2/basic-pool.test.js
@@ -5,19 +5,9 @@
 
 'use strict'
 
-const fs = require('node:fs')
-const path = require('node:path')
 const basicPoolTests = require('../mysql/basic-pool')
 const constants = require('./constants')
+const helper = require('../../lib/agent_helper')
 
-// exports are defined in newer versions so must read file directly
-let pkgVersion
-try {
-  ;({ version: pkgVersion } = require('mysql2/package'))
-} catch {
-  ;({ version: pkgVersion } = JSON.parse(
-    fs.readFileSync(path.join(__dirname, '/node_modules/mysql2/package.json'))
-  ))
-}
-
+const pkgVersion = helper.readPackageVersion(__dirname, 'mysql2')
 basicPoolTests({ factory: () => require('mysql2'), constants, pkgVersion })

--- a/test/versioned/mysql2/basic.test.js
+++ b/test/versioned/mysql2/basic.test.js
@@ -7,22 +7,12 @@
 
 const basicTests = require('../mysql/basic')
 const constants = require('./constants')
-const fs = require('node:fs')
-const path = require('node:path')
-
-// certain versions of mysql2 lack an export for the package.json
-// so require('mysql2/package.json') will not work
-function getPkgVersion() {
-  const resolvedPath = path.join(__dirname, '/node_modules/mysql2/package.json')
-  const result = fs.readFileSync(resolvedPath)
-  const { version } = JSON.parse(result.toString())
-  return version
-}
+const helper = require('../../lib/agent_helper')
 
 basicTests({
   lib: 'mysql2',
   factory: () => require('mysql2'),
-  version: getPkgVersion(),
+  version: helper.readPackageVersion(__dirname, 'mysql2'),
   poolFactory: () => require('generic-pool'),
   constants
 })

--- a/test/versioned/mysql2/promises.test.js
+++ b/test/versioned/mysql2/promises.test.js
@@ -6,25 +6,14 @@
 'use strict'
 
 const setup = require('../mysql/setup')
-const fs = require('fs')
 const semver = require('semver')
 const test = require('node:test')
 const assert = require('node:assert')
-const path = require('node:path')
 const helper = require('../../lib/agent_helper')
 const params = require('../../lib/params')
 const urltils = require('../../../lib/util/urltils')
 const { DATABASE, USER, TABLE } = require('./constants')
-
-// exports are defined in newer versions so must read file directly
-let pkgVersion
-try {
-  ;({ version: pkgVersion } = require('mysql2/package'))
-} catch {
-  ;({ version: pkgVersion } = JSON.parse(
-    fs.readFileSync(path.join(__dirname, '/node_modules/mysql2/package.json'))
-  ))
-}
+const pkgVersion = helper.readPackageVersion(__dirname, 'mysql2')
 
 test('mysql2 promises', { timeout: 30000 }, async (t) => {
   t.beforeEach(async (ctx) => {

--- a/test/versioned/openai/chat-completions-res-api.test.js
+++ b/test/versioned/openai/chat-completions-res-api.test.js
@@ -7,8 +7,6 @@
 
 const test = require('node:test')
 const assert = require('node:assert')
-const fs = require('node:fs')
-const path = require('node:path')
 const { tspl } = require('@matteo.collina/tspl')
 
 const { removeModules } = require('../../lib/cache-buster')
@@ -19,9 +17,7 @@ const helper = require('../../lib/agent_helper')
 const {
   AI: { OPENAI }
 } = require('../../../lib/metrics/names')
-const { version: pkgVersion } = JSON.parse(
-  fs.readFileSync(path.join(__dirname, '/node_modules/openai/package.json'))
-)
+const pkgVersion = helper.readPackageVersion(__dirname, 'openai')
 const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
 const TRACKING_METRIC = `Supportability/Nodejs/ML/OpenAI/${pkgVersion}`
 

--- a/test/versioned/openai/chat-completions.test.js
+++ b/test/versioned/openai/chat-completions.test.js
@@ -7,8 +7,6 @@
 
 const test = require('node:test')
 const assert = require('node:assert')
-const fs = require('node:fs')
-const path = require('node:path')
 const semver = require('semver')
 
 const { removeModules } = require('../../lib/cache-buster')
@@ -19,10 +17,7 @@ const helper = require('../../lib/agent_helper')
 const {
   AI: { OPENAI }
 } = require('../../../lib/metrics/names')
-// have to read and not require because openai does not export the package.json
-const { version: pkgVersion } = JSON.parse(
-  fs.readFileSync(path.join(__dirname, '/node_modules/openai/package.json'))
-)
+const pkgVersion = helper.readPackageVersion(__dirname, 'openai')
 const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
 const TRACKING_METRIC = `Supportability/Nodejs/ML/OpenAI/${pkgVersion}`
 

--- a/test/versioned/openai/embeddings.test.js
+++ b/test/versioned/openai/embeddings.test.js
@@ -7,9 +7,6 @@
 
 const test = require('node:test')
 const assert = require('node:assert')
-const fs = require('node:fs')
-const path = require('node:path')
-
 const { removeModules } = require('../../lib/cache-buster')
 const { assertSegments, assertSpanKind, match } = require('../../lib/custom-assertions')
 const createOpenAIMockServer = require('./mock-server')
@@ -18,9 +15,7 @@ const helper = require('../../lib/agent_helper')
 const {
   AI: { OPENAI }
 } = require('../../../lib/metrics/names')
-const { version: pkgVersion } = JSON.parse(
-  fs.readFileSync(path.join(__dirname, '/node_modules/openai/package.json'))
-)
+const pkgVersion = helper.readPackageVersion(__dirname, 'openai')
 const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
 
 test.beforeEach(async (ctx) => {

--- a/test/versioned/opensearch/opensearch.test.js
+++ b/test/versioned/opensearch/opensearch.test.js
@@ -6,8 +6,6 @@
 'use strict'
 const test = require('node:test')
 const assert = require('node:assert')
-const { readFile } = require('node:fs/promises')
-const path = require('node:path')
 const helper = require('../../lib/agent_helper')
 const params = require('../../lib/params')
 const urltils = require('../../../lib/util/urltils')
@@ -50,8 +48,7 @@ test('opensearch instrumentation', async (t) => {
     const client = new Client({
       node: `http://${params.opensearch_host}:${params.opensearch_port}`
     })
-    const pkg = await readFile(path.join(__dirname, '/node_modules/@opensearch-project/opensearch/package.json'))
-    const { version: pkgVersion } = JSON.parse(pkg.toString())
+    const pkgVersion = helper.readPackageVersion(__dirname, '@opensearch-project/opensearch')
 
     ctx.nr = {
       agent,

--- a/test/versioned/pg/pg.common.js
+++ b/test/versioned/pg/pg.common.js
@@ -236,7 +236,7 @@ module.exports = function runTests(name, clientFactory) {
 
     await t.test('should log tracking metrics', function(t) {
       const { agent } = t.nr
-      const { version } = require('pg/package.json')
+      const version = helper.readPackageVersion(__dirname, 'pg')
       assertPackageMetrics({ agent, pkg: 'pg', version })
     })
 


### PR DESCRIPTION
## Description

In #3408 I updated all versioned tests to assert tracking metrics. PRs don't run a full suite and mysql2 was failing because a specific version lacked exporting package.json to require. This PR adds a helper to be used in places where package.json isn't exported and instead read and parsed accordingly. Turns out we had a few places in versioned tests that did the same few lines of code so I updated to use this helper.
