### PR TITLE
chore: Pin prisma

### DIFF
--- a/test/versioned/prisma/package.json
+++ b/test/versioned/prisma/package.json
@@ -17,7 +17,7 @@
         "node": ">=20"
       },
       "dependencies": {
-        "@prisma/client": ">=5.0.0 <5.9.0 || >=5.9.1 <7.0.0"
+        "@prisma/client": ">=5.0.0 <5.9.0 || >=5.9.1 <=6.19.0"
       },
       "files": [
         "prisma.test.js"


### PR DESCRIPTION
Prisma has "backported" some fix to the v6 line that is really them using v7 packages in the v6 line -- https://github.com/prisma/prisma/compare/6.19.0...6.19.1.