### PR TITLE
chore: Update `ai-support.json` to include LangGraph

### DIFF
--- a/ai-support.json
+++ b/ai-support.json
@@ -70,7 +70,7 @@
     "providersPreamble": "Models/providers are generally supported transitively by our instrumentation of the provider's module.",
     "features": [
       {
-        "title": "Agents",
+        "title": "Agents via LangGraph",
         "supported": true
       },
       {


### PR DESCRIPTION
Previously, we had LangChain agents support equal to true. Well, that was technically incorrect at that time. Now, that we have properly instrumented LangGraph agents, we can now say we support agents within the monolith package, `langchain`.