### PR TITLE
chore: Add call to agent metadata workflow - step 1

### DIFF
--- a/.fleetControl/agentControl/agent-schema-for-agent-control.yml
+++ b/.fleetControl/agentControl/agent-schema-for-agent-control.yml
@@ -1,0 +1,106 @@
+# original source: https://github.com/newrelic/newrelic-agent-control/blob/main/agent-control/agent-type-registry/newrelic/com.newrelic.apm_node-0.1.0.yaml
+namespace: newrelic
+name: com.newrelic.apm_node
+version: 0.1.0
+variables:
+    k8s:
+        podLabelSelector:
+            description: "Pod label selector"
+            type: yaml
+            default: { }
+            required: false
+        containerSelector:
+            description: "Container selector"
+            type: yaml
+            default: { }
+            required: false
+        namespaceLabelSelector:
+            description: "Namespace label selector"
+            type: yaml
+            default: { }
+            required: false
+        # All 'agent' side-car related variables are flattened.
+        version:
+            description: "NodeJS Agent init container version"
+            type: string
+            default: "latest"
+            required: false
+        env:
+            description: "environment variables to pass to nodejs agent"
+            type: yaml
+            default: [ ]
+            required: false
+        imagePullPolicy:
+            description: "image pull policy for the NodeJS agent init container"
+            type: string
+            default: "Always"
+            required: false
+        resourceRequirements:
+            description: "resource requirements for the NodeJS agent init container"
+            type: yaml
+            default: { }
+            required: false
+        securityContext:
+            description: "security context for the NodeJS agent init container"
+            type: yaml
+            default: { }
+            required: false
+        # All health sidecar related variables are flattened and prefixed with "health_"
+        health_env:
+            description: "environment variables to pass to health sidecar"
+            type: yaml
+            default: [ ]
+            required: false
+        health_version:
+            description: "health sidecar image version"
+            type: string
+            default: "latest"
+            required: false
+        health_imagePullPolicy:
+            description: "image pull policy for the health sidecar"
+            type: string
+            default: "Always"
+            required: false
+        health_resourceRequirements:
+            description: "resource requirements for the health sidecar"
+            type: yaml
+            default: { }
+            required: false
+        health_securityContext:
+            description: "security context for the health sidecar"
+            type: yaml
+            default: { }
+            required: false
+deployment:
+    k8s:
+        health:
+            interval: 30s
+            initial_delay: 30s
+        objects:
+            instrumentation:
+                apiVersion: newrelic.com/v1beta3
+                kind: Instrumentation
+                metadata:
+                    name: ${nr-sub:agent_id}
+                    # APM CRs should be installed in "nr-ac:namespace"
+                    # Due to a limitation in the k8s-agents-operator, Instrumentation CRs must be installed in the same namespace as the operator.
+                    # Hence, the namespace is set to "nr-ac:namespace_agents".
+                    # Reference: https://github.com/newrelic/k8s-agents-operator/blob/92c19208864f051f03f457ee04b772fca5042162/api/v1beta1/instrumentation_webhook.go#L110C27-L110C72
+                    namespace: ${nr-ac:namespace_agents}
+                spec:
+                    agent:
+                        language: nodejs
+                        image: newrelic/newrelic-node-init:${nr-var:version}
+                        env: ${nr-var:env}
+                        imagePullPolicy: ${nr-var:imagePullPolicy}
+                        resources: ${nr-var:resourceRequirements}
+                        securityContext: ${nr-var:securityContext}
+                    healthAgent:
+                        image: newrelic/k8s-apm-agent-health-sidecar:${nr-var:health_version}
+                        env: ${nr-var:health_env}
+                        imagePullPolicy: ${nr-var:health_imagePullPolicy}
+                        resources: ${nr-var:health_resourceRequirements}
+                        securityContext: ${nr-var:health_securityContext}
+                    podLabelSelector: ${nr-var:podLabelSelector}
+                    namespaceLabelSelector: ${nr-var:namespaceLabelSelector}
+                    containerSelector: ${nr-var:containerSelector}

--- a/.fleetControl/agentControlDefinitions.yml
+++ b/.fleetControl/agentControlDefinitions.yml
@@ -1,0 +1,5 @@
+agentControlDefinitions:
+  - platform: KUBERNETESCLUSTER
+    supportFromAgent: 1.0.0
+    supportFromAgentControl: 1.0.0
+    content: ./agentControl/agent-schema-for-agent-control.yml

--- a/.fleetControl/configurationDefinitions.yml
+++ b/.fleetControl/configurationDefinitions.yml
@@ -1,0 +1,6 @@
+configurationDefinitions:
+  - platform: KUBERNETESCLUSTER
+    description: Node agent configuration
+    type: agent-config
+    version: 1.0.0
+# will add schema information here later

--- a/.github/workflows/agent_metadata.yml
+++ b/.github/workflows/agent_metadata.yml
@@ -1,0 +1,66 @@
+name: Agent Metadata
+
+permissions:
+  contents: read
+
+on:
+  # Allows manual triggering with parameters
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (needs to exactly match the GH tag for the release)'
+        required: true
+        type: string
+      agent-type:
+        description: 'Agent type'
+        required: false
+        default: 'NRNodeAgent'
+        type: string
+      use-cache:
+        description: 'Use cache'
+        required: false
+        default: true
+        type: boolean
+
+#  workflow_run:
+#    workflows: ["Create Release"]
+#    types:
+#      - completed
+
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'workflow_dispatch')
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+      agent-type: ${{ steps.get-version.outputs.agent-type }}
+      use-cache: ${{ steps.get-version.outputs.use-cache }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Get version and inputs
+        id: get-version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+            echo "agent-type=${{ inputs.agent-type }}" >> $GITHUB_OUTPUT
+            echo "use-cache=${{ inputs.use-cache }}" >> $GITHUB_OUTPUT
+          else
+            VERSION=$(node -p "require('./package.json').version")
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "agent-type=NRNodeAgent" >> $GITHUB_OUTPUT
+            echo "use-cache=true" >> $GITHUB_OUTPUT
+          fi
+
+  send-agent-metadata:
+    needs: [get-version]
+    uses: newrelic/newrelic-agent-init-container/.github/workflows/agent-metadata.yml@main
+    with:
+      agent-type: ${{ needs.get-version.outputs.agent-type }}
+      version: ${{ needs.get-version.outputs.version }}
+      use-cache: ${{ needs.get-version.outputs.use-cache }}
+    secrets:
+      FC_SYS_ID_CLIENT_ID: ${{ secrets.FC_SYS_ID_CLIENT_ID }}
+      FC_SYS_ID_PR_KEY: ${{ secrets.FC_SYS_ID_PR_KEY }}


### PR DESCRIPTION
## Description

This PR adds the ability for the NR agent team to send agent metadata and binaries to New Relic for use in fleets and other features. This will be triggered normally during a release. but if it fails, it will not fail the release. It can also be run on-demand for backfilling older agent versions, to make corrections, or to re-run the job after a failure.

GH action info: https://github.com/newrelic/agent-metadata-action/blob/main/README.md

## How to Test
This PR is step 1 that will be used to test with the on-demand option and needs to be merged to main to be able to run the workflow
1. Create a new tag for a test release `v0.0.6` and push the tag
2. Manually run the on-demand portion of this workflow using `TestAgent` as the agent name and `v0.0.6` as the agent version
3. Confirm the test agent is sent to NR (I'll provide a script)
4. Delete the temporary tag you created

A later PR will add a step in the release and use the real agent name

## Related Issues

Please include any related issues or pull requests in this section, using the format `Closes #<issue number>` or `Fixes #<issue number>` if applicable.