### PR TITLE
fix: Updated `@google/genai` subscriber to handle the new `embedContentInternal` method in 1.42.0

### DIFF
--- a/lib/subscribers/google-genai/config.js
+++ b/lib/subscribers/google-genai/config.js
@@ -56,7 +56,7 @@ const embedContent = {
   instrumentations: [
     {
       channelName: 'nr_embedContent',
-      module: { name: '@google/genai', versionRange: '>=1.1.0', filePath: 'dist/node/index.cjs' },
+      module: { name: '@google/genai', versionRange: '>=1.1.0 <1.42.0', filePath: 'dist/node/index.cjs' },
       functionQuery: {
         className: 'Models',
         methodName: 'embedContent',
@@ -65,10 +65,28 @@ const embedContent = {
     },
     {
       channelName: 'nr_embedContent',
-      module: { name: '@google/genai', versionRange: '>=1.1.0', filePath: 'dist/node/index.mjs' },
+      module: { name: '@google/genai', versionRange: '>=1.1.0 < 1.42.0', filePath: 'dist/node/index.mjs' },
       functionQuery: {
         className: 'Models',
         methodName: 'embedContent',
+        kind: 'Async'
+      }
+    },
+    {
+      channelName: 'nr_embedContent',
+      module: { name: '@google/genai', versionRange: '>=1.42.0', filePath: 'dist/node/index.cjs' },
+      functionQuery: {
+        className: 'Models',
+        methodName: 'embedContentInternal',
+        kind: 'Async'
+      }
+    },
+    {
+      channelName: 'nr_embedContent',
+      module: { name: '@google/genai', versionRange: '>=1.42.0', filePath: 'dist/node/index.mjs' },
+      functionQuery: {
+        className: 'Models',
+        methodName: 'embedContentInternal',
         kind: 'Async'
       }
     }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

In [1.42.0](https://github.com/googleapis/js-genai/compare/v1.41.0...v1.42.0#diff-41b76dc43070308a3e3f270eb861b65259fd377aef32fe30e32ef61b07d086f6R883) of `@google/genai`, they changed the internals of embeddings. The public method changed from `embedContent` to `embedContentInternal`.

## How to Test

```sh
npm run versioned:internal google-genai
````
