### PR TITLE
feat: Added server-side configuration for `profiling.enabled`

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -866,6 +866,14 @@ Agent.prototype._listenForConfigChanges = function _listenForConfigChanges() {
       generateEventHarvestSupportMetrics(self, harvestConfig)
     }
   })
+  this.config.on('profiling.enabled', async function onProfilingEnabledChange(value) {
+    self.profilingData.reconfigure(self.config)
+    if (value === true) {
+      self.profilingData.start()
+    } else {
+      self.profilingData.stop()
+    }
+  })
 }
 
 /**

--- a/lib/aggregators/profiling-aggregator.js
+++ b/lib/aggregators/profiling-aggregator.js
@@ -57,6 +57,11 @@ class ProfilingAggregator extends BaseAggregator {
     }
   }
 
+  /**
+   * This overrides the default `stop` method
+   * as we want to clear the setInterval but also stop
+   * all the registered profilers
+   */
   stop() {
     super.stop()
     this.profilingManager.stop()

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -618,6 +618,15 @@ Config.prototype._fromServer = function _fromServer(params, key) {
       }
       break
 
+    case 'profiling.enabled':
+      this._updateNestedIfChanged(
+        params,
+        this.profiling,
+        'profiling.enabled',
+        'enabled'
+      )
+      break
+
     // These settings are not allowed from the server.
     case 'attributes.enabled':
     case 'attributes.exclude':

--- a/lib/profiling/index.js
+++ b/lib/profiling/index.js
@@ -12,43 +12,43 @@ class ProfilingManager {
   constructor(agent, { logger = defaultLogger } = {}) {
     this.logger = logger
     this.config = agent.config.profiling
-    this.profilers = []
+    this.profilers = new Map()
     this.outputDir = process.cwd() + '/profiler-data'
   }
 
   register() {
-    if (this.config.include.includes('heap')) {
+    if (this.config.include.includes('heap') && !this.profilers.has('HeapProfiler')) {
       const { HeapProfiler } = require('./profilers')
-      this.profilers.push(new HeapProfiler({ logger: this.logger }))
+      this.profilers.set('HeapProfiler', new HeapProfiler({ logger: this.logger }))
     }
 
-    if (this.config.include.includes('cpu')) {
+    if (this.config.include.includes('cpu') && !this.profilers.has('CpuProfiler')) {
       const { CpuProfiler } = require('./profilers')
-      this.profilers.push(new CpuProfiler({ logger: this.logger }))
+      this.profilers.set('CpuProfiler', new CpuProfiler({ logger: this.logger }))
     }
   }
 
   start() {
-    if (this.profilers.length === 0) {
+    if (this.profilers.size === 0) {
       this.logger.warn('No profilers have been included in `config.profiling.include`, not starting any profilers.')
       return false
     }
 
-    for (const profiler of this.profilers) {
-      this.logger.debug(`Starting ${profiler.name}`)
+    for (const [name, profiler] of this.profilers) {
+      this.logger.debug(`Starting ${name}`)
       profiler.start()
     }
     return true
   }
 
   stop() {
-    if (this.profilers.length === 0) {
+    if (this.profilers.size === 0) {
       this.logger.warn('No profilers have been included in `config.profiling.include`, not stopping any profilers.')
       return
     }
 
-    for (const profiler of this.profilers) {
-      this.logger.debug(`Stopping ${profiler.name}`)
+    for (const [name, profiler] of this.profilers) {
+      this.logger.debug(`Stopping ${name}`)
       profiler.stop()
     }
   }
@@ -68,15 +68,15 @@ class ProfilingManager {
 
   async collect() {
     const results = []
-    if (this.profilers.length === 0) {
+    if (this.profilers.size === 0) {
       this.logger.warn('No profilers have been included in `config.profiling.include`, not collecting any profiling data.')
       return results
     }
 
-    for (const profiler of this.profilers) {
-      this.logger.debug(`Collecting profiling data for ${profiler.name}`)
+    for (const [name, profiler] of this.profilers) {
+      this.logger.debug(`Collecting profiling data for ${name}`)
       const pprofData = await profiler.collect()
-      this.writeFile({ pprofData, name: profiler.name })
+      this.writeFile({ pprofData, name })
       results.push(pprofData)
     }
 

--- a/lib/profiling/profilers/base.js
+++ b/lib/profiling/profilers/base.js
@@ -10,14 +10,6 @@ class BaseProfiler {
     this.logger = logger
   }
 
-  set name(name) {
-    this._name = name
-  }
-
-  get name() {
-    return this._name
-  }
-
   start() {
     throw new Error('start is not implemented')
   }

--- a/lib/profiling/profilers/cpu.js
+++ b/lib/profiling/profilers/cpu.js
@@ -10,7 +10,6 @@ class CpuProfiler extends BaseProfiler {
   #pprof
   constructor({ logger }) {
     super({ logger })
-    this.name = 'CpuProfiler'
     this.#pprof = require('@datadog/pprof')
   }
 
@@ -27,6 +26,11 @@ class CpuProfiler extends BaseProfiler {
   }
 
   stop() {
+    if (!this.#pprof.time.isStarted()) {
+      this.logger.trace('CpuProfiler is not started, not stopping.')
+      return
+    }
+
     this.#pprof.time.stop(false)
   }
 

--- a/lib/profiling/profilers/heap.js
+++ b/lib/profiling/profilers/heap.js
@@ -11,7 +11,6 @@ class HeapProfiler extends BaseProfiler {
   #pprof
   constructor({ logger }) {
     super({ logger })
-    this.name = 'HeapProfiler'
     this.#pprof = require('@datadog/pprof')
   }
 

--- a/test/unit/agent/agent.test.js
+++ b/test/unit/agent/agent.test.js
@@ -1034,6 +1034,37 @@ test('when sampling_target changes', async (t) => {
   })
 })
 
+test('when `profiling.enabled` changes', async (t) => {
+  t.beforeEach((ctx) => {
+    ctx.nr = {}
+    const config = {
+      profiling: {
+        enabled: false
+      }
+    }
+    ctx.nr.agent = helper.loadMockedAgent(config, false)
+  })
+
+  t.afterEach((ctx) => {
+    helper.unloadAgent(ctx.nr.agent)
+  })
+
+  await t.test('should handle changes accordingly', (t) => {
+    const { agent } = t.nr
+    assert.equal(agent.profilingData.enabled, false)
+    assert.ok(!agent.profilingData.sendTimer)
+    agent.config.onConnect({ 'profiling.enabled': true })
+    assert.equal(agent.profilingData.enabled, true)
+    assert.ok(agent.profilingData.sendTimer)
+    agent.config.onConnect({ 'profiling.enabled': false })
+    assert.equal(agent.profilingData.enabled, false)
+    assert.ok(!agent.profilingData.sendTimer)
+    agent.config.onConnect({ 'profiling.enabled': true })
+    assert.equal(agent.profilingData.enabled, true)
+    assert.ok(agent.profilingData.sendTimer)
+  })
+})
+
 test('when event_harvest_config update on connect with a valid config', async (t) => {
   t.beforeEach((ctx) => {
     const validHarvestConfig = {

--- a/test/unit/aggregators/profiling-aggregator.test.js
+++ b/test/unit/aggregators/profiling-aggregator.test.js
@@ -62,7 +62,8 @@ test('should initialize pprofData and profilingManager', (t) => {
 test('should send 2 messages per interval', async (t) => {
   const { profilingAggregator, clock, agent, cpuProfiler, heapProfiler } = t.nr
   assert.equal(profilingAggregator.profilingManager.register.callCount, 0)
-  profilingAggregator.profilingManager.profilers = [cpuProfiler, heapProfiler]
+  profilingAggregator.profilingManager.profilers.set('CpuProfiler', cpuProfiler)
+  profilingAggregator.profilingManager.profilers.set('HeapProfiler', heapProfiler)
   profilingAggregator.start()
   assert.equal(profilingAggregator.profilingManager.register.callCount, 1)
   assert.equal(agent.collector.send.callCount, 0)
@@ -84,7 +85,7 @@ test('should send 2 messages per interval', async (t) => {
 
 test('should not send any data if there are no profilers registered', async (t) => {
   const { profilingAggregator, clock, agent } = t.nr
-  profilingAggregator.profilingManager.profilers = []
+  profilingAggregator.profilingManager.profilers = new Set()
   profilingAggregator.start()
   assert.equal(agent.collector.send.callCount, 0)
   clock.tick(100)
@@ -98,15 +99,16 @@ test('should not send any data if there are no profilers registered', async (t) 
 
 test('should stop ProfilingManager when aggregator is stopped', (t) => {
   const { profilingAggregator, cpuProfiler, heapProfiler } = t.nr
-  profilingAggregator.profilingManager.profilers = [cpuProfiler, heapProfiler]
+  profilingAggregator.profilingManager.profilers.set('CpuProfiler', cpuProfiler)
+  profilingAggregator.profilingManager.profilers.set('HeapProfiler', heapProfiler)
   profilingAggregator.start()
   assert.ok(profilingAggregator.sendTimer)
-  for (const profiler of profilingAggregator.profilingManager.profilers) {
+  for (const [, profiler] of profilingAggregator.profilingManager.profilers) {
     assert.equal(profiler.stop.callCount, 0)
   }
   profilingAggregator.stop()
   assert.equal(profilingAggregator.sendTimer, null)
-  for (const profiler of profilingAggregator.profilingManager.profilers) {
+  for (const [, profiler] of profilingAggregator.profilingManager.profilers) {
     assert.equal(profiler.stop.callCount, 1)
   }
 })

--- a/test/unit/config/config-server-side.test.js
+++ b/test/unit/config/config-server-side.test.js
@@ -5,64 +5,71 @@
 
 'use strict'
 
-const test = require('node:test')
+const { describe, test } = require('node:test')
 const assert = require('node:assert')
 const Config = require('../../../lib/config')
 
-test('when receiving server-side configuration', async (t) => {
+describe('when receiving server-side configuration', () => {
   // Unfortunately, the Config currently relies on initialize to
   // instantiate the logger in the module which is later leveraged
   // by methods on the instantiated Config instance.
   Config.initialize({})
 
-  let config = null
-
-  t.beforeEach(() => {
-    config = new Config()
+  test.beforeEach((ctx) => {
+    const config = new Config()
+    ctx.nr = { config }
   })
 
-  await t.test('should set the agent run ID', () => {
+  test('should set the agent run ID', (t) => {
+    const { config } = t.nr
     config.onConnect({ agent_run_id: 1234 })
     assert.equal(config.run_id, 1234)
   })
 
-  await t.test('should set the account ID', () => {
+  test('should set the account ID', (t) => {
+    const { config } = t.nr
     config.onConnect({ account_id: 76543 })
     assert.equal(config.account_id, 76543)
   })
 
-  await t.test('should set the entity GUID', () => {
+  test('should set the entity GUID', (t) => {
+    const { config } = t.nr
     config.onConnect({ entity_guid: 1729 })
     assert.equal(config.entity_guid, 1729)
   })
 
-  await t.test('should set the application ID', () => {
+  test('should set the application ID', (t) => {
+    const { config } = t.nr
     config.onConnect({ application_id: 76543 })
     assert.equal(config.application_id, 76543)
   })
 
-  await t.test('should always respect collect_traces', () => {
+  test('should always respect collect_traces', (t) => {
+    const { config } = t.nr
     assert.equal(config.collect_traces, true)
 
     config.onConnect({ collect_traces: false })
     assert.equal(config.collect_traces, false)
   })
 
-  await t.test('should disable the transaction tracer when told to', () => {
+  test('should disable the transaction tracer when told to', (t) => {
+    const { config } = t.nr
     assert.equal(config.transaction_tracer.enabled, true)
 
     config.onConnect({ 'transaction_tracer.enabled': false })
     assert.equal(config.transaction_tracer.enabled, false)
   })
 
-  await t.test('should always respect collect_errors', () => {
+  test('should always respect collect_errors', (t) => {
+    const { config } = t.nr
     assert.equal(config.collect_errors, true)
 
     config.onConnect({ collect_errors: false })
     assert.equal(config.collect_errors, false)
   })
 
-  await t.test('should always respect collect_span_events', () => {
+  test('should always respect collect_span_events', (t) => {
+    const { config } = t.nr
     assert.equal(config.collect_span_events, true)
     assert.equal(config.span_events.enabled, true)
 
@@ -70,82 +77,97 @@ test('when receiving server-side configuration', async (t) => {
     assert.equal(config.span_events.enabled, false)
   })
 
-  await t.test('should disable the error tracer when told to', () => {
+  test('should disable the error tracer when told to', (t) => {
+    const { config } = t.nr
     assert.equal(config.error_collector.enabled, true)
 
     config.onConnect({ 'error_collector.enabled': false })
     assert.equal(config.error_collector.enabled, false)
   })
 
-  await t.test('should set apdex_t', () => {
+  test('should set apdex_t', (t) => {
+    t.plan(2)
+    const { config } = t.nr
     assert.equal(config.apdex_t, 0.1)
 
-    config.on('apdex_t', (value) => {
-      assert.equal(value, 0.05)
-      assert.equal(config.apdex_t, 0.05)
+    config.once('apdex_t', (value) => {
+      t.assert.equal(value, 0.05)
+      t.assert.equal(config.apdex_t, 0.05)
     })
 
     config.onConnect({ apdex_t: 0.05 })
   })
 
-  await t.test('should map transaction_tracer.transaction_threshold', () => {
+  test('should map transaction_tracer.transaction_threshold', (t) => {
+    const { config } = t.nr
     assert.equal(config.transaction_tracer.transaction_threshold, 'apdex_f')
 
     config.onConnect({ 'transaction_tracer.transaction_threshold': 0.75 })
     assert.equal(config.transaction_tracer.transaction_threshold, 0.75)
   })
 
-  await t.test('should map URL rules to the URL normalizer', () => {
-    config.on('url_rules', function (rules) {
-      assert.deepEqual(rules, [{ name: 'sample_rule' }])
+  test('should map URL rules to the URL normalizer', (t) => {
+    t.plan(1)
+    const { config } = t.nr
+    config.once('url_rules', function (rules) {
+      t.assert.deepEqual(rules, [{ name: 'sample_rule' }])
     })
 
     config.onConnect({ url_rules: [{ name: 'sample_rule' }] })
   })
 
-  await t.test('should map metric naming rules to the metric name normalizer', () => {
-    config.on('metric_name_rules', function (rules) {
-      assert.deepEqual(rules, [{ name: 'sample_rule' }])
+  test('should map metric naming rules to the metric name normalizer', (t) => {
+    t.plan(1)
+    const { config } = t.nr
+    config.once('metric_name_rules', function (rules) {
+      t.assert.deepEqual(rules, [{ name: 'sample_rule' }])
     })
 
     config.onConnect({ metric_name_rules: [{ name: 'sample_rule' }] })
   })
 
-  await t.test('should map txn naming rules to the txn name normalizer', () => {
-    config.on('transaction_name_rules', function (rules) {
-      assert.deepEqual(rules, [{ name: 'sample_rule' }])
+  test('should map txn naming rules to the txn name normalizer', (t) => {
+    t.plan(1)
+    const { config } = t.nr
+    config.once('transaction_name_rules', function (rules) {
+      t.assert.deepEqual(rules, [{ name: 'sample_rule' }])
     })
 
     config.onConnect({ transaction_name_rules: [{ name: 'sample_rule' }] })
   })
 
-  await t.test('should log the product level', () => {
+  test('should log the product level', (t) => {
+    const { config } = t.nr
     assert.equal(config.product_level, 0)
     config.onConnect({ product_level: 30 })
 
     assert.equal(config.product_level, 30)
   })
 
-  await t.test('should reject high_security', () => {
+  test('should reject high_security', (t) => {
+    const { config } = t.nr
     config.onConnect({ high_security: true })
     assert.equal(config.high_security, false)
   })
 
-  await t.test('should disable ai monitoring', () => {
+  test('should disable ai monitoring', (t) => {
+    const { config } = t.nr
     config.ai_monitoring.enabled = true
     assert.equal(config.ai_monitoring.enabled, true)
     config.onConnect({ collect_ai: false })
     assert.equal(config.ai_monitoring.enabled, false)
   })
 
-  await t.test('should configure cross application tracing', () => {
+  test('should configure cross application tracing', (t) => {
+    const { config } = t.nr
     config.cross_application_tracer.enabled = true
 
     config.onConnect({ 'cross_application_tracer.enabled': false })
     assert.equal(config.cross_application_tracer.enabled, false)
   })
 
-  await t.test('should load named transaction apdexes', () => {
+  test('should load named transaction apdexes', (t) => {
+    const { config } = t.nr
     const apdexes = { 'WebTransaction/Custom/UrlGenerator/en/betting/Football': 7.0 }
     assert.deepEqual(config.web_transactions_apdex, {})
 
@@ -153,60 +175,70 @@ test('when receiving server-side configuration', async (t) => {
     assert.deepEqual(config.web_transactions_apdex, apdexes)
   })
 
-  await t.test('should not configure record_sql', () => {
+  test('should not configure record_sql', (t) => {
+    const { config } = t.nr
     assert.equal(config.transaction_tracer.record_sql, 'obfuscated')
 
     config.onConnect({ 'transaction_tracer.record_sql': 'raw' })
     assert.equal(config.transaction_tracer.record_sql, 'obfuscated')
   })
 
-  await t.test('should not configure explain_threshold', () => {
+  test('should not configure explain_threshold', (t) => {
+    const { config } = t.nr
     assert.equal(config.transaction_tracer.explain_threshold, 500)
     config.onConnect({ 'transaction_tracer.explain_threshold': 100 })
     assert.equal(config.transaction_tracer.explain_threshold, 500)
   })
 
-  await t.test('should not configure slow_sql.enabled', () => {
+  test('should not configure slow_sql.enabled', (t) => {
+    const { config } = t.nr
     assert.equal(config.slow_sql.enabled, false)
 
     config.onConnect({ 'transaction_tracer.enabled': true })
     assert.equal(config.slow_sql.enabled, false)
   })
 
-  await t.test('should not configure slow_sql.max_samples', () => {
+  test('should not configure slow_sql.max_samples', (t) => {
+    const { config } = t.nr
     assert.equal(config.slow_sql.max_samples, 10)
 
     config.onConnect({ 'transaction_tracer.max_samples': 5 })
     assert.equal(config.slow_sql.max_samples, 10)
   })
 
-  await t.test('should not blow up when sampling_rate is received', () => {
+  test('should not blow up when sampling_rate is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ sampling_rate: 0 })
     })
   })
 
-  await t.test('should not blow up when cross_process_id is received', () => {
+  test('should not blow up when cross_process_id is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ cross_process_id: 'junk' })
     })
   })
 
-  await t.test('should not blow up with cross_application_tracer.enabled', () => {
+  test('should not blow up with cross_application_tracer.enabled', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ 'cross_application_tracer.enabled': true })
     })
   })
 
-  await t.test('should not blow up when encoding_key is received', () => {
+  test('should not blow up when encoding_key is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ encoding_key: 'hamsnadwich' })
     })
   })
 
-  await t.test('should not blow up when trusted_account_ids is received', () => {
+  test('should not blow up when trusted_account_ids is received', (t) => {
+    t.plan(2)
+    const { config } = t.nr
     config.once('trusted_account_ids', (value) => {
-      assert.deepEqual(value, [1, 2, 3], 'should get the initial keys')
+      t.assert.deepEqual(value, [1, 2, 3], 'should get the initial keys')
     })
 
     assert.doesNotThrow(() => {
@@ -214,7 +246,7 @@ test('when receiving server-side configuration', async (t) => {
     }, 'should allow it once')
 
     config.once('trusted_account_ids', (value) => {
-      assert.deepEqual(value, [2, 3, 4], 'should get the modified keys')
+      t.assert.deepEqual(value, [2, 3, 4], 'should get the modified keys')
     })
 
     assert.doesNotThrow(() => {
@@ -222,98 +254,114 @@ test('when receiving server-side configuration', async (t) => {
     }, 'should allow modification')
   })
 
-  await t.test('should not blow up when trusted_account_key is received', () => {
+  test('should not blow up when trusted_account_key is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ trusted_account_key: 123 })
     })
   })
 
-  await t.test('should not blow up when high_security is received', () => {
+  test('should not blow up when high_security is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ high_security: true })
     })
   })
 
-  await t.test('should not blow up when ssl is received', () => {
+  test('should not blow up when ssl is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ ssl: true })
     })
   })
 
-  await t.test('should not disable ssl', () => {
+  test('should not disable ssl', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ ssl: false })
     })
     assert.equal(config.ssl, true)
   })
 
-  await t.test('should not blow up when transaction_tracer.record_sql is received', () => {
+  test('should not blow up when transaction_tracer.record_sql is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ 'transaction_tracer.record_sql': true })
     })
   })
 
-  await t.test('should not blow up when slow_sql.enabled is received', () => {
+  test('should not blow up when slow_sql.enabled is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ 'slow_sql.enabled': true })
     })
   })
 
-  await t.test('should not blow up when rum.load_episodes_file is received', () => {
+  test('should not blow up when rum.load_episodes_file is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ 'rum.load_episodes_file': true })
     })
   })
 
-  await t.test('should not blow up when browser_monitoring.loader is received', () => {
+  test('should not blow up when browser_monitoring.loader is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ 'browser_monitoring.loader': 'none' })
     })
   })
 
-  await t.test('should not blow up when beacon is received', () => {
+  test('should not blow up when beacon is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ beacon: 'beacon-0.newrelic.com' })
     })
   })
 
-  await t.test('should not blow up when error beacon is received', () => {
+  test('should not blow up when error beacon is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ error_beacon: null })
     })
   })
 
-  await t.test('should not blow up when js_agent_file is received', () => {
+  test('should not blow up when js_agent_file is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ js_agent_file: 'jxc4afffef.js' })
     })
   })
 
-  await t.test('should not blow up when js_agent_loader_file is received', () => {
+  test('should not blow up when js_agent_loader_file is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ js_agent_loader_file: 'nr-js-bootstrap.js' })
     })
   })
 
-  await t.test('should not blow up when episodes_file is received', () => {
+  test('should not blow up when episodes_file is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ episodes_file: 'js-agent.newrelic.com/nr-100.js' })
     })
   })
 
-  await t.test('should not blow up when episodes_url is received', () => {
+  test('should not blow up when episodes_url is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ episodes_url: 'https://js-agent.newrelic.com/nr-100.js' })
     })
   })
 
-  await t.test('should not blow up when browser_key is received', () => {
+  test('should not blow up when browser_key is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ browser_key: 'beefchunx' })
     })
   })
 
-  await t.test('should not blow up when collect_analytics_events is received', () => {
+  test('should not blow up when collect_analytics_events is received', (t) => {
+    const { config } = t.nr
     config.transaction_events.enabled = true
     assert.doesNotThrow(() => {
       config.onConnect({ collect_analytics_events: false })
@@ -321,7 +369,8 @@ test('when receiving server-side configuration', async (t) => {
     assert.equal(config.transaction_events.enabled, false)
   })
 
-  await t.test('should not blow up when collect_custom_events is received', () => {
+  test('should not blow up when collect_custom_events is received', (t) => {
+    const { config } = t.nr
     config.custom_insights_events.enabled = true
     assert.doesNotThrow(() => {
       config.onConnect({ collect_custom_events: false })
@@ -329,35 +378,40 @@ test('when receiving server-side configuration', async (t) => {
     assert.equal(config.custom_insights_events.enabled, false)
   })
 
-  await t.test('should not blow up when transaction_events.enabled is received', () => {
+  test('should not blow up when transaction_events.enabled is received', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ 'transaction_events.enabled': false })
     })
     assert.equal(config.transaction_events.enabled, false)
   })
 
-  await t.test('should override default max_payload_size_in_bytes', () => {
+  test('should override default max_payload_size_in_bytes', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ max_payload_size_in_bytes: 100 })
     })
     assert.equal(config.max_payload_size_in_bytes, 100)
   })
 
-  await t.test('should not accept serverless_mode', () => {
+  test('should not accept serverless_mode', (t) => {
+    const { config } = t.nr
     assert.doesNotThrow(() => {
       config.onConnect({ 'serverless_mode.enabled': true })
     })
     assert.equal(config.serverless_mode.enabled, false)
   })
 
-  await t.test('when handling embedded agent_config', async (t) => {
-    await t.test('should not blow up when agent_config is passed in', () => {
+  describe('when handling embedded agent_config', () => {
+    test('should not blow up when agent_config is passed in', (t) => {
+      const { config } = t.nr
       assert.doesNotThrow(() => {
         config.onConnect({ agent_config: {} })
       })
     })
 
-    await t.test('should ignore status codes set on the server', () => {
+    test('should ignore status codes set on the server', (t) => {
+      const { config } = t.nr
       config.onConnect({
         agent_config: {
           'error_collector.ignore_status_codes': [401, 409, 415]
@@ -366,7 +420,8 @@ test('when receiving server-side configuration', async (t) => {
       assert.deepEqual(config.error_collector.ignore_status_codes, [404, 401, 409, 415])
     })
 
-    await t.test('should ignore status codes set on the server as strings', () => {
+    test('should ignore status codes set on the server as strings', (t) => {
+      const { config } = t.nr
       config.onConnect({
         agent_config: {
           'error_collector.ignore_status_codes': ['401', '409', '415']
@@ -375,7 +430,8 @@ test('when receiving server-side configuration', async (t) => {
       assert.deepEqual(config.error_collector.ignore_status_codes, [404, 401, 409, 415])
     })
 
-    await t.test('should ignore status codes set on the server when using a range', () => {
+    test('should ignore status codes set on the server when using a range', (t) => {
+      const { config } = t.nr
       config.onConnect({
         agent_config: {
           'error_collector.ignore_status_codes': [401, '420-421', 415, 'abc']
@@ -384,9 +440,10 @@ test('when receiving server-side configuration', async (t) => {
       assert.deepEqual(config.error_collector.ignore_status_codes, [404, 401, 420, 421, 415])
     })
 
-    await t.test(
+    test(
       'should not error out when ignore status codes are neither numbers nor strings',
-      () => {
+      (t) => {
+        const { config } = t.nr
         config.onConnect({
           agent_config: {
             'error_collector.ignore_status_codes': [{ non: 'sense' }]
@@ -396,7 +453,8 @@ test('when receiving server-side configuration', async (t) => {
       }
     )
 
-    await t.test('should not add codes that parse to NaN', () => {
+    test('should not add codes that parse to NaN', (t) => {
+      const { config } = t.nr
       config.onConnect({
         agent_config: {
           'error_collector.ignore_status_codes': ['abc']
@@ -405,7 +463,8 @@ test('when receiving server-side configuration', async (t) => {
       assert.deepEqual(config.error_collector.ignore_status_codes, [404])
     })
 
-    await t.test('should not ignore status codes from server with invalid range', () => {
+    test('should not ignore status codes from server with invalid range', (t) => {
+      const { config } = t.nr
       config.onConnect({
         agent_config: {
           'error_collector.ignore_status_codes': ['421-420']
@@ -414,7 +473,8 @@ test('when receiving server-side configuration', async (t) => {
       assert.deepEqual(config.error_collector.ignore_status_codes, [404])
     })
 
-    await t.test('should not ignore status codes from server if given out of range', () => {
+    test('should not ignore status codes from server if given out of range', (t) => {
+      const { config } = t.nr
       config.onConnect({
         agent_config: {
           'error_collector.ignore_status_codes': ['1-1776']
@@ -423,7 +483,8 @@ test('when receiving server-side configuration', async (t) => {
       assert.deepEqual(config.error_collector.ignore_status_codes, [404])
     })
 
-    await t.test('should ignore negative status codes from server', () => {
+    test('should ignore negative status codes from server', (t) => {
+      const { config } = t.nr
       config.onConnect({
         agent_config: {
           'error_collector.ignore_status_codes': [-7]
@@ -432,7 +493,8 @@ test('when receiving server-side configuration', async (t) => {
       assert.deepEqual(config.error_collector.ignore_status_codes, [404, -7])
     })
 
-    await t.test('should set `span_event_harvest_config` from server', () => {
+    test('should set `span_event_harvest_config` from server', (t) => {
+      const { config } = t.nr
       const spanEventHarvestConfig = {
         report_period_ms: 1000,
         harvest_limit: 10000
@@ -448,11 +510,12 @@ test('when receiving server-side configuration', async (t) => {
 
     const ignoreServerConfigFlags = [true, false]
     for (const ignoreServerConfig of ignoreServerConfigFlags) {
-      await t.test(
+      test(
         `should ${
           ignoreServerConfig ? 'not ' : ''
         }update local configuration with server side config values when ignore_server_configuration is set to ${ignoreServerConfig}`,
-        () => {
+        (t) => {
+          const { config } = t.nr
           assert.equal(config.slow_sql.enabled, false)
           assert.equal(config.transaction_tracer.enabled, true)
           const serverSideConfig = {
@@ -479,8 +542,10 @@ test('when receiving server-side configuration', async (t) => {
     }
   })
 
-  await t.test('when event_harvest_config is set', async (t) => {
-    await t.test('should emit event_harvest_config when harvest interval is changed', () => {
+  describe('when event_harvest_config is set', () => {
+    test('should emit event_harvest_config when harvest interval is changed', (t) => {
+      t.plan(1)
+      const { config } = t.nr
       const expectedHarvestConfig = {
         report_period_ms: 5000,
         harvest_limits: {
@@ -491,13 +556,15 @@ test('when receiving server-side configuration', async (t) => {
       }
 
       config.once('event_harvest_config', function (harvestconfig) {
-        assert.deepEqual(harvestconfig, expectedHarvestConfig)
+        t.assert.deepEqual(harvestconfig, expectedHarvestConfig)
       })
 
       config.onConnect({ event_harvest_config: expectedHarvestConfig })
     })
 
-    await t.test('should emit null when an invalid report period is provided', () => {
+    test('should emit null when an invalid report period is provided', (t) => {
+      t.plan(1)
+      const { config } = t.nr
       const invalidHarvestConfig = {
         report_period_ms: -1,
         harvest_limits: {
@@ -508,13 +575,15 @@ test('when receiving server-side configuration', async (t) => {
       }
 
       config.once('event_harvest_config', function (harvestconfig) {
-        assert.deepEqual(harvestconfig, null, 'emitted value should be null')
+        t.assert.deepEqual(harvestconfig, null, 'emitted value should be null')
       })
 
       config.onConnect({ event_harvest_config: invalidHarvestConfig })
     })
 
-    await t.test('should update event_harvest_config when a sub-value changed', () => {
+    test('should update event_harvest_config when a sub-value changed', (t) => {
+      t.plan(1)
+      const { config } = t.nr
       const originalHarvestConfig = {
         report_period_ms: 60000,
         harvest_limits: {
@@ -536,13 +605,15 @@ test('when receiving server-side configuration', async (t) => {
       }
 
       config.once('event_harvest_config', function (harvestconfig) {
-        assert.deepEqual(harvestconfig, expectedHarvestConfig)
+        t.assert.deepEqual(harvestconfig, expectedHarvestConfig)
       })
 
       config.onConnect({ event_harvest_config: expectedHarvestConfig })
     })
 
-    await t.test('should ignore invalid limits on event_harvest_config', () => {
+    test('should ignore invalid limits on event_harvest_config', (t) => {
+      t.plan(1)
+      const { config } = t.nr
       const originalHarvestConfig = {
         report_period_ms: 60000,
         harvest_limits: {
@@ -571,23 +642,26 @@ test('when receiving server-side configuration', async (t) => {
       }
 
       config.once('event_harvest_config', function (harvestconfig) {
-        assert.deepEqual(harvestconfig, cleanedHarvestLimits, 'should not include invalid limits')
+        t.assert.deepEqual(harvestconfig, cleanedHarvestLimits, 'should not include invalid limits')
       })
 
       config.onConnect({ event_harvest_config: invalidHarvestLimits })
     })
   })
 
-  await t.test('when apdex_t is set', async (t) => {
-    await t.test('should emit `apdex_t` when apdex_t changes', () => {
+  describe('when apdex_t is set', () => {
+    test('should emit `apdex_t` when apdex_t changes', (t) => {
+      t.plan(1)
+      const { config } = t.nr
       config.once('apdex_t', function (apdexT) {
-        assert.equal(apdexT, 0.75)
+        t.assert.equal(apdexT, 0.75)
       })
 
       config.onConnect({ apdex_t: 0.75 })
     })
 
-    await t.test('should update its apdex_t only when it has changed', () => {
+    test('should update its apdex_t only when it has changed', (t) => {
+      const { config } = t.nr
       assert.equal(config.apdex_t, 0.1)
 
       config.once('apdex_t', function () {
@@ -595,6 +669,52 @@ test('when receiving server-side configuration', async (t) => {
       })
 
       config.onConnect({ apdex_t: 0.1 })
+    })
+  })
+
+  describe('when handling profiling.enabled', () => {
+    test('should enable profiling when server passes `profiling.enabled` to true', (t) => {
+      t.plan(2)
+      const { config } = t.nr
+      config.on('profiling.enabled', (value) => {
+        t.assert.equal(value, true)
+      })
+      config.profiling.enabled = false
+      config.onConnect({ 'profiling.enabled': true })
+      t.assert.equal(config.profiling.enabled, true)
+    })
+
+    test('should disable profiling when server passes `profiling.enabled` to false', (t) => {
+      t.plan(2)
+      const { config } = t.nr
+      config.on('profiling.enabled', (value) => {
+        t.assert.equal(value, false)
+      })
+      config.profiling.enabled = true
+      config.onConnect({ 'profiling.enabled': false })
+      t.assert.equal(config.profiling.enabled, false)
+    })
+
+    test('should not disable profiling when server passes `profiling.enabled` to false and feature is already disabled', (t) => {
+      t.plan(1)
+      const { config } = t.nr
+      config.on('profiling.enabled', () => {
+        throw new Error('should not update dynamically')
+      })
+      config.profiling.enabled = false
+      config.onConnect({ 'profiling.enabled': false })
+      t.assert.equal(config.profiling.enabled, false)
+    })
+
+    test('should not enable profiling when server passes `profiling.enabled` to true and feature is already enabled', (t) => {
+      t.plan(1)
+      const { config } = t.nr
+      config.on('profiling.enabled', () => {
+        throw new Error('should not update dynamically')
+      })
+      config.profiling.enabled = true
+      config.onConnect({ 'profiling.enabled': true })
+      t.assert.equal(config.profiling.enabled, true)
     })
   })
 })

--- a/test/unit/lib/profiling/index.test.js
+++ b/test/unit/lib/profiling/index.test.js
@@ -46,12 +46,11 @@ describe('constructor', () => {
     assert.deepStrictEqual(profilingManager.config, t.nr.agent.config.profiling, 'should store agent config')
   })
 
-  test('should initialize empty profilers array', (t) => {
+  test('should initialize empty profilers map', (t) => {
     const { agent } = t.nr
     const profilingManager = new ProfilingManager(agent)
 
-    assert.ok(Array.isArray(profilingManager.profilers), 'profilers should be an array')
-    assert.strictEqual(profilingManager.profilers.length, 0, 'profilers array should be empty')
+    assert.strictEqual(profilingManager.profilers.size, 0, 'profilers map should be empty')
   })
 })
 
@@ -62,7 +61,23 @@ describe('register', () => {
 
     profilingManager.register()
 
-    assert.strictEqual(profilingManager.profilers.length, 0, 'should not add any profilers')
+    assert.strictEqual(profilingManager.profilers.size, 0, 'should not add any profilers')
+  })
+
+  test('should register the heap and cpu profilers only once', (t) => {
+    const { agent } = t.nr
+    const profilingManager = new ProfilingManager(agent)
+    profilingManager.config.include = ['heap']
+
+    profilingManager.register()
+    assert.strictEqual(profilingManager.profilers.size, 1, 'should only add heap profiler')
+    profilingManager.register()
+    assert.strictEqual(profilingManager.profilers.size, 1, 'should be a no-op')
+    profilingManager.config.include = ['heap', 'cpu']
+    profilingManager.register()
+    assert.strictEqual(profilingManager.profilers.size, 2, 'should only add cpu to the already registered profilers: heap')
+    profilingManager.register()
+    assert.strictEqual(profilingManager.profilers.size, 2, 'should be a no-op')
   })
 })
 
@@ -85,7 +100,8 @@ describe('start', () => {
   test('should start all registered profilers', (t) => {
     const { agent, cpuProfiler, heapProfiler, logger } = t.nr
     const profilingManager = new ProfilingManager(agent, { logger })
-    profilingManager.profilers = [cpuProfiler, heapProfiler]
+    profilingManager.profilers.set('cpu', cpuProfiler)
+    profilingManager.profilers.set('heap', heapProfiler)
     const started = profilingManager.start()
     assert.equal(started, true)
     assert.equal(cpuProfiler.start.callCount, 1)
@@ -118,7 +134,8 @@ describe('stop', () => {
   test('should stop all registered profilers', (t) => {
     const { agent, cpuProfiler, heapProfiler, logger } = t.nr
     const profilingManager = new ProfilingManager(agent, { logger })
-    profilingManager.profilers = [cpuProfiler, heapProfiler]
+    profilingManager.profilers.set('cpu', cpuProfiler)
+    profilingManager.profilers.set('heap', heapProfiler)
     profilingManager.stop()
 
     assert.equal(cpuProfiler.stop.callCount, 1)
@@ -151,7 +168,8 @@ describe('collect', (t) => {
     const expectedHeapData = { type: 'heap', data: Buffer.from('heap-profile-data') }
     cpuProfiler.collect.resolves(expectedCpuData)
     heapProfiler.collect.resolves(expectedHeapData)
-    profilingManager.profilers = [cpuProfiler, heapProfiler]
+    profilingManager.profilers.set('cpu', cpuProfiler)
+    profilingManager.profilers.set('heap', heapProfiler)
     const results = await profilingManager.collect()
     assert.equal(results.length, 2, 'should return array with two items')
     const [cpuData, heapData] = results
@@ -171,7 +189,8 @@ describe('collect', (t) => {
     const expectedHeapData = null
     cpuProfiler.collect.resolves(expectedCpuData)
     heapProfiler.collect.resolves(expectedHeapData)
-    profilingManager.profilers = [cpuProfiler, heapProfiler]
+    profilingManager.profilers.set('cpu', cpuProfiler)
+    profilingManager.profilers.set('heap', heapProfiler)
     const results = await profilingManager.collect()
     assert.equal(results.length, 2, 'should return array with two items')
     const [cpuData, heapData] = results

--- a/test/unit/lib/profiling/profilers/base.test.js
+++ b/test/unit/lib/profiling/profilers/base.test.js
@@ -19,12 +19,6 @@ test('should assign logger property', (t) => {
   assert.equal(profiler.logger, 'logger')
 })
 
-test('should set name', (t) => {
-  const { profiler } = t.nr
-  profiler.name = 'TestProfiler'
-  assert.equal(profiler.name, 'TestProfiler')
-})
-
 test('should throw error when start is called', (t) => {
   const { profiler } = t.nr
   assert.throws(() => {

--- a/test/unit/mocks/profiler.js
+++ b/test/unit/mocks/profiler.js
@@ -7,9 +7,8 @@
 const sinon = require('sinon')
 const DEFAULT_DATA = Buffer.from('test-data')
 
-function createProfiler({ sandbox = sinon, name = 'TestProfiler', data = DEFAULT_DATA } = {}) {
+function createProfiler({ sandbox = sinon, data = DEFAULT_DATA } = {}) {
   return {
-    name,
     start: sandbox.stub(),
     stop: sandbox.stub(),
     collect: sandbox.stub().resolves(data)


### PR DESCRIPTION
## Description

Adds server-side configuration for `profiling.enabled`. I had to change a few things around in the profiling manager. The profilers is now a Map, to avoid adding a profiler again when the profiling is re-enabled.  Now that the profilers is a map the name of the profiler is the key in the map, so i removed the name property from a profiler

## How to Test

```sh
npm run unit
```

## Related Issues
Closes #3721