### PR TITLE
refactor: Removed unused `distributed_tracing.in_process_spans.enabled` logic. Partial granularity tracing replaces it

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1143,19 +1143,6 @@ defaultConfig.definition = () => {
         default: false
       },
 
-      /**
-       * Controls whether the agent will generate spans for in-process actions.
-       * When disabled, this will only create spans for entry and exit spans.
-       * entry spans - initial actions for web servers and message queue consumption.
-       * exit spans - all outgoing calls to external services(external and database calls)
-       */
-      in_process_spans: {
-        enabled: {
-          formatter: boolean,
-          default: true
-        }
-      },
-
       sampler: {
         ...samplerConfigs,
         /**

--- a/lib/spans/helpers.js
+++ b/lib/spans/helpers.js
@@ -61,62 +61,15 @@ function addSpanKind({ segment, span }) {
 }
 
 /**
- * Checks if the segment is an entry point span.
+ * Checks if the segment is an entry point.
  * An entry point span is defined as the base segment of a transaction.
  * @param {object} params to function
  * @param {Transaction} params.transaction active transaction
  * @param {TraceSegment} params.segment segment that is creating span
  * @returns {boolean} true if the segment is an entry point span
  */
-function isEntryPointSpan({ transaction, segment }) {
+function isEntryPoint({ transaction, segment }) {
   return transaction?.baseSegment === segment
-}
-
-/**
- * Checks if the segment is an exit span.
- * An exit span is defined as a segment that is an external call,
- * datastore operation, or message broker operation.
- * @param {TraceSegment} segment segment that is creating span
- * @returns {boolean} true if the segment is an exit span
- */
-function isExitSpan(segment) {
-  return REGEXS.CLIENT.EXTERNAL.test(segment.name) || REGEXS.CLIENT.DATASTORE.test(segment.name) || REGEXS.PRODUCER.test(segment.name)
-}
-
-/**
- * Determines if a span should be created based on the segment and transaction.
- * If the segment is an entry point span or an exit span, a span should be created.
- * @param {object} params to function
- * @param {boolean} params.entryPoint true if the segment is an entry point span
- * @param {TraceSegment} params.segment segment that is creating span
- * @returns {boolean} true if a span should be created
- */
-function shouldCreateSpan({ entryPoint, segment }) {
-  return entryPoint ||
-         isExitSpan(segment)
-}
-
-/**
- * Reparents a span based on the transaction and inProcessSpans.
- * If inProcessSpans is true or the transaction has accepted distributed trace and it's the root segment,
- * the parentId is not changed.
- * If there is a parentId and the transaction has a base segment, the span is reparented to the base segment.
- * If there is no parentId, the span is not reparented(indicates an entry root span for a DT trace).
- * @param {object} params to function
- * @param {boolean} params.inProcessSpans true if in-process spans are enabled
- * @param {boolean} params.isRoot true if the segment is the root segment
- * @param {string} params.parentId the parent id of the segment
- * @param {Transaction} params.transaction active transaction
- * @returns {string|null} the new parentId for the span
- */
-function reparentSpan({ inProcessSpans, isRoot, parentId, transaction }) {
-  if (inProcessSpans || (transaction.acceptedDistributedTrace && isRoot)) {
-    return parentId
-  } else if (parentId && transaction?.baseSegment?.id) {
-    return transaction.baseSegment.id
-  } else {
-    return null
-  }
 }
 
 module.exports = {
@@ -125,7 +78,5 @@ module.exports = {
   SPAN_KIND,
   REGEXS,
   addSpanKind,
-  isEntryPointSpan,
-  reparentSpan,
-  shouldCreateSpan
+  isEntryPoint
 }

--- a/lib/spans/span-event-aggregator.js
+++ b/lib/spans/span-event-aggregator.js
@@ -21,7 +21,6 @@ class SpanEventAggregator extends EventAggregator {
     opts.metricNames = opts.metricNames || NAMES.SPAN_EVENTS
 
     super(opts, agent)
-    this.inProcessSpans = agent.config.distributed_tracing.in_process_spans.enabled
   }
 
   _toPayloadSync() {
@@ -96,7 +95,7 @@ class SpanEventAggregator extends EventAggregator {
       return false
     }
 
-    const span = SpanEvent.fromSegment({ segment, transaction, parentId, isRoot, inProcessSpans: this.inProcessSpans })
+    const span = SpanEvent.fromSegment({ segment, transaction, parentId, isRoot })
 
     // Do not add span to aggregator if it is part of a partial trace
     // We need to reparent spans or in the case of `compact`, associate

--- a/lib/spans/span-event.js
+++ b/lib/spans/span-event.js
@@ -9,7 +9,7 @@ const Config = require('../config')
 const { truncate } = require('../util/byte-limit')
 
 const { DESTINATIONS } = require('../config/attribute-filter')
-const { addSpanKind, isEntryPointSpan, reparentSpan, shouldCreateSpan, HTTP_LIBRARY, REGEXS, SPAN_KIND, CATEGORIES } = require('./helpers')
+const { addSpanKind, isEntryPoint, HTTP_LIBRARY, REGEXS, SPAN_KIND, CATEGORIES } = require('./helpers')
 const EMPTY_USER_ATTRS = Object.freeze(Object.create(null))
 const SERVER_ADDRESS = 'server.address'
 const logger = require('../logger').child({ component: 'span-event' })
@@ -94,7 +94,7 @@ class SpanEvent {
     return this.intrinsics
   }
 
-  addIntrinsics({ segment, spanContext, transaction, parentId, isRoot, inProcessSpans, entryPoint }) {
+  addIntrinsics({ segment, spanContext, transaction, parentId, isRoot, entryPoint }) {
     for (const [key, value] of Object.entries(spanContext.intrinsicAttributes)) {
       this.addIntrinsicAttribute(key, value)
     }
@@ -105,7 +105,7 @@ class SpanEvent {
     this.addIntrinsicAttribute('priority', transaction.priority)
     this.addIntrinsicAttribute('name', segment.name)
     this.addIntrinsicAttribute('guid', segment.id)
-    this.addIntrinsicAttribute('parentId', reparentSpan({ inProcessSpans, isRoot, segment, transaction, parentId }))
+    this.addIntrinsicAttribute('parentId', parentId)
 
     if (isRoot) {
       this.addIntrinsicAttribute('trustedParentId', transaction.traceContext.trustedParentId)
@@ -237,15 +237,9 @@ class SpanEvent {
    * @param {Transaction} params.transaction active transaction
    * @param {?string} [params.parentId] ID of the segment's parent.
    * @param {boolean} [params.isRoot] if segment is root segment; defaults to `false`
-   * @param {boolean} params.inProcessSpans if the segment is in-process, create span
    * @returns {SpanEvent} The constructed event.
    */
-  static fromSegment({ segment, transaction, parentId = null, isRoot = false, inProcessSpans }) {
-    const entryPoint = isEntryPointSpan({ segment, transaction })
-    if (!inProcessSpans && !shouldCreateSpan({ entryPoint, segment, transaction })) {
-      return null
-    }
-
+  static fromSegment({ segment, transaction, parentId = null, isRoot = false }) {
     const spanContext = segment.getSpanContext()
 
     // Since segments already hold span agent attributes and we want to leverage
@@ -262,7 +256,8 @@ class SpanEvent {
     const attributes = segment.attributes.get(DESTINATIONS.SPAN_EVENT)
     const customAttributes = spanContext.customAttributes.get(DESTINATIONS.SPAN_EVENT)
     const span = SpanEvent.createSpan({ segment, attributes, customAttributes })
-    span.addIntrinsics({ segment, spanContext, transaction, parentId, isRoot, inProcessSpans, entryPoint })
+    const entryPoint = isEntryPoint({ segment, transaction })
+    span.addIntrinsics({ segment, spanContext, transaction, parentId, isRoot, entryPoint })
 
     addSpanKind({ segment, span })
     return SpanEvent.applyPartialTraceRules({ span, entryPoint, partialType: transaction.partialType })

--- a/lib/spans/streaming-span-event-aggregator.js
+++ b/lib/spans/streaming-span-event-aggregator.js
@@ -44,7 +44,6 @@ class StreamingSpanEventAggregator extends Aggregator {
     this.metrics = metrics
     this.started = false
     this.isStream = true
-    this.inProcessSpans = agent.config.distributed_tracing.in_process_spans.enabled
   }
 
   toString() {
@@ -116,14 +115,8 @@ class StreamingSpanEventAggregator extends Aggregator {
       return false
     }
 
-    const span = StreamingSpanEvent.fromSegment({ segment, transaction, parentId, isRoot, inProcessSpans: this.inProcessSpans })
-
-    if (span) {
-      this.stream.write(span)
-      return true
-    }
-
-    return false
+    const span = StreamingSpanEvent.fromSegment({ segment, transaction, parentId, isRoot })
+    return this.stream.write(span)
   }
 
   reconfigure(config) {

--- a/lib/spans/streaming-span-event.js
+++ b/lib/spans/streaming-span-event.js
@@ -10,7 +10,7 @@ const { truncate } = require('../util/byte-limit')
 const Config = require('../config')
 
 const { DESTINATIONS } = require('../config/attribute-filter')
-const { addSpanKind, isEntryPointSpan, reparentSpan, shouldCreateSpan, HTTP_LIBRARY, REGEXS, SPAN_KIND, CATEGORIES } = require('./helpers')
+const { addSpanKind, isEntryPoint, HTTP_LIBRARY, REGEXS, SPAN_KIND, CATEGORIES } = require('./helpers')
 
 /**
  * Specialized span event class for use with infinite streaming.
@@ -108,12 +108,7 @@ class StreamingSpanEvent {
     }
   }
 
-  static fromSegment({ segment, transaction, parentId = null, isRoot = false, inProcessSpans }) {
-    const entryPoint = isEntryPointSpan({ segment, transaction })
-    if (!inProcessSpans && !shouldCreateSpan({ entryPoint, segment, transaction })) {
-      return null
-    }
-
+  static fromSegment({ segment, transaction, parentId = null, isRoot = false }) {
     const spanContext = segment.getSpanContext()
 
     // Since segments already hold span agent attributes and we want to leverage
@@ -146,9 +141,8 @@ class StreamingSpanEvent {
       span.addIntrinsicAttribute(key, value)
     }
 
-    const newParentId = reparentSpan({ inProcessSpans, isRoot, segment, transaction, parentId })
     span.addIntrinsicAttribute('guid', segment.id)
-    span.addIntrinsicAttribute('parentId', newParentId)
+    span.addIntrinsicAttribute('parentId', parentId)
     span.addIntrinsicAttribute('transactionId', transaction.id)
     span.addIntrinsicAttribute('sampled', transaction.sampled)
     span.addIntrinsicAttribute('priority', transaction.priority)
@@ -162,7 +156,7 @@ class StreamingSpanEvent {
     }
 
     // Only set this if it will be `true`. Must be `null` otherwise.
-    if (entryPoint) {
+    if (isEntryPoint({ segment, transaction })) {
       span.addIntrinsicAttribute('nr.entryPoint', true)
     }
 

--- a/test/unit/api/api-custom-attributes.test.js
+++ b/test/unit/api/api-custom-attributes.test.js
@@ -226,7 +226,7 @@ test('Agent API - custom attributes', async (t) => {
       api.startSegment('foobar', false, function () {
         api.addCustomSpanAttribute('spannnnnny', 1)
         const segment = api.shim.getSegment()
-        const span = SpanEvent.fromSegment({ segment, transaction, parentId: 'parent', inProcessSpans: true })
+        const span = SpanEvent.fromSegment({ segment, transaction, parentId: 'parent' })
         const attributes = span.customAttributes
 
         assert.equal(attributes.spannnnnny, 1)
@@ -246,7 +246,7 @@ test('Agent API - custom attributes', async (t) => {
           two: 2
         })
         const segment = api.shim.getSegment()
-        const span = SpanEvent.fromSegment({ segment, transaction, parentId: 'parent', inProcessSpans: true })
+        const span = SpanEvent.fromSegment({ segment, transaction, parentId: 'parent' })
         const attributes = span.customAttributes
 
         assert.equal(attributes.one, 1)

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -327,7 +327,6 @@ test('with default properties', async (t) => {
     assert.deepEqual(configuration.distributed_tracing, {
       enabled: true,
       exclude_newrelic_header: false,
-      in_process_spans: { enabled: true },
       sampler: {
         root: 'adaptive',
         remote_parent_sampled: 'adaptive',

--- a/test/unit/spans/create-span-event-aggregator.test.js
+++ b/test/unit/spans/create-span-event-aggregator.test.js
@@ -22,13 +22,6 @@ const metricsStub = {
 const collectorStub = sinon.stub()
 const harvesterStub = { add: sinon.stub() }
 const agent = {
-  config: {
-    distributed_tracing: {
-      in_process_spans: {
-        enabled: true
-      }
-    }
-  },
   collector: collectorStub,
   metrics: metricsStub,
   harvester: harvesterStub

--- a/test/unit/spans/partial-granularity-spans.test.js
+++ b/test/unit/spans/partial-granularity-spans.test.js
@@ -42,7 +42,7 @@ for (const mode of MODES) {
         transaction.partialType = mode
         const segment = transaction.trace.add('entrySpan')
         transaction.baseSegment = segment
-        const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true })
+        const span = SpanEvent.fromSegment({ segment, transaction })
         assert.ok(span)
         const [intrinsics] = span.toJSON()
         assert.equal(intrinsics['nr.entryPoint'], true)
@@ -57,7 +57,7 @@ for (const mode of MODES) {
       helper.runInTransaction(agent, (transaction) => {
         transaction.partialType = mode
         const segment = transaction.trace.add('Llm/foobar')
-        const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true })
+        const span = SpanEvent.fromSegment({ segment, transaction })
         assert.ok(span)
         end()
       })
@@ -76,7 +76,7 @@ for (const mode of MODES) {
         segment.addAttribute('foo', 'bar')
         const spanContext = segment.getSpanContext()
         spanContext.addCustomAttribute('custom', 'test')
-        const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true })
+        const span = SpanEvent.fromSegment({ segment, transaction })
         assert.ok(span)
         const [intrinsics, customAttrs, agentAttrs] = span.toJSON()
         assert.equal(intrinsics['name'], 'Datastore/operation/Redis/SET')
@@ -107,7 +107,7 @@ for (const mode of MODES) {
         transaction.partialType = mode
         const segment = transaction.trace.add('Datastore/operation/Redis/SET')
         segment.addAttribute('foo', 'bar')
-        const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true })
+        const span = SpanEvent.fromSegment({ segment, transaction })
         assert.ok(!span)
         end()
       })
@@ -119,7 +119,7 @@ for (const mode of MODES) {
         transaction.partialType = mode
         const segment = transaction.trace.add('test-segment')
         segment.addAttribute('foo', 'bar')
-        const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true })
+        const span = SpanEvent.fromSegment({ segment, transaction })
         assert.ok(!span)
         end()
       })
@@ -133,7 +133,7 @@ for (const mode of MODES) {
         segment.addAttribute('foo', 'bar')
         const spanContext = segment.getSpanContext()
         spanContext.addCustomAttribute('custom', 'test')
-        const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true })
+        const span = SpanEvent.fromSegment({ segment, transaction })
         assert.ok(span)
         const [intrinsics, customAttrs, agentAttrs] = span.toJSON()
         assert.equal(intrinsics['name'], 'Datastore/operation/Redis/SET')
@@ -156,7 +156,7 @@ for (const mode of MODES) {
         const spanContext = segment.getSpanContext()
         spanContext.addCustomAttribute('custom', 'test')
         segment.addAttribute('foo', 'bar')
-        const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true })
+        const span = SpanEvent.fromSegment({ segment, transaction })
         assert.ok(span)
         const [intrinsics, customAttrs, agentAttrs] = span.toJSON()
         assert.equal(intrinsics['name'], 'test-segment')
@@ -181,7 +181,7 @@ for (const mode of MODES) {
         segment.addAttribute('foo', 'bar')
         const spanContext = segment.getSpanContext()
         spanContext.addCustomAttribute('custom', 'test')
-        const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true })
+        const span = SpanEvent.fromSegment({ segment, transaction })
         assert.ok(span)
         end()
       })
@@ -193,7 +193,7 @@ for (const mode of MODES) {
         transaction.partialType = mode
         const segment = transaction.trace.add('Datastore/operation/Redis/SET')
         segment.addAttribute('foo', 'bar')
-        const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true })
+        const span = SpanEvent.fromSegment({ segment, transaction })
         assert.ok(!span)
         end()
       })
@@ -205,7 +205,7 @@ for (const mode of MODES) {
         transaction.partialType = mode
         const segment = transaction.trace.add('test-segment')
         segment.addAttribute('foo', 'bar')
-        const span = SpanEvent.fromSegment({ segment, transaction, inProcessSpans: true })
+        const span = SpanEvent.fromSegment({ segment, transaction })
         assert.ok(!span)
         end()
       })

--- a/test/unit/spans/span-event-aggregator.test.js
+++ b/test/unit/spans/span-event-aggregator.test.js
@@ -29,13 +29,6 @@ test('SpanAggregator', async (t) => {
         periodMs: DEFAULT_PERIOD
       },
       {
-        config: {
-          distributed_tracing: {
-            in_process_spans: {
-              enabled: true
-            }
-          }
-        },
         collector: {},
         metrics: new Metrics(5, {}, {}),
         harvester: { add() {} }
@@ -132,13 +125,6 @@ test('SpanAggregator', async (t) => {
         metricNames: METRIC_NAMES
       },
       {
-        config: {
-          distributed_tracing: {
-            in_process_spans: {
-              enabled: true
-            }
-          }
-        },
         collector: {},
         metrics,
         harvester: { add() {} }

--- a/test/unit/spans/streaming-span-event-aggregator.test.js
+++ b/test/unit/spans/streaming-span-event-aggregator.test.js
@@ -11,13 +11,6 @@ const sinon = require('sinon')
 
 const StreamingSpanEventAggregator = require('#agentlib/spans/streaming-span-event-aggregator.js')
 const agent = {
-  config: {
-    distributed_tracing: {
-      in_process_spans: {
-        enbabled: true
-      }
-    }
-  },
   collector: {},
   metrics: {},
   harvester: { add: sinon.stub() }

--- a/test/unit/spans/streaming-span-event.test.js
+++ b/test/unit/spans/streaming-span-event.test.js
@@ -73,7 +73,7 @@ test('fromSegment()', async (t) => {
       segment.addSpanAttribute('host', 'my-host')
       segment.addSpanAttribute('port', 22)
 
-      const span = StreamingSpanEvent.fromSegment({ segment, transaction, parentId: 'parent', inProcessSpans: true })
+      const span = StreamingSpanEvent.fromSegment({ segment, transaction, parentId: 'parent' })
 
       // Should have all the normal properties.
       assert.ok(span)
@@ -139,7 +139,7 @@ test('fromSegment()', async (t) => {
         res.on('end', () => {
           const tx = agent.tracer.getTransaction()
           const [segment] = tx.trace.getChildren(tx.trace.root.id)
-          const span = StreamingSpanEvent.fromSegment({ segment, transaction, parentId: 'parent', inProcessSpans: true })
+          const span = StreamingSpanEvent.fromSegment({ segment, transaction, parentId: 'parent' })
 
           // Should have all the normal properties.
           assert.ok(span)
@@ -245,7 +245,7 @@ test('fromSegment()', async (t) => {
       dsConn.myDbOp(longQuery, () => {
         transaction.end()
         const [segment] = transaction.trace.getChildren(transaction.trace.root.id)
-        const span = StreamingSpanEvent.fromSegment({ segment, transaction, parentId: 'parent', inProcessSpans: true })
+        const span = StreamingSpanEvent.fromSegment({ segment, transaction, parentId: 'parent' })
 
         // Should have all the normal properties.
         assert.ok(span)
@@ -336,7 +336,7 @@ test('fromSegment()', async (t) => {
         const spanContext = agent.tracer.getSpanContext()
         spanContext.addCustomAttribute('customKey', 'customValue')
 
-        const span = StreamingSpanEvent.fromSegment({ segment, transaction, parentId: 'parent', inProcessSpans: true })
+        const span = StreamingSpanEvent.fromSegment({ segment, transaction, parentId: 'parent' })
 
         const serializedSpan = span.toStreamingFormat()
         const {
@@ -373,7 +373,7 @@ test('fromSegment()', async (t) => {
         spanContext.addIntrinsicAttribute('intrinsic.1', 1)
         spanContext.addIntrinsicAttribute('intrinsic.2', 2)
 
-        const span = StreamingSpanEvent.fromSegment({ segment, transaction, parentId: 'parent', inProcessSpans: true })
+        const span = StreamingSpanEvent.fromSegment({ segment, transaction, parentId: 'parent' })
 
         const serializedSpan = span.toStreamingFormat()
         const { intrinsics } = serializedSpan
@@ -398,7 +398,7 @@ test('fromSegment()', async (t) => {
           const [segment] = transaction.trace.getChildren(transaction.trace.root.id)
           assert.ok(segment.name.startsWith('Truncated'))
 
-          const span = StreamingSpanEvent.fromSegment({ segment, transaction, inProcessSpans: true })
+          const span = StreamingSpanEvent.fromSegment({ segment, transaction })
           assert.ok(span)
           assert.ok(span instanceof StreamingSpanEvent)
 
@@ -420,7 +420,7 @@ test('fromSegment()', async (t) => {
 
       assert.ok(segment.name.startsWith('Truncated'))
 
-      const span = StreamingSpanEvent.fromSegment({ segment, transaction, inProcessSpans: true })
+      const span = StreamingSpanEvent.fromSegment({ segment, transaction })
       assert.ok(span)
       assert.ok(span instanceof StreamingSpanEvent)
 
@@ -429,78 +429,4 @@ test('fromSegment()', async (t) => {
       end()
     })
   })
-
-  await t.test('should not create spans for in-process segments when feature is disabled', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      const segment = transaction.trace.add('segmentName')
-
-      const span = StreamingSpanEvent.fromSegment({ segment, transaction, inProcessSpans: false })
-      assert.ok(!span)
-      end()
-    })
-  })
-
-  await t.test('should create span for entry span when in-process spans feature is disabled', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      const segment = transaction.trace.add('entrySpan')
-      transaction.baseSegment = segment
-      const span = StreamingSpanEvent.fromSegment({ segment, transaction, inProcessSpans: false })
-      assert.ok(span)
-      assert.deepEqual(span._intrinsicAttributes['nr.entryPoint'], { [BOOL_TYPE]: true })
-      assert.ok(!span._intrinsicAttributes.parentId)
-      end()
-    })
-  })
-
-  await t.test('should not update parentId for entry span when it is part of an acceptedDistributed trace', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      const segment = transaction.trace.add('entrySpan')
-      transaction.baseSegment = segment
-      transaction.acceptedDistributedTrace = true
-      const parentId = 'untouchedParentId'
-      const span = StreamingSpanEvent.fromSegment({ segment, transaction, inProcessSpans: false, isRoot: true, parentId })
-      assert.ok(span)
-      assert.deepEqual(span._intrinsicAttributes['nr.entryPoint'], { [BOOL_TYPE]: true })
-      assert.deepEqual(span._intrinsicAttributes['parentId'], { [STRING_TYPE]: parentId })
-      end()
-    })
-  })
-
-  await t.test('should update parentId for exit span when it is part of an acceptedDistributed trace', (t, end) => {
-    const { agent } = t.nr
-    helper.runInTransaction(agent, (transaction) => {
-      const segment = transaction.trace.add('entrySpan')
-      transaction.baseSegment = segment
-      transaction.acceptedDistributedTrace = true
-      const inProcessSegment = transaction.trace.add('inProcessSpan')
-      const exitSegment = transaction.trace.add('Datastore/operation/foo', () => {}, inProcessSegment)
-      const span = StreamingSpanEvent.fromSegment({ segment: exitSegment, transaction, inProcessSpans: false, isRoot: false, parentId: 'parentId' })
-      assert.ok(span)
-      assert.ok(!span._intrinsicAttributes['nr.entryPoint'])
-      assert.deepEqual(span._intrinsicAttributes['parentId'], { [STRING_TYPE]: segment.id })
-      end()
-    })
-  })
-
-  const exitSpans = ['Datastore/operation/test', 'External/example.com/test', 'MessageBroker/Produce/Named/test']
-  for (const exitSpan of exitSpans) {
-    await t.test(`should create span for ${exitSpan} when in-process spans feature is disabled`, (t, end) => {
-      const { agent } = t.nr
-      helper.runInTransaction(agent, (transaction) => {
-        const segment = transaction.trace.add('entrySpan')
-        transaction.baseSegment = segment
-        const inProcessSegment = transaction.trace.add('inProcessSpan')
-        const exitSegment = transaction.trace.add(exitSpan, () => {}, inProcessSegment)
-        assert.equal(exitSegment.parentId, inProcessSegment.id)
-        const span = StreamingSpanEvent.fromSegment({ segment: exitSegment, transaction, parentId: inProcessSegment.id, inProcessSpans: false })
-        assert.ok(span)
-        assert.ok(!span._intrinsicAttributes['nr.entryPoint'])
-        assert.deepEqual(span._intrinsicAttributes.parentId, { [STRING_TYPE]: segment.id })
-        end()
-      })
-    })
-  }
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
This PR removes most code from #3184. I say most code because we still need some of the helpers to share logic between SpanEvent and StreamingSpanEvent.
This feature was undocumented and was released last summer as an experiment with a customer.  
The customer is not using it any longer and Partial Granularity tracing is the replacment for this logic.  


## Related Issues
Closes #3537
