### PR TITLE
chore: Remove `actualTime` vs `segmentDuration` assertion in `memcached` tests

### DIFF
--- a/test/versioned/memcached/memcached.test.js
+++ b/test/versioned/memcached/memcached.test.js
@@ -48,7 +48,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
       const { agent, memcached } = t.nr
 
       await helper.runInTransaction(agent, async function (transaction) {
-        const { segment, actualTime } = await new Promise((resolve) => {
+        const { segment } = await new Promise((resolve) => {
           const now = process.hrtime()
           memcached.touch('foo', 1, function (err) {
             assert.ok(!err, 'should not throw an error')
@@ -57,7 +57,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
             resolve({ segment: agent.tracer.getSegment(), actualTime: end })
           })
         })
-        assertSegmentState(segment, 'Datastore/operation/Memcache/touch', actualTime)
+        assertSegmentState(segment, 'Datastore/operation/Memcache/touch')
 
         assertSegments(
           transaction.trace,
@@ -94,7 +94,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
       const { agent, memcached } = t.nr
 
       await helper.runInTransaction(agent, async function (transaction) {
-        const { segment, actualTime } = await new Promise((resolve) => {
+        const { segment } = await new Promise((resolve) => {
           const now = process.hrtime()
           memcached.get('foo', function (err) {
             assert.ok(!err, 'should not throw an error')
@@ -103,7 +103,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
             resolve({ segment: agent.tracer.getSegment(), actualTime: end })
           })
         })
-        assertSegmentState(segment, 'Datastore/operation/Memcache/get', actualTime)
+        assertSegmentState(segment, 'Datastore/operation/Memcache/get')
 
         assertSegments(
           transaction.trace,
@@ -134,7 +134,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
       const { agent, memcached } = t.nr
 
       await helper.runInTransaction(agent, async function (transaction) {
-        const { segment, actualTime } = await new Promise((resolve) => {
+        const { segment } = await new Promise((resolve) => {
           const now = process.hrtime()
           memcached.gets('foo', function (err) {
             assert.ok(!err, 'should not throw an error')
@@ -143,7 +143,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
             resolve({ segment: agent.tracer.getSegment(), actualTime: end })
           })
         })
-        assertSegmentState(segment, 'Datastore/operation/Memcache/gets', actualTime)
+        assertSegmentState(segment, 'Datastore/operation/Memcache/gets')
 
         assertSegments(
           transaction.trace,
@@ -174,7 +174,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
       const { agent, memcached } = t.nr
 
       await helper.runInTransaction(agent, async function (transaction) {
-        const { segment, actualTime } = await new Promise((resolve) => {
+        const { segment } = await new Promise((resolve) => {
           const now = process.hrtime()
           memcached.getMulti(['foo', 'bar'], function (err) {
             assert.ok(!err, 'should not throw an error')
@@ -183,7 +183,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
             resolve({ segment: agent.tracer.getSegment(), actualTime: end })
           })
         })
-        assertSegmentState(segment, 'Datastore/operation/Memcache/get', actualTime)
+        assertSegmentState(segment, 'Datastore/operation/Memcache/get')
 
         assertSegments(
           transaction.trace,
@@ -214,7 +214,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
       const { agent, memcached } = t.nr
 
       await helper.runInTransaction(agent, async function (transaction) {
-        const { segment, actualTime } = await new Promise((resolve) => {
+        const { segment } = await new Promise((resolve) => {
           const now = process.hrtime()
           memcached.set('foo', 'bar', 10, function (err) {
             assert.ok(!err, 'should not throw an error')
@@ -223,7 +223,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
             resolve({ segment: agent.tracer.getSegment(), actualTime: end })
           })
         })
-        assertSegmentState(segment, 'Datastore/operation/Memcache/set', actualTime)
+        assertSegmentState(segment, 'Datastore/operation/Memcache/set')
 
         assertSegments(
           transaction.trace,
@@ -258,7 +258,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
       })
 
       await helper.runInTransaction(agent, async function (transaction) {
-        const { segment, actualTime } = await new Promise((resolve) => {
+        const { segment } = await new Promise((resolve) => {
           const now = process.hrtime()
           memcached.replace('foo', 'new', 10, function (err) {
             assert.ok(!err, 'should not throw an error')
@@ -267,7 +267,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
             resolve({ segment: agent.tracer.getSegment(), actualTime: end })
           })
         })
-        assertSegmentState(segment, 'Datastore/operation/Memcache/replace', actualTime)
+        assertSegmentState(segment, 'Datastore/operation/Memcache/replace')
 
         assertSegments(
           transaction.trace,
@@ -298,7 +298,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
       const { agent, memcached } = t.nr
 
       await helper.runInTransaction(agent, async function (transaction) {
-        const { segment, actualTime } = await new Promise((resolve) => {
+        const { segment } = await new Promise((resolve) => {
           const now = process.hrtime()
           memcached.add('foo', 'bar', 10, function (err) {
             assert.ok(!err, 'should not throw an error')
@@ -307,7 +307,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
             resolve({ segment: agent.tracer.getSegment(), actualTime: end })
           })
         })
-        assertSegmentState(segment, 'Datastore/operation/Memcache/add', actualTime)
+        assertSegmentState(segment, 'Datastore/operation/Memcache/add')
 
         assertSegments(
           transaction.trace,
@@ -346,7 +346,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
       })
 
       await helper.runInTransaction(agent, async function (transaction) {
-        const { segment, actualTime } = await new Promise((resolve) => {
+        const { segment } = await new Promise((resolve) => {
           const now = process.hrtime()
           memcached.cas('foo', 'bar', data.cas, 10, function (err) {
             assert.ok(!err, 'should not throw an error')
@@ -355,7 +355,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
             resolve({ segment: agent.tracer.getSegment(), actualTime: end })
           })
         })
-        assertSegmentState(segment, 'Datastore/operation/Memcache/cas', actualTime)
+        assertSegmentState(segment, 'Datastore/operation/Memcache/cas')
 
         assertSegments(
           transaction.trace,
@@ -390,7 +390,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
       })
 
       await helper.runInTransaction(agent, async function (transaction) {
-        const { segment, actualTime } = await new Promise((resolve) => {
+        const { segment } = await new Promise((resolve) => {
           const now = process.hrtime()
           memcached.append('foo', 'bar', function (err) {
             assert.ok(!err)
@@ -399,7 +399,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
             resolve({ segment: agent.tracer.getSegment(), actualTime: end })
           })
         })
-        assertSegmentState(segment, 'Datastore/operation/Memcache/append', actualTime)
+        assertSegmentState(segment, 'Datastore/operation/Memcache/append')
 
         assertSegments(
           transaction.trace,
@@ -433,7 +433,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
       })
 
       await helper.runInTransaction(agent, async function (transaction) {
-        const { segment, actualTime } = await new Promise((resolve) => {
+        const { segment } = await new Promise((resolve) => {
           const now = process.hrtime()
           memcached.prepend('foo', 'bar', function (err) {
             assert.ok(!err)
@@ -442,7 +442,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
             resolve({ segment: agent.tracer.getSegment(), actualTime: end })
           })
         })
-        assertSegmentState(segment, 'Datastore/operation/Memcache/prepend', actualTime)
+        assertSegmentState(segment, 'Datastore/operation/Memcache/prepend')
 
         assertSegments(
           transaction.trace,
@@ -477,7 +477,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
       })
 
       await helper.runInTransaction(agent, async function (transaction) {
-        const { segment, actualTime } = await new Promise((resolve) => {
+        const { segment } = await new Promise((resolve) => {
           const now = process.hrtime()
           memcached.del('foo', function (err) {
             assert.ok(!err)
@@ -486,7 +486,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
             resolve({ segment: agent.tracer.getSegment(), actualTime: end })
           })
         })
-        assertSegmentState(segment, 'Datastore/operation/Memcache/delete', actualTime)
+        assertSegmentState(segment, 'Datastore/operation/Memcache/delete')
 
         assertSegments(
           transaction.trace,
@@ -517,7 +517,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
       const { agent, memcached } = t.nr
 
       await helper.runInTransaction(agent, async function (transaction) {
-        const { segment, actualTime } = await new Promise((resolve) => {
+        const { segment } = await new Promise((resolve) => {
           const now = process.hrtime()
           memcached.incr('foo', 10, function (err) {
             assert.ok(!err, 'should not throw an error')
@@ -526,7 +526,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
             resolve({ segment: agent.tracer.getSegment(), actualTime: end })
           })
         })
-        assertSegmentState(segment, 'Datastore/operation/Memcache/incr', actualTime)
+        assertSegmentState(segment, 'Datastore/operation/Memcache/incr')
 
         assertSegments(
           transaction.trace,
@@ -557,7 +557,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
       const { agent, memcached } = t.nr
 
       await helper.runInTransaction(agent, async function (transaction) {
-        const { segment, actualTime } = await new Promise((resolve) => {
+        const { segment } = await new Promise((resolve) => {
           const now = process.hrtime()
           memcached.decr('foo', 10, function (err) {
             assert.ok(!err, 'should not throw an error')
@@ -566,7 +566,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
             resolve({ segment: agent.tracer.getSegment(), actualTime: end })
           })
         })
-        assertSegmentState(segment, 'Datastore/operation/Memcache/decr', actualTime)
+        assertSegmentState(segment, 'Datastore/operation/Memcache/decr')
 
         assertSegments(
           transaction.trace,
@@ -597,7 +597,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
       const { agent, memcached } = t.nr
 
       await helper.runInTransaction(agent, async function (transaction) {
-        const { segment, actualTime } = await new Promise((resolve) => {
+        const { segment } = await new Promise((resolve) => {
           const now = process.hrtime()
           memcached.version(function (err, ok) {
             assert.ok(!err, 'should not throw an error')
@@ -607,7 +607,7 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
             resolve({ segment: agent.tracer.getSegment(), actualTime: end })
           })
         })
-        assertSegmentState(segment, 'Datastore/operation/Memcache/version', actualTime)
+        assertSegmentState(segment, 'Datastore/operation/Memcache/version')
 
         assertSegments(
           transaction.trace,
@@ -950,25 +950,18 @@ test('memcached instrumentation', { timeout: 5000 }, async function (t) {
   })
 })
 
-function hrToMillis(hr) {
-  return hr[0] * 1e3 + hr[1] / 1e6
-}
-
 /**
  * Asserts that the current segment has the expected name, has ended,
  * and has a duration within a reasonable threshold of the actual measured time.
  * @param {TraceSegment} segment segment to check
  * @param {string} expectedName expected segment name
- * @param {Array} actualTime process.hrtime() duration of the actual call
  */
-function assertSegmentState(segment, expectedName, actualTime) {
+function assertSegmentState(segment, expectedName) {
   assert.equal(segment.name, expectedName)
   assert.equal(segment._isEnded(), true, 'segment should have ended')
   const segmentDuration = segment.getDurationInMillis()
-  const actualDuration = hrToMillis(actualTime)
-  console.debug(`segment duration: ${segmentDuration}, actualDuration: ${actualDuration}`)
   // TODO: Figure out a better way to assert segment durations; what is a good non-flaky threshold?
-  assert.ok(actualDuration > segmentDuration, 'actual duration should always be greater than segment duration')
+  assert.equal(segmentDuration > 0, true, 'segment duration should be greater than 0')
 }
 
 /**


### PR DESCRIPTION
## Description

We wanted to test `actualTime` (via `timer`) versus `segmentDuration` to make sure that, after refactoring, `memcached` segments would have reasonable time duration. However, for some reason, which is evident in PR #3875, this is extremely flaky and non-deterministic. We need to investigate a more hollistic solution to this problem. So, for now, we will remove these assertions in `memcached` so that our CI will (hopefully) be less flaky. 

## How to Test

```
npm run versioned memcached
```

## Related Issues

Relates to #3862 