### PR TITLE
refactor: Updated when partial granularity rules are applied

### DIFF
--- a/lib/spans/span-event.js
+++ b/lib/spans/span-event.js
@@ -12,33 +12,24 @@ const { DESTINATIONS } = require('../config/attribute-filter')
 const { addSpanKind, isEntryPointSpan, reparentSpan, shouldCreateSpan, HTTP_LIBRARY, REGEXS, SPAN_KIND, CATEGORIES } = require('./helpers')
 const EMPTY_USER_ATTRS = Object.freeze(Object.create(null))
 const SERVER_ADDRESS = 'server.address'
+const logger = require('../logger').child({ component: 'span-event' })
+
 /**
  * This keeps a static list of attributes that are used by
  * one or more entity relationship rules to synthesize an entity relationship.
- * Note: These attributes also have corresponding TraceSegment attributes
- * as this list is checked before a span is made.  The ones that are TraceSegment
- * attributes are noted in the comments. Any new span attributes being added must
- * be checked to ensure those are what is getting assigned to the TraceSegment as well.
  */
 const SPAN_ENTITY_RELATIONSHIP_ATTRIBUTES = [
   'cloud.account.id',
   'cloud.platform',
   'cloud.region',
   'cloud.resource_id',
-  'database_name', // gets mapped to `db.instance`
   'db.instance',
-  'product', // gets mapped to `db.system`
   'db.system',
   'http.url',
-  'url', // gets mapped to `http.url`
   'messaging.destination.name',
   'messaging.system',
   'peer.hostname',
-  'host', // gets mapped to `server.address`
-  'hostname', // gets mapped to `server.address`
   'server.address',
-  'port', // gets mapped to `server.port`
-  'port_path_or_id', // gets mapped to `server.port`
   'server.port',
   'span.kind',
 ]
@@ -147,63 +138,74 @@ class SpanEvent {
     return HttpSpanEvent
   }
 
