### PR TITLE
test: Pinned next.js to skip 11.0.10 and 11.0.11

### DIFF
--- a/test/versioned/nestjs/package.json
+++ b/test/versioned/nestjs/package.json
@@ -9,7 +9,7 @@
         "node": ">=20"
       },
       "dependencies": {
-        "@nestjs/cli": ">=9.0.0 <11.0.9 || >=11.0.10"
+        "@nestjs/cli": ">=9.0.0 <11.0.9 || >11.0.11"
       },
       "files": [
         "nest.test.js"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
Nestjs is failing, we need to pin to get a patch out.
