### PR TITLE
fix: Updated langchain tool instrumentation to properly redefine the segment name on every call

### DIFF
--- a/lib/subscribers/langchain/tool.js
+++ b/lib/subscribers/langchain/tool.js
@@ -14,14 +14,14 @@ const LlmErrorMessage = require('../../llm-events/error-message')
 
 class LangchainToolSubscriber extends AiMonitoringSubscriber {
   constructor({ agent, logger }) {
-    super({ agent, logger, packageName: '@langchain/core', channelName: 'nr_call', trackingPrefix: LANGCHAIN.TRACKING_PREFIX, name: LANGCHAIN.TOOL })
+    super({ agent, logger, packageName: '@langchain/core', channelName: 'nr_call', trackingPrefix: LANGCHAIN.TRACKING_PREFIX, name: 'unknown' })
     this.events = ['asyncEnd']
     this.trackingPrefix = LANGCHAIN.TRACKING_PREFIX
   }
 
   handler(data, ctx) {
     const tool = data?.self
-    this.name = `${this.name}/${tool?.name}`
+    this.name = `${LANGCHAIN.TOOL}/${tool?.name}`
     return super.handler(data, ctx)
   }
 

--- a/test/versioned/langchain/tools.test.js
+++ b/test/versioned/langchain/tools.test.js
@@ -69,6 +69,20 @@ test('should create span on successful tools create', (t, end) => {
   })
 })
 
+test('should not append previous tool name to span on successful tools create', (t, end) => {
+  const { agent, tool, input } = t.nr
+  helper.runInTransaction(agent, async (tx) => {
+    const [result, result2] = await Promise.all([tool.call(input), tool.call(input)])
+    assert.ok(result)
+    assert.ok(result2)
+    assertSegments(tx.trace, tx.trace.root, ['Llm/tool/LangChain/node-agent-test-tool', 'Llm/tool/LangChain/node-agent-test-tool'], {
+      exact: true
+    })
+    tx.end()
+    end()
+  })
+})
+
 test('should increment tracking metric for each tool event', (t, end) => {
   const { tool, agent, input } = t.nr
   helper.runInTransaction(agent, async (tx) => {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

When reviewing #3646 with the [langgraph example app](https://github.com/newrelic/newrelic-node-examples/pull/359), I noticed the tool names were being concatenated from the previous tool calls.  This PR fixes it to redefine the segment name on every tool call.

## How to Test

```sh
npm run versioned:internal:major langchain
```
