### PR TITLE
refactor: Updated instances of `tracer.bindFunction` with `tracer.runInContext` to improve performance in hot paths

### DIFF
--- a/lib/context-manager/async-local-context-manager.js
+++ b/lib/context-manager/async-local-context-manager.js
@@ -53,14 +53,8 @@ class AsyncLocalContextManager {
    * @param {Array<*>} [args] Optional arguments object or args array to invoke the callback with.
    * @returns {*} Returns the value returned by the callback function.
    */
-  runInContext(context, callback, cbThis, args) {
-    const toInvoke = cbThis ? callback.bind(cbThis) : callback
-
-    if (args) {
-      return this._asyncLocalStorage.run(context, toInvoke, ...args)
-    }
-
-    return this._asyncLocalStorage.run(context, toInvoke)
+  runInContext(context, callback, cbThis, args = []) {
+    return this._asyncLocalStorage.run(context, Reflect.apply, callback, cbThis, args)
   }
 }
 

--- a/lib/instrumentation/core/http-outbound.js
+++ b/lib/instrumentation/core/http-outbound.js
@@ -289,7 +289,6 @@ function instrumentRequestEmit(agent, host, segment, request) {
   shimmer.wrapMethod(request, 'request.emit', 'emit', function wrapEmit(emit) {
     const context = agent.tracer.getContext()
     const newContext = context.enterSegment({ segment })
-    const boundEmit = agent.tracer.bindFunction(emit, newContext)
     return function wrappedRequestEmit(evnt, arg) {
       const transaction = agent.tracer.getTransaction()
       if (evnt === 'error') {
@@ -299,7 +298,7 @@ function instrumentRequestEmit(agent, host, segment, request) {
         handleResponse({ agent, segment, transaction, host, res: arg })
       }
 
-      return boundEmit.apply(this, arguments)
+      return agent.tracer.runInContext({ handler: emit, context: newContext, thisArg: this, args: arguments })
     }
   })
 
@@ -346,12 +345,11 @@ function handleResponse({ agent, segment, transaction, host, res }) {
   shimmer.wrapMethod(res, 'response', 'emit', function wrapEmit(emit) {
     const context = agent.tracer.getContext()
     const newContext = context.enterSegment({ segment })
-    const boundEmit = agent.tracer.bindFunction(emit, newContext)
     return function wrappedResponseEmit(evnt) {
       if (evnt === 'end') {
         segment.end()
       }
-      return boundEmit.apply(this, arguments)
+      return agent.tracer.runInContext({ handler: emit, context: newContext, thisArg: this, args: arguments })
     }
   })
   _makeNonEnumerable(res, 'emit')

--- a/lib/instrumentation/core/http.js
+++ b/lib/instrumentation/core/http.js
@@ -81,7 +81,7 @@ function wrapEmitWithTransaction(agent, emit, isHTTPS) {
     response.once('close', instrumentedFinish.bind(response, transaction))
 
     const newContext = context.enterSegment({ segment })
-    return tracer.bindFunction(emit, newContext).apply(this, arguments)
+    return tracer.runInContext({ handler: emit, context: newContext, thisArg: this, args: arguments })
   })
 }
 
@@ -368,11 +368,7 @@ module.exports = function initialize(agent, http, moduleName) {
 
         const args = agent.tracer.slice(arguments)
         const newContext = context.enterSegment({ segment })
-        if (typeof args[1] === 'function') {
-          args[1] = agent.tracer.bindFunction(args[1], newContext, true)
-        }
-
-        return agent.tracer.bindFunction(original, newContext, true).apply(this, args)
+        return agent.tracer.runInContext({ handler: original, context: newContext, full: true, thisArg: this, args })
       }
     }
   )

--- a/lib/instrumentation/core/http2.js
+++ b/lib/instrumentation/core/http2.js
@@ -94,7 +94,6 @@ function initialize(agent, http2, moduleName, shim) {
       const context = agent.tracer.getContext()
       const transaction = agent.tracer.getTransaction()
       const newContext = context.enterSegment({ segment })
-      const boundEmit = agent.tracer.bindFunction(emit, newContext)
 
       return function wrappedEmit(event, arg) {
         const isErrorEvent = ['error', 'frameError', 'timeout'].indexOf(event) > -1
@@ -106,7 +105,7 @@ function initialize(agent, http2, moduleName, shim) {
         if (isErrorEvent || event === 'end' || event === 'close') {
           segment.touch()
         }
-        return boundEmit.apply(this, arguments)
+        return agent.tracer.runInContext({ handler: emit, context: newContext, full: false, thisArg: this, args: arguments })
       }
     })
   }

