### PR TITLE
test: Updated an openai assertion with setTimeout disabled

### DIFF
--- a/test/versioned/openai/chat-completions.test.js
+++ b/test/versioned/openai/chat-completions.test.js
@@ -405,7 +405,7 @@ test('chat.completions.create', async (t) => {
         assertSegments(
           tx.trace,
           tx.trace.root,
-          ['timers.setTimeout', `External/${host}:${port}/chat/completions`],
+          [`External/${host}:${port}/chat/completions`],
           { exact: false }
         )
 


### PR DESCRIPTION
## Description

In #3414 we disabled timers instrumentation by default. Since PRs only run major version tests, I missed an assertion