### PR TITLE
test: Skipped mcp streaming tests on `@modelcontextprotocol/sdk` `1.26.0`+

### DIFF
--- a/test/versioned/mcp-sdk/client-streaming.test.js
+++ b/test/versioned/mcp-sdk/client-streaming.test.js
@@ -5,8 +5,9 @@
 
 'use strict'
 
-const test = require('node:test')
+const { describe, test } = require('node:test')
 const assert = require('node:assert')
+const semver = require('semver')
 
 const { removeModules } = require('../../lib/cache-buster')
 const helper = require('../../lib/agent_helper')
@@ -14,157 +15,159 @@ const { assertPackageMetrics, assertSegments, assertSpanKind } = require('../../
 const {
   MCP
 } = require('../../../lib/metrics/names')
+const version = helper.readPackageVersion(__dirname, '@modelcontextprotocol/sdk')
 
-test.beforeEach(async (ctx) => {
-  ctx.nr = {}
-  ctx.nr.agent = helper.instrumentMockedAgent({
-    ai_monitoring: {
-      enabled: ctx.name.includes('disabled') ? false : true
-    }
-  })
-
-  const { Client } = require('@modelcontextprotocol/sdk/client/index.js')
-  const { StreamableHTTPClientTransport } = require('@modelcontextprotocol/sdk/client/streamableHttp.js')
-  // Set up server
-  const McpTestServer = require('./streaming-server')
-  ctx.nr.mcpServer = new McpTestServer()
-  const port = await ctx.nr.mcpServer.start()
-
-  // Set up client
-  ctx.nr.transport = new StreamableHTTPClientTransport(
-    new URL(`http://localhost:${port}/mcp`)
-  )
-  ctx.nr.client = new Client(
-    {
-      name: 'test-client',
-      version: '1.0.0'
-    }
-  )
-  await ctx.nr.client.connect(ctx.nr.transport)
-})
-
-test.afterEach(async (ctx) => {
-  await ctx.nr.client.close()
-  await ctx.nr.transport.close()
-  await ctx.nr.mcpServer.stop()
-  helper.unloadAgent(ctx.nr.agent)
-  removeModules([
-    '@modelcontextprotocol/sdk/client/index.js',
-    '@modelcontextprotocol/sdk/client/streamableHttp.js'
-  ])
-})
-
-test('should log package tracking metrics', (t) => {
-  const { agent } = t.nr
-  const version = helper.readPackageVersion(__dirname, '@modelcontextprotocol/sdk')
-  assertPackageMetrics({
-    agent,
-    pkg: '@modelcontextprotocol/sdk',
-    version,
-    subscriberType: true
-  })
-})
-
-test('should create span for callTool', (t, end) => {
-  const { agent, client } = t.nr
-  helper.runInTransaction(agent, async (tx) => {
-    const result = await client.callTool({
-      name: 'echo',
-      arguments: {
-        message: 'example message'
+describe('MCP streaming tests', { skip: semver.gte(version, '1.26.0') }, () => {
+  test.beforeEach(async (ctx) => {
+    ctx.nr = {}
+    ctx.nr.agent = helper.instrumentMockedAgent({
+      ai_monitoring: {
+        enabled: ctx.name.includes('disabled') ? false : true
       }
     })
-    assert.ok(result, 'should return a result from the tool call')
-    const name = `${MCP.TOOL}/callTool/echo`
-    assertSegments(tx.trace, tx.trace.root, [name], { exact: false })
-    tx.end()
-    assertSpanKind({
+
+    const { Client } = require('@modelcontextprotocol/sdk/client/index.js')
+    const { StreamableHTTPClientTransport } = require('@modelcontextprotocol/sdk/client/streamableHttp.js')
+    // Set up server
+    const McpTestServer = require('./streaming-server')
+    ctx.nr.mcpServer = new McpTestServer()
+    const port = await ctx.nr.mcpServer.start()
+
+    // Set up client
+    ctx.nr.transport = new StreamableHTTPClientTransport(
+      new URL(`http://localhost:${port}/mcp`)
+    )
+    ctx.nr.client = new Client(
+      {
+        name: 'test-client',
+        version: '1.0.0'
+      }
+    )
+    await ctx.nr.client.connect(ctx.nr.transport)
+  })
+
+  test.afterEach(async (ctx) => {
+    await ctx.nr.client.close()
+    await ctx.nr.transport.close()
+    await ctx.nr.mcpServer.stop()
+    helper.unloadAgent(ctx.nr.agent)
+    removeModules([
+      '@modelcontextprotocol/sdk/client/index.js',
+      '@modelcontextprotocol/sdk/client/streamableHttp.js'
+    ])
+  })
+
+  test('should log package tracking metrics', (t) => {
+    const { agent } = t.nr
+    assertPackageMetrics({
       agent,
-      segments: [
-        { name, kind: 'internal' }
-      ]
+      pkg: '@modelcontextprotocol/sdk',
+      version,
+      subscriberType: true
     })
-
-    end()
   })
-})
 
-test('should create span for readResource', (t, end) => {
-  const { agent, client } = t.nr
-  helper.runInTransaction(agent, async (tx) => {
-    const resource = await client.readResource({
-      uri: 'echo://hello-world',
+  test('should create span for callTool', (t, end) => {
+    const { agent, client } = t.nr
+    helper.runInTransaction(agent, async (tx) => {
+      const result = await client.callTool({
+        name: 'echo',
+        arguments: {
+          message: 'example message'
+        }
+      })
+      assert.ok(result, 'should return a result from the tool call')
+      const name = `${MCP.TOOL}/callTool/echo`
+      assertSegments(tx.trace, tx.trace.root, [name], { exact: false })
+      tx.end()
+      assertSpanKind({
+        agent,
+        segments: [
+          { name, kind: 'internal' }
+        ]
+      })
+
+      end()
     })
-
-    assert.ok(resource, 'should return a resource from readResource')
-
-    const name = `${MCP.RESOURCE}/readResource/echo`
-    assertSegments(tx.trace, tx.trace.root, [name], { exact: false })
-
-    tx.end()
-    assertSpanKind({
-      agent,
-      segments: [
-        { name, kind: 'internal' }
-      ]
-    })
-
-    end()
   })
-})
 
-test('should create span for getPrompt', (t, end) => {
-  const { agent, client } = t.nr
-  helper.runInTransaction(agent, async (tx) => {
-    const prompt = await client.getPrompt({
-      name: 'echo',
-      arguments: {
-        message: 'example message'
-      }
+  test('should create span for readResource', (t, end) => {
+    const { agent, client } = t.nr
+    helper.runInTransaction(agent, async (tx) => {
+      const resource = await client.readResource({
+        uri: 'echo://hello-world',
+      })
+
+      assert.ok(resource, 'should return a resource from readResource')
+
+      const name = `${MCP.RESOURCE}/readResource/echo`
+      assertSegments(tx.trace, tx.trace.root, [name], { exact: false })
+
+      tx.end()
+      assertSpanKind({
+        agent,
+        segments: [
+          { name, kind: 'internal' }
+        ]
+      })
+
+      end()
     })
-
-    assert.ok(prompt, 'should return a prompt from getPrompt')
-
-    const name = `${MCP.PROMPT}/getPrompt/echo`
-    assertSegments(tx.trace, tx.trace.root, [name], { exact: false })
-
-    tx.end()
-    assertSpanKind({
-      agent,
-      segments: [
-        { name, kind: 'internal' }
-      ]
-    })
-
-    end()
   })
-})
 
-test('should not instrument if ai_monitoring is disabled', (t, end) => {
-  const { agent, client } = t.nr
+  test('should create span for getPrompt', (t, end) => {
+    const { agent, client } = t.nr
+    helper.runInTransaction(agent, async (tx) => {
+      const prompt = await client.getPrompt({
+        name: 'echo',
+        arguments: {
+          message: 'example message'
+        }
+      })
 
-  helper.runInTransaction(agent, async (tx) => {
-    const result = await client.callTool({
-      name: 'echo',
-      arguments: {
-        message: 'example message'
-      }
+      assert.ok(prompt, 'should return a prompt from getPrompt')
+
+      const name = `${MCP.PROMPT}/getPrompt/echo`
+      assertSegments(tx.trace, tx.trace.root, [name], { exact: false })
+
+      tx.end()
+      assertSpanKind({
+        agent,
+        segments: [
+          { name, kind: 'internal' }
+        ]
+      })
+
+      end()
     })
+  })
 
-    assert.ok(result, 'should still return a result from the tool call')
+  test('should not instrument if ai_monitoring is disabled', (t, end) => {
+    const { agent, client } = t.nr
 
-    const name = `${MCP.TOOL}/callTool/echo`
-    const root = tx?.trace?.segments?.root
-    assert.ok(root)
-    function assertNoMcpSegment(node) {
-      assert.notEqual(node?.segment?.name, name, 'should not create MCP segment')
-      for (const child of node?.children) {
-        assertNoMcpSegment(child)
+    helper.runInTransaction(agent, async (tx) => {
+      const result = await client.callTool({
+        name: 'echo',
+        arguments: {
+          message: 'example message'
+        }
+      })
+
+      assert.ok(result, 'should still return a result from the tool call')
+
+      const name = `${MCP.TOOL}/callTool/echo`
+      const root = tx?.trace?.segments?.root
+      assert.ok(root)
+      function assertNoMcpSegment(node) {
+        assert.notEqual(node?.segment?.name, name, 'should not create MCP segment')
+        for (const child of node?.children) {
+          assertNoMcpSegment(child)
+        }
       }
-    }
-    assertNoMcpSegment(root)
+      assertNoMcpSegment(root)
 
-    tx.end()
-    end()
+      tx.end()
+      end()
+    })
   })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

It looks like 1.26.0 of mcp was a refactor of the code layout into smaller packages. I cannot tell how to fix the issue described in #3727. 
To unblock CI we are just skipping running streaming tests on 1.26.0 until this can be addressed.
