### PR TITLE
refactor: Updated `config.instrumentation.timers.enabled` to false to disable `timers.setTimeout` and `timers.setInterval` by default.

### DIFF
--- a/lib/config/build-instrumentation-config.js
+++ b/lib/config/build-instrumentation-config.js
@@ -15,6 +15,7 @@ pkgNames.push(...subscribers)
 // Manually adding domain as it is registered separately in shimmer
 corePkgs.push('domain')
 pkgNames.push(...corePkgs)
+const disabledPkgs = ['timers']
 
 /**
  * Builds the stanza for config.instrumentation.*
@@ -22,6 +23,10 @@ pkgNames.push(...corePkgs)
  * formatter for the environment variable conversion of the values
  */
 module.exports = pkgNames.reduce((config, pkg) => {
-  config[pkg] = { enabled: { formatter: boolean, default: true } }
+  let defaultValue = true
+  if (disabledPkgs.includes(pkg)) {
+    defaultValue = false
+  }
+  config[pkg] = { enabled: { formatter: boolean, default: defaultValue } }
   return config
 }, {})

--- a/lib/config/build-instrumentation-config.js
+++ b/lib/config/build-instrumentation-config.js
@@ -15,6 +15,13 @@ pkgNames.push(...subscribers)
 // Manually adding domain as it is registered separately in shimmer
 corePkgs.push('domain')
 pkgNames.push(...corePkgs)
