### PR TITLE
chore: Enabled all OTEL signals by default when OTEL is enabled

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1707,7 +1707,7 @@ defaultConfig.definition = () => {
        * agent.
        */
       traces: {
-        enabled: { default: false, formatter: boolean }
+        enabled: { default: true, formatter: boolean }
       },
 
       /**
@@ -1719,7 +1719,7 @@ defaultConfig.definition = () => {
        * application logs forwarding must be enabled as well.
        */
       logs: {
-        enabled: { default: false, formatter: boolean }
+        enabled: { default: true, formatter: boolean }
       },
 
       /**
@@ -1729,7 +1729,7 @@ defaultConfig.definition = () => {
        * application entity that is instrumented by the New Relic agent.
        */
       metrics: {
-        enabled: { default: false, formatter: boolean },
+        enabled: { default: true, formatter: boolean },
 
         /**
          * `export_interval` defines the number of milliseconds between each

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -349,9 +349,9 @@ test('with default properties', async (t) => {
   await t.test('opentelemetry', () => {
     const otel = configuration.opentelemetry
     assert.equal(otel.enabled, false)
-    assert.equal(otel.traces.enabled, false)
-    assert.equal(otel.logs.enabled, false)
-    assert.equal(otel.metrics.enabled, false)
+    assert.equal(otel.traces.enabled, true)
+    assert.equal(otel.logs.enabled, true)
+    assert.equal(otel.metrics.enabled, true)
     assert.equal(otel.metrics.export_interval, 60_000)
     assert.equal(otel.metrics.export_timeout, 10_000)
   })

--- a/test/unit/lib/otel/setup.test.js
+++ b/test/unit/lib/otel/setup.test.js
@@ -91,6 +91,7 @@ test('should log message if logs is not enabled', async (t) => {
 test('should log message if metrics is not enabled', async (t) => {
   const { agent, loggerMock } = t.nr
   agent.config.opentelemetry.enabled = true
+  agent.config.opentelemetry.metrics.enabled = false
   agent.config.opentelemetry.traces.enabled = true
   setupOtel(agent, loggerMock)
 


### PR DESCRIPTION
This PR resolves #3708.