### PR TITLE
test: Moved mock aws bedrock server creation to `test/lib/aws-server-stubs/index.js`

### DIFF
--- a/test/lib/aws-server-stubs/ai-server/http2.js
+++ b/test/lib/aws-server-stubs/ai-server/http2.js
@@ -338,7 +338,3 @@ function encodeChunks(chunks) {
     }
   }).pause()
 }
-
-module.exports.internals = {
-  encodeChunks
-}

--- a/test/lib/aws-server-stubs/ai-server/index.js
+++ b/test/lib/aws-server-stubs/ai-server/index.js
@@ -322,7 +322,3 @@ function encodeChunks(chunks) {
     }
   }).pause()
 }
-
-module.exports.internals = {
-  encodeChunks
-}

--- a/test/lib/aws-server-stubs/index.js
+++ b/test/lib/aws-server-stubs/index.js
@@ -7,6 +7,9 @@
 
 const createEmptyResponseServer = require('./empty-response-server')
 const createResponseServer = require('./response-server')
+const semver = require('semver')
+const path = require('node:path')
+const fs = require('node:fs')
 
 // Specific values are unimportant because we'll be hitting our
 // custom servers. But they need to be populated.
@@ -15,8 +18,27 @@ const FAKE_CREDENTIALS = {
   secretAccessKey: 'FAKE KEY'
 }
 
+/**
+ * Determines whether to use the http or http2 mock server
+ * given the `@aws-sdk/client-bedrock-runtime` package
+ * version.
+ * @param {string} rootPath The root path to the `node_modules` folder with AWS Bedrock `package.json`.
+ * @returns {object} The mock AWS Bedrock server, http or http2.
+ */
+function getAiResponseServer(rootPath) {
+  const bedrockPackagePath = path.join(rootPath, '/node_modules/@aws-sdk/client-bedrock-runtime/package.json')
+  const { version: pkgVersion } = JSON.parse(
+    fs.readFileSync(bedrockPackagePath)
+  )
+  if (semver.gte(pkgVersion, '3.798.0')) {
+    return require('./ai-server/http2')
+  }
+  return require('./ai-server')
+}
+
 module.exports = {
   createEmptyResponseServer,
   createResponseServer,
-  FAKE_CREDENTIALS
+  FAKE_CREDENTIALS,
+  getAiResponseServer
 }

--- a/test/versioned/aws-sdk-v3/bedrock-chat-completions.test.js
+++ b/test/versioned/aws-sdk-v3/bedrock-chat-completions.test.js
@@ -11,15 +11,14 @@ const {
   assertChatCompletionMessages,
   assertChatCompletionSummary,
   assertChatCompletionMessage,
-  getAiResponseServer
 } = require('./common')
 const helper = require('../../lib/agent_helper')
-const { FAKE_CREDENTIALS } = require('../../lib/aws-server-stubs')
+const { FAKE_CREDENTIALS, getAiResponseServer } = require('../../lib/aws-server-stubs')
 const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
 const { assertSegments, match } = require('../../lib/custom-assertions')
 const promiseResolvers = require('../../lib/promise-resolvers')
 const { tspl } = require('@matteo.collina/tspl')
