### PR TITLE
chore: Concurrent vendors info resolution

### DIFF
--- a/lib/utilization/index.js
+++ b/lib/utilization/index.js
@@ -26,31 +26,44 @@ module.exports.getVendors = async function getVendors(
   } = {}
 ) {
   let vendors = null
+  const toResolve = []
 
-  for (const [vendor, fn] of Object.entries(vendorDataFuncs)) {
-    logger.trace({ utilization: vendor }, 'Detecting utilization info for vendor %s.', vendor)
-    try {
-      const result = await new Promise((resolve, reject) => {
-        fn(agent, (error, data) => {
-          if (error) return reject(error)
-          resolve(data)
-        })
-      })
+  for (const [vendor, resolver] of Object.entries(vendorDataFuncs)) {
+    const promise = resolveVendor({ vendor, resolver, agent, logger })
+    toResolve.push(promise)
+  }
 
-      if (result == null) {
-        logger.trace({ utilization: vendor }, 'No information returned for vendor %s.', vendor)
-        continue
-      }
-
-      vendors = vendors || Object.create(null)
-      vendors[vendor] = result
-      logger.info({ utilization: vendor, result }, 'Information for vendor %s retrieved successfully.', vendor)
-    } catch (error) {
-      logger.error({ utilization: vendor, error }, 'Failed to get information about vendor %s.', vendor)
-    } finally {
-      logger.trace({ utilization: vendor }, 'Vendor %s finished.', vendor)
-    }
+  const results = await Promise.all(toResolve)
+  for (const [vendor, result] of results) {
+    if (!vendor) continue
+    vendors = vendors || Object(null)
+    vendors[vendor] = result
   }
 
   return vendors
+}
+
+async function resolveVendor({ vendor, resolver, agent, logger }) {
+  logger.trace({ utilization: vendor }, 'Detecting utilization info for vendor %s.', vendor)
+  try {
+    const result = await new Promise((resolve, reject) => {
+      resolver(agent, (error, data) => {
+        if (error) return reject(error)
+        resolve(data)
+      })
+    })
+
+    if (result == null) {
+      logger.trace({ utilization: vendor }, 'No information returned for vendor %s.', vendor)
+      return []
+    }
+
+    logger.info({ utilization: vendor, result }, 'Information for vendor %s retrieved successfully.', vendor)
+    return [vendor, result]
+  } catch (error) {
+    logger.error({ utilization: vendor, error }, 'Failed to get information about vendor %s.', vendor)
+    return []
+  } finally {
+    logger.trace({ utilization: vendor }, 'Vendor %s finished.', vendor)
+  }
 }

--- a/test/unit/utilization/main.test.js
+++ b/test/unit/utilization/main.test.js
@@ -239,36 +239,63 @@ describe('getVendors', () => {
     assert.equal(logs.info.length, 0)
     assert.equal(logs.trace.length, 6)
 
-    assert.deepStrictEqual(logs.trace[0], [
-      { utilization: 'aws' },
-      'Detecting utilization info for vendor %s.',
-      'aws'
-    ])
-    assert.deepStrictEqual(logs.trace[1], [
-      { utilization: 'aws' },
-      'No information returned for vendor %s.',
-      'aws'
-    ])
-    assert.deepStrictEqual(logs.trace[2], [
-      { utilization: 'aws' },
-      'Vendor %s finished.',
-      'aws'
-    ])
+    assert.equal(
+      hasLog(logs.trace, [
+        { utilization: 'aws' },
+        'Detecting utilization info for vendor %s.',
+        'aws'
+      ]),
+      true
+    )
+    assert.equal(
+      hasLog(logs.trace, [
+        { utilization: 'aws' },
+        'No information returned for vendor %s.',
+        'aws'
+      ]),
+      true
+    )
+    assert.equal(
+      hasLog(logs.trace, [
+        { utilization: 'aws' },
+        'Vendor %s finished.',
+        'aws'
+      ]),
+      true
+    )
 
-    assert.deepStrictEqual(logs.trace[3], [
-      { utilization: 'foo' },
-      'Detecting utilization info for vendor %s.',
-      'foo'
-    ])
-    assert.deepStrictEqual(logs.trace[4], [
-      { utilization: 'foo' },
-      'No information returned for vendor %s.',
-      'foo'
-    ])
-    assert.deepStrictEqual(logs.trace[5], [
-      { utilization: 'foo' },
-      'Vendor %s finished.',
-      'foo'
-    ])
+    assert.equal(
+      hasLog(logs.trace, [
+        { utilization: 'foo' },
+        'Detecting utilization info for vendor %s.',
+        'foo'
+      ]),
+      true
+    )
+    assert.equal(
+      hasLog(logs.trace, [
+        { utilization: 'foo' },
+        'No information returned for vendor %s.',
+        'foo'
+      ]),
+      true
+    )
+    assert.equal(
+      hasLog(logs.trace, [
+        { utilization: 'foo' },
+        'Vendor %s finished.',
+        'foo'
+      ]),
+      true
+    )
   })
 })
+
+function hasLog(logs, log) {
+  return logs.find(
+    (l) => {
+      if (l[0].utilization !== log[0].utilization) return false
+      return l[1] === log[1] && l[2] === log[2]
+    }
+  ) !== undefined
+}


### PR DESCRIPTION
Yesterday I refactored the vendor information resolution code to serially resolve the information (#3552). Thinking about it some more, I think it might not be a great idea to do this work serially. Yes, we get easier to reason through logs, but we lose a bit of time to the resolution of platforms the application isn't running on. For example, if the app is running on GCP, the AWS resolution is going to  hit a non-existent endpoint and take some amount of time to recognize that and abort the metadata network request. In the serial version, this blocks the resolution of other vendors. In the concurrent version, this resolution is likely to happen in roughly the same amount of time as the other vendors, thus marginally reducing startup time.

We still have all of the logs tagged `utilization: <vendor_name>`. So we can filter logs based on that data if we need to see them in context.