### PR TITLE
fix: Updated `Supportability/Nodejs/PartialGranularity/NrIds/Dropped` metric to only keep track of spans that got dropped when `nr.ids` execeeded 63 spans.

### DIFF
--- a/lib/spans/span-event.js
+++ b/lib/spans/span-event.js
@@ -60,6 +60,8 @@ class SpanIntrinsics {
     this.duration = null
     this['nr.entryPoint'] = null
     this['nr.pg'] = null
+    this['nr.durations'] = null
+    this['nr.ids'] = null
     this['span.kind'] = null
     this.trustedParentId = null
     this.tracingVendors = null

--- a/lib/transaction/trace/partial-trace.js
+++ b/lib/transaction/trace/partial-trace.js
@@ -217,6 +217,7 @@ class PartialTrace {
 
     const meta = {
       ids: [],
+      droppedIds: 0,
       totalDuration: 0,
       currentStart: null,
       currentEnd: null,
@@ -231,23 +232,34 @@ class PartialTrace {
       // do not push its own id to `nr.ids`
       // first span in array is always the retained exit span
       if (i !== 0) {
-        meta.ids.push(sameEntitySpan.id)
+        // Max size for `nr.ids` = 1024. Max length = 63 (each span id is 16 bytes + 8 bytes for list type).
+        if (meta.ids.length < 63) {
+          meta.ids.push(sameEntitySpan.id)
+        } else {
+          meta.droppedIds++
+        }
       }
 
       this.compactionError(meta, sameEntitySpan)
       this.calculateDuration(meta, sameEntitySpan)
     }
 
+    this.assignCompactAttrs({ span, meta })
+  }
+
+  assignCompactAttrs({ span, meta }) {
+    logger.trace('Partial trace is compact, assigning `nr.ids`: %s, `nr.durations`: %s, to span %s', meta.ids, meta.totalDuration, span.intrinsics.name)
+
     // add the final interval duration
     if (meta.currentStart !== null) {
       meta.totalDuration += meta.currentEnd - meta.currentStart
     }
 
-    logger.trace('Partial trace is compact, assigning `nr.ids`: %s, `nr.durations`: %s, to span %s', meta.ids, meta.totalDuration, span.intrinsics.name)
-    this.transaction.metrics.getOrCreateMetric(PARTIAL_TRACE.DROPPED).incrementCallCount(meta.ids.length)
+    if (meta.droppedIds > 0) {
+      this.transaction.metrics.getOrCreateMetric(PARTIAL_TRACE.DROPPED).incrementCallCount(meta.droppedIds)
+    }
     span.addIntrinsicAttribute('nr.ids', meta.ids)
     span.addIntrinsicAttribute('nr.durations', meta.totalDuration)
-
     if (meta.errorSpan) {
       for (const [key, value] of Object.entries(meta.errorSpan.errorAttrs)) {
         // value of `error.expected` is a boolean, cannot truncate it

--- a/test/integration/distributed-tracing/core-tracing-assertions.js
+++ b/test/integration/distributed-tracing/core-tracing-assertions.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const assert = require('node:assert')
+
+/**
+ * Asserts the expected metrics for a given test
+ *
+ * @param {object} params to function
+ * @param {Agent} params.agent agent instance
+ * @param {Array} params.expectedMetrics expected metrics multi-dimensional array
+ */
+function assertMetrics({ agent, expectedMetrics = [] }) {
+  for (const metric of expectedMetrics) {
+    // test case has Java in names, replace with Nodejs
+    const name = metric[0].replace('Java', 'Nodejs')
+    const expectedValue = metric[1]
+    const value = agent.metrics._metrics.unscoped[name].callCount
+    assert.equal(value, expectedValue, `metric ${name} should be ${expectedValue}, got ${value}`)
+  }
+}
+
+/**
+ * Asserts that a span does not exist aka dropped
+ *
+ * @param {object} params to function
+ * @param {Array} params.spans spans created during transaction
+ * @param {Array} params.droppedSpans list of dropped spans
+ */
+function assertDroppedSpans({ spans, droppedSpans = [] }) {
+  for (const span of droppedSpans) {
+    assert.ok(!findSpan({ name: span, spans }), `${span} should have been dropped`)
+  }
+}
+
+/**
+ * Asserts that a span exits, its parent id is correct,
+ * and all agent, intrinsics and custom attributes were created
+ *
+ * @param {object} params to function
+ * @param {Array} params.spans spans created during transaction
+ * @param {Array} params.expectedSpans collection of spans that were retained
+ */
+function assertSpanTree({ spans, expectedSpans = [] }) {
+  for (const expectedSpan of expectedSpans) {
+    for (const [name, values] of Object.entries(expectedSpan)) {
+      const span = findSpan({ spans, name })
+      assert.ok(span, `should have created span: ${name}`)
+      assertParentId({ span, spans, parent: values.parent })
+      assertAttrs({ span, attrs: values.agent_attrs, type: 'attributes' })
+      assertAttrs({ span, attrs: values.user_attrs, type: 'customAttributes' })
+      assertAttrs({ span, attrs: values.intrinsics, type: 'intrinsics' })
+    }
+  }
+}
+
+/**
+ * Attempts to find a span in the collection of spans
+ *
+ * @param {object} params to function
+ * @param {Array} params.spans spans created during transaction
+ * @param {string} params.name name of span to find
+ * @returns {SpanEvent|null} returns span if it exists
+ */
+function findSpan({ spans, name }) {
+  return spans.find((span) => span.intrinsics.name === name)
+}
+
+/**
+ * Asserts the parent id is correct for a given span
+ *
+ * @param {object} params to function
+ * @param {Array} params.spans spans created during transaction
+ * @param {string|null} params.parent name of parent span
+ * @param {SpanEvent} params.span span to check its parent
+ */
+function assertParentId({ parent, spans, span }) {
+  if (parent) {
+    const parentSpan = findSpan({ spans, name: parent })
+    assert.equal(span.parentId, parentSpan.id, `span ${span.intrinsics.name} should have parent ${parent}, got ${parentSpan.intrinsics.name}`)
+  } else {
+    assert.equal(span.parentId, parent)
+  }
+}
+
+/**
+ *  Asserts that an attribute is equal, exists or does not exist
+ *
+ * @param {object} params to function
+ * @param {SpanEvent} params.span span to check its attributes
+ * @param {object} params.attrs fixture to check the relevant attributes
+ * @param {string} params.type type of attributes to check against
+ */
+function assertAttrs({ span, attrs = {}, type }) {
+  const { exact = {}, unexpected = [], expected = [] } = attrs
+
+  for (const key of expected) {
+    assert.ok(Object.prototype.hasOwnProperty.call(span[type], key), `${key} ${type} should exist on ${span.intrinsics.name}`)
+  }
+  for (const key of unexpected) {
+    assert.ok(!Object.prototype.hasOwnProperty.call(span[type], key), `${key} ${type} should not exist on ${span.intrinsics.name}`)
+  }
+
+  for (const [key, value] of Object.entries(exact)) {
+    if (key === 'nr.durations') {
+      // numbers are fun in javascript, have to fix the values to 2 digits
+      const fixedValue = span[type][key].toFixed(2)
+      const expectedFixedValue = value.toFixed(2)
+      assert.equal(fixedValue, expectedFixedValue, `${key} ${type} should be ${expectedFixedValue}, got ${fixedValue}`)
+    } else {
+      assert.equal(span[type][key], value, `${key} ${type} should be ${value}, got ${span.attributes[key]}`)
+    }
+  }
+}
+
+module.exports = {
+  assertMetrics,
+  assertDroppedSpans,
+  assertSpanTree
+}

--- a/test/integration/distributed-tracing/core-tracing.test.js
+++ b/test/integration/distributed-tracing/core-tracing.test.js
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const test = require('node:test')
+const helper = require('#testlib/agent_helper.js')
+const testCases = require('#testlib/cross_agent_tests/distributed_tracing/partial_granularity.json')
+const { assertDroppedSpans, assertMetrics, assertSpanTree } = require('./core-tracing-assertions')
+
+for (const testCase of testCases) {
+  test(testCase.test_name, (t, end) => {
+    const config = {
+      distributed_tracing: {
+        sampler: {
+          full_granularity: {
+            enabled: false
+          },
+          partial_granularity: {
+            enabled: true,
+            type: testCase.partial_granularity_type
+          }
+        }
+      }
+    }
+    const agent = helper.instrumentMockedAgent(config)
+    t.after(() => {
+      helper.unloadAgent(agent)
+    })
+
+    const fixture = require(`#testlib/cross_agent_tests/distributed_tracing/${testCase.tracer_info}`)
+
+    helper.runInTransaction(agent, (transaction) => {
+      transaction.baseSegment = transaction.trace.root
+      generateTxData({ agent, transaction, fixture })
+      transaction.end()
+      const spans = agent.spanEventAggregator.getEvents()
+      assertSpanTree({ spans, expectedSpans: testCase.expected_spans })
+      assertDroppedSpans({ spans, droppedSpans: testCase.unexpected_spans })
+      assertMetrics({ agent, expectedMetrics: testCase.expected_metrics })
+      end()
+    })
+  })
+}
+
+/**
+ * Creates n segments based on test case
+ * It either builds a specific tree of segments or a random set of segments with the same parent
+ *
+ * @param {object} params to function
+ * @param {Agent} params.agent agent instance
+ * @param {Transaction} params.transaction active transaction
+ * @param {object} params.fixture DSL to define the segments
+ */
+function generateTxData({ agent, transaction, fixture }) {
+  const rootTracer = fixture.root_tracer
+  const rootSegment = createSegment({ agent, name: rootTracer.name, parent: transaction.trace.root, transaction, fixture: rootTracer })
+  transaction.baseSegment = rootSegment
+  if (rootTracer.children_formula) {
+    createRandomSegments({ agent, transaction, fixture: rootTracer.children_formula, parent: rootSegment })
+  } else {
+    createChildSegments({ agent, transaction, fixture: rootTracer.children, parent: rootSegment })
+  }
+}
+
+/**
+ * Iterates over fixture and creates segments with appropriate parent
+ *
+ * @param {object} params to function
+ * @param {Agent} params.agent agent instance
+ * @param {Transaction} params.transaction active transaction
+ * @param {object} params.fixture DSL to define the segments
+ * @param {TraceSegment} params.parent parent segment
+ */
+function createChildSegments({ agent, transaction, fixture, parent }) {
+  for (const child of fixture) {
+    const segment = createSegment({ agent, name: child.name, parent, transaction, fixture: child })
+    if (child.children) {
+      createChildSegments({ agent, transaction, parent: segment, fixture: child.children })
+    }
+  }
+}
+
+/**
+ * Creates a segment with the appropriate parent, and relevant agent and user attrs(custom attributes)
+ *
+ * @param {object} params to function
+ * @param {Agent} params.agent agent instance
+ * @param {string} params.name name of segment
+ * @param {TraceSegment} params.parent parent segment
+ * @param {Transaction} params.transaction active transaction
+ * @param {object} params.fixture DSL to define the segments
+ * @returns {TraceSegment} segment created
+ */
+function createSegment({ agent, name, parent, transaction, fixture }) {
+  const segment = agent.tracer.createSegment({ name, parent, transaction })
+  segment.timer.start = fixture.timestamp
+  segment.setDurationInMillis(fixture.duration_millis, segment.timer.start)
+
+  if (fixture.agent_attrs) {
+    for (const [key, value] of Object.entries(fixture.agent_attrs)) {
+      segment.addAttribute(key, value)
+    }
+  }
+
+  if (fixture.user_attrs) {
+    const spanContext = segment.getSpanContext()
+    for (const [key, value] of Object.entries(fixture.user_attrs)) {
+      spanContext.addCustomAttribute(key, value)
+    }
+  }
+  return segment
+}
+
+/**
+ * Creates a set of random segments with the same parent
+ *
+ * @param {object} params to function
+ * @param {Agent} params.agent agent instance
+ * @param {Transaction} params.transaction active transaction
+ * @param {object} params.fixture DSL to define the segments
+ * @param {TraceSegment} params.parent parent segment
+ */
+function createRandomSegments({ agent, transaction, fixture, parent }) {
+  let segment = parent
+  for (let i = 1; i <= fixture.num_children; i++) {
+    fixture.timestamp = segment.timer.start + segment.timer.durationInMillis + fixture.duration_gap_millis
+    const name = fixture.name_prefix + i
+    segment = createSegment({ agent, name, parent, transaction, fixture })
+  }
+}

--- a/test/lib/cross_agent_tests/distributed_tracing/partial_granularity.json
+++ b/test/lib/cross_agent_tests/distributed_tracing/partial_granularity.json
@@ -1,0 +1,336 @@
+[
+  {
+    "test_name": "partial_granularity_reduced",
+    "comment": [ "Use transaction from tracer_info.json, with partial granularity set to 'reduced'",
+      "We should drop the in-process span and keep the rest.",
+      "The External span External/B2 under the in-process span should be re-parented to the root span."],
+    "tracer_info":"tracer_info_standard.json",
+    "partial_granularity_type": "reduced",
+    "expected_spans": [
+      {
+        "root": {
+          "parent": null,
+          "intrinsics": {
+            "exact": {
+              "nr.pg": true
+            }
+          }
+        }
+      },
+      {
+        "External/B1": {
+          "parent": "root",
+          "agent_attrs": {
+            "exact": {
+              "http.url": "serviceB",
+              "non_essential_attr": "somevalue",
+              "error.class": "errorclass1",
+              "error.message": "errormessage1",
+              "error.expected": true
+            }
+          },
+          "user_attrs": {
+            "exact": {
+              "my_user_attr": "my_value"
+            }
+          }
+        }
+      },
+      {
+        "External/B2": {
+          "parent": "root",
+          "agent_attrs": {
+            "exact": {
+              "http.url": "serviceB",
+              "error.class": "errorclass2",
+              "error.message": "errormessage2",
+              "error.expected": false
+            }
+          }
+        }
+      },
+      {
+        "External/C": {
+          "parent": "root",
+          "agent_attrs": {
+            "exact": {
+              "http.url": "serviceC",
+              "cloud.account.id": "12345",
+              "cloud.platform": "AWS",
+              "cloud.region": "US-EAST-1",
+              "cloud.resource_id": "67890",
+              "db.instance": "MYDB",
+              "db.system": "Postgres",
+              "http.url": "http://url1/",
+              "messaging.destination.name": "dest",
+              "messaging.system": "MQS",
+              "peer.hostname": "peer",
+              "server.address": "server",
+              "server.port": 80,
+              "span.kind": "SPAN"
+            }
+          }
+        }
+      },
+      {
+        "Llm/SOMETHING/function": {
+          "parent": "root",
+          "agent_attrs": {
+            "exact": {
+              "http.url": "myllm"
+            }
+          }
+        }
+      },
+      {
+        "External/D": {
+          "parent": "Llm/SOMETHING/function",
+          "agent_attrs": {
+            "exact": {
+              "http.url": "serviceD"
+            }
+          }
+        }
+      }
+    ],
+    "unexpected_spans": ["inprocess"]
+  },
+  {
+    "test_name": "partial_granularity_essential",
+    "comment": [ "Use transaction from tracer_info.json, with partial granularity set to 'essential'",
+      "We should drop the in-process span and keep the rest.",
+      "The External span External/B2 under the in-process span should be re-parented to the root span.",
+      "The non-essential attribute on External/B1 should be dropped"],
+    "tracer_info":"tracer_info_standard.json",
+    "partial_granularity_type": "essential",
+    "expected_spans": [
+      {
+        "root": {
+          "parent": null,
+          "intrinsics": {
+            "exact": {
+              "nr.pg": true
+            }
+          }
+        }
+      },
+      {
+        "External/B1": {
+          "parent": "root",
+          "agent_attrs": {
+            "exact": {
+              "http.url": "serviceB",
+              "error.class": "errorclass1",
+              "error.message": "errormessage1",
+              "error.expected": true
+            },
+            "unexpected": ["non_essential_attr"]
+          },
+          "user_attrs": {
+            "unexpected": ["my_user_attr"]
+          }
+        }
+      },
+      {
+        "External/B2": {
+          "parent": "root",
+          "agent_attrs": {
+            "exact": {
+              "http.url": "serviceB",
+              "error.class": "errorclass2",
+              "error.message": "errormessage2",
+              "error.expected": false
+            }
+          }
+        }
+      },
+      {
+        "External/C": {
+          "parent": "root",
+          "agent_attrs": {
+            "exact": {
+              "http.url": "serviceC",
+              "cloud.account.id": "12345",
+              "cloud.platform": "AWS",
+              "cloud.region": "US-EAST-1",
+              "cloud.resource_id": "67890",
+              "db.instance": "MYDB",
+              "db.system": "Postgres",
+              "http.url": "http://url1/",
+              "messaging.destination.name": "dest",
+              "messaging.system": "MQS",
+              "peer.hostname": "peer",
+              "server.address": "server",
+              "server.port": 80,
+              "span.kind": "SPAN"
+            }
+          }
+        }
+      },
+      {
+        "Llm/SOMETHING/function": {
+          "parent": "root",
+          "agent_attrs": {
+            "exact": {
+              "http.url": "myllm"
+            }
+          }
+        }
+      },
+      {
+        "External/D": {
+          "parent": "Llm/SOMETHING/function",
+          "agent_attrs": {
+            "exact": {
+              "http.url": "serviceD"
+            }
+          }
+        }
+      }
+    ],
+    "unexpected_spans": ["inprocess"]
+  },
+  {
+    "test_name": "partial_granularity_compact",
+    "comment": [ "Use transaction from tracer_info.json, with partial granularity set to 'compact'",
+      "We should drop the in-process span and keep the rest.",
+      "The External span External/B2 under the in-process span should be merged into External/B1.",
+      "Their durations should be merged and the merged span should have 2 new attributes: nr.ids and nr.durations.",
+      "The non-essential attribute on ExternalB1 should be dropped"],
+    "tracer_info":"tracer_info_standard.json",
+    "partial_granularity_type": "compact",
+    "expected_spans": [
+      {
+        "root": {
+          "parent": null,
+          "intrinsics": {
+            "exact": {
+              "nr.pg": true
+            }
+          }
+        }
+      },
+      {
+        "External/B1": {
+          "parent": "root",
+          "intrinsics": {
+            "exact": {
+              "timestamp": 1766435410010,
+              "duration": 0.1,
+              "nr.durations": 0.16
+            },
+            "expected": ["nr.ids"]
+          },
+          "agent_attrs": {
+            "exact": {
+              "http.url": "serviceB"
+            },
+            "expected": [
+              "error.class",
+              "error.message",
+              "error.expected"
+            ],
+            "unexpected": [
+              "non_essential_attr"
+            ]
+          },
+          "user_attrs": {
+            "unexpected": ["my_user_attr"]
+          }
+        }
+      },
+      {
+        "External/C": {
+          "parent": "root",
+          "agent_attrs": {
+            "exact": {
+              "http.url": "serviceC",
+              "cloud.account.id": "12345",
+              "cloud.platform": "AWS",
+              "cloud.region": "US-EAST-1",
+              "cloud.resource_id": "67890",
+              "db.instance": "MYDB",
+              "db.system": "Postgres",
+              "http.url": "http://url1/",
+              "messaging.destination.name": "dest",
+              "messaging.system": "MQS",
+              "peer.hostname": "peer",
+              "server.address": "server",
+              "server.port": 80,
+              "span.kind": "SPAN"
+            }
+          }
+        }
+      },
+      {
+        "Llm/SOMETHING/function": {
+          "parent": "root",
+          "agent_attrs": {
+            "exact": {
+              "http.url": "myllm"
+            }
+          }
+        }
+      },
+      {
+        "External/D": {
+          "parent": "root",
+          "agent_attrs": {
+            "exact": {
+              "http.url": "serviceD"
+            }
+          }
+        }
+      }
+    ],
+    "unexpected_spans": ["inprocess", "External/B2"]
+  },
+  {
+    "test_name": "partial_granularity_compact_too_many_nrids",
+    "comment": [ "Use transaction from tracer_info.json, with partial granularity set to 'compact'",
+      "We should group all the child spans together which should be too many to add all to nr.ids",
+      "This should produce a metric called Supportability/Java/PartialGranularity/NrIds/Dropped with the right value"
+    ],
+    "tracer_info":"tracer_info_compact_too_many.json",
+    "partial_granularity_type": "compact",
+    "expected_metrics": [
+      ["Supportability/Java/PartialGranularity/NrIds/Dropped", 6]
+    ],
+    "expected_spans": [
+      {
+        "root": {
+          "parent": null,
+          "intrinsics": {
+            "exact": {
+              "nr.pg": true
+            }
+          }
+        }
+      },
+      {
+        "External/1": {
+          "parent": "root",
+          "intrinsics": {
+            "exact": {
+              "nr.durations": 0.7
+            },
+            "expected": ["nr.ids"]
+          },
+          "agent_attrs": {
+            "exact": {
+              "http.url": "service"
+            }
+          }
+        }
+      }
+    ],
+    "unexpected_spans": ["External/2", "External/3", "External/4", "External/5", "External/6", "External/7", "External/8", "External/9", "External/10",
+      "External/11", "External/12", "External/13", "External/14", "External/15", "External/16", "External/17", "External/18", "External/19", "External/20",
+      "External/21", "External/22", "External/23", "External/24", "External/25", "External/26", "External/27", "External/28", "External/29", "External/30",
+      "External/31", "External/32", "External/33", "External/34", "External/35", "External/36", "External/37", "External/38", "External/39", "External/40",
+      "External/41", "External/42", "External/43", "External/44", "External/45", "External/46", "External/47", "External/48", "External/49", "External/50",
+      "External/51", "External/52", "External/53", "External/54", "External/55", "External/56", "External/57", "External/58", "External/59", "External/60",
+      "External/61", "External/62", "External/63", "External/64", "External/65", "External/66", "External/67", "External/68", "External/69", "External/70"
+    ]
+  }
+]

--- a/test/lib/cross_agent_tests/distributed_tracing/trace_context.json
+++ b/test/lib/cross_agent_tests/distributed_tracing/trace_context.json
@@ -633,7 +633,7 @@
     }
   },
   {
-    "test_name": "newrelic_remote_parent_sampled_uses_partial_ratio_sampler_not_smapled",
+    "test_name": "newrelic_remote_parent_sampled_uses_partial_ratio_sampler_not_sampled",
     "comment": "New Relic parent header determines parent is sampled and New Relic trace id is passed to partial ratio sampler and returns false because ratio is 0",
     "trusted_account_key": "33",
     "account_id": "33",

--- a/test/lib/cross_agent_tests/distributed_tracing/tracer_info_compact_too_many.json
+++ b/test/lib/cross_agent_tests/distributed_tracing/tracer_info_compact_too_many.json
@@ -1,0 +1,25 @@
+{
+  "data_name": "partial_granularity_compact_too_many_nrids",
+  "comments": ["A simple trace with X children that are all to be kept and grouped under the compact option",
+    "The agent test should generate the correct num_children spans that will be merged",
+    "The name_prefix should be appended with a simple counter 1 to X",
+    "There should be enough child spans that are grouped to max out the nr.ids list and have IDs that could not be added.",
+    "duration_gap should be used to calculate the start timestamp for each span, adding that many milliseconds to the end of the previous span to create gaps",
+    "Note: overlapping timespans are tested in the normal tests"
+  ],
+  "root_tracer": {
+    "name": "root",
+    "timestamp": 1766435410000,
+    "duration_millis": 5000,
+    "children_formula": {
+      "num_children": 70,
+      "duration_millis": 10,
+      "duration_gap_millis": 1,
+      "name_prefix": "External/",
+      "agent_attrs": {
+        "http.url": "service"
+      }
+    }
+  }
+}
+

--- a/test/lib/cross_agent_tests/distributed_tracing/tracer_info_standard.json
+++ b/test/lib/cross_agent_tests/distributed_tracing/tracer_info_standard.json
@@ -1,0 +1,87 @@
+{
+  "data_name": "partial_granularity_standard_test",
+  "comments": ["A standard test that can be used with all types of partial granularity",
+    "All options will have to: drop and re-parent span(s)",
+    "Compact will have at least 2 spans to group",
+    "Reduced and Compact will have an attribute to drop"
+  ],
+  "root_tracer": {
+    "name": "root",
+    "timestamp": 1766435410000,
+    "duration_millis": 1500,
+    "children": [
+      {
+        "name": "External/B1",
+        "timestamp": 1766435410010,
+        "duration_millis": 100,
+        "agent_attrs": {
+          "http.url": "serviceB",
+          "non_essential_attr": "somevalue",
+          "error.class": "errorclass1",
+          "error.message": "errormessage1",
+          "error.expected": true
+        },
+        "user_attrs": {
+          "my_user_attr": "my_value"
+        }
+      },
+      {
+        "name": "inprocess",
+        "timestamp": 1766435410020,
+        "duration_millis": 200,
+        "children": [
+          {
+            "name": "External/B2",
+            "timestamp": 1766435410070,
+            "duration_millis": 100,
+            "agent_attrs": {
+              "http.url": "serviceB",
+              "error.class": "errorclass2",
+              "error.message": "errormessage2",
+              "error.expected": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "External/C",
+        "timestamp": 1766435410500,
+        "duration_millis": 200,
+        "agent_attrs": {
+          "http.url": "serviceC",
+          "cloud.account.id": "12345",
+          "cloud.platform": "AWS",
+          "cloud.region": "US-EAST-1",
+          "cloud.resource_id": "67890",
+          "db.instance": "MYDB",
+          "db.system": "Postgres",
+          "http.url": "http://url1/",
+          "messaging.destination.name": "dest",
+          "messaging.system": "MQS",
+          "peer.hostname": "peer",
+          "server.address": "server",
+          "server.port": 80,
+          "span.kind": "SPAN"
+        }
+      },
+      {
+        "name": "Llm/SOMETHING/function",
+        "timestamp": 1766435411000,
+        "duration_millis": 200,
+        "agent_attrs": {
+          "http.url": "myllm"
+        },
+        "children": [
+          {
+            "name": "External/D",
+            "timestamp": 1766435411100,
+            "duration_millis": 250,
+            "agent_attrs": {
+              "http.url": "serviceD"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/lib/cross_agent_tests/samplers/sampler_configuration.json
+++ b/test/lib/cross_agent_tests/samplers/sampler_configuration.json
@@ -87,7 +87,6 @@
         },
         "remote_parent_sampled": {
           "trace_id_ratio_based": {
-            "ratio": ""
           }
         },
         "remote_parent_not_sampled": {


### PR DESCRIPTION
## Description
This PR adds the final cross agent tests for core tracing. I did discover one issue where we were incorrectly incrementing `Supportability/Nodejs/PartialGranularity/NrIds/Dropped`. The intention of this metric is to only increment when we exceed the max size of `nr.ids` which is 63 ids.  This PR fixes that and also brings in the tests around core tracing logic.  

## How to Test

```sh
node test/integration/distributed-tracing/core-tracing.test.js
node test/unit/transaction/trace/partial-trace.test.js
```

## Related Issues
Closes #3640 