### PR TITLE
chore: Collect OTEL instrumentation scope metadata

### DIFF
--- a/lib/otel/traces/span-processor.js
+++ b/lib/otel/traces/span-processor.js
@@ -51,6 +51,20 @@ module.exports = class NrSpanProcessor {
   onEnd(span) {
     if (span[otelSynthesis] && span[otelSynthesis].segment) {
       const { segment, transaction, rule } = span[otelSynthesis]
+      const { instrumentationScope } = span
+
+      // We always attach the instrumentation scope data as agent attributes
+      // if the OTEL span has them set.
+      // See https://opentelemetry.io/docs/specs/otel/common/mapping-to-non-otlp/#instrumentationscope
+      if (typeof instrumentationScope.name === 'string') {
+        segment.addAttribute('otel.scope.name', instrumentationScope.name)
+        segment.addAttribute('otel.library.name', instrumentationScope.name)
+      }
+      if (typeof instrumentationScope.version === 'string') {
+        segment.addAttribute('otel.scope.version', instrumentationScope.version)
+        segment.addAttribute('otel.library.version', instrumentationScope.version)
+      }
+
       this.updateDuration(segment, span)
       this.handleError({ segment, transaction, span })
       this.reconcileAttributes({ segment, span, transaction, rule })


### PR DESCRIPTION
This PR resolves #3534.

The internal spec states that the same metadata should be recorded for log events, but the [JS LogRecord](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api-logs.LogRecord.html) does not contain such information. So this PR does not attempt to attach the metadata to logs, only to traces.