### PR TITLE
test: Pinned Next.js tests to <16.0.0

### DIFF
--- a/test/versioned/nextjs/package.json
+++ b/test/versioned/nextjs/package.json
@@ -9,7 +9,7 @@
         "node": ">=20"
       },
       "dependencies": {
-        "next": ">=13.4.19"
+        "next": ">=13.4.19 <16"
       },
       "files": [
         "app-dir.test.js"
@@ -20,7 +20,7 @@
         "node": ">=20"
       },
       "dependencies": {
-        "next": ">=14.0.0"
+        "next": ">=14.0.0 <16"
       },
       "files": [
         "attributes.test.js",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
Next.js released 16.0.0 and there are some breaking changes that need to be addressed in our codebase:
 * Our `next.config.js` needs to remove some options that are no longer supported.
 * It looks like middleware is no longer supported, and we don't really support it as well, so we can remove that file.

I pinned for now as there may be more changes and i don't want to block CI.
