### PR TITLE
feat: Disabled `profiling.enabled` when high security mode is enabled

### DIFF
--- a/lib/collector/remote-method.js
+++ b/lib/collector/remote-method.js
@@ -151,7 +151,8 @@ RemoteMethod.prototype._post = function _post(data, nrHeaders, callback) {
 
   // Check trace enabled first since we're creating an object for this log message.
   if (logger.traceEnabled()) {
-    logger.trace({ data, compressed: options.compressed }, 'Calling %s on collector API', this.name)
+    const logData = Buffer.isBuffer(data) ? 'Buffer ' + data.length : data
+    logger.trace({ data: logData, compressed: options.compressed }, 'Calling %s on collector API', this.name)
   }
 
   if (options.compressed) {

--- a/lib/config/hsm.js
+++ b/lib/config/hsm.js
@@ -58,6 +58,9 @@ const HIGH_SECURITY_SETTINGS = {
   },
   ai_monitoring: {
     enabled: false
+  },
+  profiling: {
+    enabled: false
   }
 }
 

--- a/test/unit/agent/agent.test.js
+++ b/test/unit/agent/agent.test.js
@@ -759,6 +759,7 @@ test('when connected', async (t) => {
     agent.config.transaction_tracer.enabled = enableAggregator
     agent.config.collect_errors = enableAggregator
     agent.config.error_collector.capture_events = enableAggregator
+    agent.config.profiling.enabled = enableAggregator
 
     const runId = 1122
     const config = { agent_run_id: runId }
@@ -801,6 +802,9 @@ test('when connected', async (t) => {
     collector.addHandler(helper.generateCollectorPath('error_event_data', runId), (req, res) => {
       res.json({ payload })
     })
+    collector.addHandler(helper.generateCollectorPath('pprof_data', runId), (req, res) => {
+      res.json({ payload })
+    })
   }
 
   await t.test('should force harvest of all aggregators 1 second after connect', (t, end) => {
@@ -827,6 +831,7 @@ test('when connected', async (t) => {
     const err = Error('test error')
     agent.errors.traceAggregator.add(err)
     agent.errors.eventAggregator.add(err)
+    agent.profilingData.pprofData = Buffer.from('data')
 
     agent.start((error) => {
       agent.forceHarvestAll(() => {
@@ -842,6 +847,7 @@ test('when connected', async (t) => {
         assert.equal(collector.isDone('custom_event_data'), true)
         assert.equal(collector.isDone('error_data'), true)
         assert.equal(collector.isDone('error_event_data'), true)
+        assert.equal(collector.isDone('pprof_data'), true)
         end()
       })
     })
@@ -873,6 +879,7 @@ test('when connected', async (t) => {
       const err = Error('test error')
       agent.errors.traceAggregator.add(err)
       agent.errors.eventAggregator.add(err)
+      agent.profilingData.pprofData = Buffer.from('data')
 
       agent.start((error) => {
         agent.forceHarvestAll(() => {
@@ -888,6 +895,7 @@ test('when connected', async (t) => {
           assert.equal(collector.isDone('custom_event_data'), false)
           assert.equal(collector.isDone('error_data'), false)
           assert.equal(collector.isDone('error_event_data'), false)
+          assert.equal(collector.isDone('pprof_data'), false)
           end()
         })
       })
@@ -914,6 +922,7 @@ test('when connected', async (t) => {
         assert.equal(collector.isDone('custom_event_data'), false)
         assert.equal(collector.isDone('error_data'), false)
         assert.equal(collector.isDone('error_event_data'), false)
+        assert.equal(collector.isDone('pprof_data'), false)
         end()
       })
     }

--- a/test/unit/high-security.test.js
+++ b/test/unit/high-security.test.js
@@ -79,7 +79,18 @@ test('conditional application of server side settings', async (t) => {
   await t.test('when high_security === true', async (t) => {
     t.beforeEach((ctx) => {
       ctx.nr = {}
-      ctx.nr.config = new Config({ high_security: true })
+      ctx.nr.config = new Config({
+        high_security: true,
+        ai_monitoring: {
+          enabled: true
+        },
+        application_logging: {
+          enabled: true
+        },
+        profiling: {
+          enabled: true
+        }
+      })
     })
 
     await t.test('should reject disabling ssl', (t) => {
@@ -143,6 +154,16 @@ test('conditional application of server side settings', async (t) => {
     await t.test('should disable application logging forwarding', (t) => {
       const { config } = t.nr
       checkServer(config, 'application_logging.forwarding.enabled', false, true)
+    })
+
+    await t.test('should disable ai monitoring', (t) => {
+      const { config } = t.nr
+      checkServer(config, 'ai_monitoring.enabled', false, true)
+    })
+
+    await t.test('should disable profiling', (t) => {
+      const { config } = t.nr
+      checkServer(config, 'profiling.enabled', false, true)
     })
   })
 


### PR DESCRIPTION
## Description

This disables profiling when high security mode is enabled.  I tested with staging account 10002850. Set profiling.enabled to true, and high_security to true. Verified it turns profiling.enabled to false and no profiling data is sent.  

## Related Issues
Closes #3789 