### PR TITLE
fix: Updated `app.use` or `router.use` Express instrumentation to properly wrap all middleware defined

### DIFF
--- a/lib/subscribers/express/use.js
+++ b/lib/subscribers/express/use.js
@@ -42,6 +42,7 @@ class ExpressUseSubscriber extends ExpressSubscriber {
       const middleware = middlewares[i]
       if (Array.isArray(middleware)) {
         this.wrapAllMiddleware({ middlewares: middleware, route })
+        continue
       }
 
       // we only want to wrap functions


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We weren't properly handling all the ways you can define middleware on `.use` both with express and router.  This PR resolves this by iterating over all the arguments and wrapping any functions that are defined.

## How to Test

```sh
npm run versioned:internal express
```

## Related Issues

Closes #3518 