### PR TITLE
test: Add `redis-client` and `node-redis-client` segment duration timing tests

### DIFF
--- a/test/versioned/redis/redis-v4-legacy-mode.test.js
+++ b/test/versioned/redis/redis-v4-legacy-mode.test.js
@@ -349,7 +349,7 @@ test('Redis instrumentation', async function (t) {
       assert.ok(waitSegment, 'trace segment for wait should exist')
       assert.equal(waitSegment.name, 'Datastore/operation/Redis/wait', 'should register the wait')
       assert.ok(waitSegment.timer.hrDuration, 'trace segment should have ended')
-      assert.ok(waitSegment.getDurationInMillis() > WAIT)
+      assert.ok(waitSegment.getDurationInMillis() >= WAIT)
     })
   })
 })

--- a/test/versioned/redis/redis-v4-promises.test.js
+++ b/test/versioned/redis/redis-v4-promises.test.js
@@ -287,7 +287,7 @@ test('should time segments accordingly', function (t, end) {
     assert.ok(waitSegment, 'trace segment for wait should exist')
     assert.equal(waitSegment.name, 'Datastore/operation/Redis/wait', 'should register the wait')
     assert.ok(waitSegment.timer.hrDuration, 'trace segment should have ended')
-    assert.ok(waitSegment.getDurationInMillis() > WAIT)
+    assert.ok(waitSegment.getDurationInMillis() >= WAIT)
 
     tx.end()
     end()

--- a/test/versioned/redis/redis-v4.test.js
+++ b/test/versioned/redis/redis-v4.test.js
@@ -387,7 +387,7 @@ test('Redis instrumentation', async function (t) {
       assert.ok(waitSegment, 'trace segment for wait should exist')
       assert.equal(waitSegment.name, 'Datastore/operation/Redis/wait', 'should register the wait')
       assert.ok(waitSegment.timer.hrDuration, 'trace segment should have ended')
-      assert.ok(waitSegment.getDurationInMillis() > WAIT)
+      assert.ok(waitSegment.getDurationInMillis() >= WAIT)
 
       tx.end()
       end()


### PR DESCRIPTION
## Description

Title

## How to Test

```
npm run versioned redis
```