### PR TITLE
feat: Add `timestamp` to Google Gen AI `LlmChatCompletionMessage`s

### DIFF
--- a/lib/llm-events/google-genai/chat-completion-message.js
+++ b/lib/llm-events/google-genai/chat-completion-message.js
@@ -33,6 +33,11 @@ module.exports = class LlmChatCompletionMessage extends LlmEvent {
       this.content = this.is_response ? message?.parts?.[0]?.text : message
     }
 
+    // only add timestamp for request/input messages
+    if (this.is_response === false) {
+      this.timestamp = segment.timer.start
+    }
+
     this.setTokenCount(agent, request, response)
   }
 

--- a/lib/subscribers/google-genai/embed-content.js
+++ b/lib/subscribers/google-genai/embed-content.js
@@ -6,9 +6,7 @@
 const { AiMonitoringEmbeddingSubscriber } = require('../ai-monitoring')
 const { AI } = require('../../../lib/metrics/names')
 const { GEMINI } = AI
-const {
-  LlmEmbedding
-} = require('../../../lib/llm-events/google-genai')
+const { LlmEmbedding } = require('#agentlib/llm-events/google-genai/index.js')
 
 class GoogleGenAIEmbedContentSubscriber extends AiMonitoringEmbeddingSubscriber {
   constructor ({ agent, logger }) {

--- a/lib/subscribers/google-genai/generate-content-stream.js
+++ b/lib/subscribers/google-genai/generate-content-stream.js
@@ -73,12 +73,11 @@ class GoogleGenAIGenerateContentStreamSubscriber extends GoogleGenAIGenerateCont
   }
 
   asyncEnd(data) {
+    // Check config to see if ai_monitoring is still enabled
     if (!this.enabled) {
       this.logger.debug('`ai_monitoring.enabled` is set to false, stream will not be instrumented.')
       return
     }
-
-    // Check config is ai_monitoring is still enabled
     if (!this.streamingEnabled) {
       this.logger.warn(
         '`ai_monitoring.streaming.enabled` is set to `false`, stream will not be instrumented.'

--- a/test/unit/llm-events/google-genai/chat-completion-message.test.js
+++ b/test/unit/llm-events/google-genai/chat-completion-message.test.js
@@ -43,6 +43,7 @@ test('should create a LlmChatCompletionMessage event', (t, end) => {
         index: 0
       })
       const expected = getExpectedResult(tx, chatMessageEvent, 'message', summaryId)
+      expected.timestamp = segment.timer.start
       assert.deepEqual(chatMessageEvent, expected)
       end()
     })

--- a/test/versioned/google-genai/common.js
+++ b/test/versioned/google-genai/common.js
@@ -37,11 +37,13 @@ function assertChatCompletionMessages(
       expectedChatMsg.id = /[a-f0-9]{36}/
       expectedChatMsg.content = reqContent
       expectedChatMsg.token_count = 0
+      expectedChatMsg.timestamp = /\d{13}/
     } else if (msg[1].sequence === 1) {
       expectedChatMsg.sequence = 1
       expectedChatMsg.id = /[a-f0-9]{36}/
       expectedChatMsg.content = 'What does 1 plus 1 equal?'
       expectedChatMsg.token_count = 0
+      expectedChatMsg.timestamp = /\d{13}/
     } else {
       expectedChatMsg.sequence = 2
       expectedChatMsg.role = 'model'


### PR DESCRIPTION
## Description

Adds the `timestamp` field to Google Gen AI request/input `LlmChatCompletionMessage`s. Also some minor readability/documentation fixes.

## How to Test

```
npm run unit
npm run versioned:major google-genai
```

## Related Issues

Part of #3582