### PR TITLE
chore: Added log line when `max_trace_segments` is hit

### DIFF
--- a/lib/transaction/tracer/index.js
+++ b/lib/transaction/tracer/index.js
@@ -123,6 +123,7 @@ function createSegment({ id, name, recorder, parent, transaction }) {
   let collect = true
 
   if (transaction.numSegments >= this.agent.config.max_trace_segments) {
+    logger.trace(`Transaction ${transaction.id} has exceeded its max segment limit of ${this.agent.config.max_trace_segments}, it will no longer collect trace segments for this transaction`)
     collect = false
   }
   transaction.incrementCounters()

--- a/test/unit/transaction/tracer.test.js
+++ b/test/unit/transaction/tracer.test.js
@@ -6,6 +6,8 @@
 'use strict'
 const assert = require('node:assert')
 const test = require('node:test')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
 const helper = require('#testlib/agent_helper.js')
 const Segment = require('#agentlib/transaction/trace/segment.js')
 const Transaction = require('#agentlib/transaction/index.js')
@@ -261,7 +263,17 @@ test('Tracer', async function (t) {
     })
 
     await t.test('should stop adding segments to trace when `max_trace_segments` is exceeded', (t) => {
-      const { agent, tracer } = t.nr
+      const { agent } = t.nr
+      const loggerStub = {
+        trace: sinon.stub(),
+        traceEnabled: sinon.stub().returns(true)
+      }
+      const Tracer = proxyquire('../../../lib/transaction/tracer/index.js', {
+        '../../logger': {
+          child: sinon.stub().returns(loggerStub)
+        }
+      })
+      const tracer = new Tracer(agent)
       const tx = new Transaction(agent)
 
       const ar = new Array(1000).fill('a')
@@ -272,6 +284,9 @@ test('Tracer', async function (t) {
       const [,,,,childSegments] = tx.trace.toJSON()
       // max_trace_segments is 900(ROOT + 899 child segments
       assert.equal(childSegments.length, 899)
+
+      const logCalls = loggerStub.trace.args.filter(([msg]) => typeof msg === 'string' && msg.includes('has exceeded its max segment limit'))
+      assert.ok(logCalls.length > 0, 'should log trace message when max_trace_segments is exceeded')
     })
   })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Added a trace-level log line when a transaction hits the max_trace_segments limit, so that future issues where segments are dropped (due to this limit) can be identified quickly from the trace level agent log.

## How to Test
Run `npm run unit`