### PR TITLE
test: pin `@aws-sdk/client-bedrock-runtime` tests

### DIFF
--- a/test/versioned/aws-sdk-v3/package.json
+++ b/test/versioned/aws-sdk-v3/package.json
@@ -202,7 +202,7 @@
         "node": ">=20"
       },
       "dependencies": {
-        "@aws-sdk/client-bedrock-runtime": ">=3.474.0"
+        "@aws-sdk/client-bedrock-runtime": ">=3.474.0 <3.929.0"
       },
       "files": [
         "bedrock-chat-completions.test.js",
@@ -215,7 +215,7 @@
         "node": ">=20"
       },
       "dependencies": {
-        "@aws-sdk/client-bedrock-runtime": ">=3.587.0"
+        "@aws-sdk/client-bedrock-runtime": ">=3.587.0 <3.929.0"
       },
       "files": [
         "bedrock-converse-api.test.js"


### PR DESCRIPTION
`@aws-sdk/client-bedrock-runtime@3.929.0` changed their response object leading to our current instrumentation breaking. We will pin our tests while we work on adding instrumentation support for >=3.929.0