### PR TITLE
test: Added a `randomString` helper to agent_helper and use it in ioredis to avoid flappy tests

### DIFF
--- a/test/lib/agent_helper.js
+++ b/test/lib/agent_helper.js
@@ -636,3 +636,12 @@ helper.readPackageVersion = function readPackageVersion(dirname, pkg) {
   const { version } = JSON.parse(packageFile)
   return version
 }
+
+/**
+ * Creates a random string prefixed with the provided value
+ * @param {string} prefix value to prefix random string
+ * @returns {string} random string
+ */
+helper.randomString = function randomString(prefix = '') {
+  return `${prefix}${crypto.randomBytes(8).toString('hex')}`
+}

--- a/test/versioned/elastic/elasticsearch.test.js
+++ b/test/versioned/elastic/elasticsearch.test.js
@@ -9,16 +9,11 @@ const assert = require('node:assert')
 const helper = require('../../lib/agent_helper')
 const params = require('../../lib/params')
 const urltils = require('../../../lib/util/urltils')
-const crypto = require('crypto')
 const { assertPackageMetrics } = require('../../lib/custom-assertions')
 const semver = require('semver')
-const DB_INDEX = `test-${randomString()}`
-const DB_INDEX_2 = `test2-${randomString()}`
-const SEARCHTERM_1 = randomString()
-
-function randomString() {
-  return crypto.randomBytes(5).toString('hex')
-}
+const DB_INDEX = helper.randomString('test-')
+const DB_INDEX_2 = helper.randomString('test2-')
+const SEARCHTERM_1 = helper.randomString()
 
 // request bodies are structured differently in ElasticSearch v7.x vs v8.x
 function setRequestBody(body, version) {
@@ -92,7 +87,7 @@ test('Elasticsearch instrumentation', async (t) => {
 
   await t.test('should be able to record creating an index', async (t) => {
     const { agent, client } = t.nr
-    const index = `test-index-${randomString()}`
+    const index = helper.randomString('test-index-')
     t.after(async () => {
       await client.indices.delete({ index })
     })
@@ -117,7 +112,7 @@ test('Elasticsearch instrumentation', async (t) => {
       return
     }
 
-    const index = `test-index-${randomString()}`
+    const index = helper.randomString('test-index-')
     t.after(async () => {
       await client.indices.delete({ index })
     })
@@ -368,7 +363,7 @@ test('Elasticsearch instrumentation', async (t) => {
 
   await t.test('should create correct metrics', async function (t) {
     const { agent, client, pkgVersion, HOST_ID } = t.nr
-    const id = `key-${randomString()}`
+    const id = helper.randomString('key-')
     await helper.runInTransaction(agent, async function transactionInScope(transaction) {
       const documentProp = setRequestBody(
         {

--- a/test/versioned/elastic/elasticsearchNoop.test.js
+++ b/test/versioned/elastic/elasticsearchNoop.test.js
@@ -8,12 +8,7 @@ const test = require('node:test')
 const assert = require('node:assert')
 const helper = require('../../lib/agent_helper')
 const params = require('../../lib/params')
-const crypto = require('crypto')
-const DB_INDEX = `test-${randomString()}`
-
-function randomString() {
-  return crypto.randomBytes(5).toString('hex')
-}
+const DB_INDEX = helper.randomString('test-')
 
 test('Elasticsearch instrumentation', async (t) => {
   t.beforeEach(async (ctx) => {

--- a/test/versioned/ioredis-esm/ioredis.test.js
+++ b/test/versioned/ioredis-esm/ioredis.test.js
@@ -29,11 +29,13 @@ test('ioredis instrumentation', async (t) => {
       ? agent.config.getHostnameSafe()
       : params.redis_host
     const HOST_ID = METRIC_HOST_NAME + '/' + params.redis_port
+    const redisKey = helper.randomString('redis-key')
 
     await redisClient.select(DB_INDEX)
     ctx.nr = {
       agent,
       redisClient,
+      redisKey,
       HOST_ID,
       METRIC_HOST_NAME
     }
@@ -47,7 +49,7 @@ test('ioredis instrumentation', async (t) => {
   })
 
   await t.test('creates expected metrics', async (t) => {
-    const { agent, redisClient, HOST_ID } = t.nr
+    const { agent, redisClient, redisKey, HOST_ID } = t.nr
     const plan = tspl(t, { plan: 6 })
     agent.on('transactionFinished', function (tx) {
       const expected = [
@@ -61,7 +63,7 @@ test('ioredis instrumentation', async (t) => {
     })
 
     helper.runInTransaction(agent, async (transaction) => {
-      await redisClient.set('testkey', 'testvalue')
+      await redisClient.set(redisKey, 'testvalue')
       transaction.end()
     })
 
@@ -69,7 +71,7 @@ test('ioredis instrumentation', async (t) => {
   })
 
   await t.test('creates expected segments', async (t) => {
-    const { agent, redisClient } = t.nr
+    const { agent, redisClient, redisKey } = t.nr
     const plan = tspl(t, { plan: 5 })
 
     agent.on('transactionFinished', function (tx) {
@@ -89,20 +91,19 @@ test('ioredis instrumentation', async (t) => {
     })
 
     helper.runInTransaction(agent, async (transaction) => {
-      await redisClient.set('testkey', 'testvalue')
-      const value = await redisClient.get('testkey')
-      plan.equal(value, 'testvalue', 'should have expected value')
+      await redisClient.set(redisKey, 'testvalue')
+      const value = await redisClient.get(redisKey)
+      plan.equal(value, 'testvalue')
       transaction.end()
     })
     await plan.completed
   })
 
   await t.test('should add instance attributes to all redis segments', async (t) => {
-    const { agent, redisClient, METRIC_HOST_NAME } = t.nr
+    const { agent, redisClient, redisKey, METRIC_HOST_NAME } = t.nr
     agent.config.datastore_tracer.instance_reporting.enabled = true
     agent.config.datastore_tracer.database_name_reporting.enabled = true
     const plan = tspl(t, { plan: 12 })
-
     agent.on('transactionFinished', function (tx) {
       const root = tx.trace.root
       const children = tx.trace.getChildren(root.id)
@@ -113,27 +114,27 @@ test('ioredis instrumentation', async (t) => {
       const getAttrs = getSegment.getAttributes()
       plan.equal(setAttrs.host, METRIC_HOST_NAME)
       plan.equal(setAttrs.product, 'Redis')
-      plan.equal(setAttrs.key, '"testkey"')
+      plan.equal(setAttrs.key, `"${redisKey}"`)
       plan.equal(setAttrs.port_path_or_id, params.redis_port.toString())
       plan.equal(setAttrs.database_name, String(DB_INDEX))
       plan.equal(getAttrs.host, METRIC_HOST_NAME)
       plan.equal(getAttrs.product, 'Redis')
-      plan.equal(getAttrs.key, '"testkey"')
+      plan.equal(getAttrs.key, `"${redisKey}"`)
       plan.equal(getAttrs.port_path_or_id, params.redis_port.toString())
       plan.equal(getAttrs.database_name, String(DB_INDEX))
     })
 
     helper.runInTransaction(agent, async (transaction) => {
-      await redisClient.set('testkey', 'testvalue')
-      const value = await redisClient.get('testkey')
-      plan.equal(value, 'testvalue', 'should have expected value')
+      await redisClient.set(redisKey, 'testvalue')
+      const value = await redisClient.get(redisKey)
+      plan.equal(value, 'testvalue')
       transaction.end()
     })
     await plan.completed
   })
 
   await t.test('should not add instance attributes to redis segments when disabled', async (t) => {
-    const { agent, redisClient, HOST_ID } = t.nr
+    const { agent, redisClient, redisKey, HOST_ID } = t.nr
     const plan = tspl(t, { plan: 13 })
     agent.config.datastore_tracer.instance_reporting.enabled = false
     agent.config.datastore_tracer.database_name_reporting.enabled = false
@@ -148,12 +149,12 @@ test('ioredis instrumentation', async (t) => {
       const getAttrs = getSegment.getAttributes()
       plan.equal(setAttrs.host, undefined)
       plan.equal(setAttrs.product, 'Redis')
-      plan.equal(setAttrs.key, '"testkey"')
+      plan.equal(setAttrs.key, `"${redisKey}"`)
       plan.equal(setAttrs.port_path_or_id, undefined)
       plan.equal(setAttrs.database_name, undefined)
       plan.equal(getAttrs.host, undefined)
       plan.equal(getAttrs.product, 'Redis')
-      plan.equal(getAttrs.key, '"testkey"')
+      plan.equal(getAttrs.key, `"${redisKey}"`)
       plan.equal(getAttrs.port_path_or_id, undefined)
       plan.equal(getAttrs.database_name, undefined)
       const unscoped = tx.metrics.unscoped
@@ -161,16 +162,16 @@ test('ioredis instrumentation', async (t) => {
     })
 
     helper.runInTransaction(agent, async (transaction) => {
-      await redisClient.set('testkey', 'testvalue')
-      const value = await redisClient.get('testkey')
-      plan.equal(value, 'testvalue', 'should have expected value')
+      await redisClient.set(redisKey, 'testvalue')
+      const value = await redisClient.get(redisKey)
+      plan.equal(value, 'testvalue')
       transaction.end()
     })
     await plan.completed
   })
 
   await t.test('should follow selected database', async (t) => {
-    const { agent, redisClient } = t.nr
+    const { agent, redisClient, redisKey } = t.nr
     const plan = tspl(t, { plan: 7 })
     const SELECTED_DB = 8
 
@@ -189,9 +190,9 @@ test('ioredis instrumentation', async (t) => {
     })
 
     helper.runInTransaction(agent, async (transaction) => {
-      await redisClient.set('testkey', 'testvalue')
+      await redisClient.set(redisKey, 'testvalue')
       await redisClient.select(SELECTED_DB)
-      await redisClient.set('testkey2', 'testvalue')
+      await redisClient.set(`${redisKey}2`, 'testvalue')
       transaction.end()
     })
     await plan.completed
@@ -199,10 +200,10 @@ test('ioredis instrumentation', async (t) => {
 
   // NODE-1524 regression
   await t.test('does not crash when ending out of transaction', (t, end) => {
-    const { agent, redisClient } = t.nr
+    const { agent, redisClient, redisKey } = t.nr
     helper.runInTransaction(agent, (transaction) => {
       assert.ok(agent.getTransaction(), 'transaction should be in progress')
-      redisClient.set('testkey', 'testvalue').then(function () {
+      redisClient.set(redisKey, 'testvalue').then(function () {
         assert.ok(!agent.getTransaction(), 'transaction should have ended')
         end()
       })

--- a/test/versioned/kafkajs/kafka.test.js
+++ b/test/versioned/kafkajs/kafka.test.js
@@ -27,9 +27,9 @@ test.beforeEach(async (ctx) => {
 
   const { Kafka, logLevel } = require('kafkajs')
   ctx.nr.Kafka = Kafka
-  const topic = utils.randomString()
+  const topic = helper.randomString('topic')
   ctx.nr.topic = topic
-  const clientId = utils.randomString('kafka-test')
+  const clientId = helper.randomString('kafka-test')
   ctx.nr.clientId = clientId
 
   const kafka = new Kafka({

--- a/test/versioned/kafkajs/utils.js
+++ b/test/versioned/kafkajs/utils.js
@@ -6,17 +6,9 @@
 'use strict'
 
 const { assertMetrics, assertSpanKind } = require('../../lib/custom-assertions')
-const { makeId } = require('../../../lib/util/hashes')
 const utils = module.exports
 const metrics = require('../../lib/metrics_helper')
 const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
-
-/**
- * Creates a random string with prefix to be used for testing
- * @param {string} [prefix] prefix for random string
- * @returns {string} prefix with random id appended
- */
-utils.randomString = (prefix = 'test-topic') => `${prefix}-${makeId()}`
 
 /**
  * Creates a topic with the admin class

--- a/test/versioned/opensearch/opensearch.test.js
+++ b/test/versioned/opensearch/opensearch.test.js
@@ -9,15 +9,10 @@ const assert = require('node:assert')
 const helper = require('../../lib/agent_helper')
 const params = require('../../lib/params')
 const urltils = require('../../../lib/util/urltils')
-const crypto = require('crypto')
-const DB_INDEX = `test-${randomString()}`
-const DB_INDEX_2 = `test2-${randomString()}`
-const SEARCHTERM_1 = randomString()
+const DB_INDEX = helper.randomString('test-')
+const DB_INDEX_2 = helper.randomString('test2-')
+const SEARCHTERM_1 = helper.randomString()
 const { assertPackageMetrics } = require('../../lib/custom-assertions')
-
-function randomString() {
-  return crypto.randomBytes(5).toString('hex')
-}
 
 function setRequestBody(body) {
   return { body }
@@ -75,7 +70,7 @@ test('opensearch instrumentation', async (t) => {
 
   await t.test('should be able to record creating an index', async (t) => {
     const { agent, client } = t.nr
-    const index = `test-index-${randomString()}`
+    const index = helper.randomString('test-index-')
     t.after(async () => {
       await client.indices.delete({ index })
     })
@@ -316,7 +311,7 @@ test('opensearch instrumentation', async (t) => {
 
   await t.test('should create correct metrics', async function (t) {
     const { agent, client, pkgVersion, HOST_ID } = t.nr
-    const id = `key-${randomString()}`
+    const id = helper.randomString('key-')
     await helper.runInTransaction(agent, async function transactionInScope(transaction) {
       const documentProp = setRequestBody({
         document: {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
We've had flappy ioredis tests. I suspect it has to do with flushing db between tests and using the same key between tests. This PR fixes that by creating a random key before every test to avoid this potential issue.
