### PR TITLE
refactor: Moved generic AWS `Client` middleware to subscriber

### DIFF
--- a/lib/instrumentation/aws-sdk/v3/smithy-client.js
+++ b/lib/instrumentation/aws-sdk/v3/smithy-client.js
@@ -12,7 +12,6 @@ const { lambdaMiddlewareConfig } = require('./lambda')
 const MIDDLEWARE = Symbol('nrMiddleware')
 
 const middlewareByClient = {
-  Client: middlewareConfig,
   Lambda: [...middlewareConfig, lambdaMiddlewareConfig],
   SQS: [...middlewareConfig, sqsMiddlewareConfig],
   DynamoDB: [...middlewareConfig, ...dynamoMiddlewareConfig],
@@ -27,14 +26,6 @@ module.exports = function instrumentSmithyClient(shim, smithyClientExport) {
   }
 }
 
-// Clients handled by subscriber-based instrumentation in
-// lib/subscribers/smithy-client/send.js. Skip them here to avoid
-// double middleware registration during the migration.
-const subscriberHandledClients = new Set([
-  'BedrockRuntime',
-  'SNS'
-])
-
 function wrapSend(shim, send) {
   return function wrappedSend() {
     // most clients we want to instrument aside from smithy-client
@@ -43,12 +34,15 @@ function wrapSend(shim, send) {
     const client = this.constructor.name.replace(/Client$/, '')
     shim.logger.trace('Sending with client %s', client)
 
-    if (subscriberHandledClients.has(client)) {
+    // Common middleware (headers, attributes) is now handled by the subscriber
+    // in lib/subscribers/aws-sdk/send.js for ALL clients. This shim only
+    // registers service-specific middleware for clients not yet migrated.
+    const middlewares = middlewareByClient[client]
+    if (!middlewares) {
       return send.apply(this, arguments)
     }
 
     const config = this.config
-    const middlewares = middlewareByClient[client] || middlewareByClient.Client
 
     // only attach the middleware to the stack instance once
     // We just assign a symbol indicating this application

--- a/lib/subscribers/aws-sdk/send.js
+++ b/lib/subscribers/aws-sdk/send.js
@@ -6,11 +6,11 @@
 
 const Subscriber = require('../base')
 const nrMiddleware = require('./middleware/nr-specific/index.js')
-
 const MIDDLEWARE = Symbol('nrMiddleware')
 
 // Service-specific middleware by client name
 const middlewareByClient = {
+  Client: nrMiddleware,
   BedrockRuntime: [...nrMiddleware, require('./middleware/bedrock/index.js')],
   SNS: [...nrMiddleware, require('./middleware/sns/index.js')]
 }
@@ -37,12 +37,9 @@ module.exports = class SmithyClientSendSubscriber extends Subscriber {
     const clientName = client.constructor.name.replace(/Client$/, '')
 
     // Only handle clients that have subscriber-based middleware.
-    // Other clients (SNS, SQS, DynamoDB, Lambda, etc.) are still handled
+    // Other clients not in the `middlewareByClient` list are still handled
     // by the shim-based instrumentation in lib/instrumentation/aws-sdk/v3/smithy-client.js.
-    const middlewares = middlewareByClient[clientName]
-    if (!middlewares) {
-      return ctx
-    }
+    const middlewares = middlewareByClient[clientName] || nrMiddleware
     this.logger.trace('Sending with client %s', clientName)
 
     // Only attach middleware to a client instance once.

--- a/lib/subscribers/aws-sdk/send.js
+++ b/lib/subscribers/aws-sdk/send.js
@@ -10,7 +10,6 @@ const MIDDLEWARE = Symbol('nrMiddleware')
 
 // Service-specific middleware by client name
 const middlewareByClient = {
-  Client: nrMiddleware,
   BedrockRuntime: [...nrMiddleware, require('./middleware/bedrock/index.js')],
   SNS: [...nrMiddleware, require('./middleware/sns/index.js')]
 }
@@ -36,9 +35,8 @@ module.exports = class SmithyClientSendSubscriber extends Subscriber {
     const { self: client } = data
     const clientName = client.constructor.name.replace(/Client$/, '')
 
-    // Only handle clients that have subscriber-based middleware.
-    // Other clients not in the `middlewareByClient` list are still handled
-    // by the shim-based instrumentation in lib/instrumentation/aws-sdk/v3/smithy-client.js.
+    // Clients not in `middlewareByClient` (e.g. APIGateway, S3) fall back
+    // to the common nrMiddleware for basic header/attribute instrumentation.
     const middlewares = middlewareByClient[clientName] || nrMiddleware
     this.logger.trace('Sending with client %s', clientName)
 


### PR DESCRIPTION

## Description

This PR moves the generic AWS `Client` middleware to the subscriber-based instrumentation. This middleware is used for services like `elasticache`, `s3`, etc.

Now the old shim only runs for Lambda, SQS, DynamoDB, and DynamoDBDocument — everything else passes through to `send.apply()` and the subscriber handles the common middleware. As we migrate these remaining services to the subscriber, we'll just remove them from `lib/instrumentation/aws-sdk/v3/smithy-client.js`'s `middlewareByClient` instead of updating two places.

## How to Test

```
npm run versioned aws-sdk-v3
```

## Related Issues

Closes #3888 