### PR TITLE
test: Fixed fastify segment tree assertion when security agent is enabled

### DIFF
--- a/test/versioned/fastify/add-hook.test.js
+++ b/test/versioned/fastify/add-hook.test.js
@@ -95,11 +95,9 @@ test('non-error hooks', async (t) => {
         'WebTransaction/WebFrameworkUri/Fastify/GET//add-hook',
         [
           'Nodejs/Middleware/Fastify/onRequest/<anonymous>',
-          [
-            ...getExpectedSegments(REQUEST_HOOKS),
-            'Nodejs/Middleware/Fastify/routeHandler//add-hook',
-            getExpectedSegments(AFTER_HANDLER_HOOKS)
-          ]
+          ...getExpectedSegments(REQUEST_HOOKS),
+          'Nodejs/Middleware/Fastify/routeHandler//add-hook',
+          getExpectedSegments(AFTER_HANDLER_HOOKS)
         ]
       ]
     } else {
@@ -155,10 +153,8 @@ test('error hook', async function errorHookTest(t) {
         'WebTransaction/WebFrameworkUri/Fastify/GET//error',
         [
           'Nodejs/Middleware/Fastify/onRequest/<anonymous>',
-          [
-            'Nodejs/Middleware/Fastify/errorRoute//error',
-            `Nodejs/Middleware/Fastify/${hookName}/testHook`
-          ]
+          'Nodejs/Middleware/Fastify/errorRoute//error',
+          `Nodejs/Middleware/Fastify/${hookName}/testHook`
         ]
       ]
     } else {

--- a/test/versioned/fastify/code-level-metrics-hooks.test.js
+++ b/test/versioned/fastify/code-level-metrics-hooks.test.js
@@ -46,8 +46,9 @@ async function performTest(t) {
     const [baseSegment] = transaction.trace.getChildren(transaction.trace.root.id)
     let [onRequestSegment, handlerSegment] = transaction.trace.getChildren(baseSegment.id)
     if (helper.isSecurityAgentEnabled(agent)) {
-      ;[onRequestSegment, handlerSegment] = transaction.trace.getChildren(onRequestSegment.id)
+      ;[, onRequestSegment, handlerSegment] = transaction.trace.getChildren(baseSegment.id)
     }
+
     const [onSendSegment] = transaction.trace.getChildren(handlerSegment.id)
     assertCLMAttrs({
       segments: [

--- a/test/versioned/fastify/code-level-metrics-middleware.test.js
+++ b/test/versioned/fastify/code-level-metrics-middleware.test.js
@@ -49,11 +49,11 @@ async function setup(t, config) {
 
 function assertSegments({ t, trace, baseSegment, isCLMEnabled }) {
   const { agent } = t.nr
-  let children = trace.getChildren(baseSegment.id)
+  const children = trace.getChildren(baseSegment.id)
+  let [middieSegment, handlerSegment] = children
   if (helper.isSecurityAgentEnabled(agent)) {
-    children = trace.getChildren(children[0].id)
+    ;[, middieSegment, handlerSegment] = children
   }
-  const [middieSegment, handlerSegment] = children
   assertCLMAttrs({
     segments: [
       {

--- a/test/versioned/fastify/naming-common.js
+++ b/test/versioned/fastify/naming-common.js
@@ -34,7 +34,7 @@ module.exports = async function runTests(t, getExpectedSegments) {
           // it sometimes has timers.setTimeout depending on route
           expectedSegments = [
             `WebTransaction/WebFrameworkUri/Fastify/GET/${uri}`,
-            ['Nodejs/Middleware/Fastify/onRequest/<anonymous>', getExpectedSegments(uri)]
+            ['Nodejs/Middleware/Fastify/onRequest/<anonymous>', ...getExpectedSegments(uri)]
           ]
         } else {
           expectedSegments = [


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
The fastify instrumentation was migrated to tracing channel. The segment tree was slightly flattened but seems more accurate now.  Previously all the hooks were children of the `onRequest` hook but they should be siblings. This PR fixes that for security agent as they register an `onRequest` hook.
