### PR TITLE
refactor: Updated instances of `Array.forEach` for a more performant for...of or for index loop

### DIFF
--- a/api.js
+++ b/api.js
@@ -1813,16 +1813,16 @@ API.prototype.setUserID = function setUserID(id) {
  */
 function _filterAttributes(attributes, name) {
   const filteredAttributes = Object.create(null)
-  Object.keys(attributes).forEach((attributeKey) => {
+  for (const attributeKey of Object.keys(attributes)) {
     if (!isValidType(attributes[attributeKey])) {
       logger.info(
         `Omitting attribute ${attributeKey} from ${name} call, type must ` +
           'be boolean, number, or string'
       )
-      return
+      continue
     }
     filteredAttributes[attributeKey] = attributes[attributeKey]
-  })
+  }
   return filteredAttributes
 }
 

--- a/lib/aggregators/log-aggregator.js
+++ b/lib/aggregators/log-aggregator.js
@@ -81,9 +81,9 @@ class LogAggregator extends EventAggregator {
   }
 
   addBatch(logs, priority) {
-    logs.forEach((logLine) => {
+    for (const logLine of logs) {
       super.add(logLine, priority)
-    })
+    }
   }
 
   reconfigure(config) {

--- a/lib/collector/api.js
+++ b/lib/collector/api.js
@@ -63,15 +63,15 @@ const AGENT_RUN_BEHAVIOR = CollectorResponse.AGENT_RUN_BEHAVIOR
 function dumpErrors(errors, name) {
   let index = 1
 
-  errors.forEach(function forEachError(error) {
+  for (const error of errors) {
     logger.trace(error, 'Error %s during %s:', index++, name)
 
     if (error.laterErrors) {
-      error.laterErrors.forEach(function forEachLaterError(laterError) {
+      for (const laterError of error.laterErrors) {
         logger.trace(laterError, 'Error %s during %s:', index++, name)
-      })
+      }
     }
-  })
+  }
 }
 
 /**
@@ -421,9 +421,9 @@ CollectorAPI.prototype._onConnect = function _onConnect(callback, error, res) {
 
   // Log "Reporting to..." message from connect response.
   if (config.messages) {
-    config.messages.forEach((element) => {
+    for (const element of config.messages) {
       logger.info(element.message)
-    })
+    }
   }
 
   // Store request headers for future collector requests if they're present

--- a/lib/config/attribute-filter.js
+++ b/lib/config/attribute-filter.js
@@ -70,12 +70,12 @@ function AttributeFilter(config) {
   this._rules.global = Object.create(null)
 
   // And all the destination rules.
-  DESTINATION_DETAILS.forEach(function forEachDestination(dest) {
+  for (const dest of DESTINATION_DETAILS) {
     config.on(dest.name + '.attributes.enabled', updater)
     config.on(dest.name + '.attributes.include', updater)
     config.on(dest.name + '.attributes.exclude', updater)
     this._rules[dest.name] = Object.create(null)
-  }, this)
+  }
 
   // Now pull in all the rules.
   this.update()
@@ -184,10 +184,10 @@ AttributeFilter.prototype.update = function update() {
   this._cachedCount = 0
 
   // And all the destination rules.
-  DESTINATION_DETAILS.forEach(function forEachDestination(dest) {
+  for (const dest of DESTINATION_DETAILS) {
     const name = dest.name
     if (!this.config[name].attributes.enabled) {
-      return
+      continue
     }
 
     this._enabledDestinations |= dest.id
@@ -196,7 +196,7 @@ AttributeFilter.prototype.update = function update() {
     )
     this._rules[name].exclude = _importRules(this.config[name].attributes.exclude)
     this._cache[name] = Object.create(null)
-  }, this)
+  }
 }
 
 /**
@@ -291,13 +291,13 @@ function _importRules(rules) {
   }
   const exactRules = []
   const wildcardRules = []
-  rules.forEach(function separateRules(rule) {
+  for (const rule of rules) {
     if (rule[rule.length - 1] === '*') {
       wildcardRules.push(rule)
     } else {
       exactRules.push(rule)
     }
-  })
+  }
 
   if (exactRules.length) {
     out.exact = new RegExp('^' + _convertRulesToRegex(exactRules) + '$')

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -277,9 +277,9 @@ Config.prototype.onConnect = function onConnect(json, recursion) {
     return
   }
 
-  Object.keys(json).forEach(function updateProp(key) {
+  for (const key of Object.keys(json)) {
     this._fromServer(json, key)
-  }, this)
+  }
 
   this._warnDeprecations()
 
@@ -652,11 +652,11 @@ Config.prototype._alwaysUpdateIfChanged = function _alwaysUpdateIfChanged(json, 
   const value = json[key]
   if (value != null && this[key] !== value) {
     if (Array.isArray(value) && Array.isArray(this[key])) {
-      value.forEach(function pushIfNew(element) {
+      for (const element of value) {
         if (this[key].indexOf(element) === -1) {
           this[key].push(element)
         }
-      }, this)
+      }
     } else {
       this[key] = value
     }
@@ -703,7 +703,7 @@ function _validateThenUpdateStatusCodes(remote, local, remoteKey, localKey) {
   }
 
   let valid = true
-  valueToTest.forEach(function validateArray(thingToTest) {
+  for (const thingToTest of valueToTest) {
     if (!(typeof thingToTest === 'string' || typeof thingToTest === 'number')) {
       logger.warn(
         'Saw SSC (ignore|expect)_status_code that is not a number or string,' +
@@ -712,7 +712,7 @@ function _validateThenUpdateStatusCodes(remote, local, remoteKey, localKey) {
       )
       valid = false
     }
-  })
+  }
   if (!valid) {
     return
   }
@@ -747,7 +747,7 @@ function _validateThenUpdateErrorClasses(remote, local, remoteKey, localKey) {
   }
 
   let valid = true
-  Object.keys(valueToTest).forEach(function validateArray(key) {
+  for (const key of Object.keys(valueToTest)) {
     const thingToTest = valueToTest[key]
     if (typeof thingToTest !== 'string') {
       logger.warn(
@@ -756,7 +756,7 @@ function _validateThenUpdateErrorClasses(remote, local, remoteKey, localKey) {
       )
       valid = false
     }
-  })
+  }
   if (!valid) {
     return
   }
@@ -801,13 +801,13 @@ function _validateThenUpdateErrorMessages(remote, local, remoteKey, localKey) {
   }
 
   let valid = true
-  Object.keys(valueToTest).forEach(function validateArray(key) {
+  for (const key of Object.keys(valueToTest)) {
     const arrayToTest = valueToTest[key]
     if (!Array.isArray(arrayToTest)) {
       logger.warn('Saw SSC message array that is not an array, will not merge: %s', arrayToTest)
       valid = false
     }
-  })
+  }
   if (!valid) {
     return
   }
@@ -1058,15 +1058,15 @@ Config.prototype._fromPassed = function _fromPassed(external, internal, arbitrar
     internal = this
   }
 
-  Object.keys(external).forEach(function overwrite(key) {
+  for (const key of Object.keys(external)) {
     // if it's not in the defaults, it doesn't exist
     if (!arbitrary && !(key in internal)) {
-      return
+      continue
     }
 
     if (key === 'ssl' && !isTruthular(external.ssl)) {
       logger.warn(SSL_WARNING)
-      return
+      continue
     }
 
     let node = null
@@ -1074,7 +1074,7 @@ Config.prototype._fromPassed = function _fromPassed(external, internal, arbitrar
       node = external[key]
     } catch {
       logger.warn('Error thrown on access of user config for key: %s', key)
-      return
+      continue
     }
 
     if (typeof node === 'object' && !Array.isArray(node) && !(node instanceof RegExp)) {
@@ -1084,7 +1084,7 @@ Config.prototype._fromPassed = function _fromPassed(external, internal, arbitrar
     } else {
       internal[key] = node
     }
-  }, this)
+  }
 }
 
 /**
@@ -1117,12 +1117,12 @@ Config.prototype._fromSpecial = function _fromSpecial() {
 Config.prototype._featureFlagsFromEnv = function _featureFlagsFromEnv() {
   const flags = Object.keys(featureFlag.prerelease).concat(featureFlag.released)
   const config = this
-  flags.forEach(function checkFlag(flag) {
+  for (const flag of flags) {
     const envVal = process.env['NEW_RELIC_FEATURE_FLAG_' + flag.toUpperCase()]
     if (envVal) {
       config.feature_flag[flag] = isTruthular(envVal)
     }
-  })
+  }
 }
 
 /**
@@ -1341,7 +1341,7 @@ Config.prototype._serverlessDT = function _serverlessDT() {
  */
 Config.prototype._preventServerlessDT = function _preventServerlessDT() {
   // Don't allow DT config settings to be set if serverless_mode is disabled
-  SERVERLESS_DT_KEYS.forEach((key) => {
+  for (const key of SERVERLESS_DT_KEYS) {
     if (this[key]) {
       logger.warn(
         key +
@@ -1350,7 +1350,7 @@ Config.prototype._preventServerlessDT = function _preventServerlessDT() {
       )
       this[key] = null
     }
-  })
+  }
 }
 
 /**
@@ -1502,7 +1502,9 @@ Config.prototype._applyHighSecurity = function _applyHighSecurity() {
   this.attributes.exclude.push('request.parameters.*')
 
   function checkNode(base, target, settings) {
-    Object.keys(settings).forEach(checkKey.bind(null, base, target, settings))
+    for (const key of Object.keys(settings)) {
+      checkKey(base, target, settings, key)
+    }
   }
 
   function checkKey(base, target, settings, key) {
@@ -1623,12 +1625,12 @@ Config.prototype.applyLasp = function applyLasp(agent, policies) {
   const { finalPolicies, missingRequired } = this._buildLaspPolicy(agent, policies)
 
   const missingLASP = []
-  Object.keys(LASP_MAP).forEach(function checkPolicy(name) {
+  for (const name of Object.keys(LASP_MAP)) {
     if (!policies[name]) {
       // agent is expecting a policy that was not sent from server -- fail
       missingLASP.push(name)
     }
-  })
+  }
 
   let fatalMessage = null
   if (missingLASP.length) {
@@ -1655,14 +1657,14 @@ Config.prototype.applyLasp = function applyLasp(agent, policies) {
 }
 
 Config.prototype.validateFlags = function validateFlags() {
-  Object.keys(this.feature_flag).forEach(function forEachFlag(key) {
+  for (const key of Object.keys(this.feature_flag)) {
     if (featureFlag.released.indexOf(key) > -1) {
       logger.warn('Feature flag %s has been released', key)
     }
     if (featureFlag.unreleased.indexOf(key) > -1) {
       logger.warn('Feature flag %s has been deprecated', key)
     }
-  })
+  }
 }
 
 function redactValue(value) {

--- a/lib/config/merge-server-config.js
+++ b/lib/config/merge-server-config.js
@@ -32,28 +32,28 @@ class MergeServerConfig {
   }
 
   updateArray(value, local, localKey) {
-    value.forEach((element) => {
+    for (const element of value) {
       if (local[localKey].indexOf(element) === -1) {
         local[localKey].push(element)
       }
-    })
+    }
   }
 
   updateObject(value, local, localKey) {
     // go through each key of the object and update it
-    Object.keys(value).forEach((element) => {
+    for (const element of Object.keys(value)) {
       if (Array.isArray(local[localKey][element]) && Array.isArray(value[element])) {
         // if both key-values are arrays, push the remote value onto the local array
-        value[element].forEach((elementValue) => {
+        for (const elementValue of value[element]) {
           if (local[localKey][element].indexOf(elementValue) === -1) {
             local[localKey][element].push(elementValue)
           }
-        })
+        }
       } else {
         // otherwise, replace the local value with the server value
         local[localKey][element] = value[element]
       }
-    })
+    }
   }
 }
 

--- a/lib/db/query-parsers/elasticsearch.js
+++ b/lib/db/query-parsers/elasticsearch.js
@@ -72,18 +72,19 @@ function parsePath(pathString, method) {
       operation = 'index.create'
       return { collection, operation }
     }
-    path.forEach((segment, idx) => {
+    for (let idx = 0; idx < path.length; idx++) {
+      const segment = path[idx]
       const prev = idx - 1
-      let opname
       if (segment === '_search') {
         collection = path?.[prev] || defaultCollection
         operation = 'search'
       } else if (segment[0] === '_') {
-        opname = segment.substring(1)
+        const opname = segment.substring(1)
         collection = path?.[prev] || defaultCollection
         operation = `${opname}.${suffix}`
       }
-    })
+    }
+
     if (!operation && !collection) {
       // likely creating an index--no underscore segments
       collection = path?.[1] || defaultCollection

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -240,7 +240,7 @@ function getGlobalPackages() {
  */
 function flattenVersions(packages) {
   const info = Object.create(null)
-  packages.forEach((pair) => {
+  for (const pair of packages) {
     const p = pair[0]
     const v = pair[1]
 
@@ -251,7 +251,7 @@ function flattenVersions(packages) {
     } else {
       info[p] = [v]
     }
-  })
+  }
 
   return Object.keys(info)
     .map((key) => [key, info[key].join(', ')])
@@ -277,7 +277,7 @@ function flattenVersions(packages) {
 function remapConfigSettings() {
   if (process.config && process.config.variables) {
     const variables = process.config.variables
-    Object.keys(variables).forEach((key) => {
+    for (const key of Object.keys(variables)) {
       if (remapping[key]) {
         let value = variables[key]
 
@@ -290,7 +290,7 @@ function remapConfigSettings() {
 
         addSetting(remapping[key], value)
       }
-    })
+    }
 
     addMissingProcessVars()
   }
@@ -334,10 +334,10 @@ async function getOtherPackages() {
     2
   )
 
-  otherPackages.forEach((pkg) => {
+  for (const pkg of otherPackages) {
     other.packages.push.apply(other.packages, pkg.packages)
     other.dependencies.push.apply(other.dependencies, pkg.dependencies)
-  })
+  }
 
   _log('Done getting other packages')
   return other
@@ -442,21 +442,21 @@ function refreshSyncOnly() {
   settings = Object.create(null)
   // add persisted settings
   if (framework.length) {
-    framework.forEach(function addFrameworks(fw) {
+    for (const fw of framework) {
       addSetting('Framework', fw)
-    })
+    }
   }
 
   if (dispatcher.length) {
-    dispatcher.forEach(function addDispatchers(d) {
+    for (const d of dispatcher) {
       addSetting('Dispatcher', d)
-    })
+    }
   }
 
   if (dispatcherVersion.length) {
-    dispatcher.forEach(function addDispatchers(d) {
+    for (const d of dispatcher) {
       addSetting(DISPATCHER_VERSION, d)
-    })
+    }
   }
 
   gatherEnv()
@@ -498,11 +498,11 @@ async function getJSON() {
   }
 
   const items = []
-  Object.keys(settings).forEach(function settingKeysForEach(key) {
-    settings[key].forEach(function settingsValuesForEach(setting) {
+  for (const [key, value] of Object.entries(settings)) {
+    for (const setting of value) {
       items.push([key, setting])
-    })
-  })
+    }
+  }
   _log('JSON got')
   return items
 }

--- a/lib/harvester.js
+++ b/lib/harvester.js
@@ -18,11 +18,11 @@ module.exports = class Harvester {
    * Calls start on every registered aggregator that is enabled.
    */
   start() {
-    this.aggregators.forEach((aggregator) => {
+    for (const aggregator of this.aggregators) {
       if (aggregator.enabled) {
         aggregator.start()
       }
-    })
+    }
   }
 
   /**
@@ -57,7 +57,9 @@ module.exports = class Harvester {
    * Calls stop on every registered aggregator.
    */
   stop() {
-    this.aggregators.forEach((aggregator) => aggregator.stop())
+    for (const aggregator of this.aggregators) {
+      aggregator.stop()
+    }
   }
 
   /**
@@ -66,9 +68,9 @@ module.exports = class Harvester {
    * @param {object} config updated agent configuration
    */
   update(config) {
-    this.aggregators.forEach((aggregator) => {
+    for (const aggregator of this.aggregators) {
       aggregator.reconfigure(config)
-    })
+    }
   }
 
   /**

--- a/lib/header-attributes.js
+++ b/lib/header-attributes.js
@@ -78,9 +78,9 @@ _setHeaderAttrNames(REQUEST_HEADER_NAMES, REQUEST_HEADER_PREFIX)
 _setHeaderAttrNames(RESPONSE_HEADER_NAMES, RESPONSE_HEADER_PREFIX)
 
 function _setHeaderAttrNames(dest, prefix) {
-  Object.keys(HEADER_ATTR_NAMES).forEach(function forEachHeader(h) {
-    dest[h] = prefix + HEADER_ATTR_NAMES[h]
-  })
+  for (const header of Object.keys(HEADER_ATTR_NAMES)) {
+    dest[header] = prefix + HEADER_ATTR_NAMES[header]
+  }
 }
 
 function _headerToCamelCase(header) {

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -290,12 +290,12 @@ Metrics.prototype._getScopedData = function _getScopedData(name, scope) {
 Metrics.prototype._toUnscopedData = function _toUnscopedData() {
   const metricData = []
 
-  Object.keys(this.unscoped).forEach((name) => {
+  for (const name of Object.keys(this.unscoped)) {
     const data = this._getUnscopedData(name)
     if (data) {
       metricData.push(data)
     }
-  })
+  }
 
   return metricData
 }
@@ -307,14 +307,14 @@ Metrics.prototype._toUnscopedData = function _toUnscopedData() {
 Metrics.prototype._toScopedData = function _toScopedData() {
   const metricData = []
 
-  Object.keys(this.scoped).forEach(function forEachScope(scope) {
-    Object.keys(this.scoped[scope]).forEach(function forEachMetric(name) {
-      const data = this._getScopedData(name, scope)
+  for (const [key, scope] of Object.entries(this.scoped)) {
+    for (const name of Object.keys(scope)) {
+      const data = this._getScopedData(name, key)
       if (data) {
         metricData.push(data)
       }
-    }, this)
-  }, this)
+    }
+  }
 
   return metricData
 }

--- a/lib/metrics/normalizer.js
+++ b/lib/metrics/normalizer.js
@@ -96,14 +96,14 @@ MetricNormalizer.prototype.load = function load(json) {
     this.rules = []
     logger.debug('Received %s %s normalization rule(s) from the server', json.length, this.type)
 
-    json.forEach((ruleJSON) => {
+    for (const ruleJSON of json) {
       // no need to add the same rule twice
       const rule = new NormalizerRule(ruleJSON)
       if (!this.rules.find(deepEqual.bind(null, rule))) {
         this.rules.push(rule)
         logger.trace('Loaded %s normalization rule: %s', this.type, rule)
       }
-    })
+    }
 
     /* I (FLN) always forget this, so making a note: JS sort is always
      * IN-PLACE, even though it returns the sorted array.
@@ -159,14 +159,16 @@ MetricNormalizer.prototype.loadFromConfig = function loadFromConfig() {
   const ctx = this
   const rules = this.config.rules
 
-  if (rules && rules.name && rules.name.length > 0) {
-    rules.name.forEach((name) => processNameRule(name, ctx))
+  if (rules?.name?.length > 0) {
+    for (const name of rules.name) {
+      processNameRule(name, ctx)
+    }
   }
 
-  if (rules && rules.ignore && rules.ignore.length > 0) {
-    rules.ignore.forEach((pattern) => {
+  if (rules?.ignore?.length > 0) {
+    for (const pattern of rules.ignore) {
       this.addSimple(pattern)
-    })
+    }
   }
 }
 

--- a/lib/metrics/normalizer/tx_segment.js
+++ b/lib/metrics/normalizer/tx_segment.js
@@ -13,6 +13,28 @@ function TxSegmentNormalizer() {
   this.terms = []
 }
 
+function normalizeParts(parts, currentTerm) {
+  const results = []
+  let prev
+  for (let j = 0; j < parts.length; j++) {
+    const part = parts[j]
+    if (part === '' && j + 1 === parts.length) {
+      continue // if this is the last one, don't iterate
+    }
+    if (currentTerm.terms.indexOf(part) === -1) {
+      if (prev === '*') {
+        continue
+      }
+      prev = '*'
+      results.push(prev)
+    } else {
+      prev = part
+      results.push(prev)
+    }
+  }
+  return results
+}
+
 /**
  * This normalize method is wicked. The best bet is to read the spec:
  * https://source.datanerd.us/agents/agent-specs/blob/main/Metric-Name-Rules-PORTED.md
@@ -32,44 +54,20 @@ function TxSegmentNormalizer() {
  * @returns {{ignore: boolean, matched: boolean, value: string}} - The results of normalizing the given path.
  */
 TxSegmentNormalizer.prototype.normalize = function normalize(path) {
-  let currentTerm
-  let prefix
-  let result
-  let prev
-
-  const normalizeParts = (part, idx, parts) => {
-    if (part === '' && idx + 1 === parts.length) {
-      return // if this is the last one, don't iterate
-    }
-    if (currentTerm.terms.indexOf(part) === -1) {
-      if (prev === '*') {
-        return
-      }
-      prev = '*'
-      result.push(prev)
-    } else {
-      prev = part
-      result.push(prev)
-    }
-  }
-
   for (let i = 0; i < this.terms.length; i++) {
-    currentTerm = this.terms[i]
-    prefix = currentTerm.prefix
+    const currentTerm = this.terms[i]
+    const prefix = currentTerm.prefix
     if (path.lastIndexOf(prefix, 0) === -1) {
       continue
     }
     const fragment = path.slice(prefix.length)
     const parts = fragment.split('/')
-    result = []
-
-    parts.forEach(normalizeParts)
-
+    const results = normalizeParts(parts, currentTerm)
     logger.trace('Normalizing %s because of rule: %s', path, currentTerm)
     return {
       matched: true, // To match MetricNormalizer
       ignore: false, // ^^
-      value: prefix + result.join('/')
+      value: prefix + results.join('/')
     }
   }
 

--- a/lib/metrics/recorders/distributed-trace.js
+++ b/lib/metrics/recorders/distributed-trace.js
@@ -19,7 +19,7 @@ function recordDistributedTrace(tx, suffix, duration, exclusive) {
 
   const suffixes = ['', suffix]
 
-  suffixes.forEach(function record(suf) {
+  for (const suf of suffixes) {
     tx.measure(`${NAMES.DISTRIBUTED_TRACE.DURATION}/${tag}${suf}`, null, duration, exclusive)
 
     if (tx.hasErrors()) {
@@ -29,7 +29,7 @@ function recordDistributedTrace(tx, suffix, duration, exclusive) {
     if (distTraceReceived) {
       tx.measure(`${NAMES.DISTRIBUTED_TRACE.TRANSPORT}/${tag}${suf}`, null, duration, exclusive)
     }
-  })
+  }
 }
 
 module.exports = recordDistributedTrace

--- a/lib/system-metrics-sampler.js
+++ b/lib/system-metrics-sampler.js
@@ -124,7 +124,7 @@ function sampleGc(agent, nativeMetrics) {
   return function gcSampler() {
     const gcMetrics = nativeMetrics.getGCMetrics()
 
-    Object.keys(gcMetrics).forEach(function forEachGCType(gcType) {
+    for (const gcType of Object.keys(gcMetrics)) {
       // Convert from milliseconds to seconds.
       const gc = gcMetrics[gcType]
       divideMetric(gc.metrics, MILLIS)
@@ -135,7 +135,7 @@ function sampleGc(agent, nativeMetrics) {
       } else {
         logger.debug(gc, 'Unknown GC type %j', gc.typeId)
       }
-    })
+    }
   }
 }
 
@@ -192,9 +192,9 @@ module.exports = {
   },
 
   stop: function stop() {
-    samplers.forEach(function forEachSampler(s) {
-      s.stop()
-    })
+    for (const sampler of samplers) {
+      sampler.stop()
+    }
     samplers = []
     this.state = 'stopped'
     if (this.nativeMetrics) {

--- a/lib/transaction/name-state.js
+++ b/lib/transaction/name-state.js
@@ -223,11 +223,11 @@ NameState.prototype.getFullName = function getFullName() {
 }
 
 NameState.prototype.forEachParams = function forEachParams(fn, ctx) {
-  this.pathStack.forEach(function forEachPathStack(a) {
-    if (a.params) {
-      fn.call(ctx, a.params)
+  for (const path of this.pathStack) {
+    if (path.params) {
+      fn.call(ctx, path.params)
     }
-  })
+  }
 }
 
 /**

--- a/lib/transaction/trace/index.js
+++ b/lib/transaction/trace/index.js
@@ -235,7 +235,9 @@ Trace.prototype.getTotalTimeDurationInMillis = function getTotalTimeDurationInMi
     const node = children.pop()
     const { segment, children: childChildren } = node
     totalTimeInMillis += segment.getExclusiveDurationInMillis(this)
-    childChildren.forEach((child) => children.push(child))
+    for (const child of childChildren) {
+      children.push(child)
+    }
   }
 
   if (!this.transaction.isActive()) {

--- a/lib/transaction/trace/segment.js
+++ b/lib/transaction/trace/segment.js
@@ -144,11 +144,11 @@ TraceSegment.prototype.markAsWeb = function markAsWeb(transaction, obfuscatedUrl
   this.setNameFromTransaction(transaction)
 
   const traceAttrs = transaction.trace.attributes.get(DESTINATIONS.TRANS_TRACE)
-  Object.keys(traceAttrs).forEach((key) => {
+  for (const key of Object.keys(traceAttrs)) {
     if (!this.attributes.has(key)) {
       this.addAttribute(key, traceAttrs[key])
     }
-  })
+  }
 
   this.addSpanAttribute('request.uri', obfuscatedUrl)
 }

--- a/lib/uninstrumented.js
+++ b/lib/uninstrumented.js
@@ -23,9 +23,9 @@ function logUninstrumented() {
       'The following modules were required before newrelic and are not being ' +
       'instrumented:'
 
-    modules.forEach(function buildMessage(module) {
+    for (const module of modules) {
       message += '\n\t' + uninstrumented[module].name + ': ' + uninstrumented[module].filename
-    })
+    }
 
     logger.warn(message)
   }
@@ -40,11 +40,11 @@ function createMetrics(metrics) {
     metrics.getOrCreateMetric(NAMES.SUPPORTABILITY.UNINSTRUMENTED).incrementCallCount()
   }
 
-  modules.forEach(function addMetrics(module) {
+  for (const module of modules) {
     metrics
       .getOrCreateMetric(NAMES.SUPPORTABILITY.UNINSTRUMENTED + '/' + uninstrumented[module].name)
       .incrementCallCount()
-  })
+  }
 }
 
 // Check for any instrument-able modules that have already been loaded. This does

--- a/lib/util/label-parser.js
+++ b/lib/util/label-parser.js
@@ -26,9 +26,9 @@ function parse(labels, parentLogger) {
     results = fromMap(labels)
   }
 
-  results.warnings.forEach(function logWarnings(message) {
+  for (const message of results.warnings) {
     logger.warn(message)
-  })
+  }
 
   return results.labels
 }
@@ -76,27 +76,27 @@ function fromMap(map) {
   const warnings = []
   let labels = []
 
-  Object.keys(map).forEach(function processKeys(key) {
+  for (const [key, val] of Object.entries(map)) {
     const type = truncate(key, 255)
 
-    if (!map[key] || typeof map[key] !== 'string') {
+    if (!val || typeof val !== 'string') {
       return warnings.push(
         'Label value for ' + type + 'should be a string with a length between 1 and 255 characters'
       )
     }
 
-    const value = truncate(map[key], 255)
+    const value = truncate(val, 255)
 
     if (type !== key) {
       warnings.push('Label key too long: ' + type)
     }
 
-    if (value !== map[key]) {
+    if (value !== val) {
       warnings.push('Label value too long: ' + value)
     }
 
     labels.push({ label_type: type, label_value: value })
-  })
+  }
 
   if (labels.length > 64) {
     warnings.push('Too many Labels, list truncated to 64')

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -116,7 +116,7 @@ Logger.prototype.coerce = function coerce(value) {
 
 const loggingFunctions = Object.create(null)
 
-Object.keys(LEVELS).forEach(function buildLevel(_level) {
+for (const _level of Object.keys(LEVELS)) {
   const level = Logger.prototype.coerce(LEVELS[_level])
 
   function log(extra) {
@@ -199,7 +199,7 @@ Object.keys(LEVELS).forEach(function buildLevel(_level) {
   loggingFunctions[_level + 'Enabled'] = function levelEnabled() {
     return level >= this.options._level
   }
-})
+}
 
 Logger.prototype._flushQueuedLogs = function _flushQueuedLogs() {
   while (this.logQueue.length) {

--- a/lib/utilization/index.js
+++ b/lib/utilization/index.js
@@ -23,7 +23,7 @@ module.exports.getVendors = getVendors
 function getVendors(agent, callback) {
   let done = 0
   let vendors = null
-  VENDOR_NAMES.forEach(function getVendorInfo(vendor) {
+  for (const vendor of VENDOR_NAMES) {
     logger.trace({ utilization: vendor }, 'Detecting utilization info for vendor %s', vendor)
     VENDOR_METHODS[vendor](agent, function getInfo(_, result) {
       logger.trace({ utilization: vendor, data: { result } }, 'Vendor %s finished.', vendor)
@@ -36,5 +36,5 @@ function getVendors(agent, callback) {
         callback(null, vendors)
       }
     })
-  })
+  }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
I noticed we have a lot of `Array.forEach`, especially in hot paths.  This PR removes `Array.forEach` in favor of `for...of` of for index.
This is because `Array.forEach` is 95% slower than `for...of`, [see](https://jsperf.app/for-for-of-for-in-foreach-comparison).

**Note**: There are more `.forEach` but i'm splitting out the instrumentation files from the other agent files