### PR TITLE
feat: Added `timestamp` to AWS Bedrock `LlmChatCompletionSummary`s

### DIFF
--- a/lib/llm-events/aws-bedrock/chat-completion-summary.js
+++ b/lib/llm-events/aws-bedrock/chat-completion-summary.js
@@ -37,6 +37,7 @@ class LlmChatCompletionSummary extends LlmEvent {
     this['request.temperature'] = cmd.temperature
     this['response.number_of_messages'] = (cmd.prompt.length ?? 0) + (res.completions.length ?? 0)
 
+    this.timestamp = segment.timer.start
     this.setTokens(agent)
   }
 

--- a/test/unit/llm-events/aws-bedrock/chat-completion-summary.test.js
+++ b/test/unit/llm-events/aws-bedrock/chat-completion-summary.test.js
@@ -43,6 +43,7 @@ test.beforeEach((ctx) => {
     id: 'tx-1'
   }
   ctx.nr.segment = {
+    timer: { start: 1769450379777 },
     getDurationInMillis() {
       return 100
     }
@@ -94,6 +95,7 @@ test('creates a basic summary', async (t) => {
   assert.equal(event['request.temperature'], 0.5)
   assert.equal(event['response.choices.finish_reason'], 'done')
   assert.equal(event['response.number_of_messages'], 2)
+  assert.equal(event.timestamp, t.nr.segment.timer.start)
 })
 
 test('creates an claude summary', async (t) => {

--- a/test/versioned/aws-sdk-v3/bedrock-chat-completions.test.js
+++ b/test/versioned/aws-sdk-v3/bedrock-chat-completions.test.js
@@ -163,8 +163,11 @@ test.afterEach(afterEach)
         expectedId: modelId.includes('ai21') || modelId.includes('cohere') ? '1234' : null,
         chatMsgs
       })
-
       assertChatCompletionSummary({ tx, modelId, chatSummary })
+
+      const requestMsg = chatMsgs.filter((msg) => msg[1].is_response === false)[0]
+      assert.equal(requestMsg[0].timestamp, requestMsg[1].timestamp, 'time added to event aggregator should equal `timestamp` property')
+      assert.equal(chatSummary[0].timestamp, chatSummary[1].timestamp, 'time added to event aggregator should equal `timestamp` property')
 
       tx.end()
     })

--- a/test/versioned/aws-sdk-v3/bedrock-converse-api.test.js
+++ b/test/versioned/aws-sdk-v3/bedrock-converse-api.test.js
@@ -117,8 +117,11 @@ test('properly create the LlmChatCompletionMessage(s) and LlmChatCompletionSumma
       chatMsgs,
       resContent: 'This is a test.'
     })
-
     assertChatCompletionSummary({ tx, modelId, chatSummary, tokenUsage: true })
+
+    const requestMsg = chatMsgs.filter((msg) => msg[1].is_response === false)[0]
+    assert.equal(requestMsg[0].timestamp, requestMsg[1].timestamp, 'time added to event aggregator should equal `timestamp` property')
+    assert.equal(chatSummary[0].timestamp, chatSummary[1].timestamp, 'time added to event aggregator should equal `timestamp` property')
 
     tx.end()
   })

--- a/test/versioned/aws-sdk-v3/common.js
+++ b/test/versioned/aws-sdk-v3/common.js
@@ -137,7 +137,7 @@ function assertChatCompletionMessage({
   expectedChatMsg.content = expectedContent
   expectedChatMsg.is_response = isResponse
   if (isResponse === false) {
-    expectedChatMsg.timestamp = /\d{13}/
+    expectedChatMsg.timestamp = segment.timer.start
   }
 
   assert.equal(messageBase.type, 'LlmChatCompletionMessage')
@@ -162,7 +162,8 @@ function assertChatCompletionSummary({ tx, modelId, chatSummary, error = false, 
     'response.choices.finish_reason': error ? undefined : 'endoftext',
     'request.temperature': 0.5,
     'request.max_tokens': 100,
-    error
+    error,
+    timestamp: segment.timer.start
   }
 
   if (!error) {


### PR DESCRIPTION
## Description

Adds `timestamp` property to AWS Bedrock `LlmChatCompletionSummary`s and relevant tests.

## How to Test

```
npm run unit
npm run versioned:major aws-sdk-v3
```

## Related Issues

Closes #3656