### PR TITLE
fix: Added defensive code in `lib/subscribers/middleware-wrapper.js` to prevent crash when attempting to associate an error on an incoming http request

### DIFF
--- a/lib/subscribers/middleware-wrapper.js
+++ b/lib/subscribers/middleware-wrapper.js
@@ -161,7 +161,11 @@ class MiddlewareWrapper {
       errorWare = true
       route = null
     }
-    const txInfo = request?.raw?.[transactionInfo] || request?.[transactionInfo]
+
+    // fallback to empty object, this is purely defensive code and will not correlate
+    // the error with the http request
+    // see: https://github.com/newrelic/node-newrelic/issues/3696
+    const txInfo = request?.raw?.[transactionInfo] || request?.[transactionInfo] || {}
     if (errorWare) {
       txInfo.errorHandled = errorWare
     }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
#3696 explains the issue. This PR adds defensive code to prevent a crash. Not fix the fact that we will not be logging errors if not handled
when using express/lambda/serverless-http. A customer must use `newrelic.noticeError` to handle errors.

## How to Test

```sh
node test/unit/lib/subscribers/middleare-wrapper.test.js
```

## Related Issues
Closes #3696
