### PR TITLE
feat: Updated global and full granularity samplers based on precedence

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -200,6 +200,9 @@ function Config(config) {
   // 10. Setup labels for both `collector/facts` and application logging
   this.parsedLabels = parseLabels(this.labels, logger)
   this.loggingLabels = this._setApplicationLoggingLabels()
+
+  // 11. Reconfigure DT samplers based on precedence
+  this._reconfigureSamplers()
 }
 
 util.inherits(Config, EventEmitter)
@@ -214,6 +217,25 @@ Object.defineProperty(Config.prototype, 'sampling_target', {
     this.emit('sampling_target', value)
   }
 })
+
+// This only reconfigures samples between full granularity and global samplers
+Config.prototype._reconfigureSamplers = function _reconfigureSamplers() {
+  const samplerTypes = ['root', 'remote_parent_sampled', 'remote_parent_not_sampled']
+
+  for (let i = 0; i < samplerTypes.length; i++) {
+    const samplerType = samplerTypes[i]
+    const fullGranularitySampler = this.distributed_tracing?.sampler?.full_granularity?.[samplerType]
+    const globalSampler = this.distributed_tracing?.sampler?.[samplerType]
+
+    if (fullGranularitySampler === 'default' && globalSampler !== 'default') {
+      this.distributed_tracing.sampler.full_granularity[samplerType] = globalSampler
+      logger.warn(`Full granularity sampler for ${samplerType} was set to 'default', overriding with global sampler value '${globalSampler}'.`)
+    } else if (fullGranularitySampler !== globalSampler) {
+      this.distributed_tracing.sampler[samplerType] = fullGranularitySampler
+      logger.warn(`Both global and full granularity samplers for ${samplerType} differ. Setting global sampler to full granularity sampler value '${fullGranularitySampler}'.`)
+    }
+  }
+}
 
 /**
  * Compares the labels list to the application logging excluded label list and removes any labels that need to be excluded.

--- a/test/unit/config/config.test.js
+++ b/test/unit/config/config.test.js
@@ -451,3 +451,106 @@ test('distributed tracing samplers', async (t) => {
     assert.equal(configuration.distributed_tracing.sampler.partial_granularity.type, 'reduced')
   })
 })
+
+test('distributed tracing reconfigure samplers', async (t) => {
+  await t.test('should change full granularity root sampler from default to match global root sampler', () => {
+    const config = {
+      distributed_tracing: {
+        sampler: {
+          root: 'always_on'
+        }
+      }
+    }
+
+    const configuration = Config.initialize(config)
+    assert.equal(configuration.distributed_tracing.sampler.root, 'always_on')
+    assert.equal(configuration.distributed_tracing.sampler.full_granularity.root, 'always_on')
+  })
+
+  await t.test('should set global root sampler to match full granularity root sampler', () => {
+    const config = {
+      distributed_tracing: {
+        sampler: {
+          full_granularity: {
+            root: 'adaptive'
+          }
+        }
+      }
+    }
+
+    const configuration = Config.initialize(config)
+    assert.equal(configuration.distributed_tracing.sampler.root, 'adaptive')
+    assert.equal(configuration.distributed_tracing.sampler.full_granularity.root, 'adaptive')
+  })
+
+  await t.test('should change global root sampler to match full granularity root sampler', () => {
+    const config = {
+      distributed_tracing: {
+        sampler: {
+          root: 'always_off',
+          full_granularity: {
+            root: 'always_on'
+          }
+        }
+      }
+    }
+
+    const configuration = Config.initialize(config)
+    assert.equal(configuration.distributed_tracing.sampler.root, 'always_on')
+    assert.equal(configuration.distributed_tracing.sampler.full_granularity.root, 'always_on')
+  })
+
+  await t.test('should leave both on \'always_off\' since they are same values', () => {
+    const config = {
+      distributed_tracing: {
+        sampler: {
+          root: 'always_off',
+          full_granularity: {
+            root: 'always_off'
+          }
+        }
+      }
+    }
+
+    const configuration = Config.initialize(config)
+    assert.equal(configuration.distributed_tracing.sampler.root, 'always_off')
+    assert.equal(configuration.distributed_tracing.sampler.full_granularity.root, 'always_off')
+  })
+
+  await t.test('should leave all samples as default since they are the same values', () => {
+    const config = {}
+
+    const configuration = Config.initialize(config)
+    assert.equal(configuration.distributed_tracing.sampler.root, 'default')
+    assert.equal(configuration.distributed_tracing.sampler.remote_parent_sampled, 'default')
+    assert.equal(configuration.distributed_tracing.sampler.remote_parent_not_sampled, 'default')
+    assert.equal(configuration.distributed_tracing.sampler.full_granularity.root, 'default')
+    assert.equal(configuration.distributed_tracing.sampler.full_granularity.remote_parent_sampled, 'default')
+    assert.equal(configuration.distributed_tracing.sampler.full_granularity.remote_parent_not_sampled, 'default')
+  })
+
+  await t.test('should reconfigure global samplers to match full granularity samplers ', () => {
+    const config = {
+      distributed_tracing: {
+        sampler: {
+          root: 'always_off',
+          remote_parent_sampled: 'always_on',
+          remote_parent_not_sampled: 'adaptive',
+          full_granularity: {
+            root: 'adaptive',
+            remote_parent_sampled: 'always_off',
+            remote_parent_not_sampled: 'always_on',
+          }
+        }
+      }
+    }
+
+    const configuration = Config.initialize(config)
+    assert.equal(configuration.distributed_tracing.sampler.root, 'adaptive')
+    assert.equal(configuration.distributed_tracing.sampler.remote_parent_sampled, 'always_off')
+    assert.equal(configuration.distributed_tracing.sampler.remote_parent_not_sampled, 'always_on')
+    assert.equal(configuration.distributed_tracing.sampler.full_granularity.root, 'adaptive')
+    assert.equal(configuration.distributed_tracing.sampler.full_granularity.remote_parent_sampled, 'always_off')
+    assert.equal(configuration.distributed_tracing.sampler.full_granularity.remote_parent_not_sampled, 'always_on')
+  })
+})


### PR DESCRIPTION

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Updated the config setup logic to reconfigure the full granularity vs global (aka the top level samplers) based on precedence. 

Both the global sampler and the full granularity sampler are suppose to be the same thing: be the full granularity sampler. 

-If both global and full granularity samplers are default, do nothing. 
-If the global sampler has a non default value and the full granularity sampler has a default value, set the full granularity sampler to match the global sampler value and log a warning. 
-If the global sampler has a non default value and the full granularity sampler has a non default value as well, set the global sampler to match the full granularity sampler and log a warning. 

Note: one of these samplers (global or full granularity) might be removed. 

## How to Test

Run `npm run unit`

## Related Issues

Closes issue #3530 