### PR TITLE
chore: add version comment for agent-metadata.yml

### DIFF
--- a/.github/workflows/agent-metadata.yml
+++ b/.github/workflows/agent-metadata.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag (needs to exactly match the GH tag for the release)'
+        description: 'Version number (needs to match package.json)'
         required: true
         type: string
       agent-type:


### PR DESCRIPTION
Adds a comment for `version`, so it asks for `package.json` format e.g. 13.14.0 and not v13.14.0.