### PR TITLE
fix: Updated samplers to properly assign sampling decisions based on appropriate context

### DIFF
--- a/lib/samplers/adaptive-sampler.js
+++ b/lib/samplers/adaptive-sampler.js
@@ -108,19 +108,25 @@ class AdaptiveSampler extends Sampler {
   applySamplingDecision({ transaction, tracestate, partialType }) {
     if (!transaction) return
     transaction.partialType = partialType
-    if (tracestate) {
+    if (tracestate?.intrinsics) {
       // Explicitly set sampled and priority from tracestate intrinsics if available
-      transaction.sampled = tracestate?.intrinsics ? tracestate.isSampled : null
-      transaction.priority = tracestate?.intrinsics ? tracestate.priority : null
+      transaction.sampled = tracestate.isSampled
+      let initPriority = tracestate.priority
+      // If tracestate has intrinsics but lacks a priority we must generate a random priority
+      // if sampled, we also have to increment accordingly based on full/partial traces
+      if (!initPriority && tracestate.isSampled) {
+        initPriority = Sampler.generatePriority()
+        initPriority = Sampler.incrementPriority(initPriority, partialType)
+      }
+
+      transaction.priority = initPriority
       return
     }
 
     // If a tracestate is not defined, then do our normal priority calculation.
-
     const initPriority = Sampler.generatePriority()
     transaction.sampled = this.shouldSample(initPriority)
-    // only add 1 to priority when doing a full trace
-    transaction.priority = transaction.sampled && !partialType ? Sampler.incrementPriority(initPriority, 1) : initPriority
+    transaction.priority = transaction.sampled ? Sampler.incrementPriority(initPriority, partialType) : initPriority
   }
 
   /**

--- a/lib/samplers/ratio-based-sampler.js
+++ b/lib/samplers/ratio-based-sampler.js
@@ -26,8 +26,7 @@ class TraceIdRatioBasedSampler extends Sampler {
     transaction.partialType = partialType
     const initPriority = Sampler.generatePriority()
     transaction.sampled = this.shouldSample(transaction.traceId)
-    // only add 1 to priority when doing a full trace
-    transaction.priority = transaction.sampled && !partialType ? Sampler.incrementPriority(initPriority, 1) : initPriority
+    transaction.priority = transaction.sampled ? Sampler.incrementPriority(initPriority, partialType) : initPriority
   }
 
   /**

--- a/lib/samplers/sampler.js
+++ b/lib/samplers/sampler.js
@@ -45,11 +45,13 @@ class Sampler {
 
   /**
    * Used to increment priority and truncate to 6 decimal places.
+   * Full traces are incremented by 2 and partial traces are incremented by 1
    * @param {number} priority the current priority
-   * @param {number} increment the amount to increment by
+   * @param {string|null} partialType if a partial trace
    * @returns {number} the incremented priority
    */
-  static incrementPriority(priority, increment) {
+  static incrementPriority(priority, partialType) {
+    const increment = partialType ? 1 : 2
     const newPriority = priority + increment
     return ((newPriority * 1e6) | 0) / 1e6
   }

--- a/test/integration/distributed-tracing/custom-assertions.js
+++ b/test/integration/distributed-tracing/custom-assertions.js
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const assert = require('node:assert')
+const { getEventsToCheck, getExactExpectedUnexpectedFromIntrinsics } = require('./helpers')
+
+function getDescendantValue(object, descendants) {
+  const arrayDescendants = descendants.split('.')
+  const noop = () => { }
+  while (arrayDescendants.length && (object = object[arrayDescendants.shift()])) {
+    noop()
+  }
+  return object
+}
+
+function hasNestedProperty(object, descendants) {
+  const arrayDescendants = descendants.split('.')
+
+  let currentItem = object
+  for (let i = 0; i < arrayDescendants.length; i++) {
+    const property = arrayDescendants[i]
+
+    if (!currentItem || currentItem[property] == null) {
+      return false
+    }
+
+    currentItem = currentItem[property]
+  }
+
+  return true
+}
+
+function exact(object, fixture) {
+  for (let [descendants, fixtureValue] of Object.entries(fixture)) {
+    if (descendants === 'tracestate.parent_type') {
+      // The fixture data has the original source value, an integer, as the
+      // value to check for. Our Transaction expects a string value. Instead
+      // of mutating the `Tracestate` object after it is created in the test,
+      // we re-define the fixture value in-place.
+      // eslint-disable-next-line sonarjs/updated-loop-counter
+      fixtureValue = 'App'
+    }
+
+    const valueToTest = getDescendantValue(object, descendants)
+    assert.deepEqual(
+      valueToTest,
+      fixtureValue,
+      `Expected ${descendants} to be ${fixtureValue} but got ${valueToTest}`
+    )
+  }
+}
+
+function expected(object, fixture) {
+  for (const fixtureValue of fixture) {
+    const exists = hasNestedProperty(object, fixtureValue)
+    assert.ok(exists, 'is ' + fixtureValue + ' set?')
+  }
+}
+
+function unexpected(object, fixture) {
+  for (const fixtureValue of fixture) {
+    const exists = hasNestedProperty(object, fixtureValue)
+    assert.equal(exists, false, 'is ' + fixtureValue + ' absent?')
+  }
+}
+
+function notEqual(object, fixture) {
+  for (const [descendants, fixtureValue] of Object.entries(fixture)) {
+    const valueToTest = getDescendantValue(object, descendants)
+    assert.ok(valueToTest !== fixtureValue, 'is ' + descendants + ' not equal?')
+  }
+}
+
+function assertVendors(object, vendors) {
+  assert.deepStrictEqual(object.tracestate.vendors ?? [], vendors, 'do vendors match?')
+}
+
+function expectedFixtureKeys(thingWithKeys, expectedKeys) {
+  let actualKeys = thingWithKeys
+  if (!Array.isArray(actualKeys)) {
+    actualKeys = Object.keys(thingWithKeys)
+  }
+  for (const key of actualKeys) {
+    assert.ok(expectedKeys.indexOf(key) !== -1, 'key [' + key + '] should be expected?')
+  }
+}
+
+function assertSingleEvent(event, eventType, fixture) {
+  const { exact, expected, unexpected } = fixture
+  const attributes = event[0]
+
+  assert.ok(attributes, 'Should have attributes')
+  const attributesHasOwnProperty = Object.hasOwnProperty.bind(attributes)
+
+  for (const key of expected) {
+    const hasAttribute = attributesHasOwnProperty(key)
+    assert.ok(hasAttribute, `does ${eventType} have ${key}`)
+  }
+
+  for (const key of unexpected) {
+    const hasAttribute = attributesHasOwnProperty(key)
+
+    assert.equal(hasAttribute, false, `${eventType} should not have ${key}`)
+  }
+
+  for (const key of Object.keys(exact)) {
+    const attributeValue = attributes[key]
+    const expectedValue = exact[key]
+
+    assert.equal(attributeValue, expectedValue, `${eventType} should have ${key}=${expectedValue}`)
+  }
+}
+
+function assertOutboundPayloads(testCase, context) {
+  if (!testCase.outbound_payloads) {
+    return
+  }
+  for (const [key, testToRun] of Object.entries(testCase.outbound_payloads)) {
+    for (const [assertType, fields] of Object.entries(testToRun)) {
+      switch (assertType) {
+        case 'exact':
+          exact(context[key], fields)
+          break
+        case 'expected':
+          expected(context[key], fields)
+          break
+        case 'unexpected':
+          unexpected(context[key], fields)
+          break
+        case 'notequal':
+          notEqual(context[key], fields)
+          break
+        case 'vendors':
+          assertVendors(context[key], fields)
+          break
+        default:
+          throw new Error("I don't know how to test a(n) " + assertType)
+      }
+    }
+  }
+}
+
+function assertMetrics(testCase, agent) {
+  if (!testCase.expected_metrics) {
+    return
+  }
+  const metrics = agent.metrics
+  for (const metricPair of Object.values(testCase.expected_metrics)) {
+    const metricName = metricPair[0]
+    const callCount = metrics.getOrCreateMetric(metricName).callCount
+    const metricCount = metricPair[1]
+    assert.ok(callCount === metricCount, `${metricName} should have ${metricCount} samples`)
+  }
+}
+
+function assertEvents(testCase, agent) {
+  if (!testCase.intrinsics) {
+    return
+  }
+  for (const eventType of Object.values(testCase.intrinsics.target_events)) {
+    const toCheck = getEventsToCheck(eventType, agent)
+    assert.ok(toCheck.length > 0, 'do we have an event ( ' + eventType + ' ) to test?')
+    const fixture = getExactExpectedUnexpectedFromIntrinsics(testCase, eventType)
+
+    for (const event of toCheck) {
+      // Span events are not payload-formatted
+      // straight out of the aggregator.
+      const finalEvent = eventType === 'Span' ? event.toJSON() : event
+      assertSingleEvent(finalEvent, eventType, fixture)
+    }
+  }
+}
+
+module.exports = {
+  assertEvents,
+  assertMetrics,
+  assertOutboundPayloads,
+  exact,
+  expected,
+  expectedFixtureKeys,
+  notEqual,
+  unexpected
+}

--- a/test/integration/distributed-tracing/custom-assertions.test.js
+++ b/test/integration/distributed-tracing/custom-assertions.test.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const test = require('node:test')
+const { exact, expected, notEqual, unexpected } = require('./custom-assertions')
+
+test('helper functions', () => {
+  const objectExact = {
+    foo: { bar: 'baz' },
+    one: { two: 'three' }
+  }
+  exact(objectExact, { 'foo.bar': 'baz', 'one.two': 'three' })
+
+  const objectExpected = {
+    foo: { bar: 'baz' },
+    one: { two: 'three' },
+    science: false,
+    science2: NaN
+  }
+  expected(objectExpected, ['foo.bar', 'one.two', 'science', 'science2'])
+
+  const objectUnExpected = {
+    foo: { bar: 'baz' },
+    one: { two: 'three' },
+    science: false,
+    science2: NaN
+  }
+  unexpected(objectUnExpected, ['apple', 'orange'])
+
+  const objectNotEqual = {
+    foo: { bar: 'baz' },
+    one: { two: 'three' }
+  }
+  notEqual(objectNotEqual, { 'foo.bar': 'bazz', 'one.two': 'threee' })
+})

--- a/test/integration/distributed-tracing/helpers.js
+++ b/test/integration/distributed-tracing/helpers.js
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { hasOwn } = require('../../../lib/util/properties')
+function buildFullTracingConfig(initConfig, testCase) {
+  initConfig.distributed_tracing.sampler.remote_parent_sampled = testCase.remote_parent_sampled ?? 'adaptive'
+  initConfig.distributed_tracing.sampler.remote_parent_not_sampled = testCase.remote_parent_not_sampled ?? 'adaptive'
+  initConfig.distributed_tracing.sampler.root = testCase.root ?? 'adaptive'
+
+  if (hasOwn(testCase, 'full_granularity_ratio')) {
+    // The ratio to use for all of the trace ID ratio samplers defined in the test.
+    // For testing purposes we are not defining different ratios for each trace ID ratio sampler instance.
+    if (initConfig.distributed_tracing.sampler.root === 'trace_id_ratio_based') {
+      initConfig.distributed_tracing.sampler.root = {
+        trace_id_ratio_based: {
+          ratio: testCase.full_granularity_ratio
+        }
+      }
+    }
+    if (initConfig.distributed_tracing.sampler.remote_parent_sampled === 'trace_id_ratio_based') {
+      initConfig.distributed_tracing.sampler.remote_parent_sampled = {
+        trace_id_ratio_based: {
+          ratio: testCase.full_granularity_ratio
+        }
+      }
+    }
+    if (initConfig.distributed_tracing.sampler.remote_parent_not_sampled === 'trace_id_ratio_based') {
+      initConfig.distributed_tracing.sampler.remote_parent_not_sampled = {
+        trace_id_ratio_based: {
+          ratio: testCase.full_granularity_ratio
+        }
+      }
+    }
+  }
+
+  if (hasOwn(testCase, 'full_granularity_enabled')) {
+    initConfig.distributed_tracing.sampler.full_granularity.enabled = testCase.full_granularity_enabled
+  }
+}
+
+function buildPartialTracingConfig(initConfig, testCase) {
+  if (hasOwn(testCase, 'partial_granularity_enabled')) {
+    initConfig.distributed_tracing.sampler.partial_granularity.enabled = testCase.partial_granularity_enabled
+  }
+
+  initConfig.distributed_tracing.sampler.partial_granularity.remote_parent_sampled = testCase.partial_granularity_remote_parent_sampled ?? 'adaptive'
+  initConfig.distributed_tracing.sampler.partial_granularity.remote_parent_not_sampled = testCase.partial_granularity_remote_parent_not_sampled ?? 'adaptive'
+  initConfig.distributed_tracing.sampler.partial_granularity.root = testCase.partial_granularity_root ?? 'adaptive'
+
+  if (hasOwn(testCase, 'partial_granularity_ratio')) {
+    // The ratio to use for all of the trace ID ratio samplers defined in the test.
+    // For testing purposes we are not defining different ratios for each trace ID ratio sampler instance.
+    if (initConfig.distributed_tracing.sampler.partial_granularity.root === 'trace_id_ratio_based') {
+      initConfig.distributed_tracing.sampler.partial_granularity.root = {
+        trace_id_ratio_based: {
+          ratio: testCase.partial_granularity_ratio
+        }
+      }
+    }
+    if (initConfig.distributed_tracing.sampler.partial_granularity.remote_parent_sampled === 'trace_id_ratio_based') {
+      initConfig.distributed_tracing.sampler.partial_granularity.remote_parent_sampled = {
+        trace_id_ratio_based: {
+          ratio: testCase.partial_granularity_ratio
+        }
+      }
+    }
+    if (initConfig.distributed_tracing.sampler.partial_granularity.remote_parent_not_sampled === 'trace_id_ratio_based') {
+      initConfig.distributed_tracing.sampler.partial_granularity.remote_parent_not_sampled = {
+        trace_id_ratio_based: {
+          ratio: testCase.partial_granularity_ratio
+        }
+      }
+    }
+  }
+}
+
+function buildSamplerConfig(testCase) {
+  // Sampling config has to be given on agent initialization
+  const initConfig = {
+    distributed_tracing: {
+      enabled: true,
+      sampler: {
+        full_granularity: {
+          enabled: true
+        },
+        partial_granularity: {
+          enabled: false
+        }
+      }
+    }
+  }
+  if (hasOwn(testCase, 'distributed_tracing_enabled')) {
+    initConfig.distributed_tracing.enabled = testCase.distributed_tracing_enabled
+  }
+  buildFullTracingConfig(initConfig, testCase)
+  buildPartialTracingConfig(initConfig, testCase)
+
+  return initConfig
+}
+
+function getEventsToCheck(eventType, agent) {
+  let toCheck
+  switch (eventType) {
+    case 'Transaction':
+      toCheck = agent.transactionEventAggregator.getEvents()
+      break
+    case 'TransactionError':
+      toCheck = agent.errors.eventAggregator.getEvents()
+      break
+    case 'Span':
+      toCheck = agent.spanEventAggregator.getEvents()
+      break
+    default:
+      throw new Error('I do no know how to test an ' + eventType)
+  }
+  return toCheck
+}
+
+function getExactExpectedUnexpectedFromIntrinsics(testCase, eventType) {
+  const common = testCase.intrinsics.common
+  const specific = testCase.intrinsics[eventType] || {}
+  const exact = Object.assign(specific.exact || {}, common.exact || {})
+  const expected = (specific.expected || []).concat(common.expected || [])
+  const unexpected = (specific.unexpected || []).concat(common.unexpected || [])
+
+  return {
+    exact,
+    expected,
+    unexpected
+  }
+}
+
+function forceAdaptiveSamplers(agent, forceAdaptiveSampled) {
+  if (forceAdaptiveSampled === undefined || forceAdaptiveSampled === null) return
+  // "The sampling decision to force on a transaction whenever the adaptive sampler is used"
+  // implies this affects all samplers that are adaptive samplers
+  const samplers = [
+    agent.samplers.root,
+    agent.samplers.remoteParentSampled,
+    agent.samplers.remoteParentNotSampled
+  ]
+  for (const sampler of samplers) {
+    if (sampler?.toString() === 'AdaptiveSampler') {
+      sampler.shouldSample = function stubShouldSample() {
+        return forceAdaptiveSampled
+      }
+    }
+  }
+}
+
+module.exports = {
+  buildSamplerConfig,
+  forceAdaptiveSamplers,
+  getEventsToCheck,
+  getExactExpectedUnexpectedFromIntrinsics
+}

--- a/test/integration/distributed-tracing/traceparent-sampled-flag.test.js
+++ b/test/integration/distributed-tracing/traceparent-sampled-flag.test.js
@@ -103,8 +103,9 @@ test('remote_parent_sampled: adaptive', async (t) => {
     assert.equal(tx.acceptedDistributedTrace, true)
     assert.equal(tx.traceId, TRACE_ID)
     assert.equal(tx.parentSpanId, SPAN_ID)
-    assert.equal(tx.sampled, null)
-    assert.equal(tx.priority, null)
+    assert.equal(tx.sampled, true)
+    assert.equal(typeof tx.priority, 'number')
+    assert.ok(tx.priority > 2 && tx.priority < 3)
   }
 })
 
@@ -128,8 +129,9 @@ test('remote_parent_sampled: adaptive, remote_parent_not_sampled: always_on (fla
     assert.equal(tx.acceptedDistributedTrace, true)
     assert.equal(tx.traceId, TRACE_ID)
     assert.equal(tx.parentSpanId, SPAN_ID)
-    assert.equal(tx.sampled, null)
-    assert.equal(tx.priority, null)
+    assert.equal(tx.sampled, true)
+    assert.equal(typeof tx.priority, 'number')
+    assert.ok(tx.priority > 2 && tx.priority < 3)
   }
 })
 
