### PR TITLE
fix: Updated `MessageConsumerSubscriber` to end transaction created for a given message consumption

### DIFF
--- a/lib/subscribers/message-consumer.js
+++ b/lib/subscribers/message-consumer.js
@@ -65,6 +65,14 @@ class MessageConsumerSubscriber extends Subscriber {
     }
   }
 
+  /**
+   * Ends the transaction created for the consumption callback.
+   */
+  asyncEnd() {
+    const ctx = this.agent.tracer.getContext()
+    ctx?.transaction?.end()
+  }
+
   enable() {
     super.enable()
     this.channel.asyncStart.bindStore(this.store, (data) => {
@@ -83,9 +91,8 @@ class MessageConsumerSubscriber extends Subscriber {
   /**
    * Used to create a transaction for every consumption callback.
    *
-   * @param {object} data event passed to asyncStart handler
    */
-  asyncStart(data) {
+  asyncStart() {
     const ctx = this.agent.tracer.getContext()
     const tx = ctx?.transaction
     tx.setPartialName(this.name)

--- a/test/versioned/amqplib/callback.test.js
+++ b/test/versioned/amqplib/callback.test.js
@@ -323,7 +323,6 @@ test('amqplib callback instrumentation', async function (t) {
 
             channel.ack(msg)
             produceTx.end()
-            consumeTx.end()
             resolve()
           })
           helper.runInTransaction(agent, function (tx) {
@@ -373,7 +372,6 @@ test('amqplib callback instrumentation', async function (t) {
 
             channel.ack(msg)
             produceTx.end()
-            consumeTx.end()
             resolve()
           })
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

As mentioned in linked bug, when the message consumption was migrated from shim to a subscriber. Code was missed to end the transaction after message consumption.
This was masked because the amqplib tests were manually ending the transaction.  This PR fixes the issue by ending the transaction in the subscriber after message consumption, and updated the tests to not explicitly end the transaction.

## Related Issues
Closes #3502
