### PR TITLE
Security: Potential prototype pollution when merging remote configuration objects

### DIFF
--- a/lib/config/merge-server-config.js
+++ b/lib/config/merge-server-config.js
@@ -42,6 +42,10 @@ class MergeServerConfig {
   updateObject(value, local, localKey) {
     // go through each key of the object and update it
     for (const element of Object.keys(value)) {
+      if (element === '__proto__' || element === 'constructor' || element === 'prototype') {
+        continue
+      }
+
       if (Array.isArray(local[localKey][element]) && Array.isArray(value[element])) {
         // if both key-values are arrays, push the remote value onto the local array
         for (const elementValue of value[element]) {


### PR DESCRIPTION
## Summary

Security: Potential prototype pollution when merging remote configuration objects

## Problem

**Severity**: `Medium` | **File**: `lib/config/merge-server-config.js:L47`

Remote object keys are copied directly into local config objects (`local[localKey][element] = value[element]`) without filtering dangerous keys like `__proto__`, `constructor`, or `prototype`. If attacker-controlled JSON reaches this merge path, it can mutate object prototypes and alter application behavior.

## Solution

Block or ignore unsafe keys (`__proto__`, `constructor`, `prototype`) during merge. Prefer safe merge utilities that prevent prototype pollution, and consider using `Object.create(null)` for merge targets where possible.

## Changes

- `lib/config/merge-server-config.js` (modified)