### PR TITLE
feat: Added `reduced` type for partial granularity traces.

### DIFF
--- a/lib/spans/span-event-aggregator.js
+++ b/lib/spans/span-event-aggregator.js
@@ -22,6 +22,7 @@ class SpanEventAggregator extends EventAggregator {
 
     super(opts, agent)
     this.inProcessSpans = agent.config.distributed_tracing.in_process_spans.enabled
+    this.partialGranularityMode = agent.config.distributed_tracing?.sampler?.partial_granularity?.enabled === false ? null : agent.config.distributed_tracing?.sampler?.partial_granularity?.type
   }
 
   _toPayloadSync() {
@@ -77,7 +78,7 @@ class SpanEventAggregator extends EventAggregator {
 
       return false
     }
-    const span = SpanEvent.fromSegment({ segment, transaction, parentId, isRoot, inProcessSpans: this.inProcessSpans })
+    const span = SpanEvent.fromSegment({ segment, transaction, parentId, isRoot, inProcessSpans: this.inProcessSpans, partialGranularityMode: this.partialGranularityMode })
 
     if (span) {
       this.add(span, transaction.priority)

--- a/lib/spans/span-event.js
+++ b/lib/spans/span-event.js
@@ -12,6 +12,36 @@ const { DESTINATIONS } = require('../config/attribute-filter')
 const { addSpanKind, isEntryPointSpan, reparentSpan, shouldCreateSpan, HTTP_LIBRARY, REGEXS, SPAN_KIND, CATEGORIES } = require('./helpers')
 const EMPTY_USER_ATTRS = Object.freeze(Object.create(null))
 const SERVER_ADDRESS = 'server.address'
+/**
+ * This keeps a static list of attributes that are used by
+ * one or more entity relationship rules to synthesize an entity relationship.
+ * Note: These attributes also have corresponding TraceSegment attributes
+ * as this list is checked before a span is made.  The ones that are TraceSegment
+ * attributes are noted in the comments. Any new span attributes being added must
+ * be checked to ensure those are what is getting assigned to the TraceSegment as well.
+ */
+const SPAN_ENTITY_RELATIONSHIP_ATTRIBUTES = [
+  'cloud.account.id',
+  'cloud.platform',
+  'cloud.region',
+  'cloud.resource_id',
+  'database_name', // gets mapped to `db.instance`
+  'db.instance',
+  'product', // gets mapped to `db.system`
+  'db.system',
+  'http.url',
+  'url', // gets mapped to `http.url`
+  'messaging.destination.name',
+  'messaging.system',
+  'peer.hostname',
+  'host', // gets mapped to `server.address`
+  'hostname', // gets mapped to `server.address`
+  'server.address',
+  'port', // gets mapped to `server.port`
+  'port_path_or_id', // gets mapped to `server.port`
+  'server.port',
+  'span.kind',
+]
 
 /**
  * All the intrinsic attributes for span events, regardless of kind.
@@ -31,6 +61,7 @@ class SpanIntrinsics {
     this.timestamp = null
     this.duration = null
     this['nr.entryPoint'] = null
+    this['nr.pg'] = null
     this['span.kind'] = null
     this.trustedParentId = null
     this.tracingVendors = null
@@ -67,6 +98,39 @@ class SpanEvent {
     return this.intrinsics
   }
 
+  addIntrinsics({ segment, spanContext, transaction, parentId, isRoot, inProcessSpans, entryPoint }) {
+    for (const [key, value] of Object.entries(spanContext.intrinsicAttributes)) {
+      this.addIntrinsicAttribute(key, value)
+    }
+
+    this.addIntrinsicAttribute('traceId', transaction.traceId)
+    this.addIntrinsicAttribute('transactionId', transaction.id)
+    this.addIntrinsicAttribute('sampled', transaction.sampled)
+    this.addIntrinsicAttribute('priority', transaction.priority)
+    this.addIntrinsicAttribute('name', segment.name)
+    this.addIntrinsicAttribute('guid', segment.id)
+    this.addIntrinsicAttribute('parentId', reparentSpan({ inProcessSpans, isRoot, segment, transaction, parentId }))
+
+    if (isRoot) {
+      this.addIntrinsicAttribute('trustedParentId', transaction.traceContext.trustedParentId)
+      if (transaction.traceContext.tracingVendors) {
+        this.addIntrinsicAttribute('tracingVendors', transaction.traceContext.tracingVendors)
+      }
+    }
+
+    // Only set this if it will be `true`. Must be `null` otherwise.
+    if (entryPoint) {
+      this.addIntrinsicAttribute('nr.entryPoint', true)
+      if (transaction.isPartialTrace) {
+        this.addIntrinsicAttribute('nr.pg', true)
+      }
+    }
+
+    // Timestamp in milliseconds, duration in seconds. Yay consistency!
+    this.addIntrinsicAttribute('timestamp', segment.timer.start)
+    this.addIntrinsicAttribute('duration', segment.timer.getDurationInMillis() / 1000)
+  }
+
   addIntrinsicAttribute(key, value) {
     this.intrinsics[key] = value
   }
@@ -83,6 +147,66 @@ class SpanEvent {
     return HttpSpanEvent
   }
 
+  static isExitSpan(segment) {
+    return REGEXS.CLIENT.EXTERNAL.test(segment.name) || REGEXS.CLIENT.DATASTORE.test(segment.name) || REGEXS.PRODUCER.test(segment.name)
+  }
+
+  static isLlmSpan(segment) {
+    return segment.name.startsWith('Llm/')
+  }
+
+  /**
+   * Filters attributes for partial trace span events based on a given mode.
+   * The rules are as such:
+   *  - If not a partial trace, return all attributes.
+   *  - If an entry point span, return all attributes.
+   *  - If an LLM span, return all attributes.
+   *  - If not an exit span, return no attributes.
+   *  - If mode is 'reduced' and there are entity relationship attributes, return all attributes.
+   *  - Otherwise, return no attributes.
+   *
+   *  @param {object} params to function
+   *  @param {TraceSegment} params.segment segment to filter attributes from
+   *  @param {SpanContext} params.spanContext span context to filter attributes from
+   *  @param {boolean} params.entryPoint whether the span is an entry point
+   *  @param {string} params.partialGranularityMode mode of partial trace ('reduced', 'essential', 'compact')
+   *  @param {boolean} params.isPartialTrace whether the trace is a partial trace
+   *  @returns {object} { attributes, customAttributes, dropSpan: boolean }
+   */
+  static filterPartialTraceAttributes({ segment, spanContext, entryPoint, partialGranularityMode, isPartialTrace }) {
+    const attributes = segment.attributes.get(DESTINATIONS.SPAN_EVENT)
+    const customAttributes = spanContext.customAttributes.get(DESTINATIONS.SPAN_EVENT)
+    if (!isPartialTrace || entryPoint || SpanEvent.isLlmSpan(segment)) {
+      return { attributes, customAttributes, dropSpan: false }
+    }
+
+    if (!SpanEvent.isExitSpan(segment)) {
+      return { dropSpan: true }
+    }
+
+    const attrKeys = Object.keys(attributes)
+    const entityRelationshipAttrs = SPAN_ENTITY_RELATIONSHIP_ATTRIBUTES.filter((item) => attrKeys.includes(item))
+    if (partialGranularityMode === 'reduced') {
+      if (entityRelationshipAttrs.length > 0) {
+        return { attributes, customAttributes, dropSpan: false }
+      }
+    }
+
+    return { dropSpan: true }
+  }
+
+  static createSpan({ segment, attributes, customAttributes }) {
+    let span = null
+    if (HttpSpanEvent.testSegment(segment)) {
+      span = new HttpSpanEvent(attributes, customAttributes)
+    } else if (DatastoreSpanEvent.testSegment(segment)) {
+      span = new DatastoreSpanEvent(attributes, customAttributes)
+    } else {
+      span = new SpanEvent(attributes, customAttributes)
+    }
+    return span
+  }
+
   /**
    * Constructs a `SpanEvent` from the given segment.
    *
@@ -95,9 +219,10 @@ class SpanEvent {
    * @param {?string} [params.parentId] ID of the segment's parent.
    * @param {boolean} [params.isRoot] if segment is root segment; defaults to `false`
    * @param {boolean} params.inProcessSpans if the segment is in-process, create span
+   * @param {string} params.partialGranularityMode mode of partial trace ('reduced', 'essential', 'compact')
    * @returns {SpanEvent} The constructed event.
    */
-  static fromSegment({ segment, transaction, parentId = null, isRoot = false, inProcessSpans }) {
+  static fromSegment({ segment, transaction, parentId = null, isRoot = false, inProcessSpans, partialGranularityMode }) {
     const entryPoint = isEntryPointSpan({ segment, transaction })
     if (!inProcessSpans && !shouldCreateSpan({ entryPoint, segment, transaction })) {
       return null
@@ -116,46 +241,14 @@ class SpanEvent {
       }
     }
 
-    const attributes = segment.attributes.get(DESTINATIONS.SPAN_EVENT)
-
-    const customAttributes = spanContext.customAttributes.get(DESTINATIONS.SPAN_EVENT)
-
-    let span = null
-    if (HttpSpanEvent.testSegment(segment)) {
-      span = new HttpSpanEvent(attributes, customAttributes)
-    } else if (DatastoreSpanEvent.testSegment(segment)) {
-      span = new DatastoreSpanEvent(attributes, customAttributes)
-    } else {
-      span = new SpanEvent(attributes, customAttributes)
+    const { attributes, customAttributes, dropSpan } = SpanEvent.filterPartialTraceAttributes({ spanContext, entryPoint, segment, partialGranularityMode, isPartialTrace: transaction.isPartialTrace })
+    // If attributes were stripped out due to partial trace filtering, do not create span.
+    if (dropSpan) {
+      return null
     }
 
-    for (const [key, value] of Object.entries(spanContext.intrinsicAttributes)) {
-      span.intrinsics[key] = value
-    }
-
-    span.intrinsics.traceId = transaction.traceId
-    span.intrinsics.guid = segment.id
-    span.intrinsics.parentId = reparentSpan({ inProcessSpans, isRoot, segment, transaction, parentId })
-    span.intrinsics.transactionId = transaction.id
-    span.intrinsics.sampled = transaction.sampled
-    span.intrinsics.priority = transaction.priority
-    span.intrinsics.name = segment.name
-
-    if (isRoot) {
-      span.intrinsics.trustedParentId = transaction.traceContext.trustedParentId
-      if (transaction.traceContext.tracingVendors) {
-        span.intrinsics.tracingVendors = transaction.traceContext.tracingVendors
-      }
-    }
-
-    // Only set this if it will be `true`. Must be `null` otherwise.
-    if (entryPoint) {
-      span.intrinsics['nr.entryPoint'] = true
-    }
-
-    // Timestamp in milliseconds, duration in seconds. Yay consistency!
-    span.intrinsics.timestamp = segment.timer.start
-    span.intrinsics.duration = segment.timer.getDurationInMillis() / 1000
+    const span = SpanEvent.createSpan({ segment, attributes, customAttributes })
+    span.addIntrinsics({ segment, spanContext, transaction, parentId, isRoot, inProcessSpans, entryPoint })
 
     addSpanKind({ segment, span })
     return span
@@ -196,9 +289,9 @@ class HttpSpanEvent extends SpanEvent {
   constructor(attributes, customAttributes) {
     super(attributes, customAttributes)
 
-    this.intrinsics.category = CATEGORIES.HTTP
-    this.intrinsics.component = attributes.library || HTTP_LIBRARY
-    this.intrinsics['span.kind'] = SPAN_KIND.CLIENT
+    this.addIntrinsicAttribute('category', CATEGORIES.HTTP)
+    this.addIntrinsicAttribute('component', attributes.library || HTTP_LIBRARY)
+    this.addIntrinsicAttribute('span.kind', SPAN_KIND.CLIENT)
 
     if (attributes.library) {
       attributes.library = null
@@ -236,11 +329,11 @@ class DatastoreSpanEvent extends SpanEvent {
   constructor(attributes, customAttributes) {
     super(attributes, customAttributes)
 
-    this.intrinsics.category = CATEGORIES.DATASTORE
-    this.intrinsics['span.kind'] = SPAN_KIND.CLIENT
+    this.addIntrinsicAttribute('category', CATEGORIES.DATASTORE)
+    this.addIntrinsicAttribute('span.kind', SPAN_KIND.CLIENT)
 
     if (attributes.product) {
-      this.intrinsics.component = attributes.product
+      this.addIntrinsicAttribute('component', attributes.product)
       this.addAttribute('db.system', attributes.product)
       attributes.product = null
     }

--- a/test/unit/spans/partial-granularity-spans.test.js
+++ b/test/unit/spans/partial-granularity-spans.test.js
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const assert = require('node:assert')
+const test = require('node:test')
+const helper = require('#testlib/agent_helper.js')
+const SpanEvent = require('#agentlib/spans/span-event.js')
+
+test.beforeEach((ctx) => {
+  const agent = helper.instrumentMockedAgent({
+    distributed_tracing: {
+      enabled: true,
+      full_granularity: {
+        enabled: false
+      },
+      partial_granularity: {
+        enabled: true,
+        type: 'reduced'
+      }
+    }
+  })
+  ctx.nr = { agent }
+})
+
+test.afterEach((ctx) => {
+  helper.unloadAgent(ctx.nr.agent)
+})
+
+test('should include entry span', (t, end) => {
+  const { agent } = t.nr
+  helper.runInTransaction(agent, (transaction) => {
+    transaction.isPartialTrace = true
+    const segment = transaction.trace.add('entrySpan')
+    transaction.baseSegment = segment
+    const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'reduced' })
+    assert.ok(span)
+    assert.equal(span.intrinsics['nr.entryPoint'], true)
+    assert.equal(span.intrinsics['nr.pg'], true)
+    assert.equal(span.intrinsics.parentId, null)
+    end()
+  })
+})
+
+test('should include Llm span', (t, end) => {
+  const { agent } = t.nr
+  helper.runInTransaction(agent, (transaction) => {
+    transaction.isPartialTrace = true
+    const segment = transaction.trace.add('Llm/foobar')
+    const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'reduced' })
+    assert.ok(span)
+    end()
+  })
+})
+
+test('should include exit span that has entity relationship attrs', (t, end) => {
+  const { agent } = t.nr
+  helper.runInTransaction(agent, (transaction) => {
+    transaction.isPartialTrace = true
+    const segment = transaction.trace.add('Datastore/operation/Redis/SET')
+    segment.addAttribute('host', 'redis-service')
+    segment.addAttribute('port_path_or_id', 6379)
+    segment.addAttribute('foo', 'bar')
+    const spanContext = segment.getSpanContext()
+    spanContext.addCustomAttribute('custom', 'test')
+    const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'reduced' })
+    assert.ok(span)
+    const [instrinsics, customAttrs, agentAttrs] = span.toJSON()
+    assert.equal(instrinsics['name'], 'Datastore/operation/Redis/SET')
+    assert.equal(instrinsics['span.kind'], 'client')
+    assert.deepEqual(customAttrs, {
+      custom: 'test'
+    })
+    assert.equal(span.intrinsics['nr.entryPoint'], null)
+    assert.equal(span.intrinsics['nr.pg'], null)
+    assert.equal(agentAttrs['peer.address'], 'redis-service:6379')
+    assert.equal(agentAttrs['peer.hostname'], 'redis-service')
+    assert.equal(agentAttrs['server.address'], 'redis-service')
+    assert.equal(agentAttrs['server.port'], '6379')
+    assert.equal(agentAttrs.foo, 'bar')
+    end()
+  })
+})
+
+test('should not include exit span that does not have entity relationship attrs', (t, end) => {
+  const { agent } = t.nr
+  helper.runInTransaction(agent, (transaction) => {
+    transaction.isPartialTrace = true
+    const segment = transaction.trace.add('Datastore/operation/Redis/SET')
+    segment.addAttribute('foo', 'bar')
+    const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'reduced' })
+    assert.ok(!span)
+    end()
+  })
+})
+
+test('should not include in process span', (t, end) => {
+  const { agent } = t.nr
+  helper.runInTransaction(agent, (transaction) => {
+    transaction.isPartialTrace = true
+    const segment = transaction.trace.add('test-segment')
+    segment.addAttribute('foo', 'bar')
+    const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'reduced' })
+    assert.ok(!span)
+    end()
+  })
+})
+
+test('should include exit span that does not have entity relationship attrs when not part of partialTrace', (t, end) => {
+  const { agent } = t.nr
+  helper.runInTransaction(agent, (transaction) => {
+    transaction.isPartialTrace = false
+    const segment = transaction.trace.add('Datastore/operation/Redis/SET')
+    segment.addAttribute('foo', 'bar')
+    const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'reduced' })
+    assert.ok(span)
+    const [instrinsics, , agentAttrs] = span.toJSON()
+    assert.equal(instrinsics['name'], 'Datastore/operation/Redis/SET')
+    assert.equal(instrinsics['span.kind'], 'client')
+    assert.equal(span.intrinsics['nr.entryPoint'], null)
+    assert.equal(span.intrinsics['nr.pg'], null)
+    assert.equal(agentAttrs.foo, 'bar')
+    end()
+  })
+})
+
+test('should include in process span when not part of partialTrace', (t, end) => {
+  const { agent } = t.nr
+  helper.runInTransaction(agent, (transaction) => {
+    transaction.isPartialTrace = false
+    const segment = transaction.trace.add('test-segment')
+    const spanContext = segment.getSpanContext()
+    spanContext.addCustomAttribute('custom', 'test')
+    segment.addAttribute('foo', 'bar')
+    const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'reduced' })
+    assert.ok(span)
+    const [instrinsics, customAttrs, agentAttrs] = span.toJSON()
+    assert.equal(instrinsics['name'], 'test-segment')
+    assert.equal(instrinsics['span.kind'], 'internal')
+    assert.deepEqual(customAttrs, {
+      custom: 'test'
+    })
+    assert.equal(span.intrinsics['nr.entryPoint'], null)
+    assert.equal(span.intrinsics['nr.pg'], null)
+    assert.equal(agentAttrs.foo, 'bar')
+    end()
+  })
+})

