### PR TITLE
fix: Updated `pg` instrumentation to properly capture the TraceSegment duration for promise based queries

### DIFF
--- a/lib/subscribers/pg/connect.js
+++ b/lib/subscribers/pg/connect.js
@@ -6,6 +6,7 @@
 'use strict'
 
 const Subscriber = require('../base.js')
+const { wrapPromise } = require('../utils')
 
 /**
  * Subscribes to the `connect` event for PostgreSQL's (`pg`) `Client` class.
@@ -13,8 +14,12 @@ const Subscriber = require('../base.js')
 class PgConnectSubscriber extends Subscriber {
   constructor({ agent, logger, channelName = 'nr_connect', packageName = 'pg' }) {
     super({ agent, logger, channelName, packageName })
-    this.events = ['asyncEnd']
+    this.events = ['asyncEnd', 'end']
     this.callback = -1
+  }
+
+  end(data) {
+    wrapPromise.call(this, data)
   }
 
   handler(data, ctx) {

--- a/lib/subscribers/pg/native-connect.js
+++ b/lib/subscribers/pg/native-connect.js
@@ -17,7 +17,7 @@ const PgConnectSubscriber = require('./connect.js')
 class PgNativeConnectSubscriber extends PgConnectSubscriber {
   constructor({ agent, logger, channelName = 'nr_nativeConnect' }) {
     super({ agent, logger, channelName })
-    this.events = ['asyncStart', 'asyncEnd']
+    this.events = ['asyncStart', 'asyncEnd', 'end']
     this.propagateContext = true
   }
 }

--- a/lib/subscribers/pg/native-query.js
+++ b/lib/subscribers/pg/native-query.js
@@ -14,7 +14,7 @@ const PgQuerySubscriber = require('./query.js')
 class PgNativeQuerySubscriber extends PgQuerySubscriber {
   constructor({ agent, logger, channelName = 'nr_nativeQuery' }) {
     super({ agent, logger, channelName })
-    this.events = ['asyncStart', 'asyncEnd']
+    this.events = ['asyncStart', 'asyncEnd', 'end']
     this.propagateContext = true
   }
 }

--- a/lib/subscribers/pg/query.js
+++ b/lib/subscribers/pg/query.js
@@ -8,6 +8,7 @@
 const DbQuerySubscriber = require('../db-query.js')
 const { POSTGRES } = require('#agentlib/metrics/names.js')
 const { EventEmitter } = require('node:events')
+const { wrapPromise } = require('../utils')
 
 /**
  * Defaults to subscribing to the `query` event for PostgreSQL's (`pg`) `Client` class
@@ -18,9 +19,13 @@ const { EventEmitter } = require('node:events')
 class PgQuerySubscriber extends DbQuerySubscriber {
   constructor({ agent, logger, channelName = 'nr_query', packageName = 'pg' }) {
     super({ agent, logger, channelName, packageName, system: POSTGRES.PREFIX })
-    this.events = ['asyncEnd']
+    this.events = ['asyncEnd', 'end']
     this.operation = 'query'
     this.callback = -1
+  }
+
+  end(data) {
+    wrapPromise.call(this, data)
   }
 
   /**

--- a/lib/subscribers/utils.js
+++ b/lib/subscribers/utils.js
@@ -20,7 +20,7 @@
  */
 function wrapPromise(data) {
   const promise = data?.result
-  if (typeof promise.then !== 'function') {
+  if (typeof promise?.then !== 'function') {
     return promise
   }
 


### PR DESCRIPTION
## Description
This PR adds an `end` event to pg instrumenation to wrap the promise, when present.  This will ensure that the segment is getting touched so the proper duration is being recorded.  Currently for promise based queries a segment isn't being touched so the duration is from the start of query to end of transaction. This is because when a transaction ends, it finalizes all segments.

You can see here this is an app the runs a pg promise based query, sleeps 5 seconds and responds.  Before the fix the query segment was the same duration as the handler. After the fix, the duration is correct

### Before Fix

<img width="1226" height="252" alt="screenshot 2026-01-28 at 10 39 01 AM" src="https://github.com/user-attachments/assets/905a6204-b282-4036-902f-ac5dcd7cba76" />

### After Fix

<img width="1215" height="342" alt="screenshot 2026-01-28 at 10 38 47 AM" src="https://github.com/user-attachments/assets/8f214f00-ad16-4907-aae0-17c49115fe91" />

We still have yet to figure out a reliable, holistic way to assert segment durations are correct. These previous tests attempted that by asserting the metrics for the database queries, but since it was a >2.0, it was working. It probably needed a > 2.0 < 2.1. I've added asserting the segment duration + that the segment was touched. The reason for this is because if you call `segment.getDurationInMillis()` it will calculate the duration from the time it is called but asserting it was touched, proves the duration was stamped from instrumentation and not by calling `getDurationInMillis`

## Related Issues
Closes #3694