### PR TITLE
feat: Add `timestamp` to AWS Bedrock llm chat msgs

### DIFF
--- a/lib/instrumentation/aws-sdk/v3/bedrock.js
+++ b/lib/instrumentation/aws-sdk/v3/bedrock.js
@@ -75,9 +75,10 @@ function isStreamingEnabled({ commandName, config }) {
 function recordEvent({ agent, type, msg }) {
   msg.serialize()
   const llmContext = extractLlmContext(agent)
+  const timestamp = msg?.timestamp ?? Date.now()
 
   agent.customEventAggregator.add([
-    { type, timestamp: Date.now() },
+    { type, timestamp },
     Object.assign({}, msg, llmContext)
   ])
 }

--- a/lib/llm-events/aws-bedrock/chat-completion-message.js
+++ b/lib/llm-events/aws-bedrock/chat-completion-message.js
@@ -38,7 +38,7 @@ class LlmChatCompletionMessage extends LlmEvent {
     params = Object.assign({}, defaultParams, params)
     super(params)
 
-    const { agent, content, isResponse, index, completionId, role } = params
+    const { agent, content, isResponse, index, completionId, role, segment } = params
     const recordContent = agent.config?.ai_monitoring?.record_content?.enabled
 
     this.is_response = isResponse
@@ -46,6 +46,10 @@ class LlmChatCompletionMessage extends LlmEvent {
     this.sequence = index
     this.content = recordContent === true ? content : undefined
     this.role = role
+    if (this.is_response === false) {
+      // Only record for request/input messages
+      this.timestamp = segment.timer.start
+    }
 
     this.#setId(index)
     this.setTokenCount(agent)

--- a/test/unit/llm-events/aws-bedrock/chat-completion-message.test.js
+++ b/test/unit/llm-events/aws-bedrock/chat-completion-message.test.js
@@ -54,7 +54,10 @@ test.beforeEach((ctx) => {
     traceId: 'trace-1'
   }
   ctx.nr.segment = {
-    id: 'segment-1'
+    id: 'segment-1',
+    timer: {
+      start: 1769119395346
+    }
   }
   ctx.nr.role = 'assistant'
 
@@ -201,4 +204,17 @@ test('should not set token_count if outputTokenCount is set but not inputTokenCo
 test('should set token_count to 0 if inputTokenCount and outputTokenCount are on response', async (t) => {
   const event = new LlmChatCompletionMessage(t.nr)
   assert.equal(event.token_count, 0)
+})
+
+test('should set timestamp if request/input msg', async (t) => {
+  t.nr.role = 'user'
+  t.nr.isResponse = false
+  const event = new LlmChatCompletionMessage(t.nr)
+  assert.equal(event.timestamp, t.nr.segment.timer.start)
+})
+
+test('should not set timestamp if response msg', async (t) => {
+  t.nr.isResponse = true
+  const event = new LlmChatCompletionMessage(t.nr)
+  assert.equal(event.timestamp, undefined)
 })

--- a/test/versioned/aws-sdk-v3/common.js
+++ b/test/versioned/aws-sdk-v3/common.js
@@ -136,6 +136,9 @@ function assertChatCompletionMessage({
   expectedChatMsg.id = id
   expectedChatMsg.content = expectedContent
   expectedChatMsg.is_response = isResponse
+  if (isResponse === false) {
+    expectedChatMsg.timestamp = /\d{13}/
+  }
 
   assert.equal(messageBase.type, 'LlmChatCompletionMessage')
   match(messageData, expectedChatMsg)


### PR DESCRIPTION
## Description

Decided to PR this now as it does **not** build off the AIM subscriber refactor. Adds the `timestamp` field to request/input `LlmChatCompletionMessage`s for AWS Bedrock's Converse API and `InvokeModel` API. 

## How to Test

```
npm run versioned:major aws-sdk-v3
npm run unit
```

## Related Issues

Part of #3582