@@ -178,8 +180,9 @@ test('remote_parent_sampled: adaptive, remote_parent_not_sampled: always_off (fl
     assert.equal(tx.acceptedDistributedTrace, true)
     assert.equal(tx.traceId, TRACE_ID)
     assert.equal(tx.parentSpanId, SPAN_ID)
-    assert.equal(tx.sampled, null)
-    assert.equal(tx.priority, null)
+    assert.equal(tx.sampled, true)
+    assert.equal(typeof tx.priority, 'number')
+    assert.ok(tx.priority > 2 && tx.priority < 3)
   }
 })
 
@@ -228,8 +231,9 @@ test('remote_parent_sampled: adaptive, remote_parent_not_sampled: adaptive (flag
     assert.equal(tx.acceptedDistributedTrace, true)
     assert.equal(tx.traceId, TRACE_ID)
     assert.equal(tx.parentSpanId, SPAN_ID)
-    assert.equal(tx.sampled, null)
-    assert.equal(tx.priority, null)
+    assert.equal(tx.sampled, true)
+    assert.equal(typeof tx.priority, 'number')
+    assert.ok(tx.priority > 2 && tx.priority < 3)
   }
 })
 
@@ -253,8 +257,9 @@ test('remote_parent_sampled: adaptive, remote_parent_not_sampled: adaptive (flag
     assert.equal(tx.acceptedDistributedTrace, true)
     assert.equal(tx.traceId, TRACE_ID)
     assert.equal(tx.parentSpanId, SPAN_ID)
-    assert.equal(tx.sampled, null)
-    assert.equal(tx.priority, null)
+    assert.equal(tx.sampled, true)
+    assert.equal(typeof tx.priority, 'number')
+    assert.ok(tx.priority > 2 && tx.priority < 3)
   }
 })
 

