### PR TITLE
feat!: Updated `config.distributed_tracing.exclude_newrelic_header` to be set to `true` by default

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1140,7 +1140,7 @@ defaultConfig.definition = () => {
        */
       exclude_newrelic_header: {
         formatter: boolean,
-        default: false
+        default: true
       },
 
       sampler: {

--- a/test/integration/distributed-tracing/background.test.js
+++ b/test/integration/distributed-tracing/background.test.js
@@ -14,7 +14,7 @@ const API = require('../../../api')
 let compareSampled = null
 
 test('background transactions should not blow up with DT', async (t) => {
-  const plan = tspl(t, { plan: 24 })
+  const plan = tspl(t, { plan: 25 })
 
   const config = {
     distributed_tracing: {
@@ -37,7 +37,8 @@ test('background transactions should not blow up with DT', async (t) => {
   const api = new API(agent)
 
   const server = http.createServer(function (req, res) {
-    plan.ok(req.headers.newrelic, 'got incoming newrelic header')
+    plan.ok(req.headers.traceparent, 'got incoming traceparent header')
+    plan.ok(req.headers.tracestate, 'got incoming tracestate header')
 
     req.resume()
     res.end()

--- a/test/integration/distributed-tracing/dt.test.js
+++ b/test/integration/distributed-tracing/dt.test.js
@@ -21,7 +21,7 @@ const symbols = require('../../../lib/symbols')
 let compareSampled = null
 
 test('distributed tracing full integration', async (t) => {
-  const plan = tspl(t, { plan: 79 })
+  const plan = tspl(t, { plan: 81 })
 
   const config = {
     distributed_tracing: {
@@ -73,7 +73,8 @@ test('distributed tracing full integration', async (t) => {
   const START_PORT = start.address().port
 
   const middle = generateServer(http, api, started, (req, res) => {
-    plan.ok(req.headers.newrelic, 'middle received newrelic from start')
+    plan.ok(req.headers.traceparent, 'received `traceparent` header within call')
+    plan.ok(req.headers.tracestate, 'received `tracestate` header within call')
 
     const tx = agent.tracer.getTransaction()
     tx.nameState.appendPath('foobar')
@@ -90,7 +91,8 @@ test('distributed tracing full integration', async (t) => {
   MIDDLE_PORT = middle.address().port
 
   const end = generateServer(http, api, started, (req, res) => {
-    plan.ok(req.headers.newrelic, 'end received newrelic from middle')
+    plan.ok(req.headers.traceparent, 'received `traceparent` header within end call')
+    plan.ok(req.headers.tracestate, 'received `tracestate` header within end call')
     res.end()
   })
 
@@ -302,8 +304,10 @@ test('distributed tracing', async (t) => {
       get(generateUrl(START_PORT, 'start'), (err, { body }) => {
         assert.ifError(err)
 
-        assert.ok(body.start.newrelic, 'should have DT headers from the start')
-        assert.ok(body.middle.newrelic, 'should continue trace to through next state')
+        assert.ok(body.start.traceparent, 'should have traceparent from the start')
+        assert.ok(body.start.tracestate, 'should have tracestate from the start')
+        assert.ok(body.middle.traceparent, 'should continue traceparent to through next state')
+        assert.ok(body.middle.tracestate, 'should continue tracestate to through next state')
         assert.ok(tx.isDistributedTrace, 'should mark transaction as distributed')
 
         end()
@@ -319,9 +323,11 @@ test('distributed tracing', async (t) => {
         const headers = { [header]: 'true' }
         get(generateUrl(START_PORT, 'start'), { headers }, (err, { body }) => {
           assert.ifError(err)
-          assert.equal(body.start.newrelic, undefined, 'should not add DT header when disabled')
+          assert.equal(body.start.traceparent, undefined, 'should not add traceparent when disabled')
+          assert.equal(body.start.tracestate, undefined, 'should not add tracestate when disabled')
           assert.equal(body.start[OLD_HEADER], undefined, 'should not add old CAT header either')
-          assert.ok(body.middle.newrelic, undefined, 'should not stop down-stream DT from working')
+          assert.ok(body.middle.traceparent, undefined, 'should not stop down-stream traceparent from working')
+          assert.ok(body.middle.tracestate, undefined, 'should not stop down-stream tracestate from working')
 
           assert.equal(
             tx.isDistributedTrace,

--- a/test/integration/distributed-tracing/trace-context-cross-agent.test.js
+++ b/test/integration/distributed-tracing/trace-context-cross-agent.test.js
@@ -111,6 +111,8 @@ async function runTestCase(testCase, parentTest) {
     agent.config.primary_application_id = 4657
     agent.config.span_events.enabled = testCase.span_events_enabled
     agent.config.transaction_events.enabled = testCase.transaction_events_enabled
+    agent.config.distributed_tracing.enabled = true
+    agent.config.distributed_tracing.exclude_newrelic_header = false
 
     t.after(() => helper.unloadAgent(agent))
 

--- a/test/unit/config/config-defaults.test.js
+++ b/test/unit/config/config-defaults.test.js
@@ -326,7 +326,7 @@ test('with default properties', async (t) => {
   await t.test('distributed tracing defaults', () => {
     assert.deepEqual(configuration.distributed_tracing, {
       enabled: true,
-      exclude_newrelic_header: false,
+      exclude_newrelic_header: true,
       sampler: {
         root: 'adaptive',
         remote_parent_sampled: 'adaptive',

--- a/test/unit/distributed_tracing/dt-newrelic-header.test.js
+++ b/test/unit/distributed_tracing/dt-newrelic-header.test.js
@@ -15,10 +15,10 @@ const recordSupportability = require('../../../lib/agent').prototype.recordSuppo
 
 const testCases = require('../../lib/cross_agent_tests/distributed_tracing/distributed_tracing.json')
 
-test('distributed tracing', async function (t) {
+test('distributed tracing(newrelic header)', async function (t) {
   t.beforeEach((ctx) => {
     ctx.nr = {}
-    const agent = helper.loadMockedAgent({ distributed_tracing: { enabled: true } })
+    const agent = helper.loadMockedAgent({ distributed_tracing: { enabled: true, exclude_newrelic_header: false } })
     agent.recordSupportability = recordSupportability
     ctx.nr.agent = agent
   })

--- a/test/unit/instrumentation/http/outbound.test.js
+++ b/test/unit/instrumentation/http/outbound.test.js
@@ -585,11 +585,12 @@ test('when working with http.request', async (t) => {
     })
   })
 
-  await t.test('generates dt and w3c trace context headers to outbound request', (t, end) => {
+  await t.test('generates dt and w3c trace context headers to outbound request when exclude_newrelic_header: false', (t, end) => {
     const { agent } = t.nr
     agent.config.trusted_account_key = 190
     agent.config.account_id = 190
     agent.config.primary_application_id = '389103'
+    agent.config.distributed_tracing.exclude_newrelic_header = false
     const host = 'http://www.google.com'
     const path = '/index.html'
     let headers

--- a/test/unit/transaction.test.js
+++ b/test/unit/transaction.test.js
@@ -1411,7 +1411,13 @@ test('acceptDistributedTraceHeaders', async (t) => {
 test('insertDistributedTraceHeaders', async (t) => {
   t.beforeEach(function (ctx) {
     ctx.nr = {}
-    ctx.nr.agent = helper.loadMockedAgent()
+    const trustedAccountKey = '123'
+    ctx.nr.agent = helper.loadMockedAgent({
+      distributed_tracing: { enabled: true, exclude_newrelic_header: true },
+      span_events: { enabled: true }
+    })
+    ctx.nr.agent.config.trusted_account_key = trustedAccountKey
+    ctx.nr.trustedAccountKey = trustedAccountKey
     ctx.nr.tracer = helper.getTracer()
   })
 
@@ -1422,14 +1428,11 @@ test('insertDistributedTraceHeaders', async (t) => {
   await t.test(
     'should lowercase traceId for tracecontext when received upper from newrelic format',
     (t, end) => {
-      const { agent } = t.nr
-      const trustedAccountKey = '123'
+      const { agent, trustedAccountKey } = t.nr
 
       agent.config.account_id = 'AccountId1'
       agent.config.primary_application_id = 'Application1'
-      agent.config.distributed_tracing.enabled = true
-      agent.config.trusted_account_key = trustedAccountKey
-      agent.config.span_events.enabled = true
+      agent.config.distributed_tracing.exclude_newrelic_header = false
 
       const incomingTraceId = '6E2fEA0B173FDAD0'
       const expectedTraceContextTraceId = '0000000000000000' + incomingTraceId.toLowerCase()
@@ -1487,9 +1490,6 @@ test('insertDistributedTraceHeaders', async (t) => {
 
   await t.test('should generate a valid new trace context traceparent header', (t) => {
     const { agent, tracer } = t.nr
-    agent.config.distributed_tracing.enabled = true
-    agent.config.trusted_account_key = '1'
-    agent.config.span_events.enabled = true
 
     const txn = new Transaction(agent)
 
@@ -1513,8 +1513,6 @@ test('insertDistributedTraceHeaders', async (t) => {
 
   await t.test('should generate new parentId when spans_events disabled', (t) => {
     const { agent, tracer } = t.nr
-    agent.config.distributed_tracing.enabled = true
-    agent.config.trusted_account_key = '1'
     agent.config.span_events.enabled = false
 
     const txn = new Transaction(agent)
@@ -1533,9 +1531,6 @@ test('insertDistributedTraceHeaders', async (t) => {
 
   await t.test('should set traceparent sample part to 01 for sampled transaction', (t) => {
     const { agent, tracer } = t.nr
-    agent.config.distributed_tracing.enabled = true
-    agent.config.trusted_account_key = '1'
-    agent.config.span_events.enabled = true
 
     const txn = new Transaction(agent)
 
@@ -1551,9 +1546,6 @@ test('insertDistributedTraceHeaders', async (t) => {
 
   await t.test('should set traceparent traceid if traceparent exists on transaction', (t) => {
     const { agent, tracer } = t.nr
-    agent.config.distributed_tracing.enabled = true
-    agent.config.trusted_account_key = '1'
-    agent.config.span_events.enabled = true
 
     const txn = new Transaction(agent)
     const traceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00'
@@ -1583,14 +1575,10 @@ test('insertDistributedTraceHeaders', async (t) => {
   })
 
   await t.test('should build traceparent from spanContext', (t) => {
-    const { agent } = t.nr
-    const trustedAccountKey = '123'
+    const { agent, trustedAccountKey } = t.nr
 
     agent.config.account_id = 'AccountId1'
     agent.config.primary_application_id = 'Application1'
-    agent.config.distributed_tracing.enabled = true
-    agent.config.trusted_account_key = trustedAccountKey
-    agent.config.span_events.enabled = true
     const txn = new Transaction(agent)
     const traceId = hashes.makeId(32)
     const spanId = hashes.makeId()
@@ -1614,8 +1602,7 @@ test('insertDistributedTraceHeaders', async (t) => {
 
   await t.test('should not set newrelic header if empty string', (t) => {
     const { agent } = t.nr
-    agent.config.distributed_tracing.enabled = true
-    agent.config.span_events.enabled = true
+    agent.config.distributed_tracing.exclude_newrelic_header = false
     const txn = new Transaction(agent)
     const headers = {}
     txn.insertDistributedTraceHeaders(headers)
@@ -1628,7 +1615,11 @@ test('insertDistributedTraceHeaders', async (t) => {
 test('acceptTraceContextPayload', async (t) => {
   t.beforeEach(function (ctx) {
     ctx.nr = {}
-    ctx.nr.agent = helper.loadMockedAgent()
+    ctx.nr.agent = helper.loadMockedAgent({
+      distributed_tracing: { enabled: true, exclude_newrelic_header: true },
+      span_events: { enabled: true }
+    })
+    ctx.nr.agent.config.trusted_account_key = '1'
   })
 
   t.afterEach((ctx) => {
@@ -1637,10 +1628,6 @@ test('acceptTraceContextPayload', async (t) => {
 
   await t.test('should accept a valid trace context traceparent header', (t, end) => {
     const { agent } = t.nr
-    agent.config.distributed_tracing.enabled = true
-    agent.config.trusted_account_key = '1'
-    agent.config.span_events.enabled = true
-
     const goodParent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00'
 
     helper.runInTransaction(agent, function (txn) {
@@ -1659,10 +1646,6 @@ test('acceptTraceContextPayload', async (t) => {
 
   await t.test('should not accept invalid trace context traceparent header', (t, end) => {
     const { agent } = t.nr
-    agent.config.distributed_tracing.enabled = true
-    agent.config.trusted_account_key = '1'
-    agent.config.span_events.enabled = true
-
     helper.runInTransaction(agent, function (txn) {
       const childSegment = txn.trace.add('child')
       childSegment.start()
@@ -1685,8 +1668,6 @@ test('acceptTraceContextPayload', async (t) => {
   await t.test('should not accept tracestate when trusted_account_key missing', (t, end) => {
     const { agent } = t.nr
     agent.config.trusted_account_key = null
-    agent.config.distributed_tracing.enabled = true
-    agent.config.span_events.enabled = true
 
     const incomingTraceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00'
     // When two bugs combine, we might accept a tracestate we shouldn't
@@ -1716,14 +1697,10 @@ test('acceptTraceContextPayload', async (t) => {
 
   await t.test('should accept tracestate when trusted_account_key matches', (t, end) => {
     const { agent } = t.nr
-    agent.config.trusted_account_key = '33'
-    agent.config.distributed_tracing.enabled = true
-    agent.config.span_events.enabled = true
-
     const incomingTraceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00'
     // When two bugs combine, we might accept a tracestate we shouldn't
     const incomingNullKeyedTracestate =
-      '33@nr=0-0-33-2827902-7d3efb1b173fecfa-e8b91a159289ff74-1-1.23456-1518469636035'
+      '1@nr=0-0-1-2827902-7d3efb1b173fecfa-e8b91a159289ff74-1-1.23456-1518469636035'
 
     helper.runInTransaction(agent, function (txn) {
       const childSegment = txn.trace.add('child')
@@ -1737,7 +1714,7 @@ test('acceptTraceContextPayload', async (t) => {
 
       // tracestate
       assert.equal(txn.parentType, 'App')
-      assert.equal(txn.parentAcct, '33')
+      assert.equal(txn.parentAcct, '1')
       assert.equal(txn.parentApp, '2827902')
       assert.equal(txn.parentId, 'e8b91a159289ff74')
 


### PR DESCRIPTION
## Description
This defaults to `exclude_newrelic_header` to `true`. Turns out we had more tests than expected that assumed this was also going to be inserted into outgoing headers.  I cleaned up the tests as best as possible.  I had to set the value to `false` for some cross agent tests as it either exclusive relied on a `newrelic` header or tested behavior where both `newrelic` and `traceparent`/`tracestate` were being set.

## Related Issues

Closes #3924 