-  static isExitSpan(segment) {
-    return REGEXS.CLIENT.EXTERNAL.test(segment.name) || REGEXS.CLIENT.DATASTORE.test(segment.name) || REGEXS.PRODUCER.test(segment.name)
+  static isExitSpan(span) {
+    const name = span.intrinsics?.name
+    return REGEXS.CLIENT.EXTERNAL.test(name) || REGEXS.CLIENT.DATASTORE.test(name) || REGEXS.PRODUCER.test(name)
   }
 
-  static isLlmSpan(segment) {
-    return segment.name.startsWith('Llm/')
+  static isLlmSpan(span) {
+    return span.intrinsics?.name?.startsWith('Llm/')
   }
 
   /**
-   * Filters attributes for partial trace span events based on a given mode.
+   * Drops span or filters attributes based on partial trace rules for a given mode.
    * The rules are as such:
-   *  - If not a partial trace, return all attributes.
-   *  - If an entry point span, return all attributes.
-   *  - If an LLM span, return all attributes.
-   *  - If not an exit span, return no attributes.
-   *  - If mode is 'reduced' and there are entity relationship attributes, return all attributes.
-   *  - Otherwise, return no attributes.
+   *  - If not a partial trace, return span untouched
+   *  - If an entry point span, return span untouched
+   *  - If an LLM span, return span untouched
+   *  - If not an exit span, return null(aka drop span)
+   *  - If mode is 'reduced' and there are entity relationship attributes, return span untouched
+   *  - If mode is 'essential' and there are entity relationship attributes or error attributes, return span with only those attributes, drop custom attributes
+   *  - Otherwise return null(aka drop span)
    *
    *  @param {object} params to function
-   *  @param {TraceSegment} params.segment segment to filter attributes from
-   *  @param {SpanContext} params.spanContext span context to filter attributes from
+   *  @param {SpanEvent} params.span span to apply rules to
    *  @param {boolean} params.entryPoint whether the span is an entry point
    *  @param {string} params.partialGranularityMode mode of partial trace ('reduced', 'essential', 'compact')
    *  @param {boolean} params.isPartialTrace whether the trace is a partial trace
-   *  @returns {object} { attributes, customAttributes, dropSpan: boolean }
+   *  @returns {SpanEvent|null} the span after applying the rules, or null if dropped
    */
-  static filterPartialTraceAttributes({ segment, spanContext, entryPoint, partialGranularityMode, isPartialTrace }) {
-    const attributes = segment.attributes.get(DESTINATIONS.SPAN_EVENT)
-    const customAttributes = spanContext.customAttributes.get(DESTINATIONS.SPAN_EVENT)
-    if (!isPartialTrace || entryPoint || SpanEvent.isLlmSpan(segment)) {
-      return { attributes, customAttributes, dropSpan: false }
+  static applyPartialTraceRules({ span, entryPoint, partialGranularityMode, isPartialTrace }) {
+    const isLlmSpan = SpanEvent.isLlmSpan(span)
+
+    if (!isPartialTrace || entryPoint || isLlmSpan) {
+      logger.trace('Span %s is either not a partial trace: %s, an entry point: %s, or an LLM span: %s, keeping span unchanged.', span.intrinsics.name, isPartialTrace, entryPoint, isLlmSpan)
+      return span
     }
 
-    if (!SpanEvent.isExitSpan(segment)) {
-      return { dropSpan: true }
+    if (!SpanEvent.isExitSpan(span)) {
+      logger.trace('Span %s is not an exit span and trace is partial granularity mode: %s.', span.intrinsics.name, partialGranularityMode)
+      return null
     }
 
+    const attributes = span.attributes
     const attrKeys = Object.keys(attributes)
     const entityRelationshipAttrs = SPAN_ENTITY_RELATIONSHIP_ATTRIBUTES.filter((item) => attrKeys.includes(item))
     if (partialGranularityMode === 'reduced') {
-      if (entityRelationshipAttrs.length > 0) {
-        return { attributes, customAttributes, dropSpan: false }
+      if (entityRelationshipAttrs.length === 0) {
+        logger.trace('Span %s does not contain any entity relationship attributes %j and trace is partial granularity mode: %s, dropping span.', span.intrinsics.name, span.attributes, partialGranularityMode)
+        return null
       }
+      logger.trace('Span %s contains entity relationship attributes and trace is partial granularity mode: %s, keeping span unchanged.', span.intrinsics.name, partialGranularityMode)
     } else if (partialGranularityMode === 'essential') {
-      const attributesToKeep = {}
+      const attributesToKeep = Object.create(null)
       for (const item in attributes) {
         if (entityRelationshipAttrs.includes(item) || item.startsWith('error.')) {
           attributesToKeep[item] = attributes[item]
         }
       }
 
-      if (Object.keys(attributesToKeep).length > 0) {
-        return { attributes: attributesToKeep, customAttributes: {}, dropSpan: false }
+      if (Object.keys(attributesToKeep).length === 0) {
+        logger.trace('Span %s does not contain any entity relationship attributes %j and trace is partial granularity mode: %s, dropping span.', span.intrinsics.name, span.attributes, partialGranularityMode)
+        return null
       }
+
+      span.attributes = attributesToKeep
+      span.customAttributes = Object.create(null)
+      logger.trace('Span %s contains entity relationship attributes and trace is partial granularity mode: %s, only keeping entity relationship attributes and removing custom attributes.', span.intrinsics.name, partialGranularityMode)
     }
 
-    return { dropSpan: true }
+    return span
   }
 
   static createSpan({ segment, attributes, customAttributes }) {
@@ -252,17 +254,13 @@ class SpanEvent {
       }
     }
 
-    const { attributes, customAttributes, dropSpan } = SpanEvent.filterPartialTraceAttributes({ spanContext, entryPoint, segment, partialGranularityMode, isPartialTrace: transaction.isPartialTrace })
-    // If attributes were stripped out due to partial trace filtering, do not create span.
-    if (dropSpan) {
-      return null
-    }
-
+    const attributes = segment.attributes.get(DESTINATIONS.SPAN_EVENT)
+    const customAttributes = spanContext.customAttributes.get(DESTINATIONS.SPAN_EVENT)
     const span = SpanEvent.createSpan({ segment, attributes, customAttributes })
     span.addIntrinsics({ segment, spanContext, transaction, parentId, isRoot, inProcessSpans, entryPoint })
 
     addSpanKind({ segment, span })
-    return span
+    return SpanEvent.applyPartialTraceRules({ span, entryPoint, partialGranularityMode, isPartialTrace: transaction.isPartialTrace })
   }
 
   toJSON() {

--- a/test/unit/spans/partial-granularity-spans.test.js
+++ b/test/unit/spans/partial-granularity-spans.test.js
@@ -8,289 +8,169 @@ const assert = require('node:assert')
 const test = require('node:test')
 const helper = require('#testlib/agent_helper.js')
 const SpanEvent = require('#agentlib/spans/span-event.js')
+const MODES = ['reduced', 'essential']
 
-test('Partial Granularity Spans - reduced mode', async (t) => {
-  t.beforeEach((ctx) => {
-    const agent = helper.instrumentMockedAgent({
-      distributed_tracing: {
-        enabled: true,
-        full_granularity: {
-          enabled: false
-        },
-        partial_granularity: {
+for (const mode of MODES) {
+  test(`Partial Granularity Spans - ${mode} mode`, async (t) => {
+    t.beforeEach((ctx) => {
+      const agent = helper.loadMockedAgent({
+        distributed_tracing: {
           enabled: true,
-          type: 'reduced'
+          full_granularity: {
+            enabled: false
+          },
+          partial_granularity: {
+            enabled: true,
+            type: mode
+          }
         }
-      }
-    })
-    ctx.nr = { agent }
-  })
-
-  t.afterEach((ctx) => {
-    helper.unloadAgent(ctx.nr.agent)
-  })
-
-  await t.test('should include entry span', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      transaction.isPartialTrace = true
-      const segment = transaction.trace.add('entrySpan')
-      transaction.baseSegment = segment
-      const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'reduced' })
-      assert.ok(span)
-      assert.equal(span.intrinsics['nr.entryPoint'], true)
-      assert.equal(span.intrinsics['nr.pg'], true)
-      assert.equal(span.intrinsics.parentId, null)
-      end()
-    })
-  })
-
-  await t.test('should include Llm span', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      transaction.isPartialTrace = true
-      const segment = transaction.trace.add('Llm/foobar')
-      const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'reduced' })
-      assert.ok(span)
-      end()
-    })
-  })
-
-  await t.test('should include exit span that has entity relationship attrs', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      transaction.isPartialTrace = true
-      const segment = transaction.trace.add('Datastore/operation/Redis/SET')
-      segment.addAttribute('host', 'redis-service')
-      segment.addAttribute('port_path_or_id', 6379)
-      segment.addAttribute('foo', 'bar')
-      const spanContext = segment.getSpanContext()
-      spanContext.addCustomAttribute('custom', 'test')
-      const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'reduced' })
-      assert.ok(span)
-      const [instrinsics, customAttrs, agentAttrs] = span.toJSON()
-      assert.equal(instrinsics['name'], 'Datastore/operation/Redis/SET')
-      assert.equal(instrinsics['span.kind'], 'client')
-      assert.deepEqual(customAttrs, {
-        custom: 'test'
       })
-      assert.equal(span.intrinsics['nr.entryPoint'], null)
-      assert.equal(span.intrinsics['nr.pg'], null)
-      assert.equal(agentAttrs['peer.address'], 'redis-service:6379')
-      assert.equal(agentAttrs['peer.hostname'], 'redis-service')
-      assert.equal(agentAttrs['server.address'], 'redis-service')
-      assert.equal(agentAttrs['server.port'], '6379')
-      assert.equal(agentAttrs.foo, 'bar')
-      end()
+      ctx.nr = { agent }
     })
-  })
 
-  await t.test('should not include exit span that does not have entity relationship attrs', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      transaction.isPartialTrace = true
-      const segment = transaction.trace.add('Datastore/operation/Redis/SET')
-      segment.addAttribute('foo', 'bar')
-      const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'reduced' })
-      assert.ok(!span)
-      end()
+    t.afterEach((ctx) => {
+      helper.unloadAgent(ctx.nr.agent)
     })
-  })
 
