### PR TITLE
chore: Lazy load OTEL dependencies

### DIFF
--- a/lib/otel/setup.js
+++ b/lib/otel/setup.js
@@ -5,16 +5,11 @@
 
 'use strict'
 
-const opentelemetry = require('@opentelemetry/api')
-
-const SetupLogs = require('./logs/index.js')
-const SetupMetrics = require('./metrics/index.js')
-const SetupTraces = require('./traces/index.js')
-const ContextManager = require('./context-manager')
-const TracePropagator = require('./trace-propagator')
+// The majority of dependencies in this module are lazy loaded in order to
+// limit the impact on memory usage. In general, the OTEL dependencies are
+// only loaded when they are needed, because they can have a significant
+// impact once loaded.
 const defaultLogger = require('../logger').child({ component: 'opentelemetry-bridge' })
-const createOtelLogger = require('./logger')
-const interceptSpanKey = require('./span-key-interceptor')
 
 const signals = []
 
@@ -25,6 +20,12 @@ function setupOtel(agent, logger = defaultLogger) {
     )
     return
   }
+
+  const opentelemetry = require('@opentelemetry/api')
+  const ContextManager = require('./context-manager')
+  const TracePropagator = require('./trace-propagator')
+  const createOtelLogger = require('./logger')
+  const interceptSpanKey = require('./span-key-interceptor')
 
   // When bridge mode is enabled, our context manager must utilize the OTEL
   // context manager. Otherwise, traces within, e.g. logs, will not be
@@ -37,6 +38,7 @@ function setupOtel(agent, logger = defaultLogger) {
   opentelemetry.propagation.setGlobalPropagator(new TracePropagator(agent))
 
   if (agent.config.opentelemetry.traces.enabled === true) {
+    const SetupTraces = require('./traces/index.js')
     const signal = new SetupTraces({ agent })
     signals.push(signal)
   } else {
@@ -47,6 +49,7 @@ function setupOtel(agent, logger = defaultLogger) {
   }
 
   if (agent.config.opentelemetry.metrics.enabled === true) {
+    const SetupMetrics = require('./metrics/index.js')
     const signal = new SetupMetrics({ agent })
     signals.push(signal)
   } else {
@@ -57,6 +60,7 @@ function setupOtel(agent, logger = defaultLogger) {
   }
 
   if (agent.config.opentelemetry.logs.enabled === true) {
+    const SetupLogs = require('./logs/index.js')
     const signal = new SetupLogs({ agent })
     signals.push(signal)
   } else {
@@ -68,7 +72,7 @@ function setupOtel(agent, logger = defaultLogger) {
     .incrementCallCount()
 }
 
-function teardownOtel(agent) {
+function teardownOtel(agent, { opentelemetry = require('@opentelemetry/api') } = {}) {
   if (agent?.config?.opentelemetry?.enabled !== true) {
     return
   }


### PR DESCRIPTION
This PR lazy loads the OTEL dependencies based upon which bridge features are actually being enabled. This will keep resource usage impact of the OTEL code to a minimum.