### PR TITLE
fix: Updated message consumer subscribers to properly time the consumption actions

### DIFF
--- a/lib/subscribers/message-consumer.js
+++ b/lib/subscribers/message-consumer.js
@@ -105,7 +105,7 @@ class MessageConsumerSubscriber extends Subscriber {
    */
   asyncStart() {
     const ctx = this.agent.tracer.getContext()
-    const tx = ctx?.transaction
+    const tx = ctx.transaction
     tx.setPartialName(this.name)
     // Note: this is not using `Subscriber.createSegment`
     // this is because it enters the segment and returns a new ctx
@@ -117,6 +117,7 @@ class MessageConsumerSubscriber extends Subscriber {
       parent: tx.trace.root,
       transaction: tx
     })
+    tx.baseSegment.start()
 
     this.addConsumeParameters(tx)
 

--- a/test/versioned/amqplib/callback.test.js
+++ b/test/versioned/amqplib/callback.test.js
@@ -480,6 +480,8 @@ test('amqplib callback instrumentation', async function (t) {
     agent.on('transactionFinished', function (tx) {
       amqpUtils.verifyConsumeTransaction(tx, exchange, queue, 'consume-tx-key')
       assert.ok(tx.trace.getDurationInMillis() >= PROMISE_WAIT, 'transaction should account for async work')
+
+      assert.ok(tx.baseSegment.getDurationInMillis() >= PROMISE_WAIT, 'base segment should account for async work')
       end()
     })
 

--- a/test/versioned/amqplib/promises.test.js
+++ b/test/versioned/amqplib/promises.test.js
@@ -457,6 +457,7 @@ test('amqplib promise instrumentation', async function (t) {
     process.nextTick(() => {
       amqpUtils.verifyConsumeTransaction(tx, amqpUtils.DIRECT_EXCHANGE, queue, 'consume-tx-key')
       assert.ok(tx.trace.getDurationInMillis() >= PROMISE_WAIT, 'transaction should account for async work')
+      assert.ok(tx.baseSegment.getDurationInMillis() >= PROMISE_WAIT, 'base segment should account for async work')
     })
   })
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
In #3510 we fixed the message consumer instrumentation to properly handle async consumer methods.  However, the total transaction duration was still incorrect.
This is because we were not starting the base segment.  The transaction duration metrics are calculated [here](https://github.com/newrelic/node-newrelic/blob/fa0e2d1bd78051c7f716ebc65bd7f3842698103e/lib/metrics/recorders/message-transaction.js). They get the duration, exclusive duration and total trace duration to create message transaction metrics. Since the base segment wasn't getting started, the duration was off. This PR fixes that by properly starting the base segment. I also added assertions in the versioned tests to verify the base segment duration is at least the time we are waiting in the consume methods.

## How to Test

```sh
npm run versioned:internal amqplib
```

## Related Issues
Closes #3659