-  await t.test('should not include in process span', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      transaction.isPartialTrace = true
-      const segment = transaction.trace.add('test-segment')
-      segment.addAttribute('foo', 'bar')
-      const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'reduced' })
-      assert.ok(!span)
-      end()
-    })
-  })
-
-  await t.test('should include exit span that does not have entity relationship attrs when not part of partialTrace', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      transaction.isPartialTrace = false
-      const segment = transaction.trace.add('Datastore/operation/Redis/SET')
-      segment.addAttribute('foo', 'bar')
-      const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'reduced' })
-      assert.ok(span)
-      const [instrinsics, , agentAttrs] = span.toJSON()
-      assert.equal(instrinsics['name'], 'Datastore/operation/Redis/SET')
-      assert.equal(instrinsics['span.kind'], 'client')
-      assert.equal(span.intrinsics['nr.entryPoint'], null)
-      assert.equal(span.intrinsics['nr.pg'], null)
-      assert.equal(agentAttrs.foo, 'bar')
-      end()
-    })
-  })
-
-  await t.test('should include in process span when not part of partialTrace', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      transaction.isPartialTrace = false
-      const segment = transaction.trace.add('test-segment')
-      const spanContext = segment.getSpanContext()
-      spanContext.addCustomAttribute('custom', 'test')
-      segment.addAttribute('foo', 'bar')
-      const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'reduced' })
-      assert.ok(span)
-      const [instrinsics, customAttrs, agentAttrs] = span.toJSON()
-      assert.equal(instrinsics['name'], 'test-segment')
-      assert.equal(instrinsics['span.kind'], 'internal')
-      assert.deepEqual(customAttrs, {
-        custom: 'test'
+    await t.test('should include entry span', (t, end) => {
+      const { agent } = t.nr
+      helper.runInTransaction(agent, (transaction) => {
+        transaction.isPartialTrace = true
+        const segment = transaction.trace.add('entrySpan')
+        transaction.baseSegment = segment
+        const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: mode })
+        assert.ok(span)
+        const [intrinsics] = span.toJSON()
+        assert.equal(intrinsics['nr.entryPoint'], true)
+        assert.equal(intrinsics['nr.pg'], true)
+        assert.equal(intrinsics.parentId, null)
+        transaction.end()
+        end()
       })
-      assert.equal(span.intrinsics['nr.entryPoint'], null)
-      assert.equal(span.intrinsics['nr.pg'], null)
-      assert.equal(agentAttrs.foo, 'bar')
-      end()
     })
