### PR TITLE
chore: Update OTEL metrics test

### DIFF
--- a/test/integration/otel/metrics.test.js
+++ b/test/integration/otel/metrics.test.js
@@ -71,7 +71,7 @@ test.afterEach((ctx) => {
   ctx.nr.server.close()
 })
 
-test('sends metrics', { timeout: 5555_000 }, async (t) => {
+test('sends metrics', { timeout: 5_000 }, async (t) => {
   // This test verifies that the metrics exporter ships expected metrics
   // data, with the correct `entity.guid` attached, to the backend system.
   // Due to the way bootstrapping of the metrics API client works, there will


### PR DESCRIPTION
This PR fixes an issue in our OTEL metrics integration test. In short, an update released upstream today seems to adjust the timing on when the metric exporter ships data to the remote collector. Previously, our manual collection of metrics recorded prior the agent being ready would be sent along with the next tick. Now, they are sent immediately and the subsequent metrics are included in the following tick.