### PR TITLE
refactor: Updated Lambda instrumentation to a subscriber middleware

### DIFF
--- a/lib/instrumentation/aws-sdk/v3/smithy-client.js
+++ b/lib/instrumentation/aws-sdk/v3/smithy-client.js
@@ -8,11 +8,9 @@
 const { middlewareConfig } = require('./common')
 const { sqsMiddlewareConfig } = require('./sqs')
 const { dynamoMiddlewareConfig } = require('./dynamodb')
-const { lambdaMiddlewareConfig } = require('./lambda')
 const MIDDLEWARE = Symbol('nrMiddleware')
 
 const middlewareByClient = {
-  Lambda: [...middlewareConfig, lambdaMiddlewareConfig],
   SQS: [...middlewareConfig, sqsMiddlewareConfig],
   DynamoDB: [...middlewareConfig, ...dynamoMiddlewareConfig],
   DynamoDBDocument: [...middlewareConfig, ...dynamoMiddlewareConfig]

--- a/lib/subscribers/aws-sdk/middleware/lambda/index.js
+++ b/lib/subscribers/aws-sdk/middleware/lambda/index.js
@@ -4,27 +4,27 @@
  */
 
 'use strict'
-const InstrumentationDescriptor = require('../../../instrumentation-descriptor')
 
 /**
  * Defines a deserialize middleware to add the
  * cloud.resource_id segment attributes for the AWS command
  *
- * @param {Shim} shim New Relic agent shim
+ * @param {Subscriber} subscriber instance of subscriber
  * @param {object} config AWS command configuration
  * @param {Function} next next function in middleware chain
  * @returns {Function} wrapped version of middleware function
  */
-function resourceIdMiddleware(shim, config, next) {
+function resourceIdMiddleware(subscriber, config, next) {
+  const { logger } = subscriber
+  // We can't derive account ID, so we have to consume it from config
+  const accountId = subscriber.config.cloud.aws.account_id
   return async function wrappedResourceIdMiddleware(args) {
     let result
     try {
       const region = await config.region()
       result = await next(args)
       const { response } = result
-      const segment = shim.getSegment(response.body.req)
-      // We can't derive account ID, so we have to consume it from config
-      const accountId = shim.agent.config.cloud.aws.account_id
+      const segment = subscriber.getSegment(response.body.req)
       const functionName = args?.input?.FunctionName // have to get function from params
       if (accountId && functionName) {
         segment.addAttribute(
@@ -34,23 +34,18 @@ function resourceIdMiddleware(shim, config, next) {
         segment.addAttribute('cloud.platform', 'aws_lambda')
       }
     } catch (err) {
-      shim.logger.debug(err, 'Failed to add AWS cloud resource id to segment')
+      logger.debug(err, 'Failed to add AWS cloud resource id to segment')
     }
     return result
   }
 }
 
-const lambdaMiddlewareConfig = {
-  middleware: resourceIdMiddleware,
-  type: InstrumentationDescriptor.TYPE_GENERIC,
+module.exports = {
+  fn: resourceIdMiddleware,
   config: {
     name: 'NewRelicGetResourceId',
     step: 'deserialize',
     priority: 'low',
     override: true
   }
-}
-
-module.exports = {
-  lambdaMiddlewareConfig
 }

--- a/lib/subscribers/aws-sdk/middleware/lambda/index.js
+++ b/lib/subscribers/aws-sdk/middleware/lambda/index.js
@@ -9,10 +9,7 @@
  * Defines a deserialize middleware to add the
  * cloud.resource_id segment attributes for the AWS command
  *
- * @param {Subscriber} subscriber instance of subscriber
- * @param {object} config AWS command configuration
- * @param {Function} next next function in middleware chain
- * @returns {Function} wrapped version of middleware function
+ * @type {AwsSdkBoundMiddlewareFunction}
  */
 function resourceIdMiddleware(subscriber, config, next) {
   const { logger } = subscriber

--- a/lib/subscribers/aws-sdk/middleware/nr-specific/attributes.js
+++ b/lib/subscribers/aws-sdk/middleware/nr-specific/attributes.js
@@ -5,7 +5,6 @@
 
 'use strict'
 
-const { segment: SYM_SEGMENT } = require('#agentlib/symbols.js')
 const UNKNOWN = 'Unknown'
 
 module.exports = {
@@ -25,7 +24,7 @@ module.exports = {
  * @type {AwsSdkBoundMiddlewareFunction}
  */
 function middleware (subscriber, config, next, context) {
-  const { agent, logger } = subscriber
+  const { logger } = subscriber
   return async function wrappedAttrMw(args) {
     let region
     try {
@@ -38,13 +37,7 @@ function middleware (subscriber, config, next, context) {
 
     try {
       const { response } = result
-      // When some instrumentations, e.g. the SNS one, do not instrument
-      // specific execution paths, there should be an active segment attached to
-      // the HTTP request that was added by the `http` instrumentation. If that
-      // is the case, utilize that segment to attach the attributes. Otherwise,
-      // utilize the current segment by way of the current context.
-      const segment = response.body.req[SYM_SEGMENT] ||
-        agent.tracer.getContext().segment
+      const segment = subscriber.getSegment(response.body.req)
       segment.addAttribute('aws.operation', context.commandName || UNKNOWN)
       segment.addAttribute('aws.requestId', response.headers['x-amzn-requestid'] || UNKNOWN)
       segment.addAttribute('aws.service', config.serviceId || UNKNOWN)

--- a/lib/subscribers/aws-sdk/send.js
+++ b/lib/subscribers/aws-sdk/send.js
@@ -23,7 +23,6 @@ const legacyClients = new Set([
   'DynamoDBDocument'
 ])
 
-
 /**
  * Subscriber for `@smithy/smithy-client` `Client.send()` calls. Registers
  * common AWS middleware (DT header suppression, response attributes) and

--- a/lib/subscribers/aws-sdk/send.js
+++ b/lib/subscribers/aws-sdk/send.js
@@ -6,13 +6,23 @@
 
 const Subscriber = require('../base')
 const nrMiddleware = require('./middleware/nr-specific/index.js')
+const { segment: SYM_SEGMENT } = require('#agentlib/symbols.js')
 const MIDDLEWARE = Symbol('nrMiddleware')
 
 // Service-specific middleware by client name
 const middlewareByClient = {
   BedrockRuntime: [...nrMiddleware, require('./middleware/bedrock/index.js')],
+  Lambda: [...nrMiddleware, require('./middleware/lambda/index.js')],
   SNS: [...nrMiddleware, require('./middleware/sns/index.js')]
 }
+
+// clients handled by legacy instrumentation from lib/instrumentation/aws-sdk/v3
+const legacyClients = new Set([
+  'SQS',
+  'DynamoDB',
+  'DynamoDBDocument'
+])
+
 
 /**
  * Subscriber for `@smithy/smithy-client` `Client.send()` calls. Registers
@@ -34,6 +44,11 @@ module.exports = class SmithyClientSendSubscriber extends Subscriber {
   handler(data, ctx) {
     const { self: client } = data
     const clientName = client.constructor.name.replace(/Client$/, '')
+
+    // remove once we migrate all legacy middleware
+    if (legacyClients.has(clientName)) {
+      return ctx
+    }
 
     // Clients not in `middlewareByClient` (e.g. APIGateway, S3) fall back
     // to the common nrMiddleware for basic header/attribute instrumentation.
@@ -60,6 +75,20 @@ module.exports = class SmithyClientSendSubscriber extends Subscriber {
     }
 
     return ctx
+  }
+
+  /**
+   * When some instrumentations, e.g. the SNS one, do not instrument
+   * specific execution paths, there should be an active segment attached to
+   * the HTTP request that was added by the `http` instrumentation. If that
+   * is the case, utilize that segment to attach the attributes. Otherwise,
+   * utilize the current segment by way of the current context.
+   *
+   * @param {IncomingMessage} req http request to possibly pull segment from symbol
+   * @returns {TraceSegment|null} active segment
+   */
+  getSegment(req) {
+    return req[SYM_SEGMENT] || this.agent.tracer.getContext().segment
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Migrates lambda instrumentation to middleware of subscriber. I also added a `getSegment` method on the smithy client subscriber which pulls the segment from the symbol on request or context manager. This is used in at least 2 places now and wanted to centralize it.

## How to Test

```sh
npm run versioned:internal aws-sdk-v3
```

## Related Issues
Closes #3840
