### PR TITLE
chore: Removed writing pprof to temp file

### DIFF
--- a/lib/profiling/index.js
+++ b/lib/profiling/index.js
@@ -5,15 +5,12 @@
 
 'use strict'
 const defaultLogger = require('#agentlib/logger.js').child({ component: 'profiling-manager' })
-const { mkdir, writeFile } = require('node:fs/promises')
-const { randomUUID } = require('node:crypto')
 
 class ProfilingManager {
   constructor(agent, { logger = defaultLogger } = {}) {
     this.logger = logger
     this.config = agent.config.profiling
     this.profilers = new Map()
-    this.outputDir = process.cwd() + '/profiler-data'
   }
 
   register() {
@@ -53,19 +50,6 @@ class ProfilingManager {
     }
   }
 
-  async writeFile({ pprofData, name }) {
-    if (this.config.debug) {
-      const fileName = `${this.outputDir}/${name}-${randomUUID()}.gz`
-      try {
-        this.logger.trace(`Writing ${name} pprof data to ${fileName}`)
-        await mkdir(this.outputDir, { recursive: true })
-        writeFile(fileName, pprofData)
-      } catch (err) {
-        this.logger.error(`Failed to write pprof data to ${fileName}: ${err.message}`)
-      }
-    }
-  }
-
   async collect() {
     const results = []
     if (this.profilers.size === 0) {
@@ -76,7 +60,6 @@ class ProfilingManager {
     for (const [name, profiler] of this.profilers) {
       this.logger.debug(`Collecting profiling data for ${name}`)
       const pprofData = await profiler.collect()
-      this.writeFile({ pprofData, name })
       results.push(pprofData)
     }
 


### PR DESCRIPTION

## Description

This PR removes some debug code we were using before the collector accepted writing `pprof_data`. This undocumented code serves no utility now as there is so much logic in the profiling consumer for decoding and creating the Profiling events stored in NRDB