### PR TITLE
chore: Fix `minAgentVersion` for Anthropic versioned tests

### DIFF
--- a/test/versioned/anthropic-sdk/package.json
+++ b/test/versioned/anthropic-sdk/package.json
@@ -3,7 +3,7 @@
   "targets": [
     {
       "name": "@anthropic-ai/sdk",
-      "minAgentVersion": "13.18.0"
+      "minAgentVersion": "13.19.0"
     }
   ],
   "version": "0.0.0",


### PR DESCRIPTION
Changed `minAgentVersion` in `test/versioned/anthropic-sdk/package.json` to reflect the actual agent version the instrumentation was released, which is `13.19.0`.