### PR TITLE
test: Added `assertSegmentDuration` custom assertion and added it to `memcached` tests

### DIFF
--- a/test/lib/custom-assertions/assert-segment-duration.js
+++ b/test/lib/custom-assertions/assert-segment-duration.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/**
+ * Asserts that a segment ended at approximately the right time.
+ *
+ * Both measurements use `segment.timer.hrstart` as their reference point, so
+ * this primarily tests that the segment **ended** correctly, not that it
+ * **started** correctly. A segment that started late would still pass because
+ * both durations would be equally shorter. Testing the start requires an
+ * independent clock captured before the operation, but on constrained CI
+ * runners the diagnostics channel and subscriber overhead between that clock
+ * and `hrstart` is large enough to make any fixed threshold unreliable.
+ *
+ * Capture `actualTime` as the very first thing after the awaited operation —
+ * before any assertions, event lookups, or other work — to keep the
+ * measurement window as small as possible:
+ *
+ * @example
+ * // async/await pattern
+ * await someOperation()
+ * const [segment] = tx.trace.getChildren(tx.trace.root.id)
+ * const actualTime = process.hrtime(segment.timer.hrstart)
+ * assertSegmentDuration({ segment, actualTime })
+ * // ... other assertions ...
+ *
+ * @example
+ * // callback pattern
+ * const { segment } = await new Promise((resolve) => {
+ *   operation(function callback(err) {
+ *     resolve({ segment: agent.tracer.getSegment() })
+ *   })
+ * })
+ * const actualTime = process.hrtime(segment.timer.hrstart)
+ * assertSegmentDuration({ segment, actualTime })
+ *
+ * @example
+ * // streaming pattern
+ * await streamingOperation()
+ * const segment = metrics.findSegment(tx.trace, tx.trace.root, 'External/host/path')
+ * const actualTime = process.hrtime(segment.timer.hrstart)
+ * assertSegmentDuration({ segment, actualTime })
+ *
+ * @param {object} params function parameters
+ * @param {TraceSegment} params.segment segment to check
+ * @param {Array} params.actualTime process.hrtime() duration array [seconds, nanoseconds],
+ *   measured from segment.timer.hrstart as the reference point
+ * @param {number} [params.threshold] maximum allowed ratio difference between the
+ *   two measurements
+ * @param {object} [params.assert] assertion library to use
+ */
+module.exports = function assertSegmentDuration({
+  segment,
+  actualTime,
+  threshold = 0.20,
+  assert = require('node:assert')
+}) {
+  assert.equal(segment._isEnded(), true, 'segment should have ended')
+
+  const segmentDuration = segment.getDurationInMillis()
+  const actualDuration = actualTime[0] * 1e3 + actualTime[1] / 1e6
+
+  const maxDuration = Math.max(actualDuration, segmentDuration)
+  const diff = Math.abs(actualDuration - segmentDuration)
+  const ratio = maxDuration > 0 ? diff / maxDuration : 0
+
+  assert.ok(
+    ratio <= threshold,
+    `segment duration (${segmentDuration}ms) and actual duration (${actualDuration}ms) ` +
+    `differ by ${(ratio * 100).toFixed(1)}% which exceeds the ${threshold * 100}% threshold`
+  )
+}

--- a/test/versioned/memcached/memcached.test.js
+++ b/test/versioned/memcached/memcached.test.js
@@ -10,7 +10,7 @@ const assert = require('node:assert')
 const helper = require('../../lib/agent_helper')
 const params = require('../../lib/params')
 const { getMetricHostName } = require('../../lib/metrics_helper')
