### PR TITLE
fix: Updated middleware wrapper to not wrap handler if it is not a function

### DIFF
--- a/lib/subscribers/express/use.js
+++ b/lib/subscribers/express/use.js
@@ -23,12 +23,14 @@ class ExpressUseSubscriber extends MiddlewareSubscriber {
       fnIndex = 0
     }
     let segmentName = null
+    // sometimes route is undefined, default to `/` for segmentName only
+    const routeName = route || '/'
     // Pre v5 these were marked as `lazyrouter`
     // check for both
     if (fn.lazyrouter || fn.name === 'mounted_app') {
-      segmentName = `${this.wrapper.system}/Mounted App: ${route}`
+      segmentName = `${this.wrapper.system}/Mounted App: ${routeName}`
     } else if (fn.stack) {
-      segmentName = `${this.wrapper.system}/Router: ${route}`
+      segmentName = `${this.wrapper.system}/Router: ${routeName}`
       method = 'handle'
     }
 

--- a/lib/subscribers/middleware-wrapper.js
+++ b/lib/subscribers/middleware-wrapper.js
@@ -59,8 +59,17 @@ class MiddlewareWrapper {
    */
   wrap({ handler, prefix, route, segmentName, nextIdx = -1 }) {
     const self = this
+    if (typeof handler !== 'function') {
+      this.logger.trace('Handler: %s is not a function, not wrapping.', handler)
+      return handler
+    }
+
     function wrappedHandler (...args) {
       const ctx = self.agent.tracer.getContext()
+      if (ctx?.transaction?.isActive() !== true) {
+        self.logger.trace('No active transaction, calling original function')
+        return handler.apply(this, args)
+      }
       const transaction = ctx?.transaction
       transaction.nameState.setPrefix(self.system)
       const { txInfo, errorWare, request } = self.extractTxInfo(args, route)

--- a/test/unit/lib/subscribers/middleare-wrapper.test.js
+++ b/test/unit/lib/subscribers/middleare-wrapper.test.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const assert = require('node:assert')
+const test = require('node:test')
+const loggerMock = require('../../mocks/logger')
+const MwWrapper = require('#agentlib/subscribers/middleware-wrapper.js')
+const helper = require('#testlib/agent_helper.js')
+
+test.beforeEach((ctx) => {
+  const agent = helper.loadMockedAgent()
+  const logger = loggerMock()
+  const wrapper = new MwWrapper({ agent, logger, system: 'UnitTest' })
+  function handler (arg1, arg2, arg3) {
+    return `${arg1}, ${arg2}, ${arg3}`
+  }
+  ctx.nr = {
+    agent,
+    handler,
+    logger,
+    wrapper
+  }
+})
+
+test.afterEach((ctx) => {
+  helper.unloadAgent(ctx.nr.agent)
+})
+test('should not wrap handler if it is not a function', function (t) {
+  const { logger, wrapper } = t.nr
+  const handler = 'test'
+  const wrapped = wrapper.wrap({ handler })
+  assert.equal(wrapped, handler)
+  assert.deepEqual(logger.trace.args[0], ['Handler: %s is not a function, not wrapping.', 'test'])
+})
+
+test('should wrap handler if it is a function', function (t) {
+  const { logger, handler, wrapper } = t.nr
+  const wrapped = wrapper.wrap({ handler })
+  assert.equal(wrapped.name, 'handler')
+  assert.equal(wrapped.length, 3)
+  assert.equal(logger.trace.callCount, 0)
+})
+
+test('should not run wrapped handler in context if transaction not present', function (t) {
+  const { handler, wrapper } = t.nr
+  const wrapped = wrapper.wrap({ handler })
+  const result = wrapped('one', 'two', 'three')
+  assert.equal(result, 'one, two, three')
+})
+
+test('should run wrapped handler in context if transaction present, and properly name segment', function (t, end) {
+  const { agent, handler, wrapper } = t.nr
+  const route = '/test/url'
+  const wrapped = wrapper.wrap({ handler, route })
+  helper.runInTransaction(agent, function (tx) {
+    tx.type = 'web'
+    tx.url = route
+    const result = wrapped('one', 'two', 'three')
+    assert.equal(result, 'one, two, three')
+
+    const [segment] = tx.trace.getChildren(tx.trace.root.id)
+    assert.equal(segment.name, 'Nodejs/Middleware/UnitTest/handler//test/url')
+    tx.statusCode = 200
+    tx.end()
+    assert.equal(tx.name, 'WebTransaction/WebFrameworkUri/UnitTest/test/url')
+    end()
+  })
+})


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This PR adds defensive code around checking if middleware handler is not a function, if so return the original.
As mentioned in the linked issue, I cannot reproduce it but it's clear we are wrapping a "handler" that is not actually a function.
I added a few basic unit tests around this behavior.

## Related Issues
Closes #3468
