### PR TITLE
chore: Unpin prisma

### DIFF
--- a/test/versioned/prisma/package.json
+++ b/test/versioned/prisma/package.json
@@ -17,7 +17,7 @@
         "node": ">=20"
       },
       "dependencies": {
-        "@prisma/client": ">=5.0.0 <5.9.0 || >=5.9.1 <=6.19.0"
+        "@prisma/client": ">=5.0.0 <5.9.0 || >=5.9.1 <7.0.0"
       },
       "files": [
         "prisma.test.js"


### PR DESCRIPTION
Re-opens the version range to include the whole v6 range.