### PR TITLE
chore: Removed `@langchain/core` peer dep from LangGraph test matrix

### DIFF
--- a/test/versioned/langgraph/package.json
+++ b/test/versioned/langgraph/package.json
@@ -19,7 +19,6 @@
       },
       "dependencies": {
         "@langchain/langgraph": "^1.0.0",
-        "@langchain/core": "^1.0.0",
         "@langchain/openai": "^1.0.0"
       },
       "files": [


### PR DESCRIPTION
I removed the `@langchain/core` dependency in the LangGraph test matrix because it is a peer dependency for `@langchain/langgraph`. If the version for the explicitly listed `@langchain/core` module defers from what `@langchain/langgraph` is expecting, the tests were failing.