### PR TITLE
feat: Add `entity_guid` to Agent Control health file

### DIFF
--- a/lib/collector/api.js
+++ b/lib/collector/api.js
@@ -431,9 +431,6 @@ CollectorAPI.prototype._onConnect = function _onConnect(callback, error, res) {
 
   // pass configuration data from the API so automatic reconnect works
   agent.reconfigure(config)
-  if (config.entity_guid) {
-    agent.healthReporter.setEntityGuid(config.entity_guid)
-  }
 
   callback(null, res)
 }

--- a/lib/health-reporter.js
+++ b/lib/health-reporter.js
@@ -65,8 +65,8 @@ function directoryAvailable(dest) {
  * by the environment.
  */
 class HealthReporter {
+  #agentConfig = {}
   #enabled = false
-  #entityGuid = ''
   #status = HealthReporter.STATUS_HEALTHY
   #interval
   #destFile
@@ -122,6 +122,7 @@ class HealthReporter {
     logger = defaultLogger,
     setInterval = global.setInterval
   } = {}) {
+    this.#agentConfig = agentConfig
     const enabled = agentConfig?.agent_control?.enabled
     const checkInterval = parseInt(agentConfig?.agent_control?.health?.frequency, 10) * 1_000
     let outDir = agentConfig?.agent_control?.health?.delivery_location
@@ -163,7 +164,7 @@ class HealthReporter {
     const healthy = this.#status === HealthReporter.STATUS_HEALTHY
     writeStatus({
       file: this.#destFile,
-      entityGuid: this.#entityGuid,
+      entityGuid: this.#agentConfig.entity_guid || '',
       healthy,
       startTime: this.#startTime,
       code: this.#status,
@@ -182,20 +183,6 @@ class HealthReporter {
 
   get destFile() {
     return this.#destFile
-  }
-
-  /**
-   * Update the entity GUID. This entity GUID will be written at
-   * the top of the health file on the next interval.
-   *
-   * @param {string} entityGuid to update
-   */
-  setEntityGuid(entityGuid) {
-    if (this.#enabled === false) {
-      return
-    }
-
-    this.#entityGuid = entityGuid
   }
 
   /**
@@ -258,7 +245,7 @@ class HealthReporter {
 
     writeStatus({
       file: this.#destFile,
-      entityGuid: this.#entityGuid,
+      entityGuid: this.#agentConfig.entity_guid || '',
       startTime: this.#startTime,
       healthy,
       code,

--- a/test/unit/collector/api-connect.test.js
+++ b/test/unit/collector/api-connect.test.js
@@ -72,42 +72,6 @@ test('receiving 200 response, with valid data', async (t) => {
       end()
     })
   })
-
-  await t.test('should set entity guid on health reporter when present', (t, end) => {
-    const { agent, collector, collectorApi } = t.nr
-    const expectedGuid = 'test-entity-guid-12345'
-
-    collector.addHandler(helper.generateCollectorPath('connect', RUN_ID), (req, res) => {
-      res.json({ payload: { return_value: { agent_run_id: RUN_ID, entity_guid: expectedGuid } } })
-    })
-
-    let setEntityGuidCalled = false
-    agent.healthReporter.setEntityGuid = (guid) => {
-      setEntityGuidCalled = true
-      assert.equal(guid, expectedGuid)
-    }
-
-    collectorApi.connect((error) => {
-      assert.ifError(error)
-      assert.equal(setEntityGuidCalled, true, 'setEntityGuid should have been called')
-      end()
-    })
-  })
-
-  await t.test('should handle missing entity guid gracefully', (t, end) => {
-    const { agent, collectorApi } = t.nr
-
-    let setEntityGuidCalled = false
-    agent.healthReporter.setEntityGuid = () => {
-      setEntityGuidCalled = true
-    }
-
-    collectorApi.connect((error) => {
-      assert.ifError(error)
-      assert.equal(setEntityGuidCalled, false, 'setEntityGuid should not be called when entity_guid is missing')
-      end()
-    })
-  })
 })
 
 test('succeeds when given a different port number for redirect', async (t) => {
@@ -463,29 +427,6 @@ test('retries on receiving invalid license key (401)', async (t) => {
     collectorApi.connect(() => {})
 
     await plan.completed
-  })
-
-  await t.test('should set entity guid on health reporter after retry success', (t, end) => {
-    const { agent, collector, collectorApi } = t.nr
-    const expectedGuid = 'entity-guid-after-retry'
-
-    // Override the connect handler to include entity_guid
-    collector.addHandler(helper.generateCollectorPath('connect', RUN_ID), (req, res) => {
-      res.json({ payload: { return_value: { agent_run_id: 31338, entity_guid: expectedGuid } } })
-    })
-
-    let setEntityGuidCalled = false
-    agent.healthReporter.setEntityGuid = (guid) => {
-      setEntityGuidCalled = true
-      assert.equal(guid, expectedGuid)
-    }
-
-    collectorApi.connect((error, res) => {
-      assert.ifError(error)
-      assert.equal(res.payload.agent_run_id, 31338)
-      assert.equal(setEntityGuidCalled, true, 'setEntityGuid should be called after successful retry')
-      end()
-    })
   })
 })
 


### PR DESCRIPTION

## Description

To facilitate establishing relationships between fleet control agent entities and the related APM service that an agent creates, the entity guid will now be part of the health file written out for agent control. Note that this new field MUST be the first entry in the health file.

From the spec:
"| entity_guid           | string    | The **primary** entity GUID received in the connect response. This **MUST** be the first field in the health file  |

This format is based on the [OpAMP protocol](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#componenthealth-message). The entity
GUID is the first field in the file so as not to break the OpAmp compatibility in the remainder of the file.

For a health file written out prior to the entity GUID being available, the agent **should** include the `entity_guid` key with an empty value."

## How to Test

```
npm run unit
```

## Related Issues

Closes #3591 