### PR TITLE
chore: Added more logging around assigning hostname during preconnect

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1001,10 +1001,13 @@ function getHostnameSafe(gcpId = null) {
     // If not applicable, use the os.hostname()
     if (config.heroku.use_dyno_names && process.env.DYNO) {
       _hostname = process.env.DYNO || os.hostname()
+      logger.info('Using Heroku dyno name for host name: %s', _hostname)
     } else if (config.utilization.gcp_use_instance_as_host && process.env.K_SERVICE && gcpId) {
       _hostname = gcpId
+      logger.info('Using GCP instance ID for host name: %s', _hostname)
     } else {
       _hostname = os.hostname()
+      logger.info('Using OS hostname for host name: %s', _hostname)
     }
     return _hostname
   } catch {
@@ -1012,14 +1015,15 @@ function getHostnameSafe(gcpId = null) {
 
     if (this.process_host.ipv_preference === '6' && addresses.ipv6) {
       _hostname = addresses.ipv6
+      logger.info('Defaulting to ipv6 address for host name: %s', _hostname)
     } else if (addresses.ipv4) {
-      logger.info('Defaulting to ipv4 address for host name')
+      logger.info('Defaulting to ipv4 address for host name: %s', _hostname)
       _hostname = addresses.ipv4
     } else if (addresses.ipv6) {
-      logger.info('Defaulting to ipv6 address for host name')
+      logger.info('Defaulting to ipv6 address for host name: %s', _hostname)
       _hostname = addresses.ipv6
     } else {
-      logger.info('No hostname, ipv4, or ipv6 address found for machine')
+      logger.info('No hostname, ipv4, or ipv6 address found for machine using UNKNOWN_BOX')
       _hostname = 'UNKNOWN_BOX'
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
This is a follow up from #3552.  This logs which case is assigning the hostname. Since this is cached it'll only happen once.  This will help us identify which code path is being used in the wild and to triage the GTSE where we are not using the gcp instance id as the hostname.