--- a/test/lib/cross_agent_tests/distributed_tracing/README.md
+++ b/test/lib/cross_agent_tests/distributed_tracing/README.md
@@ -14,12 +14,19 @@ the agent under test. Here's what the various fields in each test case mean:
 | `account_id` | The account id the agent would receive on connect. |
 | `web_transaction` | Whether the transaction that's tested is a web transaction or not. |
 | `raises_exception` | Whether to simulate an exception happening within the transaction or not, resulting in a transaction error event. |
-| `root` | The sampler to use for transactions at the root of a trace. |
-| `remote_parent_sampled` | The sampler to use for transactions with a remote parent. |
-| `remote_parent_not_sampled` | The sampler to use for transactions with a remote parent that is not sampled. |
+| `distributed_tracing_enabled` | If `false`, then distributed tracing is disabled. If `true` or absent, then distributed tracing is enabled (default behavior). |
+| `full_granularity_enabled` | If `false`, then full granularity tracing is disabled. If `true` or absent, then full granularity is enabled (default behavior). |
+| `root` | The full granularity sampler to use for transactions at the root of a trace. |
+| `remote_parent_sampled` | The full granularity sampler to use for transactions with a remote parent that was sampled. |
+| `remote_parent_not_sampled` | The full granularity sampler to use for transactions with a remote parent that is not sampled. |
+| `force_adaptive_sampled` | The sampling decision to force on a transaction whenever the adaptive sampler is used. This applies to all adaptive samplers used in the test, whether they are the global sampler or an individual sampler instance. |
+| `full_granularity_ratio` | The ratio to use for all of the full granularity trace ID ratio samplers defined in the test. For testing purposes we are not defining different ratios for each trace ID ratio sampler instance. If that is necessary, we will need a different way to configure the ratios. |
+| `partial_granularity_enabled` | If `true`, then partial granularity is enabled. If `false` or absent, then partial granularity is disabled (default behavior). |
+| `partial_granularity_root` | The partial granularity sampler to use for root transactions. |
+| `partial_granularity_remote_parent_sampled` | The partial granularity sampler to use for transactions with a remote parent that was sampled. |
+| `partial_granularity_remote_parent_not_sampled` | The partial granularity sampler to use for transaction with a remote parent that was not sampled. |
+| `partial_granularity_ratio` | The partial granularity ratio to use for all the partial granularity ratio samplers defined in the test. As with `full_granularity_ratio` we're limiting these tests to have one ratio configured for all partial granularity samplers.| 
 | `expected_priority_between` | The inclusive range of the expected priority value on the generated transaction event. |
