### PR TITLE
test: Refactored mcp tests to listen on new port for every streaming test, removed unncessary shutdown of process

### DIFF
--- a/test/versioned/mcp-sdk/client-stdio.test.js
+++ b/test/versioned/mcp-sdk/client-stdio.test.js
@@ -25,9 +25,6 @@ test.beforeEach(async (ctx) => {
 
   const { Client } = require('@modelcontextprotocol/sdk/client/index.js')
   const { StdioClientTransport } = require('@modelcontextprotocol/sdk/client/stdio.js')
-  const pkgVersion = helper.readPackageVersion(__dirname, '@modelcontextprotocol/sdk')
-  ctx.nr.pkgVersion = pkgVersion
-
   ctx.nr.transport = new StdioClientTransport({
     command: 'node',
     args: ['stdio-server.js']
@@ -42,13 +39,15 @@ test.beforeEach(async (ctx) => {
 })
 
 test.afterEach(async (ctx) => {
-  ctx.nr.client.close()
+  await ctx.nr.client.close()
+  await ctx.nr.transport.close()
   helper.unloadAgent(ctx.nr.agent)
   removeModules(['@modelcontextprotocol/sdk/client/index.js', '@modelcontextprotocol/sdk/client/stdio.js'])
 })
 
 test('should log tracking metrics', function(t) {
-  const { agent, pkgVersion } = t.nr
+  const { agent } = t.nr
+  const pkgVersion = helper.readPackageVersion(__dirname, '@modelcontextprotocol/sdk')
   assertPackageMetrics({ agent, pkg: '@modelcontextprotocol/sdk', version: pkgVersion })
 })
 

--- a/test/versioned/mcp-sdk/client-streaming.test.js
+++ b/test/versioned/mcp-sdk/client-streaming.test.js
@@ -11,9 +11,6 @@ const assert = require('node:assert')
 const { removeModules } = require('../../lib/cache-buster')
 const helper = require('../../lib/agent_helper')
 const { assertPackageMetrics, assertSegments, assertSpanKind } = require('../../lib/custom-assertions')
-const { readFile } = require('node:fs/promises')
-const path = require('node:path')
-
 const {
   MCP
 } = require('../../../lib/metrics/names')
@@ -28,18 +25,14 @@ test.beforeEach(async (ctx) => {
 
   const { Client } = require('@modelcontextprotocol/sdk/client/index.js')
   const { StreamableHTTPClientTransport } = require('@modelcontextprotocol/sdk/client/streamableHttp.js')
-  const pkg = await readFile(path.join(__dirname, '/node_modules/@modelcontextprotocol/sdk/package.json'))
-  const { version: pkgVersion } = JSON.parse(pkg.toString())
-  ctx.nr.pkgVersion = pkgVersion
-
   // Set up server
   const McpTestServer = require('./streaming-server')
   ctx.nr.mcpServer = new McpTestServer()
-  await ctx.nr.mcpServer.start()
+  const port = await ctx.nr.mcpServer.start()
 
   // Set up client
   ctx.nr.transport = new StreamableHTTPClientTransport(
-    new URL('http://localhost:3000/mcp')
+    new URL(`http://localhost:${port}/mcp`)
   )
   ctx.nr.client = new Client(
     {
@@ -51,18 +44,24 @@ test.beforeEach(async (ctx) => {
 })
 
 test.afterEach(async (ctx) => {
+  await ctx.nr.client.close()
+  await ctx.nr.transport.close()
   await ctx.nr.mcpServer.stop()
-  ctx.nr.client.close()
   helper.unloadAgent(ctx.nr.agent)
   removeModules([
     '@modelcontextprotocol/sdk/client/index.js',
-    '@modelcontextprotocol/sdk/client/streamableHttp.js',
-    './streaming-server.js'
+    '@modelcontextprotocol/sdk/client/streamableHttp.js'
   ])
 })
 
+test('should log package tracking metrics', (t) => {
+  const { agent } = t.nr
+  const version = helper.readPackageVersion(__dirname, '@modelcontextprotocol/sdk')
+  assertPackageMetrics({ agent, pkg: '@modelcontextprotocol/sdk', version })
+})
+
 test('should create span for callTool', (t, end) => {
-  const { agent, client, pkgVersion } = t.nr
+  const { agent, client } = t.nr
   helper.runInTransaction(agent, async (tx) => {
     const result = await client.callTool({
       name: 'echo',
@@ -80,14 +79,13 @@ test('should create span for callTool', (t, end) => {
         { name, kind: 'internal' }
       ]
     })
-    assertPackageMetrics({ agent, pkg: '@modelcontextprotocol/sdk', version: pkgVersion })
 
     end()
   })
 })
 
 test('should create span for readResource', (t, end) => {
-  const { agent, client, pkgVersion } = t.nr
+  const { agent, client } = t.nr
   helper.runInTransaction(agent, async (tx) => {
     const resource = await client.readResource({
       uri: 'echo://hello-world',
@@ -106,14 +104,12 @@ test('should create span for readResource', (t, end) => {
       ]
     })
 
-    assertPackageMetrics({ agent, pkg: '@modelcontextprotocol/sdk', version: pkgVersion })
-
     end()
   })
 })
 
 test('should create span for getPrompt', (t, end) => {
-  const { agent, client, pkgVersion } = t.nr
+  const { agent, client } = t.nr
   helper.runInTransaction(agent, async (tx) => {
     const prompt = await client.getPrompt({
       name: 'echo',
@@ -134,8 +130,6 @@ test('should create span for getPrompt', (t, end) => {
         { name, kind: 'internal' }
       ]
     })
-
-    assertPackageMetrics({ agent, pkg: '@modelcontextprotocol/sdk', version: pkgVersion })
 
     end()
   })

--- a/test/versioned/mcp-sdk/stdio-server.js
+++ b/test/versioned/mcp-sdk/stdio-server.js
@@ -19,11 +19,6 @@ async function main() {
     },
   })
 
-  // Set up auto-shutdown after first request
-  const shutdown = () => {
-    process.exit(0)
-  }
-
   server.registerResource(
     'echo',
     new ResourceTemplate('echo://{message}', { list: undefined }),
@@ -38,7 +33,6 @@ async function main() {
           text: `Resource echo: ${message}`
         }]
       }
-      setTimeout(shutdown, 100)
       return result
     }
   )
@@ -52,7 +46,6 @@ async function main() {
     },
     async ({ message }) => {
       const result = { content: [{ type: 'text', text: `Tool echo: ${message}` }] }
-      setTimeout(shutdown, 100)
       return result
     }
   )
@@ -74,7 +67,6 @@ async function main() {
           }
         }]
       }
-      setTimeout(shutdown, 100)
       return result
     }
   )


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

In #3408 I added asserting package tracking metrics. I was unable to udpate the `client-streaming.test.js` in mcp sdk versioned tests. This Pr resolves that by listening on a random port for every test to avoid race conditions in afterEach with tearing down server. I also removed what seemed to be uncessary `process.exit` calls in the stdio mock.