-const { assertPackageMetrics, assertMetrics, assertSegments, assertSpanKind } = require('../../lib/custom-assertions')
+const { assertPackageMetrics, assertMetrics, assertSegmentDuration, assertSegments, assertSpanKind } = require('../../lib/custom-assertions')
 
 test('memcached instrumentation', { timeout: 5000 }, async function (t) {
   await t.test('generates correct metrics and trace segments', async function (t) {
@@ -49,14 +49,14 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
 
       await helper.runInTransaction(agent, async function (transaction) {
         const { segment } = await new Promise((resolve) => {
-          const now = process.hrtime()
           memcached.touch('foo', 1, function (err) {
             assert.ok(!err, 'should not throw an error')
             assert.ok(agent.getTransaction(), 'transaction should still be visible')
-            const end = process.hrtime(now)
-            resolve({ segment: agent.tracer.getSegment(), actualTime: end })
+            resolve({ segment: agent.tracer.getSegment() })
           })
         })
+        const actualTime = process.hrtime(segment.timer.hrstart)
+        assertSegmentDuration({ segment, actualTime })
         assertSegmentState(segment, 'Datastore/operation/Memcache/touch')
 
         assertSegments(
@@ -95,14 +95,14 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
 
       await helper.runInTransaction(agent, async function (transaction) {
         const { segment } = await new Promise((resolve) => {
-          const now = process.hrtime()
           memcached.get('foo', function (err) {
             assert.ok(!err, 'should not throw an error')
             assert.ok(agent.getTransaction(), 'transaction should still be visible')
-            const end = process.hrtime(now)
-            resolve({ segment: agent.tracer.getSegment(), actualTime: end })
+            resolve({ segment: agent.tracer.getSegment() })
           })
         })
+        const actualTime = process.hrtime(segment.timer.hrstart)
+        assertSegmentDuration({ segment, actualTime })
         assertSegmentState(segment, 'Datastore/operation/Memcache/get')
 
         assertSegments(
@@ -135,14 +135,14 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
 
       await helper.runInTransaction(agent, async function (transaction) {
         const { segment } = await new Promise((resolve) => {
-          const now = process.hrtime()
           memcached.gets('foo', function (err) {
             assert.ok(!err, 'should not throw an error')
             assert.ok(agent.getTransaction(), 'transaction should still be visible')
-            const end = process.hrtime(now)
-            resolve({ segment: agent.tracer.getSegment(), actualTime: end })
+            resolve({ segment: agent.tracer.getSegment() })
           })
         })
+        const actualTime = process.hrtime(segment.timer.hrstart)
+        assertSegmentDuration({ segment, actualTime })
         assertSegmentState(segment, 'Datastore/operation/Memcache/gets')
 
         assertSegments(
@@ -175,14 +175,14 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
 
       await helper.runInTransaction(agent, async function (transaction) {
         const { segment } = await new Promise((resolve) => {
-          const now = process.hrtime()
           memcached.getMulti(['foo', 'bar'], function (err) {
             assert.ok(!err, 'should not throw an error')
             assert.ok(agent.getTransaction(), 'transaction should still be visible')
-            const end = process.hrtime(now)
-            resolve({ segment: agent.tracer.getSegment(), actualTime: end })
+            resolve({ segment: agent.tracer.getSegment() })
           })
         })
+        const actualTime = process.hrtime(segment.timer.hrstart)
+        assertSegmentDuration({ segment, actualTime })
         assertSegmentState(segment, 'Datastore/operation/Memcache/get')
 
         assertSegments(
@@ -215,14 +215,14 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
 
       await helper.runInTransaction(agent, async function (transaction) {
         const { segment } = await new Promise((resolve) => {
-          const now = process.hrtime()
           memcached.set('foo', 'bar', 10, function (err) {
             assert.ok(!err, 'should not throw an error')
             assert.ok(agent.getTransaction(), 'transaction should still be visible')
-            const end = process.hrtime(now)
-            resolve({ segment: agent.tracer.getSegment(), actualTime: end })
+            resolve({ segment: agent.tracer.getSegment() })
           })
         })
+        const actualTime = process.hrtime(segment.timer.hrstart)
+        assertSegmentDuration({ segment, actualTime })
         assertSegmentState(segment, 'Datastore/operation/Memcache/set')
 
         assertSegments(
@@ -259,14 +259,14 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
 
       await helper.runInTransaction(agent, async function (transaction) {
         const { segment } = await new Promise((resolve) => {
-          const now = process.hrtime()
           memcached.replace('foo', 'new', 10, function (err) {
             assert.ok(!err, 'should not throw an error')
             assert.ok(agent.getTransaction(), 'transaction should still be visible')
-            const end = process.hrtime(now)
-            resolve({ segment: agent.tracer.getSegment(), actualTime: end })
+            resolve({ segment: agent.tracer.getSegment() })
           })
         })
+        const actualTime = process.hrtime(segment.timer.hrstart)
+        assertSegmentDuration({ segment, actualTime })
         assertSegmentState(segment, 'Datastore/operation/Memcache/replace')
 
         assertSegments(
@@ -299,14 +299,14 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
 
       await helper.runInTransaction(agent, async function (transaction) {
         const { segment } = await new Promise((resolve) => {
-          const now = process.hrtime()
           memcached.add('foo', 'bar', 10, function (err) {
             assert.ok(!err, 'should not throw an error')
             assert.ok(agent.getTransaction(), 'transaction should still be visible')
-            const end = process.hrtime(now)
-            resolve({ segment: agent.tracer.getSegment(), actualTime: end })
+            resolve({ segment: agent.tracer.getSegment() })
           })
         })
+        const actualTime = process.hrtime(segment.timer.hrstart)
+        assertSegmentDuration({ segment, actualTime })
         assertSegmentState(segment, 'Datastore/operation/Memcache/add')
 
         assertSegments(
@@ -347,14 +347,14 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
 
       await helper.runInTransaction(agent, async function (transaction) {
         const { segment } = await new Promise((resolve) => {
-          const now = process.hrtime()
           memcached.cas('foo', 'bar', data.cas, 10, function (err) {
             assert.ok(!err, 'should not throw an error')
             assert.ok(agent.getTransaction(), 'transaction should still be visible')
-            const end = process.hrtime(now)
-            resolve({ segment: agent.tracer.getSegment(), actualTime: end })
+            resolve({ segment: agent.tracer.getSegment() })
           })
         })
+        const actualTime = process.hrtime(segment.timer.hrstart)
+        assertSegmentDuration({ segment, actualTime })
         assertSegmentState(segment, 'Datastore/operation/Memcache/cas')
 
         assertSegments(
@@ -391,14 +391,14 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
 
       await helper.runInTransaction(agent, async function (transaction) {
         const { segment } = await new Promise((resolve) => {
-          const now = process.hrtime()
           memcached.append('foo', 'bar', function (err) {
             assert.ok(!err)
             assert.ok(agent.getTransaction(), 'transaction should still be visible')
-            const end = process.hrtime(now)
-            resolve({ segment: agent.tracer.getSegment(), actualTime: end })
+            resolve({ segment: agent.tracer.getSegment() })
           })
         })
+        const actualTime = process.hrtime(segment.timer.hrstart)
+        assertSegmentDuration({ segment, actualTime })
         assertSegmentState(segment, 'Datastore/operation/Memcache/append')
 
         assertSegments(
@@ -434,14 +434,14 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
 
       await helper.runInTransaction(agent, async function (transaction) {
         const { segment } = await new Promise((resolve) => {
-          const now = process.hrtime()
           memcached.prepend('foo', 'bar', function (err) {
             assert.ok(!err)
             assert.ok(agent.getTransaction(), 'transaction should still be visible')
-            const end = process.hrtime(now)
-            resolve({ segment: agent.tracer.getSegment(), actualTime: end })
+            resolve({ segment: agent.tracer.getSegment() })
           })
         })
+        const actualTime = process.hrtime(segment.timer.hrstart)
+        assertSegmentDuration({ segment, actualTime })
         assertSegmentState(segment, 'Datastore/operation/Memcache/prepend')
 
         assertSegments(
@@ -478,14 +478,14 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
 
       await helper.runInTransaction(agent, async function (transaction) {
         const { segment } = await new Promise((resolve) => {
-          const now = process.hrtime()
           memcached.del('foo', function (err) {
             assert.ok(!err)
             assert.ok(agent.getTransaction(), 'transaction should still be visible')
-            const end = process.hrtime(now)
-            resolve({ segment: agent.tracer.getSegment(), actualTime: end })
+            resolve({ segment: agent.tracer.getSegment() })
           })
         })
+        const actualTime = process.hrtime(segment.timer.hrstart)
+        assertSegmentDuration({ segment, actualTime })
         assertSegmentState(segment, 'Datastore/operation/Memcache/delete')
 
         assertSegments(
@@ -518,14 +518,14 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
 
       await helper.runInTransaction(agent, async function (transaction) {
         const { segment } = await new Promise((resolve) => {
-          const now = process.hrtime()
           memcached.incr('foo', 10, function (err) {
             assert.ok(!err, 'should not throw an error')
             assert.ok(agent.getTransaction(), 'transaction should still be visible')
-            const end = process.hrtime(now)
-            resolve({ segment: agent.tracer.getSegment(), actualTime: end })
+            resolve({ segment: agent.tracer.getSegment() })
           })
         })
+        const actualTime = process.hrtime(segment.timer.hrstart)
+        assertSegmentDuration({ segment, actualTime })
         assertSegmentState(segment, 'Datastore/operation/Memcache/incr')
 
         assertSegments(
@@ -558,14 +558,14 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
 
       await helper.runInTransaction(agent, async function (transaction) {
         const { segment } = await new Promise((resolve) => {
-          const now = process.hrtime()
           memcached.decr('foo', 10, function (err) {
             assert.ok(!err, 'should not throw an error')
             assert.ok(agent.getTransaction(), 'transaction should still be visible')
-            const end = process.hrtime(now)
-            resolve({ segment: agent.tracer.getSegment(), actualTime: end })
+            resolve({ segment: agent.tracer.getSegment() })
           })
         })
+        const actualTime = process.hrtime(segment.timer.hrstart)
+        assertSegmentDuration({ segment, actualTime })
         assertSegmentState(segment, 'Datastore/operation/Memcache/decr')
 
         assertSegments(
@@ -598,15 +598,15 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
 
       await helper.runInTransaction(agent, async function (transaction) {
         const { segment } = await new Promise((resolve) => {
-          const now = process.hrtime()
           memcached.version(function (err, ok) {
             assert.ok(!err, 'should not throw an error')
             assert.ok(ok, 'got a version')
             assert.ok(agent.getTransaction(), 'transaction should still be visible')
-            const end = process.hrtime(now)
-            resolve({ segment: agent.tracer.getSegment(), actualTime: end })
+            resolve({ segment: agent.tracer.getSegment() })
           })
         })
+        const actualTime = process.hrtime(segment.timer.hrstart)
+        assertSegmentDuration({ segment, actualTime })
         assertSegmentState(segment, 'Datastore/operation/Memcache/version')
 
         assertSegments(


### PR DESCRIPTION
## Description


As we migrate our instrumentation to use the tracing channel subscribers, we need a way to be able to check if our segment durations are expected (e.g. not ending immediately). However, previous attempts have been extremely flaky because our CI has much more constrained environments vs our PCs running locally. 

This PR adds a new custom assertion, `assertSegmentDuration` and adds it to just `memcached` for now.

The `actualTime` and the segment's duration time both have `segment.timer.hrstart` as thier starting point because there could be some time elapsed between test code and the subscriber calling `timer.begin()`. This means that this assertion primarily tests that the segment **ended** correctly, not that it started correctly. 

## How to Test

```
npm run versioned memcached
```

## Related Issues

Closes #3862