### PR TITLE
chore: Improve OTEL hrtime processing

### DIFF
--- a/lib/otel/normalize-timestamp.js
+++ b/lib/otel/normalize-timestamp.js
@@ -42,12 +42,7 @@ function normalizeTimestamp(input) {
   }
 
   if (isTimeInputHrTime(input) === true) {
-    // It's unclear why upstream tries to support a `process.hrtime()` value.
-    // Such tuples are relative to an arbitrary point in time, not the Unix
-    // epoch. So there's no way to determine an actual wall clock time and date
-    // from such input. For lack of a better solution, we'll return the
-    // current epoch in this case.
-    return Date.now()
+    return hrtimeToMilliseconds(input)
   }
 
   if (Object.getPrototypeOf(input) === Date.prototype) {
@@ -56,4 +51,29 @@ function normalizeTimestamp(input) {
 
   // We don't know what they've given us, so just return the current time.
   return Date.now()
+}
+
+const { performance } = require('node:perf_hooks')
+
+/**
+ * Converts a JS Open Telemetry hrtime tuple to milliseconds since the
+ * standard epoch.
+ *
+ * @param {number[]} hrtime Upstream represents hrtime as `[seconds, nanoseconds]`.
+ *
+ * @returns {number} Milliseconds since standard epoch time.
+ */
+function hrtimeToMilliseconds(hrtime) {
+  const seconds = hrtime[0]
+  const nanoseconds = hrtime[1]
+
+  // Convert the seconds portion to milliseconds.
+  const msSeconds = seconds * 1_000
+  // Convert the nanoseconds portion to milliseconds.
+  const msNanoseconds = nanoseconds / 1_000_000
+  // At this point, we have the number of milliseconds since the application
+  // was started.
+  const msSinceStart = msSeconds + msNanoseconds
+
+  return Math.trunc(performance.timeOrigin + msSinceStart)
 }

--- a/test/unit/lib/otel/normalize-timestamp.test.js
+++ b/test/unit/lib/otel/normalize-timestamp.test.js
@@ -8,6 +8,7 @@
 const test = require('node:test')
 const assert = require('node:assert')
 const { performance } = require('node:perf_hooks')
+const { hrTime } = require('@opentelemetry/core')
 
 const normalizeTimestamp = require('#agentlib/otel/normalize-timestamp.js')
 
@@ -43,7 +44,7 @@ test('normalizes performance.now', () => {
 
 test('normalizes hrtime', () => {
   const dnow = Date.now()
-  const input = process.hrtime()
+  const input = hrTime()
   const found = normalizeTimestamp(input)
   assert.equal(found >= dnow, true)
   assert.equal(isNaN(new Date(found)), false)


### PR DESCRIPTION
This PR resolves #3555.

It turns out that upstream uses `node_perf.performance.now()`, _not_ `process.hrtime()`. But they still don't quite represent the time as milliseconds since the epoch. Their [hrtime to milliseconds implementation](https://github.com/open-telemetry/opentelemetry-js/blob/eced3f9b261850c40505c9055920e3c5ec82023a/packages/opentelemetry-core/src/common/time.ts#L127-L133) represents the time since the start of the application in milliseconds. This PR converts it to a number that `new Date()` will accept and return a correct `.toISOString()`.