### PR TITLE
fix: resolve #506 — Don't collect data for ignored transactions

### DIFF
--- a/lib/instrumentation/descriptor.js
+++ b/lib/instrumentation/descriptor.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const UNKNOWN = 'Unknown'
+
+function getWrapper(shim, original, name, descriptor) {
+  const wrapped = shim.wrap(original, function wrapOriginal(shim, original, name, args) {
+    const transaction = shim.getActiveTransaction()
+    if (transaction && transaction.ignored) {
+      return original.apply(this, args)
+    }
+
+    let segment
+    const parameters = descriptor.parameters || null
+    const callback = shim.normalizeIndex(args.length - 1, args)
+    if (shim.isFunction(callback) && !shim.isWrapped(callback)) {
+      segment = shim.createSegment(name, descriptor.recorder, parameters)
+      if (segment) {
+        segment.start()
+        args[callback.index] = shim.bindSegment(callback, segment, true)
+      }
+    } else if (descriptor.callback) {
+      segment = shim.createSegment(name, descriptor.recorder, parameters)
+      if (segment) {
+        segment.start()
+      }
+    } else {
+      segment = shim.createSegment(name, descriptor.recorder, parameters)
+      if (segment) {
+        segment.async = false
+      }
+    }
+
+    let result
+    try {
+      result = original.apply(this, args)
+    } catch (err) {
+      if (segment) {
+        segment.end()
+      }
+      throw err
+    }
+
+    if (segment && segment.async !== false) {
+      shim.logger.trace('Created segment %s but did not end it.', name)
+    } else if (segment) {
+      segment.end()
+    }
+
+    return result
+  })
+
+  wrapped.__NR_original = original
+  return wrapped
+}
+
+module.exports = {
+  UNKNOWN,
+  getWrapper
+}

--- a/lib/metrics/recorder.js
+++ b/lib/metrics/recorder.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const NAMES = require('./names')
+
+function recordMetric(transaction, name, value) {
+  if (transaction.ignore) {
+    return
+  }
+  transaction.metrics.getOrCreateMetric(name).recordValue(value)
+}
+
+function recordMetrics(transaction, metrics) {
+  if (transaction.ignore) {
+    return
+  }
+  for (let i = 0; i < metrics.length; ++i) {
+    const metric = metrics[i]
+    transaction.metrics.getOrCreateMetric(metric[0]).recordValue(metric[1])
+  }
+}
+
+function recordValue(transaction, name, value) {
+  if (transaction.ignore) {
+    return
+  }
+  transaction.metrics.getOrCreateMetric(name).recordValue(value)
+}
+
+function recordValues(transaction, name, values) {
+  if (transaction.ignore) {
+    return
+  }
+  const metric = transaction.metrics.getOrCreateMetric(name)
+  for (let i = 0; i < values.length; ++i) {
+    metric.recordValue(values[i])
+  }
+}
+
+function recordOnce(transaction, name, value) {
+  if (transaction.ignore) {
+    return
+  }
+  const metric = transaction.metrics.getOrCreateMetric(name)
+  if (metric.callCount === 0) {
+    metric.recordValue(value)
+  }
+}
+
+function recordMilliseconds(transaction, name, ms) {
+  if (transaction.ignore) {
+    return
+  }
+  transaction.metrics.getOrCreateMetric(name).recordValue(ms)
+}
+
+module.exports = {
+  recordMetric,
+  recordMetrics,
+  recordValue,
+  recordValues,
+  recordOnce,
+  recordMilliseconds
+}


### PR DESCRIPTION
## Summary

fix: resolve #506 — Don't collect data for ignored transactions

## Problem

**Severity**: `Medium` | **File**: `lib/instrumentation/descriptor.js`

When a transaction is ignored, instrumentation descriptors should not record data. Add checks in the instrumentation layer to avoid creating segments and recording timing data when the active transaction is ignored.

## Solution

In methods that create segments or record instrumentation data, check if the active transaction exists and is ignored. If so, skip creating the segment and instead just execute the wrapped function without the overhead of segment creation and timing.

## Changes

- `lib/instrumentation/descriptor.js` (new)
- `lib/metrics/recorder.js` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v5.15.0*