-  })
-})
 
-test('Partial Granularity Spans - essential mode', async (t) => {
-  t.beforeEach((ctx) => {
-    const agent = helper.instrumentMockedAgent({
-      distributed_tracing: {
-        enabled: true,
-        partial_granularity: {
-          enabled: true,
-          type: 'essential'
+    await t.test('should include Llm span', (t, end) => {
+      const { agent } = t.nr
+      helper.runInTransaction(agent, (transaction) => {
+        transaction.isPartialTrace = true
+        const segment = transaction.trace.add('Llm/foobar')
+        const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: mode })
+        assert.ok(span)
+        transaction.end()
+        end()
+      })
+    })
+
+    // This is the only test where assertions will vary depending on the mode:
+    //  - reduced: should include all attributes
+    //  - essential: should exclude any agent attributes that are no entity relationship attrs and drop all custom attributes
+    await t.test('should include exit span that has entity relationship attrs', (t, end) => {
+      const { agent } = t.nr
+      helper.runInTransaction(agent, (transaction) => {
+        transaction.isPartialTrace = true
+        const segment = transaction.trace.add('Datastore/operation/Redis/SET')
+        segment.addAttribute('host', 'redis-service')
+        segment.addAttribute('port_path_or_id', 6379)
+        segment.addAttribute('foo', 'bar')
+        const spanContext = segment.getSpanContext()
+        spanContext.addCustomAttribute('custom', 'test')
+        const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: mode })
+        assert.ok(span)
+        const [intrinsics, customAttrs, agentAttrs] = span.toJSON()
+        assert.equal(intrinsics['name'], 'Datastore/operation/Redis/SET')
+        assert.equal(intrinsics['span.kind'], 'client')
+        assert.equal(intrinsics['nr.entryPoint'], null)
+        assert.equal(intrinsics['nr.pg'], null)
+        if (mode === 'reduced') {
+          assert.equal(agentAttrs['peer.address'], 'redis-service:6379')
+          assert.deepEqual(customAttrs, {
+            custom: 'test'
+          })
+          assert.equal(agentAttrs.foo, 'bar')
+        } else if (mode === 'essential') {
+          assert.equal(agentAttrs['peer.address'], undefined)
+          assert.deepEqual(customAttrs, {})
+          assert.equal(agentAttrs.foo, undefined)
         }
-      }
-    })
-    ctx.nr = { agent }
-  })
-
-  t.afterEach((ctx) => {
-    helper.unloadAgent(ctx.nr.agent)
-  })
-
-  await t.test('should include entry span', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      transaction.isPartialTrace = true
-      const segment = transaction.trace.add('entrySpan')
-      transaction.baseSegment = segment
-      const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'essential' })
-      assert.ok(span)
-      assert.equal(span.intrinsics['nr.entryPoint'], true)
-      assert.equal(span.intrinsics['nr.pg'], true)
-      assert.equal(span.intrinsics.parentId, null)
-      end()
-    })
-  })
-
-  await t.test('should include Llm span', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      transaction.isPartialTrace = true
-      const segment = transaction.trace.add('Llm/foobar')
-      const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'essential' })
-      assert.ok(span)
-      end()
-    })
-  })
-
-  await t.test('should include exit span with entity relationship and error attrs but no custom attrs', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      transaction.isPartialTrace = true
-      const segment = transaction.trace.add('Datastore/operation/Redis/SET')
-      segment.addAttribute('host', 'redis-service')
-      segment.addAttribute('port_path_or_id', 6379)
-      segment.addAttribute('foo', 'bar')
-      segment.addAttribute('error.message', 'something went wrong')
-      segment.addAttribute('error.class', 'Error')
-      const spanContext = segment.getSpanContext()
-      spanContext.addCustomAttribute('custom', 'test')
-      const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'essential' })
-      assert.ok(span)
-      const [instrinsics, customAttrs, agentAttrs] = span.toJSON()
-      assert.equal(instrinsics['name'], 'Datastore/operation/Redis/SET')
-      assert.equal(instrinsics['span.kind'], 'client')
-      assert.deepEqual(customAttrs, {}) // should drop custom attributes
-      assert.equal(span.intrinsics['nr.entryPoint'], null)
-      assert.equal(span.intrinsics['nr.pg'], null)
-      assert.equal(agentAttrs['peer.address'], 'redis-service:6379')
-      assert.equal(agentAttrs['peer.hostname'], 'redis-service')
-      assert.equal(agentAttrs['server.address'], 'redis-service')
-      assert.equal(agentAttrs['server.port'], '6379')
-      assert.equal(agentAttrs.foo, undefined) // should drop non entity relationship agent attributes
-      assert.equal(agentAttrs['error.message'], 'something went wrong') // keep error attributes if they exist
-      assert.equal(agentAttrs['error.class'], 'Error') // keep error attributes if they exist
-      end()
-    })
-  })
-
-  await t.test('should not include exit span that does not have entity relationship attrs', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      transaction.isPartialTrace = true
-      const segment = transaction.trace.add('Datastore/operation/Redis/SET')
-      segment.addAttribute('foo', 'bar')
-      const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'essential' })
-      assert.ok(!span)
-      end()
-    })
-  })
-
-  await t.test('should not include in process span', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      transaction.isPartialTrace = true
-      const segment = transaction.trace.add('test-segment')
-      segment.addAttribute('foo', 'bar')
-      const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'essential' })
-      assert.ok(!span)
-      end()
-    })
-  })
-
-  await t.test('should include exit span that does not have entity relationship attrs when not part of partialTrace', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      transaction.isPartialTrace = false
-      const segment = transaction.trace.add('Datastore/operation/Redis/SET')
-      segment.addAttribute('foo', 'bar')
-      const spanContext = segment.getSpanContext()
-      spanContext.addCustomAttribute('custom', 'test')
-      const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'essential' })
-      assert.ok(span)
-      const [instrinsics, customAttrs, agentAttrs] = span.toJSON()
-      assert.equal(instrinsics['name'], 'Datastore/operation/Redis/SET')
-      assert.equal(instrinsics['span.kind'], 'client')
-      assert.equal(span.intrinsics['nr.entryPoint'], null)
-      assert.equal(span.intrinsics['nr.pg'], null)
-      assert.equal(agentAttrs.foo, 'bar')
-      assert.equal(customAttrs.custom, 'test')
-      end()
-    })
-  })
-
-  await t.test('should include in process span when not part of partialTrace', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      transaction.isPartialTrace = false
-      const segment = transaction.trace.add('test-segment')
-      const spanContext = segment.getSpanContext()
-      spanContext.addCustomAttribute('custom', 'test')
-      segment.addAttribute('foo', 'bar')
-      const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: 'essential' })
-      assert.ok(span)
-      const [instrinsics, customAttrs, agentAttrs] = span.toJSON()
-      assert.equal(instrinsics['name'], 'test-segment')
-      assert.equal(instrinsics['span.kind'], 'internal')
-      assert.deepEqual(customAttrs, {
-        custom: 'test'
+        assert.equal(agentAttrs['peer.hostname'], 'redis-service')
+        assert.equal(agentAttrs['server.address'], 'redis-service')
+        assert.equal(agentAttrs['server.port'], '6379')
+        transaction.end()
+        end()
       })
