### PR TITLE
chore: Updated version format in agent-metadata.yml

### DIFF
--- a/.github/workflows/agent-metadata.yml
+++ b/.github/workflows/agent-metadata.yml
@@ -59,6 +59,7 @@ jobs:
     uses: newrelic/newrelic-agent-init-container/.github/workflows/agent-metadata.yml@main
     with:
       agent-type: ${{ needs.get-version.outputs.agent-type }}
+      # Our 'version' in package.json does not have a 'v'. This reusable workflow checks out a tag which is prefixed with a 'v', so we'll add it here.
       version: v${{ needs.get-version.outputs.version }}
       use-cache: ${{ needs.get-version.outputs.use-cache == 'true' }}
     secrets:


### PR DESCRIPTION
Agent metadata workflow failed with `13.14.0` release because the workflow assumed the version would be passed in as `'v13.14.0'`. 