### PR TITLE
feat: Added ability to delay the start of the Profiler and run for n milliseconds before shutting down.

### DIFF
--- a/lib/aggregators/base-aggregator.js
+++ b/lib/aggregators/base-aggregator.js
@@ -160,6 +160,8 @@ class Aggregator extends EventEmitter {
 
     this.defaultPeriod = this.periodMs = opts.periodMs
     this.defaultLimit = this.limit = opts.limit
+    this.delay = opts.delay ?? 0
+    this.duration = opts.duration ?? 0
     this.runId = opts.runId
     this.isAsync = opts.isAsync || false
     // function to pass in to determine if we can start a given aggregator

--- a/lib/aggregators/profiling-aggregator.js
+++ b/lib/aggregators/profiling-aggregator.js
@@ -43,8 +43,13 @@ class ProfilingAggregator extends BaseAggregator {
    * and send the gzipped binary encoded data for each profiler
    */
   start() {
-    logger.trace(`${this.method} aggregator started.`)
     this.profilingManager.register()
+    const started = this.profilingManager.start()
+    if (!started) {
+      return
+    }
+
+    logger.trace(`${this.method} aggregator started.`)
 
     if (!this.sendTimer) {
       this.sendTimer = setInterval(this.collectData.bind(this), this.periodMs)

--- a/lib/harvester.js
+++ b/lib/harvester.js
@@ -2,16 +2,17 @@
  * Copyright 2024 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
 'use strict'
+const defaultLogger = require('./logger').child({ component: 'harvester' })
 
 /**
  * @class
  * @classdesc Used to keep track of all registered aggregators.
  */
 module.exports = class Harvester {
-  constructor() {
+  constructor({ logger = defaultLogger } = {}) {
     this.aggregators = []
+    this.logger = logger
   }
 
   /**
@@ -19,8 +20,22 @@ module.exports = class Harvester {
    */
   start() {
     for (const aggregator of this.aggregators) {
-      if (aggregator.enabled) {
+      if (aggregator.enabled && aggregator.delay > 0) {
+        this.logger.debug(`Delay start of ${aggregator.method} by ${aggregator.delay} milliseconds`)
+        const timeout = setTimeout(() => {
+          aggregator.start()
+        }, aggregator.delay)
+        timeout.unref()
+      } else if (aggregator.enabled) {
         aggregator.start()
+      }
+
+      if (aggregator.enabled && aggregator.duration > 0) {
+        this.logger.debug(`Running ${aggregator.method} for ${aggregator.duration} milliseconds`)
+        const durationTimeout = setTimeout(() => {
+          aggregator.stop()
+        }, aggregator.delay + aggregator.duration)
+        durationTimeout.unref()
       }
     }
   }

--- a/lib/profiling/index.js
+++ b/lib/profiling/index.js
@@ -20,13 +20,14 @@ class ProfilingManager {
   start() {
     if (this.profilers.length === 0) {
       this.logger.warn('No profilers have been included in `config.profiling.include`, not starting any profilers.')
-      return
+      return false
     }
 
     for (const profiler of this.profilers) {
       this.logger.debug(`Starting ${profiler.name}`)
       profiler.start()
     }
+    return true
   }
 
   stop() {

--- a/test/unit/aggregators/profiling-aggregator.test.js
+++ b/test/unit/aggregators/profiling-aggregator.test.js
@@ -11,26 +11,14 @@ const sinon = require('sinon')
 const ProfilingAggregator = require('#agentlib/aggregators/profiling-aggregator.js')
 const helper = require('#testlib/agent_helper.js')
 const RUN_ID = 1337
+const createProfiler = require('../mocks/profiler')
 
 test.beforeEach((ctx) => {
   const sandbox = sinon.createSandbox()
   const agent = helper.loadMockedAgent()
-  const cpuProfiler = {
-    name: 'CpuProfiler',
-    stop: sandbox.stub(),
-    collect() {
-      return 'cpu profile data'
-    }
-  }
-
+  const cpuProfiler = createProfiler({ sandbox, name: 'CpuProfiler', data: 'cpu profile data' })
+  const heapProfiler = createProfiler({ sandbox, name: 'HeapProfiler', data: 'heap profile data' })
   const clock = sinon.useFakeTimers()
-  const heapProfiler = {
-    name: 'HeapProfiler',
-    stop: sandbox.stub(),
-    collect() {
-      return 'heap profile data'
-    }
-  }
   sandbox.spy(agent.collector, 'send')
   const profilingAggregator = new ProfilingAggregator({ runId: RUN_ID, periodMs: 100 }, agent)
   const profilingManager = profilingAggregator.profilingManager

--- a/test/unit/lib/profiling/index.test.js
+++ b/test/unit/lib/profiling/index.test.js
@@ -9,6 +9,7 @@ const { describe, test } = require('node:test')
 const assert = require('node:assert')
 const sinon = require('sinon')
 const ProfilingManager = require('#agentlib/profiling/index.js')
+const createProfiler = require('../../mocks/profiler')
 
 test.beforeEach((ctx) => {
   const sandbox = sinon.createSandbox()
@@ -21,19 +22,8 @@ test.beforeEach((ctx) => {
       }
     }
   }
-  const cpuProfiler = {
-    name: 'cpu',
-    start: sandbox.stub(),
-    stop: sandbox.stub(),
-    collect: sandbox.stub()
-  }
-
-  const heapProfiler = {
-    name: 'heap',
-    start: sandbox.stub(),
-    stop: sandbox.stub(),
-    collect: sandbox.stub()
-  }
+  const cpuProfiler = createProfiler({ sandbox, name: 'cpu' })
+  const heapProfiler = createProfiler({ sandbox, name: 'heap' })
   ctx.nr = {
     agent,
     cpuProfiler,
@@ -81,7 +71,8 @@ describe('start', () => {
     const { agent, logger } = t.nr
     const profilingManager = new ProfilingManager(agent, { logger })
 
-    profilingManager.start()
+    const started = profilingManager.start()
+    assert.equal(started, false)
 
     assert.equal(logger.warn.callCount, 1)
     assert.ok(
@@ -95,8 +86,8 @@ describe('start', () => {
     const { agent, cpuProfiler, heapProfiler, logger } = t.nr
     const profilingManager = new ProfilingManager(agent, { logger })
     profilingManager.profilers = [cpuProfiler, heapProfiler]
-    profilingManager.start()
-
+    const started = profilingManager.start()
+    assert.equal(started, true)
     assert.equal(cpuProfiler.start.callCount, 1)
     assert.equal(heapProfiler.start.callCount, 1)
     assert.ok(

--- a/test/unit/mocks/profiler.js
+++ b/test/unit/mocks/profiler.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const sinon = require('sinon')
+const DEFAULT_DATA = Buffer.from('test-data')
+
+function createProfiler({ sandbox = sinon, name = 'TestProfiler', data = DEFAULT_DATA } = {}) {
+  return {
+    name,
+    start: sandbox.stub(),
+    stop: sandbox.stub(),
+    collect: sandbox.stub().returns(data)
+  }
+}
+
+module.exports = createProfiler


### PR DESCRIPTION
## Description
This PR adds the ability to register an aggregator with a delay and duration property.  This in turn will be used when registering the aggregators with the harvester class. If a delay is specified it will delay the start. If a duration is specified it will schedule the aggregator to be stopped.  I also tweaked the profiling aggregator slightly to return if the profiling manager actually started any profilers before scheduling the profiling aggregator from running. This still isn't completely wired up so the unit tests only test the functionality with an aggregator in the harvester unit tests.

## How to Test

```sh
npm run unit
```

## Related Issues
Closes #3753 