### PR TITLE
chore: remove eslint disable next line for `sonarjs/no-dead-store`

### DIFF
--- a/lib/instrumentation/when/index.js
+++ b/lib/instrumentation/when/index.js
@@ -296,7 +296,6 @@ module.exports = function initialize(shim, when) {
         ret = agent.tracer.bindFunction(fn, context, true).apply(this, arguments)
       } finally {
         if (ret && typeof ret.then === 'function') {
-          // eslint-disable-next-line sonarjs/no-dead-store
           ret = ctx.next[symbols.context].continue(ret)
         }
       }


### PR DESCRIPTION
Fixes linting error