+
+// Packages are normally enabled without any extra
+// configuration. This list is a set of packages that
+// we want to be disabled without any extra configuration.
+// Typically, this is because the instrumentation no longer
+// provides useful data. Users can still enable them if they
+// are interested in the instrumentation they provide.
 const disabledPkgs = ['timers']
 
 /**

--- a/test/integration/core/net.test.js
+++ b/test/integration/core/net.test.js
@@ -124,7 +124,7 @@ test('connect', function connectTest(t, end) {
       }
       connectChildren = transaction.trace.getChildren(connectSegment.id)
 
-      assert.equal(connectChildren.length, 1, 'connect should have a two child segment')
+      assert.equal(connectChildren.length, 1, 'connect should have one child segment')
       const [dnsSegment] = connectChildren
 
       assert.equal(dnsSegment.name, 'dns.lookup', 'dns segment should have correct name')

--- a/test/unit/config/build-instrumentation-config.test.js
+++ b/test/unit/config/build-instrumentation-config.test.js
@@ -22,6 +22,10 @@ test('should default the instrumentation stanza', () => {
   const coreLibraries = require('../../../lib/core-instrumentation')
   const corePkgs = Object.keys(coreLibraries)
   corePkgs.forEach((pkg) => {
-    assert.deepEqual(pkgs[pkg], { enabled: { formatter: boolean, default: true } })
+    let defaultValue = true
+    if (pkg === 'timers') {
+      defaultValue = false
+    }
+    assert.deepEqual(pkgs[pkg], { enabled: { formatter: boolean, default: defaultValue } })
   })
 })

--- a/test/unit/shimmer.test.js
+++ b/test/unit/shimmer.test.js
@@ -753,7 +753,7 @@ test('Shimmer with logger mock', async (t) => {
     })
 
     require(TEST_MODULE_RELATIVE_PATH)
-    assert.deepEqual(loggerMock.warn.args[0], [
+    assert.deepEqual(loggerMock.warn.args[1], [
       instFail,
       origError,
       'Custom instrumentation for %s failed, then the onError handler threw an error',
@@ -771,7 +771,7 @@ test('Shimmer with logger mock', async (t) => {
     })
 
     require(TEST_MODULE_RELATIVE_PATH)
-    assert.deepEqual(loggerMock.warn.args[0], [
+    assert.deepEqual(loggerMock.warn.args[1], [
       origError,
       'Custom instrumentation for %s failed. Please report this to the maintainers of the custom instrumentation.',
       TEST_MODULE_PATH

--- a/test/versioned-external/external-repos.js
+++ b/test/versioned-external/external-repos.js
@@ -15,7 +15,7 @@ const repos = [
   {
     name: 'apollo-server',
     repository: 'https://github.com/newrelic/newrelic-node-apollo-server-plugin.git',
-    branch: 'main',
+    branch: 'remove-set-timeout',
     additionalFiles: [
       'tests/lib',
     ]

--- a/test/versioned/elastic/elasticsearch.test.js
+++ b/test/versioned/elastic/elasticsearch.test.js
@@ -171,11 +171,9 @@ test('Elasticsearch instrumentation', async (t) => {
       })
       assert.ok(transaction, 'transaction should still be visible after bulk create')
       const trace = transaction.trace
-      // helper interface results in a first child of timers.setTimeout, with the second child related to the operation
-      const [firstChild, secondChild] = trace.getChildren(trace.root.id)
-      assert.ok(firstChild)
+      const [firstChild] = trace.getChildren(trace.root.id)
       assert.equal(
-        secondChild.name,
+        firstChild.name,
         'Datastore/statement/ElasticSearch/any/bulk.create',
         'should record bulk operation'
       )
@@ -357,8 +355,7 @@ test('Elasticsearch instrumentation', async (t) => {
       const [firstChild] = trace.getChildren(trace.root.id)
       assert.equal(
         firstChild.name,
-        'timers.setTimeout',
-        'helpers, for some reason, generates a setTimeout metric first'
+        'Datastore/statement/ElasticSearch/any/msearch.create'
       )
       transaction.end()
       assert.ok(agent.queries.samples.size > 0, 'there should be a query sample')

--- a/test/versioned/express/client-disconnect.test.js
+++ b/test/versioned/express/client-disconnect.test.js
@@ -51,7 +51,7 @@ test('Client Premature Disconnection', { timeout: 3000 }, (t, end) => {
         [
           'Nodejs/Middleware/Expressjs/jsonParser',
           'Expressjs/Route Path: /test',
-          ['Nodejs/Middleware/Expressjs/controller', ['timers.setTimeout']]
+          ['Nodejs/Middleware/Expressjs/controller']
         ]
       ],
       { exact: false }

--- a/test/versioned/kafkajs/kafka.test.js
+++ b/test/versioned/kafkajs/kafka.test.js
@@ -20,11 +20,6 @@ const broker = `${params.kafka_host}:${params.kafka_port}`
 test.beforeEach(async (ctx) => {
   ctx.nr = {}
   ctx.nr.agent = helper.instrumentMockedAgent({
-    instrumentation: {
-      timers: {
-        enabled: false
-      }
-    },
     feature_flag: {
       kafkajs_instrumentation: true
     }

--- a/test/versioned/koa/koa.test.js
+++ b/test/versioned/koa/koa.test.js
@@ -288,7 +288,7 @@ test('produces transaction trace with multiple middleware', async (t) => {
 })
 
 test('correctly records actions interspersed among middleware', async (t) => {
-  const plan = tspl(t, { plan: 17 })
+  const plan = tspl(t, { plan: 13 })
   const { agent, app, testShim } = t.nr
 
   app.use(function one(ctx, next) {
@@ -318,7 +318,7 @@ test('correctly records actions interspersed among middleware', async (t) => {
           [
             'Truncated/testSegment',
             'Nodejs/Middleware/Koa/two',
-            ['timers.setTimeout', ['Callback: <anonymous>'], 'Nodejs/Middleware/Koa/three'],
+            ['Nodejs/Middleware/Koa/three'],
             'Truncated/nestedSegment'
           ]
         ]

--- a/test/versioned/opensearch/opensearch.test.js
+++ b/test/versioned/opensearch/opensearch.test.js
@@ -123,10 +123,9 @@ test('opensearch instrumentation', async (t) => {
       assert.ok(transaction, 'transaction should still be visible after bulk create')
       const trace = transaction.trace
       // helper interface results in a first child of timers.setTimeout, with the second child related to the operation
-      const [firstChild, secondChild] = trace.getChildren(trace.root.id)
-      assert.ok(firstChild, 'trace, trace root, and first child should exist')
+      const [firstChild] = trace.getChildren(trace.root.id)
       assert.equal(
-        secondChild.name,
+        firstChild.name,
         'Datastore/statement/OpenSearch/any/bulk.create',
         'should record bulk operation'
       )
@@ -304,8 +303,7 @@ test('opensearch instrumentation', async (t) => {
       const [firstChild] = trace.getChildren(trace.root.id)
       assert.equal(
         firstChild.name,
-        'timers.setTimeout',
-        'helpers, for some reason, generates a setTimeout metric first'
+        'Datastore/statement/OpenSearch/any/msearch.create'
       )
       transaction.end()
       assert.ok(agent.queries.samples.size > 0, 'there should be a query sample')


### PR DESCRIPTION
## Description
The Node.js agent instrumented `setTimeout` and `setInterval`. This was done many years ago to propagate async context through timers.  When we introduced an async context manager based on `AsyncLocalStorage` this instrumentation isn't necessary. On top of that, not only did we propagate context but we created segments/spans for these actions. This caused a lot of unncessary segments/spans to show that a setTimeout or setInterval was called.  This PR disables the timers instrumentation by default.  Aside from creating useless segments/spans, it typically spammed the debug+ level logger because a lot of 3rd party libraries and applications rely on `setTimeout` and `setInterval` to drive internals. You would see a lot of not recording `setTimeout` `setInterval` because it was not in an active transaction. Now, durations of child instrumented actions will be accounted for in the actual functions and not in the `setTimeout` or `setInterval`.  However, if customers still want this level of observability, they can re-enable the instrumentation via `config.instrumentation.timers.enabled` to `true` or `NEW_RELIC_INSTRUMENTATION_TIMERS_ENABLED` to `true`.

**Note**: I had to open a branch of `@newrelic/apollo-server-plugin` to fix segment trees without timers.  That PR will fail until we release the agent.

## Related Issues
Closes #3084 