### PR TITLE
chore: Update `@langchain/core` version for langchain-openai tests

### DIFF
--- a/test/versioned/langchain-openai/package.json
+++ b/test/versioned/langchain-openai/package.json
@@ -17,8 +17,9 @@
       "engines": {
         "node": ">=20"
       },
+      "comment": "@langchain/openai@>=1.2.8 imports @langchain/core/errors which was not exported until @langchain/core@1.1.18",
       "dependencies": {
-        "@langchain/core": ">=1.0.0",
+        "@langchain/core": ">=1.1.18",
         "@langchain/openai": ">=1.0.0"
       },
       "files": [


### PR DESCRIPTION
## Description

**Root cause:** `@langchain/openai@1.2.8` added an import of `ContextOverflowError` from `@langchain/core/errors` (in [utils/client.js](https://github.com/langchain-ai/langchainjs/blob/a0e1a0cf0759406a2797aaf7ad10b1ac61a1cb6c/libs/providers/langchain-openai/src/utils/client.ts#L2)), but the `./errors` subpath was only added to `@langchain/core `starting in v1.1.18. The peer dependency declared by `@langchain/openai` was ^1.0.0, which was too loose and allows npm to resolve an older `@langchain/core` that doesn't have this export.

**Fix:** Bumped the @langchain/core minimum from >=1.0.0 to >=1.1.18. This ensures the versioned test runner won't create combinations where `@langchain/openai@>=1.2.8` is paired with an incompatible `@langchain/core`.

## How to Test

```
npm run versioned langchain-openai
```

## Related Issues

CI fix.