--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -1249,7 +1249,7 @@ function applyContext({ func, context, full, boundThis, args, inContextCB }) {
     return fnApply.call(func, this, arguments)
   }
 
-  return this.tracer.bindFunction(runInContextCb, context, full).apply(boundThis, args)
+  return this.tracer.runInContext({ handler: runInContextCb, context, full, thisArg: boundThis, args })
 }
 
 /**

--- a/lib/subscribers/apollo-server/resolve.js
+++ b/lib/subscribers/apollo-server/resolve.js
@@ -44,7 +44,7 @@ module.exports = class ApolloResolveSubscriber extends BaseSubscriber {
     this.maybeCaptureFieldMetrics({ transaction, info, args: flattenedArgs })
 
     if (!this.config.apollo_server.scalars && !this.isTopLevelField(info) && this.isScalar(info)) {
-      return this.agent.tracer.bindFunction(origResolve, ctx).apply(thisArg, args)
+      return this.agent.tracer.runInContext({ handler: origResolve, context: ctx, thisArg, args })
     }
 
     const newCtx = this.createSegment({
@@ -84,7 +84,7 @@ module.exports = class ApolloResolveSubscriber extends BaseSubscriber {
       }
       // must bind a temporary function to get the resolver segment as the active segment
       // before possibly adding custom attributes
-      return this.agent.tracer.bindFunction(inContext, ctx, true).apply(thisArg, args)
+      return this.agent.tracer.runInContext({ handler: inContext, context: ctx, full: true, thisArg, args })
     } catch (err) {
       const error = err.originalError || err
       // must pass in resolverSegment as it is no longer in the context of the resolver

--- a/lib/subscribers/aws-sdk/middleware/bedrock/index.js
+++ b/lib/subscribers/aws-sdk/middleware/bedrock/index.js
@@ -31,7 +31,7 @@ function bedrockMiddleware(subscriber, _clientConfig, next, context) {
     return next
   }
 
-  return async function wrappedBedrockMw(args) {
+  return async function wrappedBedrockMw(...args) {
     const ctx = agent.tracer.getContext()
     const transaction = ctx?.transaction
     const parent = ctx?.segment
@@ -41,7 +41,7 @@ function bedrockMiddleware(subscriber, _clientConfig, next, context) {
       return next(args)
     }
 
-    const { input } = args
+    const [{ input }] = args
     const bedrockCommand = new BedrockCommand(input)
     const { modelType } = bedrockCommand
     const segmentName = `Llm/${modelType}/Bedrock/${commandName}`
@@ -50,7 +50,6 @@ function bedrockMiddleware(subscriber, _clientConfig, next, context) {
       name: segmentName,
       ctx
     })
-    const boundNext = agent.tracer.bindFunction(next, newCtx, true)
 
     const passThroughParams = {
       agent,
@@ -64,7 +63,7 @@ function bedrockMiddleware(subscriber, _clientConfig, next, context) {
     }
 
     try {
-      const result = await boundNext(args)
+      const result = await agent.tracer.runInContext({ handler: next, context: newCtx, full: true, thisArg: this, args })
       passThroughParams.response = result
       nrAfterHook(passThroughParams)
       return result

--- a/lib/subscribers/aws-sdk/middleware/dynamodb/index.js
+++ b/lib/subscribers/aws-sdk/middleware/dynamodb/index.js
@@ -52,7 +52,7 @@ function dynamoMiddleware(subscriber, config, next, context) {
   return async function nrDynamoMiddleware(...args) {
     const ctx = agent.tracer.getContext()
     if (!ctx.transaction || ctx.transaction.isActive() === false) {
-      return next(...args)
+      return next.apply(this, args)
     }
 
     let endpoint = null
@@ -78,8 +78,7 @@ function dynamoMiddleware(subscriber, config, next, context) {
       addDatastoreAttributes(segment, params, agent.config)
     }
 
-    const fn = agent.tracer.bindFunction(next, newCtx, true)
-    return fn(...args)
+    return agent.tracer.runInContext({ handler: next, context: newCtx, full: true, thisArg: this, args })
   }
 }
 

--- a/lib/subscribers/aws-sdk/middleware/nr-specific/attributes.js
+++ b/lib/subscribers/aws-sdk/middleware/nr-specific/attributes.js
@@ -25,7 +25,7 @@ module.exports = {
  */
 function middleware (subscriber, config, next, context) {
   const { logger } = subscriber
-  return async function wrappedAttrMw(args) {
+  return async function wrappedAttrMw(...args) {
     let region
     try {
       region = await config.region()
@@ -33,7 +33,7 @@ function middleware (subscriber, config, next, context) {
       logger.debug(err, 'Failed to get the AWS region')
     }
 
-    const result = await next(args)
+    const result = await next.apply(this, args)
 
     try {
       const { response } = result

--- a/lib/subscribers/aws-sdk/middleware/nr-specific/headers.js
+++ b/lib/subscribers/aws-sdk/middleware/nr-specific/headers.js
@@ -23,8 +23,8 @@ module.exports = {
  * @type {AwsSdkBoundMiddlewareFunction}
  */
 function middleware (subscriber, config, next) {
-  return async function wrappedHeaderMw(args) {
-    args.request.headers['x-new-relic-disable-dt'] = 'true'
-    return await next(args)
+  return async function wrappedHeaderMw(...args) {
+    args[0].request.headers['x-new-relic-disable-dt'] = 'true'
+    return next.apply(this, args)
   }
 }

--- a/lib/subscribers/aws-sdk/middleware/sns/index.js
+++ b/lib/subscribers/aws-sdk/middleware/sns/index.js
@@ -39,10 +39,10 @@ function snsMiddleware(subscriber, config, next, context) {
   }
 
   subscriber.opaque = true
-  return function nrSnsMiddleware(...args) {
+  return async function nrSnsMiddleware(...args) {
     const ctx = agent.tracer.getContext()
     if (!ctx.transaction || ctx.transaction.isActive() === false) {
-      return next(...args)
+      return next.apply(this, args)
     }
 
     const [command] = args
@@ -66,7 +66,6 @@ function snsMiddleware(subscriber, config, next, context) {
     })
     attachHeaders({ message: command.input, context: newCtx, subscriber })
 
-    const fn = agent.tracer.bindFunction(next, newCtx, true)
-    return fn(...args)
+    return agent.tracer.runInContext({ handler: next, context: newCtx, full: true, thisArg: this, args })
   }
 }

--- a/lib/subscribers/aws-sdk/middleware/sqs/index.js
+++ b/lib/subscribers/aws-sdk/middleware/sqs/index.js
@@ -50,7 +50,7 @@ function sqsMiddleware(subscriber, config, next, context) {
   return async function nrSqsMiddleware(...args) {
     const ctx = agent.tracer.getContext()
     if (!ctx.transaction || ctx.transaction.isActive() === false) {
-      return next(...args)
+      return next.apply(this, args)
     }
 
     const [command] = args
@@ -83,8 +83,7 @@ function sqsMiddleware(subscriber, config, next, context) {
     segment.addAttribute('cloud.account.id', accountId)
     segment.addAttribute('messaging.destination.name', queue)
 
-    const fn = agent.tracer.bindFunction(next, newCtx, true)
-    const response = await fn(...args)
+    const response = await agent.tracer.runInContext({ handler: next, context: newCtx, full: true, thisArg: this, args })
     if (mode === MessageBrokerDesc.BROKER_MODE_PRODUCE) {
       return response
     }

--- a/lib/subscribers/azure-functions/azure-handler-base.js
+++ b/lib/subscribers/azure-functions/azure-handler-base.js
@@ -48,7 +48,7 @@ module.exports = class AzureHandler {
   }
 
   runHandlerInContext({ originalHandler, ctx, thisArg, handlerArgs }) {
-    return this.agent.tracer.bindFunction(originalHandler, ctx).apply(thisArg, handlerArgs)
+    return this.agent.tracer.runInContext({ handler: originalHandler, context: ctx, thisArg, args: handlerArgs })
   }
 
   finalizeTransaction({ result, transaction }) {

--- a/lib/subscribers/azure-functions/http-handler.js
+++ b/lib/subscribers/azure-functions/http-handler.js
@@ -34,7 +34,7 @@ module.exports = class HttpHandler extends AzureHandler {
       return originalHandler.apply(this, arguments)
     }
 
-    return this.agent.tracer.bindFunction(inContext, ctx).apply(thisArg, handlerArgs)
+    return this.agent.tracer.runInContext({ handler: inContext, context: ctx, thisArg, args: handlerArgs })
   }
 
   finalizeTransaction({ result, transaction }) {

--- a/lib/subscribers/base.js
+++ b/lib/subscribers/base.js
@@ -169,14 +169,13 @@ class Subscriber {
     const orig = args[index][name]
     const self = this
     function wrapEmit(...emitArgs) {
-      const ctx = self.agent.tracer.getContext()
       const [evnt] = emitArgs
       if (evnt === 'end' || evnt === 'error') {
         ctx?.segment?.touch()
       }
-      return orig.apply(this, emitArgs)
+      return self.agent.tracer.runInContext({ handler: orig, context: ctx, full: false, thisArg: this, args: emitArgs })
     }
-    args[index][name] = this.agent.tracer.bindFunction(wrapEmit, ctx, false)
+    args[index][name] = wrapEmit
   }
 
   /**

--- a/lib/subscribers/bluebird/instrumentation.js
+++ b/lib/subscribers/bluebird/instrumentation.js
@@ -49,7 +49,7 @@ module.exports = class BluebirdPromiseSubscriber extends BaseSubscriber {
       args[0] = self.agent.tracer.bindFunction(didFulfill, ctx)
       args[1] = self.agent.tracer.bindFunction(didReject, ctx)
 
-      return self.agent.tracer.bindFunction(origThen, ctx).apply(this, args)
+      return self.agent.tracer.runInContext({ handler: origThen, context: ctx, thisArg: this, args })
     }
   }
 }

--- a/lib/subscribers/google-adk/agent-run-async.js
+++ b/lib/subscribers/google-adk/agent-run-async.js
@@ -69,8 +69,7 @@ module.exports = class GoogleAdkAgentRunSubscriber extends AiMonitoringSubscribe
       try {
         // Bind to the segment context so that child instrumentation
         // (e.g. Gemini) creates spans as children of this agent span.
-        const boundNext = self.agent.tracer.bindFunction(origNext, ctx)
-        const result = await boundNext.apply(this, args)
+        const result = await self.agent.tracer.runInContext({ handler: origNext, context: ctx, thisArg: this, args })
         if (result?.done) {
           self.#recordAgentEvent({ ctx, error: false })
         }

--- a/lib/subscribers/grpcjs/client.js
+++ b/lib/subscribers/grpcjs/client.js
@@ -89,7 +89,8 @@ module.exports = class GrpcClientSubscriber extends Subscriber {
     const agent = this.agent
     const [hostname, port] = authority.split(':')
 
-    nrListener.onReceiveStatus = function nrOnReceiveStatus(status) {
+    nrListener.onReceiveStatus = function nrOnReceiveStatus(...args) {
+      const [status] = args
       const { segment, transaction } = ctx
       const { code, details } = status
       segment.addAttribute('grpc.statusCode', code)
@@ -110,12 +111,7 @@ module.exports = class GrpcClientSubscriber extends Subscriber {
         path: method
       })
 
-      const boundFn = agent.tracer.bindFunction(
-        origListener.onReceiveStatus,
-        ctx,
-        true
-      )
-      boundFn(status)
+      return agent.tracer.runInContext({ handler: origListener.onReceiveStatus, context: ctx, thisArg: this, args, full: true })
     }
   }
 }

--- a/lib/subscribers/grpcjs/server.js
+++ b/lib/subscribers/grpcjs/server.js
@@ -70,7 +70,7 @@ module.exports = class GrpcServerSubscriber extends Subscriber {
         self.#instrumentEventListeners(transaction, call)
       }
 
-      return self.agent.tracer.bindFunction(handlerFn, ctx, true).apply(server, args)
+      return self.agent.tracer.runInContext({ handler: handlerFn, context: ctx, full: true, thisArg: server, args })
     }
 
     return ctx

--- a/lib/subscribers/kafkajs/client-constructor.js
+++ b/lib/subscribers/kafkajs/client-constructor.js
@@ -151,7 +151,7 @@ module.exports = class ConstructorSubscriber extends Subscriber {
         recorder: genericRecorder,
         ctx
       })
-      return self.agent.tracer.bindFunction(orig, ctx, true).apply(instance, args)
+      return self.agent.tracer.runInContext({ handler: orig, context: ctx, full: true, thisArg: instance, args })
     }
   }
 
@@ -213,7 +213,7 @@ module.exports = class ConstructorSubscriber extends Subscriber {
         }
       }
 
-      return self.agent.tracer.bindFunction(orig, ctx, true).apply(instance, args)
+      return self.agent.tracer.runInContext({ handler: orig, context: ctx, full: true, thisArg: instance, args })
     }
   }
 
@@ -288,7 +288,7 @@ module.exports = class ConstructorSubscriber extends Subscriber {
           data
         })
 
-        const ret = self.agent.tracer.bindFunction(orig, ctx, true).apply(instance, args)
+        const ret = self.agent.tracer.runInContext({ handler: orig, context: ctx, full: true, thisArg: instance, args })
         tools.handleResult(ret, ctx?.transaction)
       }
 
@@ -298,7 +298,7 @@ module.exports = class ConstructorSubscriber extends Subscriber {
       // out-of-band, like an incoming HTTP request, and so behave like a
       // server.
       const ctx = tools.initiateTransaction(self.agent)
-      return self.agent.tracer.bindFunction(handler, ctx, true).apply(instance, args)
+      return self.agent.tracer.runInContext({ handler, context: ctx, full: true, thisArg: instance, args })
     }
   }
 
@@ -327,7 +327,7 @@ module.exports = class ConstructorSubscriber extends Subscriber {
       if (!args?.[0]?.eachBatch) {
         // We don't have a callback to invoke for each response from the
         // Kafka server. Thus, we can simply run the function.
-        return self.agent.tracer.bindFunction(orig, ctx, true).apply(instance, args)
+        return self.agent.tracer.runInContext({ handler: orig, context: ctx, full: true, thisArg: instance, args })
       }
 
       // We have a callback that we need to wrap so that we can record
@@ -343,7 +343,7 @@ module.exports = class ConstructorSubscriber extends Subscriber {
         })
         return eachBatch.apply(instance, arguments)
       }
-      return self.agent.tracer.bindFunction(orig, ctx, true).apply(instance, args)
+      return self.agent.tracer.runInContext({ handler: orig, context: ctx, full: true, thisArg: instance, args })
     }
   }
 }

--- a/lib/subscribers/middleware-wrapper.js
+++ b/lib/subscribers/middleware-wrapper.js
@@ -105,7 +105,6 @@ class MiddlewareWrapper {
         return handler.apply(this, args)
       }
 
-      segment.start()
       self.logger.trace('Created segment %s, parent %s', segment?.name, parent?.name)
 
       if (self.config.code_level_metrics.enabled === true) {
@@ -117,7 +116,7 @@ class MiddlewareWrapper {
       self.wrapDoneHandler({ segment, ctx, args, handler, txInfo, route, nextIdx })
 
       try {
-        const result = self.agent.tracer.bindFunction(handler, newCtx, true).apply(this, args)
+        const result = self.agent.tracer.runInContext({ handler, context: newCtx, thisArg: this, args, full: true })
         if (result?.then) {
           return result.then(function onThen(val) {
             segment.touch()
@@ -207,18 +206,19 @@ class MiddlewareWrapper {
         }
 
         segment.touch()
-        return doneFn.apply(this, doneArgs)
+        // binding previous ctx as it should restore once this cb is executed
+        return self.agent.tracer.runInContext({ handler: doneFn, context: ctx, thisArg: this, args: doneArgs, full: false })
       }
+
       Object.defineProperties(wrappedDone, {
         name: { value: doneFn.name },
         length: { value: doneFn.length }
       })
-      // binding previous ctx as it should restore once this cb is executed
-      const bound = self.agent.tracer.bindFunction(wrappedDone, ctx, false)
+
       if (nextIdx === -1) {
-        args[args.length - 1] = bound
+        args[args.length - 1] = wrappedDone
       } else {
-        args[nextIdx] = bound
+        args[nextIdx] = wrappedDone
       }
     }
   }

--- a/lib/transaction/tracer/index.js
+++ b/lib/transaction/tracer/index.js
@@ -36,6 +36,7 @@ Tracer.prototype.addSegment = addSegment
 Tracer.prototype.transactionProxy = transactionProxy
 Tracer.prototype.transactionNestProxy = transactionNestProxy
 Tracer.prototype.bindFunction = bindFunction
+Tracer.prototype.runInContext = runInContext
 Tracer.prototype.bindEmitter = bindEmitter
 Tracer.prototype.getOriginal = getOriginal
 Tracer.prototype.slice = argSlice
@@ -192,7 +193,7 @@ function transactionProxy(handler) {
 
     const transaction = new Transaction(tracer.agent)
     const newContext = context.enterTransaction(transaction)
-    return tracer.bindFunction(handler, newContext, true).apply(this, arguments)
+    return tracer.runInContext({ handler, context: newContext, full: true, thisArg: this, args: arguments })
   }
 
   wrapped[symbols.original] = handler
@@ -243,7 +244,7 @@ function transactionNestProxy(type, handler) {
       context = context.enterTransaction(transaction)
     }
 
-    return tracer.bindFunction(handler, context).apply(this, arguments)
+    return tracer.runInContext({ handler, context, thisArg: this, args: arguments })
   }
 
   wrapped[symbols.original] = handler
@@ -273,10 +274,10 @@ function _makeWrapped({ tracer, handler, context, full }) {
 
     try {
       const result = tracer._contextManager.runInContext(context, handler, this, arguments)
-      _maybeBindPromise({ result, tracer, full, segment })
+      _maybeBindPromise({ result, full, segment })
       return result
     } catch (err) {
-      logger.trace(err, 'Error from wrapped function:')
+      logger.trace({ error: err }, 'Error from wrapped function:')
       throw err // Re-throwing application error, this is not an agent error.
     } finally {
       if (segment && full) {
@@ -302,6 +303,26 @@ function _maybeBindPromise({ result, full, segment }) {
     }, () => {
       segment.touch()
     })
+  }
+}
+
+function runInContext({ handler, context, full, thisArg, args }) {
+  const { segment } = context
+  if (segment && full) {
+    segment.start()
+  }
+
+  try {
+    const result = this._contextManager.runInContext(context, handler, thisArg, args)
+    _maybeBindPromise({ result, full, segment })
+    return result
+  } catch (err) {
+    logger.trace({ error: err }, 'Error from wrapped function:')
+    throw err // Re-throwing application error, this is not an agent error.
+  } finally {
+    if (segment && full) {
+      segment.touch()
+    }
   }
 }
 
@@ -415,7 +436,7 @@ function wrapFunctionLast(name, recorder, original) {
     })
     child.start()
     const newContext = context.enterSegment({ segment: child })
-    return tracer.bindFunction(original, newContext).apply(this, args)
+    return tracer.runInContext({ handler: original, context: newContext, thisArg: this, args })
   }
 }
 
@@ -457,7 +478,7 @@ function wrapFunctionFirst(name, recorder, original) {
     })
     child.start()
     const newContext = context.enterSegment({ segment: child })
-    return tracer.bindFunction(original, newContext).apply(this, args)
+    return tracer.runInContext({ handler: original, context: newContext, thisArg: this, args })
   }
 }
 
@@ -487,7 +508,7 @@ function wrapFunction(name, recorder, original, wrapper, resp) {
     const args = wrapper.call(this, child, tracer.slice(arguments), bind)
     child.start()
     const newContext = context.enterSegment({ segment: child })
-    let result = tracer.bindFunction(original, newContext).apply(this, args)
+    let result = tracer.runInContext({ handler: original, context: newContext, thisArg: this, args })
     if (resp) {
       result = resp.call(this, child, result, bind)
     }
@@ -531,7 +552,7 @@ function wrapSyncFunction(name, recorder, original) {
       child.async = false
     }
     const newContext = context.enterSegment({ segment: child })
-    return tracer.bindFunction(original, newContext, true).apply(this, arguments)
+    return tracer.runInContext({ handler: original, context: newContext, full: true, thisArg: this, args: arguments })
   }
 }
 
@@ -545,26 +566,24 @@ function wrapCallback(original, segment, wrapped) {
 
   logger.trace('Wrapping callback for "%s" segment', segment ? segment.name : 'unknown')
 
-  return tracer.bindFunction(
-    function wrappedCallback() {
-      if (wrapped) {
-        wrapped[symbols.original] = original
-      }
+  function wrappedCallback() {
+    if (wrapped) {
+      wrapped[symbols.original] = original
+    }
 
-      const child = tracer.createSegment({
-        name: 'Callback: ' + (original.name || 'anonymous'),
-        parent: segment,
-        transaction: context.transaction
-      })
+    const child = tracer.createSegment({
+      name: 'Callback: ' + (original.name || 'anonymous'),
+      parent: segment,
+      transaction: context.transaction
+    })
 
-      if (child) {
-        child.async = false
-      }
+    if (child) {
+      child.async = false
+    }
 
-      const newContext = context.enterSegment({ segment: child })
-      return tracer.bindFunction(wrapped || original, newContext, true).apply(this, arguments)
-    },
-    context,
-    false
-  )
+    const newContext = context.enterSegment({ segment: child })
+    return tracer.runInContext({ handler: wrapped || original, context: newContext, full: true, thisArg: this, args: arguments })
+  }
+
+  return tracer.bindFunction(wrappedCallback, context)
 }

--- a/test/benchmark/tracer/bindFunction-vs-runInContext.bench.js
+++ b/test/benchmark/tracer/bindFunction-vs-runInContext.bench.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const helper = require('#testlib/agent_helper.js')
+const shared = require('./shared')
+const assert = require('node:assert')
+
+const s = shared.makeSuite('runInContext')
+const suite = s.suite
+const tracer = helper.getTracer()
+
+const tx = helper.runInTransaction(s.agent, function (_tx) {
+  return _tx
+})
+tracer.setSegment({ transaction: tx, segment: tx.trace.root })
+const ctx = tracer.getContext()
+
+function handler(a, b, c) {
+  return a + b + c
+}
+
+const thisArg = {}
+const args = [1, 2, 3]
+
+function runBoundFunctionInContext(ctx, handler, thisArg, args) {
+  return tracer.bindFunction(handler, ctx, false).apply(thisArg, args)
+}
+
+function runFunctionInContext(ctx, handler, thisArg, args) {
+  return tracer.runInContext({ handler, context: ctx, thisArg, args })
+}
+
+// warmup
+for (let i = 0; i < 1000; ++i) {
+  runBoundFunctionInContext(ctx, handler, thisArg, args)
+  runFunctionInContext(ctx, handler, thisArg, args)
+}
+
+setTimeout(function () {
+  suite.add({
+    name: 'bindFunction with args',
+    fn: function () {
+      for (let i = 0; i < 1000; ++i) {
+        const result = runBoundFunctionInContext(ctx, handler, thisArg, args)
+        assert.equal(result, 6)
+      }
+    }
+  })
+
+  suite.add({
+    name: 'runInContext with args',
+    fn: function () {
+      for (let i = 0; i < 1000; ++i) {
+        const result = runFunctionInContext(ctx, handler, thisArg, args)
+        assert.equal(result, 6)
+      }
+    }
+  })
+
+  suite.run()
+}, 15)

--- a/test/versioned/aws-sdk-v3/sns.test.js
+++ b/test/versioned/aws-sdk-v3/sns.test.js
@@ -166,6 +166,7 @@ test('SNS', async (t) => {
       tx.end()
       plan.ok(res)
     })
+    await plan.completed
   })
 
   await t.test('attaches distributed trace headers when sending messages', async (t) => {


### PR DESCRIPTION
## Description

This takes work in #3809 and make it apply across the board. We had this `bindFunction` and most of the times we immediately called `.apply`. As the author of the link PR called out, this creates a lot of inefficiencies with v8.  I'm still trying to reproduce the actual issue in the linked PR. I set up an express app with a few mw and ran on 13.4.0, latest, and with this fix and I don't see any changes.