-const createAiResponseServer = getAiResponseServer()
+const createAiResponseServer = getAiResponseServer(__dirname)
 
 function consumeStreamChunk() {
   // A no-op function used to consume chunks of a stream.

--- a/test/versioned/aws-sdk-v3/bedrock-converse-api.test.js
+++ b/test/versioned/aws-sdk-v3/bedrock-converse-api.test.js
@@ -10,15 +10,14 @@ const {
   afterEach,
   assertChatCompletionMessages,
   assertChatCompletionSummary,
-  getAiResponseServer
 } = require('./common')
 const helper = require('../../lib/agent_helper')
-const { FAKE_CREDENTIALS } = require('../../lib/aws-server-stubs')
+const { FAKE_CREDENTIALS, getAiResponseServer } = require('../../lib/aws-server-stubs')
 const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
 const { assertPackageMetrics, assertSegments, match } = require('../../lib/custom-assertions')
 const promiseResolvers = require('../../lib/promise-resolvers')
 const responseConstants = require('../../lib/aws-server-stubs/ai-server/responses/constants')
-const createAiResponseServer = getAiResponseServer()
+const createAiResponseServer = getAiResponseServer(__dirname)
 
 // We'll test with only one model because the
 // request and response structure is the same

--- a/test/versioned/aws-sdk-v3/bedrock-embeddings.test.js
+++ b/test/versioned/aws-sdk-v3/bedrock-embeddings.test.js
@@ -8,10 +8,10 @@ const assert = require('node:assert')
 const test = require('node:test')
 const helper = require('../../lib/agent_helper')
 const { assertSegments, match } = require('../../lib/custom-assertions')
-const { FAKE_CREDENTIALS } = require('../../lib/aws-server-stubs')
+const { FAKE_CREDENTIALS, getAiResponseServer } = require('../../lib/aws-server-stubs')
 const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
-const { afterEach, getAiResponseServer } = require('./common')
-const createAiResponseServer = getAiResponseServer()
+const { afterEach } = require('./common')
+const createAiResponseServer = getAiResponseServer(__dirname)
 const requests = {
   amazon: (prompt, modelId) => {
     return {

--- a/test/versioned/aws-sdk-v3/bedrock-negative-tests.test.js
+++ b/test/versioned/aws-sdk-v3/bedrock-negative-tests.test.js
@@ -7,10 +7,10 @@
 const assert = require('node:assert')
 const test = require('node:test')
 const helper = require('../../lib/agent_helper')
-const { FAKE_CREDENTIALS } = require('../../lib/aws-server-stubs')
+const { FAKE_CREDENTIALS, getAiResponseServer } = require('../../lib/aws-server-stubs')
 const sinon = require('sinon')
-const { afterEach, getAiResponseServer } = require('./common')
-const createAiResponseServer = getAiResponseServer()
+const { afterEach } = require('./common')
+const createAiResponseServer = getAiResponseServer(__dirname)
 
 test.beforeEach(async (ctx) => {
   ctx.nr = {}

--- a/test/versioned/aws-sdk-v3/common.js
+++ b/test/versioned/aws-sdk-v3/common.js
@@ -16,8 +16,6 @@ const { match } = require('../../lib/custom-assertions')
 const assert = require('node:assert')
 const SEGMENT_DESTINATION = TRANS_SEGMENT
 const helper = require('../../lib/agent_helper')
-const fs = require('node:fs')
-const path = require('node:path')
 
 function checkAWSAttributes({ trace, segment, pattern, markedSegments = [] }) {
   const expectedAttrs = {
@@ -190,25 +188,6 @@ function afterEach(ctx) {
   })
 }
 
-/**
- * Determines whether to use the http or http2 mock server
- * given the `@aws-sdk/client-bedrock-runtime` package
- * version.
- * @param {string} rootPath The root path to the `node_modules` folder with AWS Bedrock `package.json`.
- * @returns {object} The mock AWS Bedrock server, http or http2.
- */
-function getAiResponseServer(rootPath = __dirname) {
-  const bedrockPackagePath = path.join(rootPath, '/node_modules/@aws-sdk/client-bedrock-runtime/package.json')
-  const semver = require('semver')
-  const { version: pkgVersion } = JSON.parse(
-    fs.readFileSync(bedrockPackagePath)
-  )
-  if (semver.gte(pkgVersion, '3.798.0')) {
-    return require('../../lib/aws-server-stubs/ai-server/http2')
-  }
-  return require('../../lib/aws-server-stubs/ai-server')
-}
-
 module.exports = {
   afterEach,
   assertChatCompletionSummary,
@@ -221,6 +200,5 @@ module.exports = {
   SEGMENT_DESTINATION,
   checkAWSAttributes,
   getMatchingSegments,
-  checkExternals,
-  getAiResponseServer
+  checkExternals
 }

--- a/test/versioned/langchain/bedrock/runnables-streaming.test.js
+++ b/test/versioned/langchain/bedrock/runnables-streaming.test.js
@@ -18,8 +18,7 @@ const {
   filterLangchainEventsByType
 } = require('../common')
 const { version: pkgVersion } = require('@langchain/core/package.json')
-const { getAiResponseServer } = require('../../aws-sdk-v3/common')
-const { FAKE_CREDENTIALS } = require('../../../lib/aws-server-stubs')
+const { FAKE_CREDENTIALS, getAiResponseServer } = require('../../../lib/aws-server-stubs')
 const helper = require('../../../lib/agent_helper')
 
 const config = {

--- a/test/versioned/langchain/bedrock/runnables.test.js
+++ b/test/versioned/langchain/bedrock/runnables.test.js
@@ -18,8 +18,7 @@ const {
   filterLangchainEventsByType
 } = require('../common')
 const { version: pkgVersion } = require('@langchain/core/package.json')
-const { getAiResponseServer } = require('../../aws-sdk-v3/common')
-const { FAKE_CREDENTIALS } = require('../../../lib/aws-server-stubs')
+const { FAKE_CREDENTIALS, getAiResponseServer } = require('../../../lib/aws-server-stubs')
 const helper = require('../../../lib/agent_helper')
 
 const config = {

--- a/test/versioned/langchain/bedrock/vectorstore.test.js
+++ b/test/versioned/langchain/bedrock/vectorstore.test.js
@@ -18,8 +18,7 @@ const {
   filterLangchainEventsByType
 } = require('../common')
 const { Document } = require('@langchain/core/documents')
-const { getAiResponseServer } = require('../../aws-sdk-v3/common')
-const { FAKE_CREDENTIALS } = require('../../../lib/aws-server-stubs')
+const { FAKE_CREDENTIALS, getAiResponseServer } = require('../../../lib/aws-server-stubs')
 const params = require('../../../lib/params')
 const helper = require('../../../lib/agent_helper')
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
The place to retrieve the mock bedrock server poses issues when running in CI.  This is because it lives in `test/versioned/aws-sdk-v3`. Since langchain now uses this it was attempting to load depdendencies, mostly `semver` from `test/versioned/aws-sdk-v3/node_modules`.  CI was failing for langchain because I suspect it was running both langchain and aws tests at the same time and aws was mid install, uninstalling its dep tree and mostly semver.


This PR moves the creation of the mock server to `test/lib` so it will reliably use `semver` installed from agent root and also group all the mock server creations into `test/lib`.
