### PR TITLE
chore: Added npm tag support to CI

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,7 +1,14 @@
 name: Create Release
 
 # Manual trigger only
-on: [workflow_dispatch]
+on:
+  workflow_dispatch:
+    inputs:
+      npm_tag:
+        description: Tag to apply when publishing to npm. You likely want "previous" if you need to change this.
+        type: string
+        default: latest
+        required: true
 
 # Since we are reusing a workflow, we must match the permissions that
 # upstream workflow requires.
@@ -14,3 +21,4 @@ jobs:
     uses: newrelic/node-newrelic/.github/workflows/release-creation.yml@main
     with:
       workflows: ci-workflow.yml,smoke-test-workflow.yml
+      npm_tag: ${{ github.event.inputs.npm_tag }}

--- a/.github/workflows/release-creation.yml
+++ b/.github/workflows/release-creation.yml
@@ -18,6 +18,11 @@ on:
         type: boolean
         required: false
         default: false
+      npm_tag:
+        description: Tag to apply when publishing to npm. You likely want "previous" if you need to change this.
+        type: string
+        default: latest
+        required: false
 
 permissions:
   # This permission is needed so that git tags can be created.
@@ -69,7 +74,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Publish to Npm
-      run: npm publish
+      run: npm publish --tag ${{ inputs.npm_tag }}
     - name: Get Created Tag
       id: get_tag
       run: echo "latest_tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR adds a new option when triggering the "create release" workflow to support specifying a dist-tag when publishing to npm.