### PR TITLE
feat: Removed samplers under `distributed_tracing.sampler.full_granularity.*`

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1173,7 +1173,6 @@ defaultConfig.definition = () => {
             default: true,
             formatter: boolean
           },
-          ...samplerConfigs
         },
         partial_granularity: {
           enabled: {

--- a/lib/config/samplers.js
+++ b/lib/config/samplers.js
@@ -7,8 +7,7 @@
 const { allowList, float } = require('./formatters')
 
 /**
- * This configuration is currently the same for `distributed_tracing.sampler`,
- * `distributed_tracing.sampler.full_granularity` and `distributed_tracing.sampler.partial_granularity`
+ * This configuration is currently the same for `distributed_tracing.sampler` and `distributed_tracing.sampler.partial_granularity`
  * Note: This also just defines the outer structure.  These values are mixed data types. Most of the time
  * it is just a string. But if you want to use the `trace_id_ratio_based` sampler, then you need to
  * provide an object with a `ratio` property. All of that mapping is done in `lib/config/index.js`
@@ -112,12 +111,12 @@ function isTraceIdRatioBasedConfig(sampler, samplerConfig) {
 }
 
 /**
- * Check if the sampler is a valid value of either 'sampler', 'full_granularity', or 'partial_granularity'
+ * Check if the sampler is a valid value of either 'sampler' or 'partial_granularity'
  * @param {string} sampler - The sampler key to validate
  * @returns {boolean} true if valid, false otherwise
  */
 function isValidDTSampler(sampler) {
-  return ['sampler', 'full_granularity', 'partial_granularity'].includes(sampler)
+  return ['sampler', 'partial_granularity'].includes(sampler)
 }
 
 /**
@@ -151,7 +150,7 @@ function setTraceIdRatioSamplerFromEnv({ key, config, paths, setNestedKey, logge
 
   const lastPath = paths[paths.length - 1]
   if (isValidDTSampler(lastPath) && isValidDTSamplerType(key)) {
-    // Get the value of `config.distributed_tracing.sampler[key]` or `config.distributed_tracing.sampler.full_granularity[key]` or `config.distributed_tracing.sampler.partial_granularity[key]`
+    // Get the value of `config.distributed_tracing.sampler[key]` or `config.distributed_tracing.sampler.partial_granularity[key]`
     const nestedValue = getNestedValue(config, [...paths, key])
     if (nestedValue !== 'trace_id_ratio_based') {
       return

--- a/lib/samplers/README.md
+++ b/lib/samplers/README.md
@@ -8,13 +8,13 @@ Customers configure how they would like their transactions to be sampled under o
 
 ### Types
 
-- A "sampler mode" refers to the following config sections: `distributed_tracing.sampler`, `distributed_tracing.sampler.full_granularity`, and `distributed_tracing.sampler.partial_granularity`. They are defined by the three sections: `root`, `remote_parent_sampled`, and `remote_parent_not_sampled`.
+- A "sampler mode" refers to the following config sections: `distributed_tracing.sampler` and `distributed_tracing.sampler.partial_granularity`. They are defined by the three sections: `root`, `remote_parent_sampled`, and `remote_parent_not_sampled`.
 - A "sampler section" refers to `root`, `remote_parent_sampled`, or `remote_parent_not_sampled` within a particular sampler mode. The config defined at this section, i.e. `SAMPLER_TYPE: SAMPLER_SUBOPTION?`, describes the sampling decision for that particular scenario within that mode.
   - `root`: This is the main sampler for traces originating from the current service.
   - `remote_parent_sampled`: The sampler for when the upstream service has sampled the trace.
   - `remote_parent_not_sampled`: The sampler for when the upstream service has not sampled the trace.
 
-NOTE: `distributed_tracing.sampler` only exists for backward compatiability and may be deprecated in favor of `distributed_tracing.sampler.full_granularity`. For now, `full_granularity` will take precedence over the old path.
+NOTE: `distributed_tracing.sampler` will be used as the setting for the full granularity samplers.
 
 ### Full Config in Accordance to Spec
 
@@ -42,15 +42,6 @@ distributed_tracing:
         ${SAMPLER_SUBOPTION}
     full_granularity:
       enabled
-      root: (when the trace originates from the current service)
-        ${SAMPLER_TYPE} (See `Sampler Options` below)
-          ${SAMPLER_SUBOPTION}
-      remote_parent_sampled: (when the upstream service has sampled the trace)
-        ${SAMPLER_TYPE} (See `Sampler Options` below)
-          ${SAMPLER_SUBOPTION}
-      remote_parent_not_sampled: (when the upstream service has not sampled the trace)
-        ${SAMPLER_TYPE}
-          ${SAMPLER_SUBOPTION}
     partial_granularity:
       enabled
       type   ("reduced", "essential", "compact")
@@ -72,18 +63,12 @@ There are three sampler modes, each with three sampler sections, resulting in po
 
 `agent.sampler` would be defined as:
 
-* `agent.sampler.fullGranularity.root`
-* `agent.sampler.fullGranularity.remoteParentSampled`
-* `agent.sampler.fullGranularity.remoteParentNotSampled`
-* `agent.sampler.partialGranularity.root`
-* `agent.sampler.partialGranularity.remoteParentSampled`
-* `agent.sampler.partialGranularity.remoteParentNotSampled`
-
-These fields currently exist (before core tracing was implemented); `agent.sampler.fullGranularity.*` will take precedence over these fields:
-
 * `agent.sampler.root`
 * `agent.sampler.remoteParentSampled`
 * `agent.sampler.remoteParentNotSampled`
+* `agent.sampler.partialGranularity.root`
+* `agent.sampler.partialGranularity.remoteParentSampled`
+* `agent.sampler.partialGranularity.remoteParentNotSampled`
 
 These samplers have a `applySamplingDecision({transaction})` function, which `Transaction` calls (in `lib/transaction/index.js`) to update its `sampled` field and therefore its `priority`.
 

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -335,9 +335,6 @@ test('with default properties', async (t) => {
         adaptive_sampling_target: 10,
         full_granularity: {
           enabled: true,
-          root: 'default',
-          remote_parent_sampled: 'default',
-          remote_parent_not_sampled: 'default'
         },
         partial_granularity: {
           enabled: false,

--- a/test/unit/config/config-env.test.js
+++ b/test/unit/config/config-env.test.js
@@ -188,9 +188,9 @@ test('when overriding configuration values via environment variables', async (t)
     })
   })
 
-  const samplers = ['SAMPLER', 'SAMPLER_FULL_GRANULARITY', 'SAMPLER_PARTIAL_GRANULARITY']
+  const samplers = ['SAMPLER', 'SAMPLER_PARTIAL_GRANULARITY']
   for (const samplerName of samplers) {
-    const key = samplerName === 'SAMPLER_FULL_GRANULARITY' ? 'full_granularity' : 'partial_granularity'
+    const key = samplerName === 'SAMPLER' ? 'sampler' : 'partial_granularity'
     const samplerTypes = ['root', 'remote_parent_sampled', 'remote_parent_not_sampled']
     for (const type of samplerTypes) {
       const envVar = type.toUpperCase()

--- a/test/unit/config/config.test.js
+++ b/test/unit/config/config.test.js
@@ -245,7 +245,7 @@ test('distributed tracing samplers', async (t) => {
     assert.equal(configuration.distributed_tracing.sampler.remote_parent_sampled, 'adaptive')
   })
 
-  const samplers = ['sampler', 'sampler.full_granularity', 'sampler.partial_granularity']
+  const samplers = ['sampler', 'sampler.partial_granularity']
   const samplerTypes = ['root', 'remote_parent_sampled', 'remote_parent_not_sampled']
   for (const samplerName of samplers) {
     const name = samplerName.split('.')[1]
@@ -347,23 +347,6 @@ test('distributed tracing samplers', async (t) => {
               ratio: 0.85
             }
           },
-          full_granularity: {
-            root: {
-              trace_id_ratio_based: {
-                ratio: 0.6
-              }
-            },
-            remote_parent_sampled: {
-              trace_id_ratio_based: {
-                ratio: 0.5
-              }
-            },
-            remote_parent_not_sampled: {
-              trace_id_ratio_based: {
-                ratio: 0.4
-              }
-            }
-          },
           partial_granularity: {
             root: {
               trace_id_ratio_based: {
@@ -389,9 +372,6 @@ test('distributed tracing samplers', async (t) => {
     assert.equal(configuration.distributed_tracing.sampler.root.trace_id_ratio_based.ratio, 0.5)
     assert.equal(configuration.distributed_tracing.sampler.remote_parent_sampled.trace_id_ratio_based.ratio, 0.6)
     assert.equal(configuration.distributed_tracing.sampler.remote_parent_not_sampled.trace_id_ratio_based.ratio, 0.85)
-    assert.equal(configuration.distributed_tracing.sampler.full_granularity.root.trace_id_ratio_based.ratio, 0.6)
-    assert.equal(configuration.distributed_tracing.sampler.full_granularity.remote_parent_sampled.trace_id_ratio_based.ratio, 0.5)
-    assert.equal(configuration.distributed_tracing.sampler.full_granularity.remote_parent_not_sampled.trace_id_ratio_based.ratio, 0.4)
     assert.equal(configuration.distributed_tracing.sampler.partial_granularity.root.trace_id_ratio_based.ratio, 0.4)
     assert.equal(configuration.distributed_tracing.sampler.partial_granularity.remote_parent_sampled.trace_id_ratio_based.ratio, 0.5)
     assert.equal(configuration.distributed_tracing.sampler.partial_granularity.remote_parent_not_sampled.trace_id_ratio_based.ratio, 0.6)
@@ -404,11 +384,6 @@ test('distributed tracing samplers', async (t) => {
           root: 'always_on',
           remote_parent_sampled: 'default',
           remote_parent_not_sampled: 'adaptive',
-          full_granularity: {
-            root: 'always_off',
-            remote_parent_sampled: 'adaptive',
-            remote_parent_not_sampled: 'always_on'
-          },
           partial_granularity: {
             root: 'adaptive',
             remote_parent_sampled: 'always_on',
@@ -422,9 +397,6 @@ test('distributed tracing samplers', async (t) => {
     assert.equal(configuration.distributed_tracing.sampler.root, 'always_on')
     assert.equal(configuration.distributed_tracing.sampler.remote_parent_sampled, 'default')
     assert.equal(configuration.distributed_tracing.sampler.remote_parent_not_sampled, 'adaptive')
-    assert.equal(configuration.distributed_tracing.sampler.full_granularity.root, 'always_off')
-    assert.equal(configuration.distributed_tracing.sampler.full_granularity.remote_parent_sampled, 'adaptive')
-    assert.equal(configuration.distributed_tracing.sampler.full_granularity.remote_parent_not_sampled, 'always_on')
     assert.equal(configuration.distributed_tracing.sampler.partial_granularity.root, 'adaptive')
     assert.equal(configuration.distributed_tracing.sampler.partial_granularity.remote_parent_sampled, 'always_on')
     assert.equal(configuration.distributed_tracing.sampler.partial_granularity.remote_parent_not_sampled, 'default')


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We will use the samplers at `distributed_tracing.sampler.*` as the full granularity samplers so we're removing the samplers defined here `distributed_tracing.sampler.full_granularity.*` but we have to leave enabled the full granularity samplers at the explicit path `distributed_tracing.sampler.full_granularity.enabled`.

## How to Test

Run Npm run test

## Related Issues

Closes #3533 