### PR TITLE
chore: add `toString` and `get [Symbol.toStringTag]()` to default Sampler class

### DIFF
--- a/lib/samplers/adaptive-sampler.js
+++ b/lib/samplers/adaptive-sampler.js
@@ -39,10 +39,6 @@ class AdaptiveSampler extends Sampler {
     }
   }
 
-  toString() {
-    return 'AdaptiveSampler'
-  }
-
   get sampled() {
     return this._sampled
   }

--- a/lib/samplers/index.js
+++ b/lib/samplers/index.js
@@ -83,12 +83,12 @@ class Samplers {
 
     if (this.fullEnabled) {
       this.root.applySamplingDecision({ transaction, isFullTrace: true })
-      logger.trace('Ran full granularity applySamplingDecision %s sampler for transaction %s, decision: { sampled: %s, priority: %n}', this.root.toString(), transaction.id, transaction.sampled, transaction.priority)
+      logger.trace('Ran full granularity applySamplingDecision %s sampler for transaction %s, decision: { sampled: %s, priority: %d }', this.root.toString(), transaction.id, transaction.sampled, transaction.priority)
     }
 
     if (this.shouldRunPartialSampling(transaction)) {
       this.partialRoot.applySamplingDecision({ transaction })
-      logger.trace('Ran partial granularity applySamplingDecision %s sampler for transaction %s, decision: { sampled: %s, priority: %n}', this.partialRoot.toString(), transaction.id, transaction.sampled, transaction.priority)
+      logger.trace('Ran partial granularity applySamplingDecision %s sampler for transaction %s, decision: { sampled: %s, priority: %d }', this.partialRoot.toString(), transaction.id, transaction.sampled, transaction.priority)
     }
   }
 
@@ -116,13 +116,13 @@ class Samplers {
     if (this.fullEnabled) {
       const sampler = traceparent?.isSampled ? this.remoteParentSampled : this.remoteParentNotSampled
       sampler.applySamplingDecision({ transaction, tracestate, isFullTrace: true })
-      logger.trace('Ran full granularity applyDTSamplingDecision %s sampler for transaction %s, decision: { sampled: %s, priority: %n}', sampler.toString(), transaction.id, transaction.sampled, transaction.priority)
+      logger.trace('Ran full granularity applyDTSamplingDecision %s sampler for transaction %s, decision: { sampled: %s, priority: %d }', sampler.toString(), transaction.id, transaction.sampled, transaction.priority)
     }
 
     if (this.shouldRunPartialSampling(transaction)) {
       const partialSampler = traceparent?.isSampled ? this.partialRemoteParentSampled : this.partialRemoteParentNotSampled
       partialSampler.applySamplingDecision({ transaction, tracestate })
-      logger.trace('Ran partial granularity applyDTSamplingDecision %s sampler for transaction %s, decision: { sampled: %s, priority: %n}', partialSampler.toString(), transaction.id, transaction.sampled, transaction.priority)
+      logger.trace('Ran partial granularity applyDTSamplingDecision %s sampler for transaction %s, decision: { sampled: %s, priority: %d }', partialSampler.toString(), transaction.id, transaction.sampled, transaction.priority)
     }
   }
 
@@ -155,7 +155,7 @@ class Samplers {
         logger.trace('Not running full granularity applyLegacyDTSamplingDecision for transaction %s because sampler is AdaptiveSampler', transaction.id)
       } else {
         sampler.applySamplingDecision({ transaction, isFullTrace: true })
-        logger.trace('Ran full granularity applyLegacyDTSamplingDecision %s sampler for transaction %s, decision: { sampled: %s, priority: %n}', sampler.toString(), transaction.id, transaction.sampled, transaction.priority)
+        logger.trace('Ran full granularity applyLegacyDTSamplingDecision %s sampler for transaction %s, decision: { sampled: %s, priority: %d }', sampler.toString(), transaction.id, transaction.sampled, transaction.priority)
       }
     }
 
@@ -165,7 +165,7 @@ class Samplers {
         logger.trace('Not running partial granularity applyLegacyDTSamplingDecision for transaction %s because sampler is AdaptiveSampler', transaction.id)
       } else {
         partialSampler.applySamplingDecision({ transaction })
-        logger.trace('Ran partial granularity applyLegacyDTSamplingDecision %s sampler for transaction %s, decision: { sampled: %s, priority: %n}', partialSampler.toString(), transaction.id, transaction.sampled, transaction.priority)
+        logger.trace('Ran partial granularity applyLegacyDTSamplingDecision %s sampler for transaction %s, decision: { sampled: %s, priority: %d }', partialSampler.toString(), transaction.id, transaction.sampled, transaction.priority)
       }
     }
   }

