### PR TITLE
test: Updated mcp streaming tests to generate sessions to reuse transport for all streaming tests

### DIFF
--- a/test/versioned/mcp-sdk/client-streaming.test.js
+++ b/test/versioned/mcp-sdk/client-streaming.test.js
@@ -5,9 +5,8 @@
 
 'use strict'
 
-const { describe, test } = require('node:test')
+const test = require('node:test')
 const assert = require('node:assert')
-const semver = require('semver')
 
 const { removeModules } = require('../../lib/cache-buster')
 const helper = require('../../lib/agent_helper')
@@ -15,159 +14,157 @@ const { assertPackageMetrics, assertSegments, assertSpanKind } = require('../../
 const {
   MCP
 } = require('../../../lib/metrics/names')
-const version = helper.readPackageVersion(__dirname, '@modelcontextprotocol/sdk')
 
-describe('MCP streaming tests', { skip: semver.gte(version, '1.26.0') }, () => {
-  test.beforeEach(async (ctx) => {
-    ctx.nr = {}
-    ctx.nr.agent = helper.instrumentMockedAgent({
-      ai_monitoring: {
-        enabled: ctx.name.includes('disabled') ? false : true
+test.beforeEach(async (ctx) => {
+  ctx.nr = {}
+  ctx.nr.agent = helper.instrumentMockedAgent({
+    ai_monitoring: {
+      enabled: ctx.name.includes('disabled') ? false : true
+    }
+  })
+
+  const { Client } = require('@modelcontextprotocol/sdk/client/index.js')
+  const { StreamableHTTPClientTransport } = require('@modelcontextprotocol/sdk/client/streamableHttp.js')
+  // Set up server
+  const McpTestServer = require('./streaming-server')
+  ctx.nr.mcpServer = new McpTestServer()
+  const port = await ctx.nr.mcpServer.start()
+
+  // Set up client
+  ctx.nr.transport = new StreamableHTTPClientTransport(
+    new URL(`http://localhost:${port}/mcp`)
+  )
+  ctx.nr.client = new Client(
+    {
+      name: 'test-client',
+      version: '1.0.0'
+    }
+  )
+  await ctx.nr.client.connect(ctx.nr.transport)
+})
+
+test.afterEach(async (ctx) => {
+  await ctx.nr.client.close()
+  await ctx.nr.transport.close()
+  await ctx.nr.mcpServer.stop()
+  helper.unloadAgent(ctx.nr.agent)
+  removeModules([
+    '@modelcontextprotocol/sdk/client/index.js',
+    '@modelcontextprotocol/sdk/client/streamableHttp.js'
+  ])
+})
+
+test('should log package tracking metrics', (t) => {
+  const { agent } = t.nr
+  const version = helper.readPackageVersion(__dirname, '@modelcontextprotocol/sdk')
+  assertPackageMetrics({
+    agent,
+    pkg: '@modelcontextprotocol/sdk',
+    version,
+    subscriberType: true
+  })
+})
+
+test('should create span for callTool', (t, end) => {
+  const { agent, client } = t.nr
+  helper.runInTransaction(agent, async (tx) => {
+    const result = await client.callTool({
+      name: 'echo',
+      arguments: {
+        message: 'example message'
       }
     })
-
-    const { Client } = require('@modelcontextprotocol/sdk/client/index.js')
-    const { StreamableHTTPClientTransport } = require('@modelcontextprotocol/sdk/client/streamableHttp.js')
-    // Set up server
-    const McpTestServer = require('./streaming-server')
-    ctx.nr.mcpServer = new McpTestServer()
-    const port = await ctx.nr.mcpServer.start()
-
-    // Set up client
-    ctx.nr.transport = new StreamableHTTPClientTransport(
-      new URL(`http://localhost:${port}/mcp`)
-    )
-    ctx.nr.client = new Client(
-      {
-        name: 'test-client',
-        version: '1.0.0'
-      }
-    )
-    await ctx.nr.client.connect(ctx.nr.transport)
-  })
-
-  test.afterEach(async (ctx) => {
-    await ctx.nr.client.close()
-    await ctx.nr.transport.close()
-    await ctx.nr.mcpServer.stop()
-    helper.unloadAgent(ctx.nr.agent)
-    removeModules([
-      '@modelcontextprotocol/sdk/client/index.js',
-      '@modelcontextprotocol/sdk/client/streamableHttp.js'
-    ])
-  })
-
-  test('should log package tracking metrics', (t) => {
-    const { agent } = t.nr
-    assertPackageMetrics({
+    assert.ok(result, 'should return a result from the tool call')
+    const name = `${MCP.TOOL}/callTool/echo`
+    assertSegments(tx.trace, tx.trace.root, [name], { exact: false })
+    tx.end()
+    assertSpanKind({
       agent,
-      pkg: '@modelcontextprotocol/sdk',
-      version,
-      subscriberType: true
+      segments: [
+        { name, kind: 'internal' }
+      ]
     })
+
+    end()
   })
+})
 
-  test('should create span for callTool', (t, end) => {
-    const { agent, client } = t.nr
-    helper.runInTransaction(agent, async (tx) => {
-      const result = await client.callTool({
-        name: 'echo',
-        arguments: {
-          message: 'example message'
-        }
-      })
-      assert.ok(result, 'should return a result from the tool call')
-      const name = `${MCP.TOOL}/callTool/echo`
-      assertSegments(tx.trace, tx.trace.root, [name], { exact: false })
-      tx.end()
-      assertSpanKind({
-        agent,
-        segments: [
-          { name, kind: 'internal' }
-        ]
-      })
-
-      end()
+test('should create span for readResource', (t, end) => {
+  const { agent, client } = t.nr
+  helper.runInTransaction(agent, async (tx) => {
+    const resource = await client.readResource({
+      uri: 'echo://hello-world',
     })
-  })
 
-  test('should create span for readResource', (t, end) => {
-    const { agent, client } = t.nr
-    helper.runInTransaction(agent, async (tx) => {
-      const resource = await client.readResource({
-        uri: 'echo://hello-world',
-      })
+    assert.ok(resource, 'should return a resource from readResource')
 
-      assert.ok(resource, 'should return a resource from readResource')
+    const name = `${MCP.RESOURCE}/readResource/echo`
+    assertSegments(tx.trace, tx.trace.root, [name], { exact: false })
 
-      const name = `${MCP.RESOURCE}/readResource/echo`
-      assertSegments(tx.trace, tx.trace.root, [name], { exact: false })
-
-      tx.end()
-      assertSpanKind({
-        agent,
-        segments: [
-          { name, kind: 'internal' }
-        ]
-      })
-
-      end()
+    tx.end()
+    assertSpanKind({
+      agent,
+      segments: [
+        { name, kind: 'internal' }
+      ]
     })
+
+    end()
   })
+})
 
-  test('should create span for getPrompt', (t, end) => {
-    const { agent, client } = t.nr
-    helper.runInTransaction(agent, async (tx) => {
-      const prompt = await client.getPrompt({
-        name: 'echo',
-        arguments: {
-          message: 'example message'
-        }
-      })
-
-      assert.ok(prompt, 'should return a prompt from getPrompt')
-
-      const name = `${MCP.PROMPT}/getPrompt/echo`
-      assertSegments(tx.trace, tx.trace.root, [name], { exact: false })
-
-      tx.end()
-      assertSpanKind({
-        agent,
-        segments: [
-          { name, kind: 'internal' }
-        ]
-      })
-
-      end()
-    })
-  })
-
-  test('should not instrument if ai_monitoring is disabled', (t, end) => {
-    const { agent, client } = t.nr
-
-    helper.runInTransaction(agent, async (tx) => {
-      const result = await client.callTool({
-        name: 'echo',
-        arguments: {
-          message: 'example message'
-        }
-      })
-
-      assert.ok(result, 'should still return a result from the tool call')
-
-      const name = `${MCP.TOOL}/callTool/echo`
-      const root = tx?.trace?.segments?.root
-      assert.ok(root)
-      function assertNoMcpSegment(node) {
-        assert.notEqual(node?.segment?.name, name, 'should not create MCP segment')
-        for (const child of node?.children) {
-          assertNoMcpSegment(child)
-        }
+test('should create span for getPrompt', (t, end) => {
+  const { agent, client } = t.nr
+  helper.runInTransaction(agent, async (tx) => {
+    const prompt = await client.getPrompt({
+      name: 'echo',
+      arguments: {
+        message: 'example message'
       }
-      assertNoMcpSegment(root)
-
-      tx.end()
-      end()
     })
+
+    assert.ok(prompt, 'should return a prompt from getPrompt')
+
+    const name = `${MCP.PROMPT}/getPrompt/echo`
+    assertSegments(tx.trace, tx.trace.root, [name], { exact: false })
+
+    tx.end()
+    assertSpanKind({
+      agent,
+      segments: [
+        { name, kind: 'internal' }
+      ]
+    })
+
+    end()
+  })
+})
+
+test('should not instrument if ai_monitoring is disabled', (t, end) => {
+  const { agent, client } = t.nr
+
+  helper.runInTransaction(agent, async (tx) => {
+    const result = await client.callTool({
+      name: 'echo',
+      arguments: {
+        message: 'example message'
+      }
+    })
+
+    assert.ok(result, 'should still return a result from the tool call')
+
+    const name = `${MCP.TOOL}/callTool/echo`
+    const root = tx?.trace?.segments?.root
+    assert.ok(root)
+    function assertNoMcpSegment(node) {
+      assert.notEqual(node?.segment?.name, name, 'should not create MCP segment')
+      for (const child of node?.children) {
+        assertNoMcpSegment(child)
+      }
+    }
+    assertNoMcpSegment(root)
+
+    tx.end()
+    end()
   })
 })

--- a/test/versioned/mcp-sdk/package.json
+++ b/test/versioned/mcp-sdk/package.json
@@ -24,9 +24,5 @@
         "client-streaming.test.js"
       ]
     }
-  ],
-  "dependencies": {
-    "express": "^5.1.0",
-    "zod": "^3.25.76"
-  }
+  ]
 }

--- a/test/versioned/mcp-sdk/streaming-server.js
+++ b/test/versioned/mcp-sdk/streaming-server.js
@@ -8,6 +8,7 @@ const express = require('express')
 const { McpServer, ResourceTemplate } = require('@modelcontextprotocol/sdk/server/mcp.js')
 const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js')
 const { z } = require('zod')
+const { randomUUID } = require('node:crypto')
 
 class McpTestServer {
   constructor() {
@@ -22,7 +23,7 @@ class McpTestServer {
     })
 
     this.transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: undefined,
+      sessionIdGenerator: () => randomUUID(),
       enableDnsRebindingProtection: true,
     })
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Apparently we were setting up a stateless transport for mcp. Stateless means no sessionId generated.  I can't seem to trace the change in MCP because their repo is all over the place.
I also had a hell of a time fixing this because the actual error was hidden from the user.  I had to put `console.log` in various places because I couldn't use the debugger as the sdk doesn't ship source maps.  
Anyways, this PR fixes the changes in 1.26.0 that made our streaming tests not work.

## How to Test

```sh
npm run versioned:internal mcp-sdk
```

## Related Issues
Closes #3727
