### PR TITLE
feat: added functionality to ingest logs from Azure Functions App automatically

### DIFF
--- a/lib/instrumentation/@azure/functions.js
+++ b/lib/instrumentation/@azure/functions.js
@@ -197,10 +197,10 @@ function registerAzureLogs(agent, azureFunctions, logger) {
 
   azureFunctions.app.hook?.log((context) => {
     const logLevel = AZURE_TO_NR_LEVEL[context.level] ?? context.level
-    
+
     if (isLogForwardingEnabled(agent.config, agent)) {
       const meta = agent.getLinkingMetadata(true)
-    
+
       const logData = {
         message: context.message,
         level: logLevel,
@@ -208,11 +208,10 @@ function registerAzureLogs(agent, azureFunctions, logger) {
         category: context.category,
         ...meta
       }
-      
+
       agent.logs.add(logData)
     }
 
-   
     if (isMetricsEnabled(agent.config)) {
       incrementLoggingLinesMetrics(logLevel, agent.metrics)
     }

--- a/lib/instrumentation/@azure/functions.js
+++ b/lib/instrumentation/@azure/functions.js
@@ -85,9 +85,10 @@ module.exports = function initialize(_agent, azureFunctions, _moduleName, shim, 
 
   azureFunctions.app.hook.log((context) => {
     const meta = _agent.getLinkingMetadata(true)
+    const logLevel = AZURE_TO_NR_LEVEL[context.level] ?? context.level
     const logData = {
       message: context.message,
-      level: context.level,
+      level: logLevel,
       timestamp: Date.now(),
       attributes: {
         CategoryName: context.category
@@ -97,8 +98,7 @@ module.exports = function initialize(_agent, azureFunctions, _moduleName, shim, 
     _agent.logs.add(logData)
 
     if (isMetricsEnabled(_agent.config)) {
-      const level = AZURE_TO_NR_LEVEL[context.level] ?? context.level
-      incrementLoggingLinesMetrics(level, _agent.metrics)
+      incrementLoggingLinesMetrics(logLevel, _agent.metrics)
     }
   })
 }

--- a/lib/instrumentation/@azure/functions.js
+++ b/lib/instrumentation/@azure/functions.js
@@ -41,6 +41,16 @@ module.exports = function initialize(_agent, azureFunctions, _moduleName, shim, 
     return
   }
 
+  azureFunctions.app.hook.log((context) => {
+    const meta = _agent.getLinkingMetadata(true)
+    const logData = {
+      message: context.message,
+      level: context.level,
+      ...meta
+    }
+    _agent.logs.add(logData)
+  })
+
   const httpMethods = ['http', 'get', 'put', 'post', 'patch', 'deleteRequest']
   shim.wrap(azureFunctions.app, httpMethods, wrapAzureHttpMethods)
 

--- a/lib/instrumentation/@azure/functions.js
+++ b/lib/instrumentation/@azure/functions.js
@@ -40,7 +40,7 @@ const AZURE_TO_NR_LEVEL = {
 
 let coldStart = true
 
-module.exports = function initialize(_agent, azureFunctions, _moduleName, shim, { logger = defaultLogger } = {}) {
+module.exports = function initialize(agent, azureFunctions, _moduleName, shim, { logger = defaultLogger } = {}) {
   if (!SUBSCRIPTION_ID || !RESOURCE_GROUP_NAME || !AZURE_FUNCTION_APP_NAME) {
     logger.warn(
       {
@@ -73,34 +73,7 @@ module.exports = function initialize(_agent, azureFunctions, _moduleName, shim, 
   ]
   shim.wrap(azureFunctions.app, backgroundMethods, wrapAzureBackgroundMethods)
 
-  if (!isApplicationLoggingEnabled(_agent.config)) {
-    logger.debug('Application logging not enabled. Not auto capturing logs from Azure Functions.')
-    return
-  }
-
-  if (!isLogForwardingEnabled(_agent.config, _agent)) {
-    logger.debug('Log forwarding not enabled. Logs from Azure Functions will not be forwarded to New Relic.')
-    return
-  }
-
-  azureFunctions.app.hook?.log((context) => {
-    const meta = _agent.getLinkingMetadata(true)
-    const logLevel = AZURE_TO_NR_LEVEL[context.level] ?? context.level
-    const logData = {
-      message: context.message,
-      level: logLevel,
-      timestamp: Date.now(),
-      attributes: {
-        CategoryName: context.category
-      },
-      ...meta
-    }
-    _agent.logs.add(logData)
-
-    if (isMetricsEnabled(_agent.config)) {
-      incrementLoggingLinesMetrics(logLevel, _agent.metrics)
-    }
-  })
+  registerAzureLogs(agent, azureFunctions, logger)
 }
 
 function wrapAzureHttpMethods(shim, appMethod) {
@@ -214,6 +187,35 @@ function wrapAzureBackgroundMethods(shim, appMethod) {
 
     await appMethod(...args)
   }
+}
+
+function registerAzureLogs(agent, azureFunctions, logger) {
+  if (!isApplicationLoggingEnabled(agent.config)) {
+    logger.debug('Application logging not enabled. Not auto capturing logs from Azure Functions.')
+    return
+  }
+
+  azureFunctions.app.hook?.log((context) => {
+    if (!isLogForwardingEnabled(agent.config, agent)) {
+      logger.debug('Log forwarding not enabled. Logs from Azure Functions will not be forwarded to New Relic.')
+      return
+    }
+
+    const meta = agent.getLinkingMetadata(true)
+    const logLevel = AZURE_TO_NR_LEVEL[context.level] ?? context.level
+    const logData = {
+      message: context.message,
+      level: logLevel,
+      timestamp: Date.now(),
+      category: context.category,
+      ...meta
+    }
+    agent.logs.add(logData)
+
+    if (isMetricsEnabled(agent.config)) {
+      incrementLoggingLinesMetrics(logLevel, agent.metrics)
+    }
+  })
 }
 
 /**

--- a/lib/instrumentation/@azure/functions.js
+++ b/lib/instrumentation/@azure/functions.js
@@ -10,6 +10,12 @@ const { Transform } = require('node:stream')
 
 const backgroundRecorder = require('../../metrics/recorders/other.js')
 const recordWeb = require('../../metrics/recorders/http')
+const {
+  isApplicationLoggingEnabled,
+  isLogForwardingEnabled,
+  isMetricsEnabled,
+  incrementLoggingLinesMetrics
+} = require('../../util/application-logging.js')
 
 const {
   DESTINATIONS: DESTS,
@@ -24,6 +30,13 @@ const {
 const SUBSCRIPTION_ID = WEBSITE_OWNER_NAME?.split('+').shift()
 const RESOURCE_GROUP_NAME = WEBSITE_RESOURCE_GROUP ?? WEBSITE_OWNER_NAME?.split('+').pop().split('-Linux').shift()
 const AZURE_FUNCTION_APP_NAME = WEBSITE_SITE_NAME
+
+// Azure Functions uses 'information' as the context level for context.log and context.info and uses 'warning' as the context level for context.warn.
+// These map to the NR standard names that LOGGING.LEVELS recognizes ('info', 'warn').
+const AZURE_TO_NR_LEVEL = {
+  information: 'info',
+  warning: 'warn'
+}
 
 let coldStart = true
 
@@ -40,16 +53,6 @@ module.exports = function initialize(_agent, azureFunctions, _moduleName, shim, 
     )
     return
   }
-
-  azureFunctions.app.hook.log((context) => {
-    const meta = _agent.getLinkingMetadata(true)
-    const logData = {
-      message: context.message,
-      level: context.level,
-      ...meta
-    }
-    _agent.logs.add(logData)
-  })
 
   const httpMethods = ['http', 'get', 'put', 'post', 'patch', 'deleteRequest']
   shim.wrap(azureFunctions.app, httpMethods, wrapAzureHttpMethods)
@@ -69,6 +72,35 @@ module.exports = function initialize(_agent, azureFunctions, _moduleName, shim, 
     'webPubSub'
   ]
   shim.wrap(azureFunctions.app, backgroundMethods, wrapAzureBackgroundMethods)
+
+  if (!isApplicationLoggingEnabled(_agent.config)) {
+    logger.debug('Application logging not enabled. Not auto capturing logs from Azure Functions.')
+    return
+  }
+
+  if (!isLogForwardingEnabled(_agent.config, _agent)) {
+    logger.debug('Log forwarding not enabled. Logs from Azure Functions will not be forwarded to New Relic.')
+    return
+  }
+
+  azureFunctions.app.hook.log((context) => {
+    const meta = _agent.getLinkingMetadata(true)
+    const logData = {
+      message: context.message,
+      level: context.level,
+      timestamp: Date.now(),
+      attributes: {
+        CategoryName: context.category
+      },
+      ...meta
+    }
+    _agent.logs.add(logData)
+
+    if (isMetricsEnabled(_agent.config)) {
+      const level = AZURE_TO_NR_LEVEL[context.level] ?? context.level
+      incrementLoggingLinesMetrics(level, _agent.metrics)
+    }
+  })
 }
 
 function wrapAzureHttpMethods(shim, appMethod) {

--- a/lib/instrumentation/@azure/functions.js
+++ b/lib/instrumentation/@azure/functions.js
@@ -83,7 +83,7 @@ module.exports = function initialize(_agent, azureFunctions, _moduleName, shim, 
     return
   }
 
-  azureFunctions.app.hook.log((context) => {
+  azureFunctions.app.hook?.log((context) => {
     const meta = _agent.getLinkingMetadata(true)
     const logLevel = AZURE_TO_NR_LEVEL[context.level] ?? context.level
     const logData = {

--- a/lib/instrumentation/@azure/functions.js
+++ b/lib/instrumentation/@azure/functions.js
@@ -196,22 +196,23 @@ function registerAzureLogs(agent, azureFunctions, logger) {
   }
 
   azureFunctions.app.hook?.log((context) => {
-    if (!isLogForwardingEnabled(agent.config, agent)) {
-      logger.debug('Log forwarding not enabled. Logs from Azure Functions will not be forwarded to New Relic.')
-      return
-    }
-
-    const meta = agent.getLinkingMetadata(true)
     const logLevel = AZURE_TO_NR_LEVEL[context.level] ?? context.level
-    const logData = {
-      message: context.message,
-      level: logLevel,
-      timestamp: Date.now(),
-      category: context.category,
-      ...meta
+    
+    if (isLogForwardingEnabled(agent.config, agent)) {
+      const meta = agent.getLinkingMetadata(true)
+    
+      const logData = {
+        message: context.message,
+        level: logLevel,
+        timestamp: Date.now(),
+        category: context.category,
+        ...meta
+      }
+      
+      agent.logs.add(logData)
     }
-    agent.logs.add(logData)
 
+   
     if (isMetricsEnabled(agent.config)) {
       incrementLoggingLinesMetrics(logLevel, agent.metrics)
     }

--- a/test/versioned/azure-functions/logs.test.js
+++ b/test/versioned/azure-functions/logs.test.js
@@ -153,7 +153,7 @@ test('adds logs from azure functions to agent logs', async (t) => {
   assert.equal(agentLogs[0].level, 'info', 'log level should match')
   assert.ok(agentLogs[0].timestamp, 'log should have a timestamp')
   assert.equal(agentLogs[0]['trace.id'], tx.traceId, 'log should include trace id')
-  assert.equal(agentLogs[0].attributes.CategoryName, 'Function.test-func', 'log should include CategoryName attribute from context.category')
+  assert.equal(agentLogs[0].category, 'Function.test-func', 'log should include context.category')
 })
 
 test('does not capture logs when application logging is disabled', async (t) => {

--- a/test/versioned/azure-functions/logs.test.js
+++ b/test/versioned/azure-functions/logs.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 New Relic Corporation. All rights reserved.
+ * Copyright 2026 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -85,7 +85,6 @@ function bootstrapModule({ t, request = basicHttpRequest }) {
     httpHandlers: {},
     httpRequest(method) {
       method = method.toUpperCase()
-      if (method === 'HTTP') method = 'GET'
       if (Object.hasOwn(mockApi.httpHandlers, method) === false) {
         throw Error(`no handler registered for method: ${method}`)
       }
@@ -116,9 +115,6 @@ function bootstrapModule({ t, request = basicHttpRequest }) {
         log(callback) {
           logHookCallbacks.push(callback)
         }
-      },
-      http(name, options) {
-        mockApi.httpHandlers.GET = options.handler
       },
       get(name, options) {
         mockApi.httpHandlers.GET = options.handler ?? options
@@ -154,7 +150,7 @@ test('adds logs from azure functions to agent logs', async (t) => {
   const agentLogs = agent.logs.getEvents()
   assert.equal(agentLogs.length, 1, 'should have one log entry in agent logs')
   assert.equal(agentLogs[0].message, 'test message', 'log message should match')
-  assert.equal(agentLogs[0].level, 'information', 'log level should match')
+  assert.equal(agentLogs[0].level, 'info', 'log level should match')
   assert.ok(agentLogs[0].timestamp, 'log should have a timestamp')
   assert.equal(agentLogs[0]['trace.id'], tx.traceId, 'log should include trace id')
   assert.equal(agentLogs[0].attributes.CategoryName, 'Function.test-func', 'log should include CategoryName attribute from context.category')
@@ -257,9 +253,9 @@ test('captures correct log level for each context log method', async (t) => {
   assert.equal(agentLogs.length, 6, 'should have one log entry per context log call')
 
   const byMessage = Object.fromEntries(agentLogs.map((l) => [l.message, l.level]))
-  assert.equal(byMessage['log message'], 'information', 'context.log() should produce information level')
-  assert.equal(byMessage['info message'], 'information', 'context.info() should produce information level')
-  assert.equal(byMessage['warn message'], 'warning', 'context.warn() should produce warning level')
+  assert.equal(byMessage['log message'], 'info', 'context.log() should produce info level')
+  assert.equal(byMessage['info message'], 'info', 'context.info() should produce info level')
+  assert.equal(byMessage['warn message'], 'warn', 'context.warn() should produce warn level')
   assert.equal(byMessage['error message'], 'error', 'context.error() should produce error level')
   assert.equal(byMessage['debug message'], 'debug', 'context.debug() should produce debug level')
   assert.equal(byMessage['trace message'], 'trace', 'context.trace() should produce trace level')

--- a/test/versioned/azure-functions/logs.test.js
+++ b/test/versioned/azure-functions/logs.test.js
@@ -71,7 +71,7 @@ function bootstrapModule({ t, request = basicHttpRequest }) {
       request.method = method
       function fireLogHook(message, level) {
         for (const cb of logHookCallbacks) {
-          cb({ message, level })
+          cb({ message, level, category: 'Function.test-func' })
         }
       }
       return mockApi.httpHandlers[method](request, {
@@ -155,6 +155,7 @@ test('adds logs from azure functions to agent logs', async (t) => {
   assert.equal(agentLogs[0].message, 'test message', 'log message should match')
   assert.equal(agentLogs[0].level, 'information', 'log level should match')
   assert.equal(agentLogs[0]['trace.id'], tx.traceId, 'log should include trace id')
+  assert.equal(agentLogs[0].attributes.CategoryName, 'Function.test-func', 'log should include CategoryName attribute from context.category')
 })
 
 test('does not capture logs when application logging is disabled', async (t) => {

--- a/test/versioned/azure-functions/logs.test.js
+++ b/test/versioned/azure-functions/logs.test.js
@@ -191,9 +191,6 @@ test('does not capture logs when log forwarding is disabled', async (t) => {
 
   const agentLogs = agent.logs.getEvents()
   assert.equal(agentLogs.length, 0, 'should have no log entries when log forwarding is disabled')
-  assert.deepStrictEqual(t.nr.logs, [
-    ['Log forwarding not enabled. Logs from Azure Functions will not be forwarded to New Relic.']
-  ], 'should log debug message when log forwarding is disabled')
 })
 
 test('increments logging metrics for each log call when metrics are enabled', async (t) => {

--- a/test/versioned/azure-functions/logs.test.js
+++ b/test/versioned/azure-functions/logs.test.js
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert')
+const { once } = require('node:events')
+
+const helper = require('../../lib/agent_helper.js')
+const { removeMatchedModules } = require('../../lib/cache-buster.js')
+const GenericShim = require('../../../lib/shim/shim.js')
+
+const MODULE_NAME = 'azure-functions'
+const TRACE_ID = '0af7651916cd43dd8448eb211c80319c'
+const SPAN_ID = 'b9c7c989f97918e1'
+
+const basicHttpRequest = {
+  url: 'http://example.com',
+  method: 'GET',
+  headers: {
+    foo: 'bar'
+  }
+}
+
+// See https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response
+class AzureFunctionHttpResponse {
+  body
+  jsonBody // Should be a serializable object
+  status // e.g. 200
+  headers // key-value hash
+  cookies // array of cookie strings
+}
+
+test.beforeEach((ctx) => {
+  ctx.nr = {}
+
+  ctx.nr.agent = helper.loadMockedAgent()
+  ctx.nr.shim = new GenericShim(ctx.nr.agent, 'azure-functions')
+
+  process.env.WEBSITE_OWNER_NAME = 'b999997b-cb91-49e0-b922-c9188372bdba+testing-rg-EastUS2webspace-Linux'
+  process.env.WEBSITE_RESOURCE_GROUP = 'test-group'
+  process.env.WEBSITE_SITE_NAME = 'test-site'
+})
+
+test.afterEach((ctx) => {
+  helper.unloadAgent(ctx.nr.agent)
+  removeMatchedModules(/lib\/instrumentation\/@azure\/functions\.js/)
+
+  delete process.env.WEBSITE_OWNER_NAME
+  delete process.env.WEBSITE_RESOURCE_GROUP
+  delete process.env.WEBSITE_SITE_NAME
+})
+
+function bootstrapModule({ t, request = basicHttpRequest }) {
+  t.nr.initialize = require('../../../lib/instrumentation/@azure/functions.js')
+
+  const logHookCallbacks = []
+
+  const mockApi = {
+    httpHandlers: {},
+    httpRequest(method) {
+      method = method.toUpperCase()
+      if (method === 'HTTP') method = 'GET'
+      if (method === 'DELETEREQUEST') method = 'DELETE'
+      if (Object.hasOwn(mockApi.httpHandlers, method) === false) {
+        throw Error(`no handler registered for method: ${method}`)
+      }
+      request.method = method
+      function fireLogHook(message, level) {
+        for (const cb of logHookCallbacks) {
+          cb({ message, level })
+        }
+      }
+      return mockApi.httpHandlers[method](request, {
+        invocationId: 'test-123',
+        functionName: 'test-func',
+        options: {
+          trigger: {
+            type: 'httpTrigger'
+          }
+        },
+        log(message) { fireLogHook(message, 'information') },
+        info(message) { fireLogHook(message, 'information') },
+        warn(message) { fireLogHook(message, 'warning') },
+        error(message) { fireLogHook(message, 'error') },
+        debug(message) { fireLogHook(message, 'debug') },
+        trace(message) { fireLogHook(message, 'trace') }
+      })
+    },
+    app: {
+      hook: {
+        log(callback) {
+          logHookCallbacks.push(callback)
+        }
+      },
+      http(name, options) {
+        mockApi.httpHandlers.GET = options.handler
+      },
+      get(name, options) {
+        mockApi.httpHandlers.GET = options.handler ?? options
+      },
+      put(name, options) {
+        mockApi.httpHandlers.PUT = options.handler
+      },
+      post(name, options) {
+        mockApi.httpHandlers.POST = options.handler
+      },
+      patch(name, options) {
+        mockApi.httpHandlers.PATCH = options.handler
+      },
+      deleteRequest(name, options) {
+        mockApi.httpHandlers.DELETE = options.handler
+      }
+    }
+  }
+  t.nr.mockApi = mockApi
+}
+
+test('adds logs from azure functions to agent logs', async (t) => {
+  const clientRequest = structuredClone(basicHttpRequest)
+  clientRequest.headers = {
+    traceparent: `00-${TRACE_ID}-${SPAN_ID}-00`,
+    tracestate: `33@nr=0-0-33-2827902-${SPAN_ID}-e8b91a159289ff74-1-1.23456-1518469636035`
+  }
+
+  bootstrapModule({ t, request: clientRequest })
+  const { agent, initialize, mockApi, shim } = t.nr
+  agent.config.distributed_tracing.enabled = true
+  agent.config.account_id = '33'
+  agent.config.trusted_account_key = '33'
+  initialize(agent, mockApi, MODULE_NAME, shim)
+
+  const handler = async function (_request, context) {
+    context.log('test message')
+    const response = new AzureFunctionHttpResponse()
+    response.body = 'ok'
+    response.status = 200
+    return response
+  }
+  const options = { handler }
+
+  const txFinished = once(agent, 'transactionFinished')
+  mockApi.app.get('a-test', options)
+  const response = await mockApi.httpRequest('get')
+  assert.equal(response.body, 'ok')
+
+  const [tx] = await txFinished
+  assert.ok(tx)
+
+  const agentLogs = agent.logs.getEvents()
+  assert.equal(agentLogs.length, 1, 'should have one log entry in agent logs')
+  assert.equal(agentLogs[0].message, 'test message', 'log message should match')
+  assert.equal(agentLogs[0].level, 'information', 'log level should match')
+  assert.equal(agentLogs[0]['trace.id'], tx.traceId, 'log should include trace id')
+})
+
+// https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#log-levels
+test('captures correct log level for each context log method', async (t) => {
+  bootstrapModule({ t })
+  const { agent, initialize, mockApi, shim } = t.nr
+  initialize(agent, mockApi, MODULE_NAME, shim)
+
+  const handler = async function (_request, context) {
+    context.log('log message')
+    context.info('info message')
+    context.warn('warn message')
+    context.error('error message')
+    context.debug('debug message')
+    context.trace('trace message')
+    const response = new AzureFunctionHttpResponse()
+    response.body = 'ok'
+    response.status = 200
+    return response
+  }
+
+  const txFinished = once(agent, 'transactionFinished')
+  mockApi.app.get('a-test', { handler })
+  await mockApi.httpRequest('get')
+  await txFinished
+
+  const agentLogs = agent.logs.getEvents()
+  assert.equal(agentLogs.length, 6, 'should have one log entry per context log call')
+
+  const byMessage = Object.fromEntries(agentLogs.map((l) => [l.message, l.level]))
+  assert.equal(byMessage['log message'], 'information', 'context.log() should produce information level')
+  assert.equal(byMessage['info message'], 'information', 'context.info() should produce information level')
+  assert.equal(byMessage['warn message'], 'warning', 'context.warn() should produce warning level')
+  assert.equal(byMessage['error message'], 'error', 'context.error() should produce error level')
+  assert.equal(byMessage['debug message'], 'debug', 'context.debug() should produce debug level')
+  assert.equal(byMessage['trace message'], 'trace', 'context.trace() should produce trace level')
+})

--- a/test/versioned/azure-functions/package.json
+++ b/test/versioned/azure-functions/package.json
@@ -17,7 +17,8 @@
       },
       "files": [
         "background.test.js",
-        "http.test.js"
+        "http.test.js",
+        "logs.test.js"
       ]
     }
   ]


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Update our Azure functions app instrumentation to automatically capture logs if application logging is enabled and log forwarding is enabled. 

Azure has 5 logging [levels](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#log-levels). Two of those levels had to be mapped to meet our naming for those levels. 
- mapped "information" to "info"
- mapped "warning to "warn". 

We capture the following for a log:
- message, level and category (from azure logs)
- timestamp and linking metadata (we add this on)

After we capture the azure logs, we update the logging metrics. 

## How to Test

Run versioned test for azure.

## Related Issues

Closes #3767 