### PR TITLE
feat: Add `time_to_first_token` for OpenAI

### DIFF
--- a/lib/llm-events/openai/chat-completion-summary.js
+++ b/lib/llm-events/openai/chat-completion-summary.js
@@ -20,9 +20,10 @@ module.exports = class OpenAiLlmChatCompletionSummary extends LlmChatCompletionS
    * @param {Transaction} params.transaction Current and active transaction.
    * @param {object} params.request OpenAI request object.
    * @param {object} params.response OpenAI response object.
+   * @param {number} [params.timeOfFirstToken] Timestamp of when the first token was sent, for streaming only.
    * @param {boolean} [params.error] Set to `true` if an error occurred, can be omitted in false cases.
    */
-  constructor({ agent, segment, transaction, request, response, error }) {
+  constructor({ agent, segment, transaction, request, response, timeOfFirstToken, error }) {
     super({
       agent,
       segment,
@@ -34,7 +35,8 @@ module.exports = class OpenAiLlmChatCompletionSummary extends LlmChatCompletionS
       requestModel: request?.model,
       requestId: response?.headers?.['x-request-id'],
       temperature: request?.temperature,
-      maxTokens: request?.max_tokens ?? request?.max_output_tokens
+      maxTokens: request?.max_tokens ?? request?.max_output_tokens,
+      timeOfFirstToken
     })
 
     if (request?.input) {

--- a/lib/subscribers/ai-monitoring/chat.js
+++ b/lib/subscribers/ai-monitoring/chat.js
@@ -50,12 +50,13 @@ class AiMonitoringChatSubscriber extends AiMonitoringSubscriber {
    * @param {Context} params.ctx active context
    * @param {object} params.request request made to method on a given llm library
    * @param {object} params.response response from method on a given llm library
-   * @param {object} params.err error if present
-   * @param {object} params.metadata used only for langchain events at the moment
-   * @param {Array} params.tags used only for langchain events at the moment
+   * @param {object} [params.err] error if present
+   * @param {number} [params.timeOfFirstToken] Timestamp of when the first streaming token was sent.
+   * @param {object} [params.metadata] used only for langchain events at the moment
+   * @param {Array} [params.tags] used only for langchain events at the moment
    * returns {object} a llm completion summary instance for the given LLM
    */
-  createCompletionSummary({ ctx, request, response, err, metadata, tags }) {
+  createCompletionSummary({ ctx, request, response, err, timeOfFirstToken, metadata, tags }) {
     throw new Error('createCompletionSummary must be implemented by your subscriber')
   }
 
@@ -79,11 +80,12 @@ class AiMonitoringChatSubscriber extends AiMonitoringSubscriber {
    * @param {Context} params.ctx active context
    * @param {object} params.request request made to method on a given llm library
    * @param {object} params.response response from method on a given llm library
-   * @param {object} params.err error if present
+   * @param {object} [params.err] error if present
+   * @param {number} [params.timeOfFirstToken] Timestamp of when the first streaming token was sent.
    * @param {object} params.metadata used only for langchain events at the moment
    * @param {Array} params.tags used only for langchain events at the moment
    */
-  recordChatCompletionEvents({ ctx, request, response, err, metadata = {}, tags = [] }) {
+  recordChatCompletionEvents({ ctx, request, response, err, timeOfFirstToken, metadata = {}, tags = [] }) {
     if (!this.enabled) {
       this.logger.debug('config.ai_monitoring.enabled is set to false, not creating chat completion events.')
       return
@@ -97,7 +99,7 @@ class AiMonitoringChatSubscriber extends AiMonitoringSubscriber {
     // Explicitly end segment to provide consistent duration
     // for both LLM events and the segment
     ctx.segment.end()
-    const completionSummary = this.createCompletionSummary({ ctx, request, response, err, metadata, tags })
+    const completionSummary = this.createCompletionSummary({ ctx, request, response, timeOfFirstToken, err, metadata, tags })
     this.recordEvent({ type: 'LlmChatCompletionSummary', msg: completionSummary })
 
     const messages = this.getMessages({ request, response })

--- a/lib/subscribers/openai/chat.js
+++ b/lib/subscribers/openai/chat.js
@@ -114,6 +114,7 @@ class OpenAIChatCompletions extends AiMonitoringChatSubscriber {
       let role = ''
       let finishReason = ''
       let chunk
+      let timeOfFirstToken
       try {
         const iterator = orig.apply(this, arguments)
 
@@ -126,6 +127,12 @@ class OpenAIChatCompletions extends AiMonitoringChatSubscriber {
             finishReason = chunk.choices[0].finish_reason
           }
 
+          if (!timeOfFirstToken && (chunk.choices?.[0]?.delta?.content || chunk?.delta)) {
+            // If there is no content in the chunk, then we haven't
+            // recieved the first token yet, so we check if we
+            // recieved content and haven't set timeOfFirstToken yet.
+            timeOfFirstToken = Date.now()
+          }
           content += chunk.choices?.[0]?.delta?.content ?? ''
           yield chunk
         }
@@ -147,6 +154,7 @@ class OpenAIChatCompletions extends AiMonitoringChatSubscriber {
           ctx,
           request,
           response: chunk,
+          timeOfFirstToken,
           err
         })
       }
@@ -160,9 +168,10 @@ class OpenAIChatCompletions extends AiMonitoringChatSubscriber {
    * @param {object} params.request OpenAI request object.
    * @param {object} [params.response] OpenAI response object, defaults to `{}`.
    * @param {object} [params.err] Error object if one occurred.
+   * @param {number} [params.timeOfFirstToken] Timestamp of when the first streaming token was sent.
    * @returns {LlmChatCompletionSummary} The OpenAI LlmChatCompletionSummary instance.
    */
-  createCompletionSummary({ ctx, request, response = {}, err = null }) {
+  createCompletionSummary({ ctx, request, response = {}, timeOfFirstToken, err = null }) {
     const { transaction, segment } = ctx
     const headers = ctx?.extras?.headers || {}
     const summary = new LlmChatCompletionSummary({
@@ -171,6 +180,7 @@ class OpenAIChatCompletions extends AiMonitoringChatSubscriber {
       transaction,
       request,
       response: { ...response, headers },
+      timeOfFirstToken,
       error: !!err
     })
     return summary


### PR DESCRIPTION
## Description

Adds the `time_to_first_token` attribute to OpenAI `LlmChatCompletionSummary`s and coordinating tests.

## How to Test

```
npm run versioned openai
```

## Related Issues

Part of #3581