--- a/lib/samplers/ratio-based-sampler.js
+++ b/lib/samplers/ratio-based-sampler.js
@@ -45,10 +45,6 @@ class TraceIdRatioBasedSampler extends Sampler {
     return accumulated <= this._upperBound
   }
 
-  toString() {
-    return 'TraceIdRatioBasedSampler'
-  }
-
   /**
    * Normalizes the sampling ratio.
    * @param {number} ratio The ratio provided by the config, granted it is a number.

--- a/lib/samplers/sampler.js
+++ b/lib/samplers/sampler.js
@@ -9,6 +9,12 @@ const util = require('node:util')
  * @interface
  */
 class Sampler {
+  get [Symbol.toStringTag]() { return this.constructor.name }
+
+  toString() {
+    return this.constructor.name
+  }
+
   /**
    * Sets `priority` and `sampled` on the transaction
    * in respect to this sampler's decision.

--- a/test/unit/samplers/adaptive-sampler.test.js
+++ b/test/unit/samplers/adaptive-sampler.test.js
@@ -13,6 +13,12 @@ const helper = require('../../lib/agent_helper')
 const AdaptiveSampler = require('../../../lib/samplers/adaptive-sampler')
 
 const shared = {
+  'should set toString and Object.prototype.toString correctly': (t) => {
+    const { sampler } = t.nr
+    assert.equal(sampler.toString(), 'AdaptiveSampler')
+    assert.equal(Object.prototype.toString.call(sampler), '[object AdaptiveSampler]')
+  },
+
   'should count the number of traces sampled': (t) => {
     const { sampler } = t.nr
     assert.equal(sampler.sampled, 0)

--- a/test/unit/samplers/always-off-sampler.test.js
+++ b/test/unit/samplers/always-off-sampler.test.js
@@ -13,6 +13,12 @@ test.beforeEach((ctx) => {
   ctx.nr = { sampler }
 })
 
+test('should set toString and Object.prototype.toString correctly', (t) => {
+  const { sampler } = t.nr
+  assert.equal(sampler.toString(), 'AlwaysOffSampler')
+  assert.equal(Object.prototype.toString.call(sampler), '[object AlwaysOffSampler]')
+})
+
 test('AlwaysOffSampler should always sample', (t) => {
   const { sampler } = t.nr
   const transaction = {}

--- a/test/unit/samplers/always-on-sampler.test.js
+++ b/test/unit/samplers/always-on-sampler.test.js
@@ -13,6 +13,12 @@ test.beforeEach((ctx) => {
   ctx.nr = { sampler }
 })
 
+test('should set toString and Object.prototype.toString correctly', (t) => {
+  const { sampler } = t.nr
+  assert.equal(sampler.toString(), 'AlwaysOnSampler')
+  assert.equal(Object.prototype.toString.call(sampler), '[object AlwaysOnSampler]')
+})
+
 test('AlwaysOnSampler should always sample', (t) => {
   const { sampler } = t.nr
   const transaction = {}

--- a/test/unit/samplers/ratio-based-sampler.test.js
+++ b/test/unit/samplers/ratio-based-sampler.test.js
@@ -17,6 +17,12 @@ function generateRandomTraceId() {
   return hashes.makeId(32)
 }
 
+test('should set toString and Object.prototype.toString correctly', (t) => {
+  const sampler = new TraceIdRatioBasedSampler({ ratio: 0.5 })
+  assert.equal(sampler.toString(), 'TraceIdRatioBasedSampler')
+  assert.equal(Object.prototype.toString.call(sampler), '[object TraceIdRatioBasedSampler]')
+})
+
 test('should create a TraceIdRatioBasedSampler with the correct ratio', (t) => {
   const sampler = new TraceIdRatioBasedSampler({ ratio: 0.5 })
   assert.strictEqual(sampler._ratio, 0.5)


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
I was testing the samplers with an app and the log lines were off for two reason:
 * `util.format` uses `%d` for numbers not `%n`
 * Not all samplers have a `toString` method. I moved this to the base Sampler class
