### PR TITLE
chore: add timed event limit of 100

### DIFF
--- a/lib/transaction/trace/segment.js
+++ b/lib/transaction/trace/segment.js
@@ -305,6 +305,10 @@ TraceSegment.prototype.addSpanLink = function addSpanLink(spanLink) {
 }
 
 TraceSegment.prototype.addTimedEvent = function addTimedEvent(timedEvent) {
+  if (this.timedEvents.length === 100) {
+    this.logger.trace({ timedEvent }, 'Timed event limit reached. Not adding new event.')
+    return
+  }
   this.timedEvents.push(timedEvent)
 }
 


### PR DESCRIPTION
## Description

Agent spec PR 775 states that like OTel span links, OTel timed (span) events also need to have a limit of 100.

## How to Test

```
npm run unit
```

## Related Issues

Closes #3646