### PR TITLE
feat!: Removed `shim.prefixRouteParameters` as the logic was previously moved to when a transaction ends

### DIFF
--- a/lib/shim/shim.js
+++ b/lib/shim/shim.js
@@ -139,7 +139,6 @@ Shim.prototype.setDefaults = setDefaults
 Shim.prototype.proxy = proxy
 Shim.prototype.require = shimRequire
 Shim.prototype.copySegmentParameters = copySegmentParameters
-Shim.prototype.prefixRouteParameters = prefixRouteParameters
 Shim.prototype.interceptPromise = interceptPromise
 Shim.prototype.fixArity = arity.fixArity
 Shim.prototype.assignId = assignId
@@ -2136,17 +2135,4 @@ function _es5WrapClass(shim, Base, fnName, spec, args) {
   WrappedClass.prototype = Base.prototype
 
   return WrappedClass
-}
-
-/**
- * This method is no longer in use. It still exists to avoid crashing
- * applications.  The logic of this method has been integrated into
- * finalizing a web transaction.
- *
- * @param {object} params - Object containing route/url parameter key/value pairs
- * @returns {void} method is now stubbed and logic ported into `finalizeWebTransaction`
- * @memberof Shim.prototype
- */
-function prefixRouteParameters(params) {
-  logger.warnOnce('shim.prefixRouteParameters logic has been moved to when a web transaction ends.  This method will be removed in the next upcoming major version v14.0.0.')
 }


### PR DESCRIPTION
## Description

See PR title

## Related Issues

Closes #3416 