### PR TITLE
test: Updated mock response to avoid retries on openai langchain vectorstore calls

### DIFF
--- a/test/versioned/openai/embeddings.test.js
+++ b/test/versioned/openai/embeddings.test.js
@@ -149,13 +149,13 @@ test('embedding invalid payload errors should be tracked', (t, end) => {
     match(tx.exceptions[0], {
       error: {
         status: 403,
-        code: null,
+        code: 'insufficient_quota',
         param: null
       },
       customAttributes: {
         'http.statusCode': 403,
-        'error.message': /You are not allowed to generate embeddings from this model/,
-        'error.code': null,
+        'error.message': /You exceeded your current quota, please check your plan and billing details/,
+        'error.code': 'insufficient_quota',
         'error.param': null,
         completion_id: undefined,
         embedding_id: /\w{32}/

--- a/test/versioned/openai/mock-chat-api-responses.js
+++ b/test/versioned/openai/mock-chat-api-responses.js
@@ -186,10 +186,10 @@ responses.set('Embedding not allowed.', {
   code: 403,
   body: {
     error: {
-      message: 'You are not allowed to generate embeddings from this model',
-      type: 'invalid_request_error',
+      message: 'You exceeded your current quota, please check your plan and billing details',
+      type: 'insufficient_quota',
       param: null,
-      code: null
+      code: 'insufficient_quota'
     }
   }
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

In `@langchain/core@1.1.14` they refactored how they handle errors vs retry failed calls.  It seems as though langchain + openai will always retry when 4xx errors exist. I logged this bug: https://github.com/langchain-ai/langchainjs/issues/9813, but since we don't really care about this being fixed, I updated our mock to return a specific code that avoids retries: `insufficient_quota`

## How to Test

```sh
npm run versioned:internal langchain-openai
npm run versioned:internal openai
```

