### PR TITLE
chore: Don't create OpenAI segments if `ai_monitoring` is disabled

### DIFF
--- a/lib/subscribers/openai/base.js
+++ b/lib/subscribers/openai/base.js
@@ -14,7 +14,7 @@ class OpenAISubscriber extends Subscriber {
   }
 
   get enabled() {
-    return super.enabled && this.config.ai_monitoring?.enabled
+    return super.enabled && this.agent.config.ai_monitoring.enabled
   }
 
   /**

--- a/lib/subscribers/openai/chat.js
+++ b/lib/subscribers/openai/chat.js
@@ -32,6 +32,10 @@ class OpenAIChatCompletions extends OpenAISubscriber {
       this.logger.warn(`Instrumenting chat completion streams is only supported with openai version ${MIN_STREAM_VERSION}+.`)
       return ctx
     }
+    if (!this.enabled) {
+      this.logger.debug('OpenAI instrumentation is disabled, not creating segment.')
+      return
+    }
 
     const segment = this.agent.tracer.createSegment({
       name: OPENAI.COMPLETION,
@@ -43,6 +47,10 @@ class OpenAIChatCompletions extends OpenAISubscriber {
   }
 
   asyncEnd(data) {
+    if (!this.enabled) {
+      this.logger.debug('OpenAI instrumentation is disabled, not recording Llm events.')
+      return
+    }
     const ctx = this.agent.tracer.getContext()
     if (!ctx?.segment || !ctx?.transaction) {
       return

--- a/lib/subscribers/openai/embeddings.js
+++ b/lib/subscribers/openai/embeddings.js
@@ -18,6 +18,10 @@ class OpenAIEmbeddings extends OpenAISubscriber {
   }
 
   handler(data, ctx) {
+    if (!this.enabled) {
+      this.logger.debug('OpenAI instrumentation is disabled, not creating segment.')
+      return
+    }
     const segment = this.agent.tracer.createSegment({
       name: OPENAI.EMBEDDING,
       parent: ctx.segment,
@@ -28,6 +32,10 @@ class OpenAIEmbeddings extends OpenAISubscriber {
   }
 
   asyncEnd(data) {
+    if (!this.enabled) {
+      this.logger.debug('OpenAI instrumentation is disabled, not recording Llm events.')
+      return
+    }
     const ctx = this.agent.tracer.getContext()
     if (!ctx?.segment || !ctx?.transaction) {
       return


### PR DESCRIPTION
## Description

OpenAI instrumentation should not create segments if `ai_monitoring.enabled === false`. This PR adds this missing logic and tests to assert it.

## How to Test

```
npm run versioned:major openai
```

## Related Issues

Closes #3622