--- a/test/unit/spans/span-event-aggregator.test.js
+++ b/test/unit/spans/span-event-aggregator.test.js
@@ -60,7 +60,7 @@ test('SpanAggregator', async (t) => {
     const { agent, spanEventAggregator } = t.nr
     helper.runInTransaction(agent, (tx) => {
       tx.priority = 42
-      tx.sample = true
+      tx.sampled = true
 
       setTimeout(() => {
         const segment = agent.tracer.getSegment()
@@ -85,7 +85,7 @@ test('SpanAggregator', async (t) => {
     const { agent, spanEventAggregator } = t.nr
     helper.runInTransaction(agent, (tx) => {
       tx.priority = 42
-      tx.sample = true
+      tx.sampled = true
 
       setTimeout(() => {
         const segment = agent.tracer.getSegment()
@@ -139,7 +139,7 @@ test('SpanAggregator', async (t) => {
 
     helper.runInTransaction(agent, (tx) => {
       tx.priority = 42
-      tx.sample = true
+      tx.sampled = true
 
       setTimeout(() => {
         const segment = agent.tracer.getSegment()
@@ -182,7 +182,7 @@ test('SpanAggregator', async (t) => {
     const { agent, spanEventAggregator } = t.nr
     helper.runInTransaction(agent, (tx) => {
       tx.priority = 1
-      tx.sample = true
+      tx.sampled = true
 
       setTimeout(() => {
         const segment = agent.tracer.getSegment()


### PR DESCRIPTION
## Description

This PR adds the `reduced` partial granularity logic: keep entry spans, llm spans, and any exit spans that have entity relationship attributes.

This is blocked until #3536 is done because this assumes that a sampling decision has been made and the transaction has assigned `.isPartialTrace` property signaling the span event logic to execute for a partial trace based on the type

## Related Issues
Closes #3455 