### PR TITLE
fix: Updated `getHostnameSafe` to invalidate the cache is trying to assign the host based on the gcp cloud run id

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -993,7 +993,21 @@ Config.prototype.getIPAddresses = function getIPAddresses() {
 function getHostnameSafe(gcpId = null) {
   let _hostname
   const config = this
-  this.getHostnameSafe = function getCachedHostname() {
+  /**
+   * We cache the result of _hostname unless an argument is passed in.
+   * The argument of `gcpId` is only passed in during the collection of
+   * facts: see `lib/collector/facts.js`. This needs to take precedence
+   * over whatever the hostname was previously because gcp cloud run instances
+   * report as localhost and we want to use the cloud run id
+   *
+   * @param {string} gcpId GCP metadata ID
+   * @returns {string} host name
+   */
+  this.getHostnameSafe = function getCachedHostname(gcpId = null) {
+    if (gcpId) {
+      return getHostnameSafe.call(config, gcpId)
+    }
+
     return _hostname
   }
   try {

--- a/test/unit/collector/facts.test.js
+++ b/test/unit/collector/facts.test.js
@@ -862,6 +862,19 @@ test('host facts', async (t) => {
     })
   })
 
+  await t.test('should be GCP id when K_SERVICE is set and `agent.config.getDisplayHost()` was previously called', (t, end) => {
+    const { agent, facts } = t.nr
+    agent.config.getDisplayHost()
+
+    agent.config.utilization = { gcp_use_instance_as_host: true }
+    process.env.K_SERVICE = 'mock-service'
+
+    facts(agent, (result) => {
+      assert.equal(result.host, 'mock-gcp-instance-id', 'Hostname should be set to GCP instance ID')
+      end()
+    })
+  })
+
   await t.test('should not be GCP id when K_SERVICE is not present', (t, end) => {
     const { agent, facts } = t.nr
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We had a customer reporting that they weren't seeing the proper host when using cloud run even though they had `config.utilization.gcp_use_instance_as_host` set to true, and there was in fact a gcp cloud run id and `K_SERVICE` env var. It turns out the issue is that the `getHostnameSafe` function is cached after the initial call. We _thought_ this was first called during the bootstrap to collect the facts of the running appilcation environment. However since the agent bootstraps async, it could start immediately instrumentating before the handshake with the collector finished. In this case it attempted to create a transaction, which create a trace, which adds the `host.displayHost` as an attribute on the trace.

Since this was called and cached with the `os.hostname`, when the agent received the metadata from the utilization endpoint for gcp, it was a no-op and never set the host to be the gcp id.  This PR updates our logic for `getHostnameSafe` to where if an argument is passed, which only happens during the `lib/collector/facts.js` flow if it has a gcp id, we invalidate the cache and re assign a hostname and then cache that result for future calls.

## How to Test

```sh
node test/unit/collector/facts.test.js
```

## Related Issues

Closes #3651