-| `force_adaptive_sampled` | The sampling decision to force on a transaction whenever the adaptive sampler is used. |
-| `ratio` | The ratio to use for all of the trace ID ratio samplers defined in the test. For testing purposes we are not defining different ratios for each trace ID ratio sampler instance. If that is necessary, we will need a different way to configure the ratios. |
 | `transport_type` | The transport type for the inbound request. |
 | `inbound_headers` | The headers you should mock coming into the agent. |
 | `outbound_payloads` | The exact/expected/unexpected values for outbound `w3c` headers. |

--- a/test/lib/cross_agent_tests/distributed_tracing/trace_context.json
+++ b/test/lib/cross_agent_tests/distributed_tracing/trace_context.json
@@ -11,8 +11,8 @@
     "transport_type": "HTTP",
     "remote_parent_sampled": "default",
     "remote_parent_not_sampled": "default",
-    "expected_priority_between": [ 0, 1 ],
     "force_adaptive_sampled": false,
+    "expected_priority_between": [ 0, 1 ],
     "inbound_headers": [
     {
       "traceparent": "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01",
@@ -104,7 +104,7 @@
     "transport_type": "HTTP",
     "remote_parent_sampled": "default",
     "remote_parent_not_sampled": "default",
-    "expected_priority_between": [ 1, 2 ],
+    "expected_priority_between": [ 2, 3 ],
     "force_adaptive_sampled": true,
     "inbound_headers": [
       {}
@@ -131,7 +131,7 @@
     "transport_type": "HTTP",
     "remote_parent_sampled": "default",
     "remote_parent_not_sampled": "adaptive",
-    "expected_priority_between": [ 1, 2 ],
+    "expected_priority_between": [ 2, 3 ],
     "force_adaptive_sampled": true,
     "inbound_headers": [
       {
@@ -342,11 +342,11 @@
     "transaction_events_enabled": true,
     "transport_type": "HTTP",
     "root": "trace_id_ratio_based",
-    "ratio": 1.0,
+    "full_granularity_ratio": 1.0,
     "remote_parent_sampled": "default",
     "remote_parent_not_sampled": "default",
 
-    "expected_priority_between": [ 1, 2 ],
+    "expected_priority_between": [ 2, 3 ],
     "force_adaptive_sampled": false,
     "inbound_headers": [
       {}
@@ -374,7 +374,7 @@
     "root": "trace_id_ratio_based",
     "remote_parent_sampled": "default",
     "remote_parent_not_sampled": "adaptive",
-    "expected_priority_between": [ 1, 2 ],
+    "expected_priority_between": [ 2, 3 ],
     "force_adaptive_sampled": true,
     "inbound_headers": [
       {
@@ -403,11 +403,11 @@
     "transaction_events_enabled": true,
     "transport_type": "HTTP",
     "root": "always_off",
-    "ratio": 1.0,
+    "full_granularity_ratio": 1.0,
     "remote_parent_sampled": "trace_id_ratio_based",
     "remote_parent_not_sampled": "always_off",
 
-    "expected_priority_between": [ 1, 2 ],
+    "expected_priority_between": [ 2, 3 ],
     "force_adaptive_sampled": false,
     "inbound_headers": [
       {
@@ -426,6 +426,39 @@
     }
   },
   {
+    "test_name": "w3c_remote_parent_sampled_uses_ratio_sampler_w3c_trace_id_not_sampled",
+    "comment": "W3C parent header determines parent is sampled and W3C trace id is passed to ratio sampler but makes a sampling decision of false because ratio is 0",
+    "trusted_account_key": "33",
+    "account_id": "33",
+    "web_transaction": true,
+    "raises_exception": false,
+    "span_events_enabled": true,
+    "transaction_events_enabled": true,
+    "transport_type": "HTTP",
+    "root": "trace_id_ratio_based",
+    "full_granularity_ratio": 0, 
+    "remote_parent_sampled": "trace_id_ratio_based",
+    "remote_parent_not_sampled": "trace_id_ratio_based",
+
+    "expected_priority_between": [ 0, 1 ],
+    "force_adaptive_sampled": false,
+    "inbound_headers": [
+      {
+        "traceparent": "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01"
+      }
+    ],
+    "intrinsics": {
+      "target_events": [ "Transaction" ],
+      "common": {
+        "exact": {
+          "traceId": "0af7651916cd43dd8448eb211c80319c",
+          "sampled": false 
+        },
+        "expected": [ "guid" ]
+      }
+    }
+  },
+  {
     "test_name": "newrelic_remote_parent_sampled_uses_ratio_sampler_newrelic_trace_id",
     "comment": "New Relic parent header determines parent is sampled and New Relic trace id is passed to ratio sampler",
     "trusted_account_key": "33",
@@ -436,10 +469,10 @@
     "transaction_events_enabled": true,
     "transport_type": "HTTP",
     "root": "always_off",
-    "ratio": 1.0,
+    "full_granularity_ratio": 1.0,
     "remote_parent_sampled": "trace_id_ratio_based",
     "remote_parent_not_sampled": "always_off",
-    "expected_priority_between": [ 1, 2 ],
+    "expected_priority_between": [ 2, 3 ],
     "force_adaptive_sampled": false,
     "inbound_headers": [
       {
@@ -456,6 +489,428 @@
         "expected": [ "guid" ]
       }
     }
+  },
+  {
+    "test_name": "newrelic_remote_parent_sampled_uses_ratio_sampler_newrelic_trace_id_not_sampled",
+    "comment": "New Relic parent header determines parent is sampled and New Relic trace id is passed to ratio sampler but makes a sampling decision of false because ratio is 0",
+    "trusted_account_key": "33",
+    "account_id": "33",
+    "web_transaction": true,
+    "raises_exception": false,
+    "span_events_enabled": true,
+    "transaction_events_enabled": true,
+    "transport_type": "HTTP",
+    "root": "trace_id_ratio_based",
+    "full_granularity_ratio": 0, 
+    "remote_parent_sampled": "trace_id_ratio_based",
+    "remote_parent_not_sampled": "trace_id_ratio_based",
+    "expected_priority_between": [ 0, 1 ],
+    "force_adaptive_sampled": false,
+    "inbound_headers": [
+      {
+        "newrelic": "{\"v\":[0,1],\"d\":{\"ty\":\"App\",\"ac\":\"33\",\"ap\":\"2827902\",\"id\":\"7d3efb1b173fecfa\",\"tr\":\"0af7651916cd43dd8448eb211c80319c\",\"pr\":0.2,\"sa\":true,\"ti\":1518469636035,\"tx\":\"0af7651916cd43dd\"}}"
+      }
+    ],
+    "intrinsics": {
+      "target_events": [ "Transaction" ],
+      "common": {
+        "exact": {
+          "traceId": "0af7651916cd43dd8448eb211c80319c",
+          "sampled": false 
+        },
+        "expected": [ "guid" ]
+      }
+    }
+  },
+  {
+    "test_name": "no_headers_root_uses_partial_ratio_sampler",
+    "comment": "Traces originating from current service are always sampled at partial granularity (ratio=1.0)",
+    "trusted_account_key": "33",
+    "account_id": "33",
+    "web_transaction": true,
+    "raises_exception": false,
+    "span_events_enabled": true,
+    "transaction_events_enabled": true,
+    "transport_type": "HTTP",
+    "root": "trace_id_ratio_based",
+    "full_granularity_ratio": 0.0,
+    "remote_parent_sampled": "default",
+    "remote_parent_not_sampled": "default",
+    "partial_granularity_enabled": true,
+    "partial_granularity_root": "trace_id_ratio_based",
+    "partial_granularity_ratio": 1.0,
+    "partial_granularity_remote_parent_sampled": "default",
+    "partial_granularity_remote_parent_not_sampled": "default",
+    "force_adaptive_sampled": false,
+    "inbound_headers": [
+      {}
+    ],
+
+    "expected_priority_between": [ 1, 2 ],
+    "intrinsics": {
+      "target_events": [ "Transaction" ],
+      "common": {
+        "exact": {
+          "sampled": true
+        },
+        "expected": [ "guid", "traceId" ]
+      }
+    }
+  },
+  {
+    "test_name": "newrelic_remote_parent_sampled_uses_partial_ratio_sampler",
+    "comment": "New Relic parent header determines parent is sampled and New Relic trace id is passed to partial ratio sampler",
+    "trusted_account_key": "33",
+    "account_id": "33",
+    "web_transaction": true,
+    "raises_exception": false,
+    "span_events_enabled": true,
+    "transaction_events_enabled": true,
+    "transport_type": "HTTP",
+    "root": "always_off",
+    "remote_parent_sampled": "always_off",
+    "remote_parent_not_sampled": "always_off",
+    "partial_granularity_enabled": true,
+    "partial_granularity_root": "default",
+    "partial_granularity_remote_parent_sampled": "trace_id_ratio_based",
+    "partial_granularity_ratio": 1.0,
+    "partial_granularity_remote_parent_not_sampled": "default",
+    "force_adaptive_sampled": false,
+
+    "expected_priority_between": [ 1, 2 ],
+    "inbound_headers": [
+      {
+        "newrelic": "{\"v\":[0,1],\"d\":{\"ty\":\"App\",\"ac\":\"33\",\"ap\":\"2827902\",\"id\":\"7d3efb1b173fecfa\",\"tr\":\"0af7651916cd43dd8448eb211c80319c\",\"pr\":0.2,\"sa\":true,\"ti\":1518469636035,\"tx\":\"0af7651916cd43dd\"}}"
+      }
+    ],
+    "intrinsics": {
+      "target_events": [ "Transaction" ],
+      "common": {
+        "exact": {
+          "traceId": "0af7651916cd43dd8448eb211c80319c",
+          "sampled": true
+        },
+        "expected": [ "guid" ]
+      }
+    }
+  },
+  {
+    "test_name": "newrelic_remote_parent_sampled_uses_partial_ratio_sampler_full_ratio_not_sampled",
+    "comment": "New Relic parent header determines parent is sampled and New Relic trace id is passed first to full ratio and then  partial ratio sampler",
+    "trusted_account_key": "33",
+    "account_id": "33",
+    "web_transaction": true,
+    "raises_exception": false,
+    "span_events_enabled": true,
+    "transaction_events_enabled": true,
+    "transport_type": "HTTP",
+    "root": "trace_id_ratio_based",
+    "remote_parent_sampled": "trace_id_ratio_based",
+    "remote_parent_not_sampled": "trace_id_ratio_based",
+    "full_granularity_ratio": 0,
+    "partial_granularity_enabled": true,
+    "partial_granularity_root": "trace_id_ratio_based",
+    "partial_granularity_remote_parent_sampled": "trace_id_ratio_based",
+    "partial_granularity_ratio": 1,
+    "partial_granularity_remote_parent_not_sampled": "trace_id_ratio_based",
+    "force_adaptive_sampled": false,
+
+    "expected_priority_between": [ 1, 2 ],
+    "inbound_headers": [
+      {
+        "newrelic": "{\"v\":[0,1],\"d\":{\"ty\":\"App\",\"ac\":\"33\",\"ap\":\"2827902\",\"id\":\"7d3efb1b173fecfa\",\"tr\":\"0af7651916cd43dd8448eb211c80319c\",\"pr\":0.2,\"sa\":true,\"ti\":1518469636035,\"tx\":\"0af7651916cd43dd\"}}"
+      }
+    ],
+    "intrinsics": {
+      "target_events": [ "Transaction" ],
+      "common": {
+        "exact": {
+          "traceId": "0af7651916cd43dd8448eb211c80319c",
+          "sampled": true 
+        },
+        "expected": [ "guid" ]
+      }
+    }
+  },
+  {
+    "test_name": "newrelic_remote_parent_sampled_uses_partial_ratio_sampler_not_smapled",
+    "comment": "New Relic parent header determines parent is sampled and New Relic trace id is passed to partial ratio sampler and returns false because ratio is 0",
+    "trusted_account_key": "33",
+    "account_id": "33",
+    "web_transaction": true,
+    "raises_exception": false,
+    "span_events_enabled": true,
+    "transaction_events_enabled": true,
+    "transport_type": "HTTP",
+    "root": "trace_id_ratio_based",
+    "remote_parent_sampled": "trace_id_ratio_based",
+    "remote_parent_not_sampled": "trace_id_ratio_based",
+    "full_granularity_ratio": 0,
+    "partial_granularity_enabled": true,
+    "partial_granularity_root": "trace_id_ratio_based",
+    "partial_granularity_remote_parent_sampled": "trace_id_ratio_based",
+    "partial_granularity_ratio": 0,
+    "partial_granularity_remote_parent_not_sampled": "trace_id_ratio_based",
+    "force_adaptive_sampled": false,
+
+    "expected_priority_between": [ 0, 1 ],
+    "inbound_headers": [
+      {
+        "newrelic": "{\"v\":[0,1],\"d\":{\"ty\":\"App\",\"ac\":\"33\",\"ap\":\"2827902\",\"id\":\"7d3efb1b173fecfa\",\"tr\":\"0af7651916cd43dd8448eb211c80319c\",\"pr\":0.2,\"sa\":true,\"ti\":1518469636035,\"tx\":\"0af7651916cd43dd\"}}"
+      }
+    ],
+    "intrinsics": {
+      "target_events": [ "Transaction" ],
+      "common": {
+        "exact": {
+          "traceId": "0af7651916cd43dd8448eb211c80319c",
+          "sampled": false 
+        },
+        "expected": [ "guid" ]
+      }
+    }
+  },
+  {
+    "test_name": "no_headers_full_traces_disabled_uses_partial_adaptive_sampler",
+    "comment": "Root traces are always sampled at partial granularity with the global adaptive sampler",
+    "trusted_account_key": "33",
+    "account_id": "33",
+    "web_transaction": true,
+    "raises_exception": false,
+    "span_events_enabled": true,
+    "transaction_events_enabled": true,
+    "transport_type": "HTTP",
+    "full_granularity_enabled": false,
+    "partial_granularity_enabled": true,
+    "partial_granularity_root": "adaptive",
+    "force_adaptive_sampled": true,
+    "partial_granularity_remote_parent_sampled": "always_off",
+    "partial_granularity_remote_parent_not_sampled": "always_off",
+    "inbound_headers": [
+      {}
+    ],
+
+    "expected_priority_between": [ 1, 2 ],
+    "intrinsics": {
+      "target_events": [ "Transaction" ],
+      "common": {
+        "exact": {
+          "sampled": true
+        },
+        "expected": [ "guid", "traceId" ]
+      }
+    }
+  },
+  {
+    "test_name": "w3c_remote_parent_not_sampled_uses_partial_ratio_sampler",
+    "comment": "Traceparent header determines parent is not sampled. Full granularity tries to run the adaptive sampler, chooses sampled=false, and W3C trace id is passed to partial ratio sampler",
+    "trusted_account_key": "33",
+    "account_id": "33",
+    "web_transaction": true,
+    "raises_exception": false,
+    "span_events_enabled": true,
+    "transaction_events_enabled": true,
+    "transport_type": "HTTP",
+    "root": "always_off",
+    "remote_parent_sampled": "always_off",
+    "remote_parent_not_sampled": "default",
+    "force_adaptive_sampled": false,
+    "partial_granularity_enabled": true,
+    "partial_granularity_root": "always_off",
+    "partial_granularity_remote_parent_sampled": "always_off",
+    "partial_granularity_remote_parent_not_sampled": "trace_id_ratio_based",
+    "partial_granularity_ratio": 1.0,
+    "inbound_headers": [
+      {
+        "traceparent": "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-00"
+      }
+    ],
+
+    "expected_priority_between": [ 1, 2 ],
+    "intrinsics": {
+      "target_events": [ "Transaction" ],
+      "common": {
+        "exact": {
+          "traceId": "0af7651916cd43dd8448eb211c80319c",
+          "sampled": true
+        },
+        "expected": [ "guid" ]
+      }
+    }
+  },
+  {
+    "test_name": "w3c_remote_parent_sampled_uses_partial_always_on",
+    "comment": "W3C parent header determines parent is sampled and passes to partial granularity always on sampler",
+    "trusted_account_key": "33",
+    "account_id": "33",
+    "web_transaction": true,
+    "raises_exception": false,
+    "span_events_enabled": true,
+    "transaction_events_enabled": true,
+    "transport_type": "HTTP",
+    "full_granularity_enabled": false,
+    "partial_granularity_enabled": true,
+    "partial_granularity_remote_parent_sampled": "always_on",
+
+    "force_adaptive_sampled": false,
+    "inbound_headers": [
+      {
+        "traceparent": "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01"
+      }
+    ],
+    "intrinsics": {
+      "target_events": [ "Transaction" ],
+      "common": {
+        "exact": {
+          "traceId": "0af7651916cd43dd8448eb211c80319c",
+          "sampled": true,
+          "priority": 2.0
+        },
+        "expected": [ "guid" ]
+      }
+    }
+  },
+  {
+    "test_name": "no_headers_root_uses_partial_always_on",
+    "comment": "Traces originating from current service are always sampled at partial granularity (with priority 2.0)",
+    "trusted_account_key": "33",
+    "account_id": "33",
+    "web_transaction": true,
+    "raises_exception": false,
+    "span_events_enabled": true,
+    "transaction_events_enabled": true,
+    "transport_type": "HTTP",
+    "root": "always_off",
+    "partial_granularity_enabled": true,
+    "partial_granularity_root": "always_on",
+    "inbound_headers": [
+      {}
+    ],
+    "intrinsics": {
+      "target_events": [
+        "Transaction"
+      ],
+      "common": {
+        "exact": {
+          "priority": 2.0,
+          "sampled": true
+        },
+        "expected": [
+          "guid",
+          "traceId"
+        ]
+      }
+    }
+  },
+  {
+    "test_name": "payload_missing_priority_incremented_to_full_granularity_priority",
+    "comment": "Remote parent was sampled and tracestate has a sampled=true flag but no priority, so a random priority between 2 and 3 should be generated without use of the sampler",
+    "trusted_account_key": "33",
+    "account_id": "33",
+    "web_transaction": true,
+    "raises_exception": false,
+    "span_events_enabled": true,
+    "transaction_events_enabled": true,
+    "transport_type": "HTTP",
+    "remote_parent_sampled": "adaptive",
+    "force_adaptive_sampled": false,
+    "inbound_headers": [
+      {
+        "traceparent": "00-f6e9c09812b22fba2f1999b318ddfc8b-7d3efb1b173fecfa-01",
+        "tracestate": "33@nr=0-2-33-2827902-7d3efb1b173fecfa--1--1518469636035"
+      }
+    ],
+    "expected_priority_between": [2,3],
+    "intrinsics": {
+      "target_events": ["Transaction"],
+      "common":{
+        "exact": {
+          "traceId": "f6e9c09812b22fba2f1999b318ddfc8b",
+          "sampled": true
+        },
+        "expected": ["guid", "priority"]
+      }
+    }
+  },
+  {
+    "test_name": "payload_missing_priority_incremented_to_partial_granularity_priority",
+    "comment": "Remote parent was sampled and tracestate has a sampled=true flag but no priority, so a random priority between 1 and 2 should be generated without use of the sampler",
+    "trusted_account_key": "33",
+    "account_id": "33",
+    "web_transaction": true,
+    "raises_exception": false,
+    "span_events_enabled": true,
+    "transaction_events_enabled": true,
+    "transport_type": "HTTP",
+    "full_granularity_enabled": false,
+    "partial_granularity_enabled": true,
+    "partial_granularity_remote_parent_sampled": "adaptive",
+    "force_adaptive_sampled": false,
+    "inbound_headers": [
+      {
+        "traceparent": "00-f6e9c09812b22fba2f1999b318ddfc8b-7d3efb1b173fecfa-01",
+        "tracestate": "33@nr=0-2-33-2827902-7d3efb1b173fecfa--1--1518469636035"
+      }
+    ],
+    "expected_priority_between": [1, 2],
+    "intrinsics": {
+      "target_events": ["Transaction"],
+      "common":{
+        "exact": {
+          "traceId": "f6e9c09812b22fba2f1999b318ddfc8b",
+          "sampled": true
+        },
+        "expected": ["guid", "priority"]
+      }
+    }
+  },
+
+  {
+    "test_name": "no_headers_root_full_and_partial_disabled",
+    "comment": "Traces are assigned a random priority <1 when full and partial tracing are both disabled. The expected_priority_between min is arbitrarily small (so that it does not include 0)",
+    "trusted_account_key": "33",
+    "account_id": "33",
+    "web_transaction": true,
+    "raises_exception": false,
+    "span_events_enabled": true,
+    "transaction_events_enabled": true,
+    "transport_type": "HTTP",
+    "full_granularity_enabled": false,
+    "root": "always_on",
+    "partial_granularity_enabled": false,
+    "partial_granularity_root": "always_on",
+    "force_adaptive_sampled": true,
+    "inbound_headers": [
+      {}
+    ],
+    "expected_priority_between": [0.000000001, 1],
+    "intrinsics": {
+      "target_events": [ "Transaction" ],
+      "common": {
+        "exact": {
+          "sampled": false
+        },
+        "expected": [ "guid", "traceId" ]
+      }
+    }
+  },
+  {
+    "test_name": "no_headers_distributed_tracing_disabled",
+    "comment": "Traces are assigned a random priority <1 when distributed tracing is disabled. The expected_priority_between min is arbitrarily small (so that it does not include 0)",
+    "trusted_account_key": "33",
+    "account_id": "33",
+    "web_transaction": true,
+    "raises_exception": false,
+    "span_events_enabled": true,
+    "transaction_events_enabled": true,
+    "distributed_tracing_enabled": false,
+    "transport_type": "HTTP",
+    "root": "always_on",
+    "force_adaptive_sampled": true,
+    "inbound_headers": [
+      {}
+    ],
+    "expected_priority_between": [0.000000001, 1]
   },
   {
     "test_name": "accept_payload",

--- a/test/unit/samplers/sampler.test.js
+++ b/test/unit/samplers/sampler.test.js
@@ -22,8 +22,14 @@ test('should generate a random priority between 0 and 1 with at most 6 decimal p
   assert.match(`${priority}`, /[01]\.\d{1,6}/)
 })
 
-test('should increment priority by n and truncate to  6 decimal places', () => {
+test('should increment priority by 1 and truncate to  6 decimal places if partial trace', () => {
   const priority = 0.123456789
-  const incremented = Sampler.incrementPriority(priority, 2)
+  const incremented = Sampler.incrementPriority(priority, 'essential')
+  assert.equal(incremented, 1.123456)
+})
+
+test('should increment priority by 2 and truncate to  6 decimal places if full trace', () => {
+  const priority = 0.123456789
+  const incremented = Sampler.incrementPriority(priority)
   assert.equal(incremented, 2.123456)
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This PR adds the new `tracecontext.json` DT cross agent tests.  This was mostly to verify interactions between full and partial traces in the context of DT intrinsics of `priority` and `sampled`.  With that being said, I had to fix a few issues with our agent:

 * We were incorrectly assigning priority and sampled to null if missing from adaptive sampler when tracestate intrinsics were present.  In case where `priority` is missing from tracestate, we generate a random priority, and if sampled we increment by 1 for partial and 2 for full traces.  
 * In both ratio and adaptive samplers we weren't incrementing priority by 1 for partial and 2 for full traces.


I also refactored the tracecontext cross agent test suite to separate our helpers, assertions and the test itself. Lastly, our tracecontext cross agent tests suite wasn't asserting that priority was actually a number, so I fixed that. Which is why I had to fix the things mentioned above about adaptive sampler.

Basically when a sampling decision is applied, the result should assign a priority and sampled flag in all situations, it should never assign null or not assign values at all.  In the case of interactions between full/partial traces. Full sampling is applied(if enabled), and partial sampling is applied only if full didn't sample.  There should never be a time where it applies DT/legacy DT sampling and if no decision was made, apply root sampling decisions. That was not the case until this PR.

## How to Test

```sh
node test/integration/distributed-tracing/trace-context-cross-agent.test.js
```

## Related Issues
Closes #3580
