### PR TITLE
chore: Updated Undici tests to cover version 8

### DIFF
--- a/test/versioned/undici/package.json
+++ b/test/versioned/undici/package.json
@@ -9,7 +9,19 @@
         "node": ">=20"
       },
       "dependencies": {
-        "undici": ">=5.0.0"
+        "undici": ">=5.0.0 <8.0.0"
+      },
+      "files": [
+        "requests.test.js"
+      ]
+    },
+
+    {
+      "engines": {
+        "node": ">=22"
+      },
+      "dependencies": {
+        "undici": ">=8.0.0"
       },
       "files": [
         "requests.test.js"


### PR DESCRIPTION
This PR updates the versioned tests configuration for `undici` such that it is run on the correct Node.js + `undici` versions.

Related: https://github.com/nodejs/undici/issues/5024