### PR TITLE
test: Updated minimum tested version of `@langchain/core` to 1.0.0

### DIFF
--- a/test/versioned/langchain/package.json
+++ b/test/versioned/langchain/package.json
@@ -11,28 +11,18 @@
       "engines": {
         "node": ">=20"
       },
-      "comment": "This is implicitly testing `@langchain/core` as it's a peer dep",
+      "comment": "`@langchain/core` is the only dep under test. The rest are to help seed tests and assert real-life scenarios. In the future feel free to change semver ranges of those packages.",
       "dependencies": {
-        "@langchain/openai": ">=0.0.34"
+        "@langchain/openai": ">=1.0.0",
+        "@langchain/core": ">=1.0.0",
+        "openai": "4.90.0",
+        "@langchain/community": ">=1.0.0",
+        "@elastic/elasticsearch": "8.13.1"
       },
       "files": [
         "tools.test.js",
         "runnables.test.js",
-        "runnables-streaming.test.js"
-      ]
-    },
-    {
-      "engines": {
-        "node": ">=20"
-      },
-      "comment": "Using latest of `@langchain/openai` only as it is being used to seed embeddings, nothing to test that hasn't been done in the above stanza",
-      "dependencies": {
-        "@langchain/openai": "latest",
-        "openai": "4.90.0",
-        "@langchain/community": ">=0.2.2",
-        "@elastic/elasticsearch": "8.13.1"
-      },
-      "files": [
+        "runnables-streaming.test.js",
         "vectorstore.test.js"
       ]
     }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
It appears that over the weekend langchain released 1.x of their packages. This caused some issues with peer dep resolution for <1.x. 
There is no clean way to verify 0.x and 1.x work. It'll be fine on a fresh run. But if you return to your repo and try to re-run, it will fail 
as some of the deps are 1.x and would fail peer dep resolution. We agreed to keep this simple and stop testing on 0.x as they are less stable.