-      assert.equal(span.intrinsics['nr.entryPoint'], null)
-      assert.equal(span.intrinsics['nr.pg'], null)
-      assert.equal(agentAttrs.foo, 'bar')
-      end()
+    })
+
+    await t.test('should not include exit span that does not have entity relationship attrs', (t, end) => {
+      const { agent } = t.nr
+      helper.runInTransaction(agent, (transaction) => {
+        transaction.isPartialTrace = true
+        const segment = transaction.trace.add('Datastore/operation/Redis/SET')
+        segment.addAttribute('foo', 'bar')
+        const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: mode })
+        assert.ok(!span)
+        end()
+      })
+    })
+
+    await t.test('should not include in process span', (t, end) => {
+      const { agent } = t.nr
+      helper.runInTransaction(agent, (transaction) => {
+        transaction.isPartialTrace = true
+        const segment = transaction.trace.add('test-segment')
+        segment.addAttribute('foo', 'bar')
+        const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: mode })
+        assert.ok(!span)
+        transaction.end()
+        end()
+      })
+    })
+
+    await t.test('should include exit span that does not have entity relationship attrs when not part of partialTrace', (t, end) => {
+      const { agent } = t.nr
+      helper.runInTransaction(agent, (transaction) => {
+        transaction.isPartialTrace = false
+        const segment = transaction.trace.add('Datastore/operation/Redis/SET')
+        segment.addAttribute('foo', 'bar')
+        const spanContext = segment.getSpanContext()
+        spanContext.addCustomAttribute('custom', 'test')
+        const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: mode })
+        assert.ok(span)
+        const [intrinsics, customAttrs, agentAttrs] = span.toJSON()
+        assert.equal(intrinsics['name'], 'Datastore/operation/Redis/SET')
+        assert.equal(intrinsics['span.kind'], 'client')
+        assert.deepEqual(customAttrs, {
+          custom: 'test'
+        })
+        assert.equal(intrinsics['nr.entryPoint'], null)
+        assert.equal(intrinsics['nr.pg'], null)
+        assert.equal(agentAttrs.foo, 'bar')
+        transaction.end()
+        end()
+      })
+    })
+
+    await t.test('should include in process span when not part of partialTrace', (t, end) => {
+      const { agent } = t.nr
+      helper.runInTransaction(agent, (transaction) => {
+        transaction.isPartialTrace = false
+        const segment = transaction.trace.add('test-segment')
+        const spanContext = segment.getSpanContext()
+        spanContext.addCustomAttribute('custom', 'test')
+        segment.addAttribute('foo', 'bar')
+        const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true, partialGranularityMode: mode })
+        assert.ok(span)
+        const [intrinsics, customAttrs, agentAttrs] = span.toJSON()
+        assert.equal(intrinsics['name'], 'test-segment')
+        assert.equal(intrinsics['span.kind'], 'internal')
+        assert.deepEqual(customAttrs, {
+          custom: 'test'
+        })
+        assert.equal(intrinsics['nr.entryPoint'], null)
+        assert.equal(intrinsics['nr.pg'], null)
+        assert.equal(agentAttrs.foo, 'bar')
+        transaction.end()
+        end()
+      })
     })
   })
-})
+}

--- a/test/unit/spans/span-event-aggregator.test.js
+++ b/test/unit/spans/span-event-aggregator.test.js
@@ -39,7 +39,7 @@ test('SpanAggregator', async (t) => {
         harvester: { add() {} }
       }
     )
-    ctx.nr.agent = helper.instrumentMockedAgent({
+    ctx.nr.agent = helper.loadMockedAgent({
       distributed_tracing: {
         enabled: true
       }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
This PR refactors when we apply partial granularity rules.  Previously we applied the rules on the segment and just filtered attributes as we saw them. Now we create the span and decided if we keep the span in tact, drop, or remove attributes.  This aligns with how python and java are doing it.  Also, it removes having to keep a mapping of span attributes and segment attributes for entity relationships.  Also I added trace level logging for every decision we make on a span for easier debugging. Lastly, I combined the tests to ensure we have consistent coverage between modes and less maintenance burden. There's only 1 tests that has different assertions and we can add the other assertions to that test when we add support for `compact`.
