### PR TITLE
feat: Add timestamp to OpenAI `LlmChatCompletionSummary`s

### DIFF
--- a/lib/llm-events/openai/chat-completion-summary.js
+++ b/lib/llm-events/openai/chat-completion-summary.js
@@ -14,16 +14,18 @@ module.exports = class LlmChatCompletionSummary extends LlmEvent {
     this['request.temperature'] = request.temperature
 
     if (request?.input) {
-      // `responses.create` logic
+      // `responses.create` api logic
       // `request.input` can be an array or a string.
       const requestLength = Array.isArray(request?.input) ? request.input.length : 1
       this['response.number_of_messages'] = requestLength + (response?.output?.length ?? 0)
       this['response.choices.finish_reason'] = response?.status
     } else {
-      // `chat.completions.create` logic
+      // `chat.completions.create` api logic
       this['response.number_of_messages'] = request?.messages?.length + response?.choices?.length
       this['response.choices.finish_reason'] = response?.choices?.[0]?.finish_reason
     }
+
+    this.timestamp = segment.timer.start
 
     this.setTokens(agent, request, response)
   }

--- a/test/versioned/openai/chat-completions-res-api.test.js
+++ b/test/versioned/openai/chat-completions-res-api.test.js
@@ -142,9 +142,12 @@ test('responses.create', async (t) => {
         resContent: '1 plus 2 is 3.',
         reqContent: content
       })
+      const requestMsg = chatMsgs.filter((msg) => msg[1].is_response === false)[0]
+      assert.equal(requestMsg[0].timestamp, requestMsg[1].timestamp, 'time added to event aggregator should equal `timestamp` property')
 
       const chatSummary = events.filter(([{ type }]) => type === 'LlmChatCompletionSummary')[0]
       assertChatCompletionSummary({ tx, model, chatSummary })
+      assert.equal(chatSummary[0].timestamp, chatSummary[1].timestamp, 'time added to event aggregator should equal `timestamp` property')
 
       tx.end()
       end()

--- a/test/versioned/openai/chat-completions.test.js
+++ b/test/versioned/openai/chat-completions.test.js
@@ -147,9 +147,12 @@ test('chat.completions.create', async (t) => {
         resContent: '1 plus 2 is 3.',
         reqContent: content
       })
+      const requestMsg = chatMsgs.filter((msg) => msg[1].is_response === false)[0]
+      assert.equal(requestMsg[0].timestamp, requestMsg[1].timestamp, 'time added to event aggregator should equal `timestamp` property')
 
       const chatSummary = events.filter(([{ type }]) => type === 'LlmChatCompletionSummary')[0]
       assertChatCompletionSummary({ tx, model, chatSummary })
+      assert.equal(chatSummary[0].timestamp, chatSummary[1].timestamp, 'time added to event aggregator should equal `timestamp` property')
 
       tx.end()
       end()

--- a/test/versioned/openai/common-chat-api.js
+++ b/test/versioned/openai/common-chat-api.js
@@ -91,7 +91,8 @@ function assertChatCompletionSummary(
     'response.headers.ratelimitRemainingRequests': '199',
     'response.number_of_messages': 3,
     'response.choices.finish_reason': 'stop',
-    error
+    error,
+    timestamp: /\d{13}/
   }
 
   if (!(error || noUsageTokens)) {

--- a/test/versioned/openai/common-responses-api.js
+++ b/test/versioned/openai/common-responses-api.js
@@ -114,7 +114,8 @@ function assertChatCompletionSummary(
       'response.usage.total_tokens': totalTokens,
       span_id: segment.id,
       trace_id: tx.traceId,
-      vendor: 'openai'
+      vendor: 'openai',
+      timestamp: /\d{13}/
     }
 
     // For some reason the responses API streaming does not return rate limit headers
@@ -137,6 +138,7 @@ function assertChatCompletionSummary(
       span_id: segment.id,
       trace_id: tx.traceId,
       vendor: 'openai',
+      timestamp: /\d{13}/
     }
   }
 


### PR DESCRIPTION
## Description

Adds the `timestamp` property to OpenAI `LlmChatCompletionSummary`s.

## How to Test

```
npm run versioned:major openai
npm run unit
```

## Related Issues

Part of #3656