### PR TITLE
chore: Update Azure publishing with OIDC steps

### DIFF
--- a/.github/workflows/azure-site-extension.yml
+++ b/.github/workflows/azure-site-extension.yml
@@ -113,7 +113,7 @@ jobs:
         uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.1.0
         id: login
         with:
-          user: ${{ env.NUGET_TRUSTED_PUBLISH_POLICY_USER }}
+          user: ${{ vars.NUGET_TRUSTED_PUBLISH_POLICY_USER }}
 
       - name: Publish site extension
         working-directory: cloud-tooling/azure-site-extension


### PR DESCRIPTION
This PR resolves #3609. It follows the instructions provided in https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/ along with those in the issue.

+ [x] The policy has been added to NuGet under the bot user's account.
+ [x] The bot user has been added as repository secret.