### PR TITLE
fix: Updated AWS Lambda instrumentation to skip wrapping handler callback if not present

### DIFF
--- a/lib/serverless/aws-lambda.js
+++ b/lib/serverless/aws-lambda.js
@@ -200,14 +200,13 @@ class AwsLambda {
         return handler.apply(this, args)
       }
 
-      const event = args[0]
-      const context = args[2]
+      const [event, responseStream, context] = args
       logger.trace('In stream handler, lambda function name', context?.functionName)
       const { segment, txnEnder } = awsLambda.createSegment({ context, event, transaction, recorder: recordBackground })
       args[1] = awsLambda.wrapStreamAndCaptureError(
         transaction,
         txnEnder,
-        args[1]
+        responseStream
       )
 
       let res
@@ -238,8 +237,7 @@ class AwsLambda {
         return handler.apply(this, args)
       }
 
-      const event = args[0]
-      const context = args[1]
+      const [event, context, callback] = args
       logger.trace('Lambda function name', context?.functionName)
       const isApiGatewayLambdaProxy = apiGateway.isLambdaProxyEvent(event)
       logger.trace('Is this Lambda event an API Gateway or ALB web proxy?', isApiGatewayLambdaProxy)
@@ -256,16 +254,24 @@ class AwsLambda {
         setWebRequest(transaction, webRequest)
         resultProcessor = getApiGatewayLambdaProxyResultProcessor(transaction)
       }
-      const cbIndex = args.length - 1
-      args[cbIndex] = awsLambda.wrapCallbackAndCaptureError(
-        transaction,
-        txnEnder,
-        args[cbIndex],
-        resultProcessor
-      )
+
+      if (typeof callback === 'function') {
+        logger.trace('Wrapping Lambda handler callback')
+        const cbIndex = args.length - 1
+        args[cbIndex] = awsLambda.wrapCallbackAndCaptureError(
+          transaction,
+          txnEnder,
+          callback,
+          resultProcessor
+        )
+      } else {
+        logger.trace('Lambda handler callback not present, skip wrapping')
+      }
 
       // context.{done,fail,succeed} are all considered deprecated by
       // AWS, but are considered functional.
+      // TODO: Remove when we drop Node.js 22
+      // see: https://aws.amazon.com/blogs/compute/node-js-24-runtime-now-available-in-aws-lambda/
       context.done = awsLambda.wrapCallbackAndCaptureError(transaction, txnEnder, context.done)
       context.fail = awsLambda.wrapCallbackAndCaptureError(transaction, txnEnder, context.fail)
       shim.wrap(context, 'succeed', function wrapSucceed(shim, original) {


### PR DESCRIPTION

## Description

On November 25th, AWS release support for [Node.js 24 in Lambda](https://aws.amazon.com/blogs/compute/node-js-24-runtime-now-available-in-aws-lambda/).  They removed the callback to a lambda handler. This PR checks the last arg to make sure it's a function before wrapping.

## Related Issues
Closes #3599 