### PR TITLE
fix: Updated `connect` instrumentation queries to handle file restructure in `<3.4.0`

### DIFF
--- a/lib/subscribers/connect/config.js
+++ b/lib/subscribers/connect/config.js
@@ -11,18 +11,32 @@ module.exports = {
   [modName]: [
     {
       path: './connect/use.js',
-      instrumentations: [{
-        channelName: 'nr_use',
-        module: {
-          name: modName,
-          filePath: 'index.js',
-          versionRange: '>=3.0.0'
+      instrumentations: [
+        {
+          channelName: 'nr_use',
+          module: {
+            name: modName,
+            filePath: 'index.js',
+            versionRange: '>=3.4.0'
+          },
+          functionQuery: {
+            expressionName: 'use',
+            kind: 'Sync'
+          }
         },
-        functionQuery: {
-          expressionName: 'use',
-          kind: 'Sync'
-        }
-      }]
+        {
+          channelName: 'nr_use',
+          module: {
+            name: modName,
+            filePath: 'lib/proto.js',
+            versionRange: '>=3.0.0 <3.4.0'
+          },
+          functionQuery: {
+            expressionName: 'use',
+            kind: 'Sync'
+          }
+        },
+      ]
     }
   ]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

In #3912 we migrated `connect` instrumentation to use subscribers.  When reviewing, we didn't run the full suite of tests. In `connect@3.4.0` the module is in one file `index.js`.
However in `<3.4.0` the code we want to wrap lives in `lib/proto.js`. This PR handles that.

## How to Test

```sh
npm run versioned:internal connect
```
