### PR TITLE
feat: Updated how license keys are redacted in logs

### DIFF
--- a/lib/collector/remote-method.js
+++ b/lib/collector/remote-method.js
@@ -345,21 +345,6 @@ RemoteMethod.prototype._userAgent = function _userAgent() {
 }
 
 /**
- * Redact a license key, preserving its original length.
- * The first 10 characters remain visible; the rest are replaced with '*'.
- * Keys of 10 or fewer characters are fully redacted.
- *
- * @param {string} key the license key to redact
- * @returns {string} the redacted key
- */
-RemoteMethod.prototype._redactLicenseKey = function _redactLicenseKey(key) {
-  if (!key || key.length <= 10) {
-    return '*'.repeat(key ? key.length : 0)
-  }
-  return key.substring(0, 10) + '*'.repeat(key.length - 10)
-}
-
-/**
  * Generate a URL the collector understands.
  *
  * @param {boolean} redactLicenseKey flag to redact license key in path
@@ -370,7 +355,7 @@ RemoteMethod.prototype._path = function _path({ redactLicenseKey } = {}) {
     marshal_format: 'json',
     protocol_version: this._protocolVersion,
     license_key: redactLicenseKey
-      ? this._redactLicenseKey(this._config.license_key)
+      ? this._config.redacted_license_key
       : this._config.license_key,
     method: this.name
   }

--- a/lib/collector/remote-method.js
+++ b/lib/collector/remote-method.js
@@ -345,6 +345,21 @@ RemoteMethod.prototype._userAgent = function _userAgent() {
 }
 
 /**
+ * Redact a license key, preserving its original length.
+ * The first 10 characters remain visible; the rest are replaced with '*'.
+ * Keys of 10 or fewer characters are fully redacted.
+ *
+ * @param {string} key the license key to redact
+ * @returns {string} the redacted key
+ */
+RemoteMethod.prototype._redactLicenseKey = function _redactLicenseKey(key) {
+  if (!key || key.length <= 10) {
+    return '*'.repeat(key ? key.length : 0)
+  }
+  return key.substring(0, 10) + '*'.repeat(key.length - 10)
+}
+
+/**
  * Generate a URL the collector understands.
  *
  * @param {boolean} redactLicenseKey flag to redact license key in path
@@ -354,7 +369,9 @@ RemoteMethod.prototype._path = function _path({ redactLicenseKey } = {}) {
   const query = {
     marshal_format: 'json',
     protocol_version: this._protocolVersion,
-    license_key: redactLicenseKey ? 'REDACTED' : this._config.license_key,
+    license_key: redactLicenseKey
+      ? this._redactLicenseKey(this._config.license_key)
+      : this._config.license_key,
     method: this.name
   }
 

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1470,6 +1470,8 @@ Config.prototype._canonicalize = function _canonicalize() {
   if (this.license_key) {
     this.license_key = this.license_key.trim()
   }
+
+  this.redacted_license_key = redactLicenseKey(this.license_key)
 }
 
 /**
@@ -1725,6 +1727,24 @@ function redactValue(value) {
   }
 
   return result
+}
+
+/**
+ * Redact a license key, preserving its original length.
+ * The first 10 characters remain visible; the rest are replaced with '*'.
+ * Keys of 10 or fewer characters are fully redacted.
+ *
+ * @param {string} key the license key to redact
+ * @returns {string} the redacted key
+ */
+function redactLicenseKey(key) {
+  if (!key) {
+    return ''
+  }
+  if (key.length <= 10) {
+    return '*'.repeat(key.length)
+  }
+  return key.substring(0, 10) + '*'.repeat(key.length - 10)
 }
 
 /**

--- a/test/unit/collector/remote-method.test.js
+++ b/test/unit/collector/remote-method.test.js
@@ -751,13 +751,10 @@ test('_safeRequest logging', async (t) => {
       body: 'test-body',
       path: '/nonexistent'
     }
-    ctx.nr.config = {
-      license_key: 'shhh-dont-tell',
-      max_payload_size_in_bytes: 10_000
-    }
+    ctx.nr.config = new Config({ license_key: 'shhh-dont-tell' })
   })
 
-  await t.test('should redact license key in logs', (t) => {
+  await t.test('should use redacted license key in logs', (t) => {
     const { RemoteMethod, options, config } = t.nr
     const method = new RemoteMethod({ name: 'test', agent: { config }, endpoint: {} })
     method._safeRequest(options)
@@ -775,31 +772,6 @@ test('_safeRequest logging', async (t) => {
       ],
       'should redact key in trace level log'
     )
-  })
-
-  await t.test('should maintain original license key length after redaction', (t) => {
-    const { RemoteMethod, config } = t.nr
-    const method = new RemoteMethod({ name: 'test', agent: { config }, endpoint: {} })
-    const redacted = method._redactLicenseKey(config.license_key)
-    assert.equal(redacted.length, config.license_key.length, 'redacted key should have same length as original')
-    assert.equal(redacted, 'shhh-dont-****', 'first 10 chars visible, rest replaced with *')
-  })
-
-  await t.test('should fully redact license keys of 10 or fewer characters', (t) => {
-    const { RemoteMethod, config } = t.nr
-    const method = new RemoteMethod({ name: 'test', agent: { config }, endpoint: {} })
-    const shortKey = 'short'
-    const redacted = method._redactLicenseKey(shortKey)
-    assert.equal(redacted.length, shortKey.length, 'redacted key should have same length as original')
-    assert.equal(redacted, '*****', 'short keys should be fully redacted')
-  })
-
-  await t.test('should return empty string for null, undefined, or empty license keys', (t) => {
-    const { RemoteMethod, config } = t.nr
-    const method = new RemoteMethod({ name: 'test', agent: { config }, endpoint: {} })
-    assert.equal(method._redactLicenseKey(null), '', 'null key should return empty string')
-    assert.equal(method._redactLicenseKey(undefined), '', 'undefined key should return empty string')
-    assert.equal(method._redactLicenseKey(''), '', 'empty key should return empty string')
   })
 
   await t.test('should call logger if trace is not enabled but audit logging is enabled', (t) => {
@@ -822,7 +794,7 @@ test('_safeRequest logging', async (t) => {
           '/agent_listener/invoke_raw_method?marshal_format=json&protocol_version=17&license_key=shhh-dont-****&method=test'
         ]
       ],
-      'should redact key in trace level log'
+      'should use redacted key in trace level log'
     )
   })
 

--- a/test/unit/collector/remote-method.test.js
+++ b/test/unit/collector/remote-method.test.js
@@ -751,7 +751,7 @@ test('_safeRequest logging', async (t) => {
       body: 'test-body',
       path: '/nonexistent'
     }
-    ctx.nr.config = new Config({ license_key: 'shhh-dont-tell' })
+    ctx.nr.config = new Config({ license_key: 'shhh-dont-tell', max_payload_size_in_bytes: 10_000 })
   })
 
   await t.test('should use redacted license key in logs', (t) => {

--- a/test/unit/collector/remote-method.test.js
+++ b/test/unit/collector/remote-method.test.js
@@ -770,11 +770,36 @@ test('_safeRequest logging', async (t) => {
           'https',
           options.host,
           options.port,
-          '/agent_listener/invoke_raw_method?marshal_format=json&protocol_version=17&license_key=REDACTED&method=test'
+          '/agent_listener/invoke_raw_method?marshal_format=json&protocol_version=17&license_key=shhh-dont-****&method=test'
         ]
       ],
       'should redact key in trace level log'
     )
+  })
+
+  await t.test('should maintain original license key length after redaction', (t) => {
+    const { RemoteMethod, config } = t.nr
+    const method = new RemoteMethod({ name: 'test', agent: { config }, endpoint: {} })
+    const redacted = method._redactLicenseKey(config.license_key)
+    assert.equal(redacted.length, config.license_key.length, 'redacted key should have same length as original')
+    assert.equal(redacted, 'shhh-dont-****', 'first 10 chars visible, rest replaced with *')
+  })
+
+  await t.test('should fully redact license keys of 10 or fewer characters', (t) => {
+    const { RemoteMethod, config } = t.nr
+    const method = new RemoteMethod({ name: 'test', agent: { config }, endpoint: {} })
+    const shortKey = 'short'
+    const redacted = method._redactLicenseKey(shortKey)
+    assert.equal(redacted.length, shortKey.length, 'redacted key should have same length as original')
+    assert.equal(redacted, '*****', 'short keys should be fully redacted')
+  })
+
+  await t.test('should return empty string for null, undefined, or empty license keys', (t) => {
+    const { RemoteMethod, config } = t.nr
+    const method = new RemoteMethod({ name: 'test', agent: { config }, endpoint: {} })
+    assert.equal(method._redactLicenseKey(null), '', 'null key should return empty string')
+    assert.equal(method._redactLicenseKey(undefined), '', 'undefined key should return empty string')
+    assert.equal(method._redactLicenseKey(''), '', 'empty key should return empty string')
   })
 
   await t.test('should call logger if trace is not enabled but audit logging is enabled', (t) => {
@@ -794,7 +819,7 @@ test('_safeRequest logging', async (t) => {
           'https',
           options.host,
           options.port,
-          '/agent_listener/invoke_raw_method?marshal_format=json&protocol_version=17&license_key=REDACTED&method=test'
+          '/agent_listener/invoke_raw_method?marshal_format=json&protocol_version=17&license_key=shhh-dont-****&method=test'
         ]
       ],
       'should redact key in trace level log'

--- a/test/unit/config/config.test.js
+++ b/test/unit/config/config.test.js
@@ -557,3 +557,31 @@ test('distributed tracing samplers', async (t) => {
     assert.deepEqual(configuration.profiling.include, ['cpu'])
   })
 })
+
+test('redacted_license_key', async (t) => {
+  await t.test('should show first 10 characters and redact the rest', () => {
+    const key = 'usa123abcdefghijklmnopqrstuvwxyz1234'
+    const config = new Config({ license_key: key })
+    assert.equal(config.redacted_license_key.substring(0, 10), key.substring(0, 10), 'first 10 chars should be visible')
+    assert.equal(config.redacted_license_key.substring(10), '*'.repeat(key.length - 10), 'remaining chars should be redacted')
+  })
+
+  await t.test('should maintain original license key length after redaction', () => {
+    const key = 'usa123abcdefghijklmnopqrstuvwxyz1234'
+    const config = new Config({ license_key: key })
+    assert.equal(config.redacted_license_key.length, key.length, 'redacted key should have same length as original')
+    assert.equal(config.redacted_license_key, 'usa123abcd**************************', 'first 10 chars visible, rest replaced with *')
+  })
+
+  await t.test('should fully redact license keys of 10 or fewer characters', () => {
+    const key = 'usa123'
+    const config = new Config({ license_key: key })
+    assert.equal(config.redacted_license_key.length, key.length, 'redacted key should have same length as original')
+    assert.equal(config.redacted_license_key, '******', 'short keys should be fully redacted')
+  })
+
+  await t.test('should return empty string when license_key is empty', () => {
+    const config = new Config({ license_key: '' })
+    assert.equal(config.redacted_license_key, '', 'should return empty string for empty license')
+  })
+})


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Updated how we redact license keys when we log the license key in the logs. 

Previously we redacted with `"REDACTED"` but now we need to:

- Keep the first 10 characters visible and the remaining characters are replaced by *.
- keys must retain their original length after reduction
- if a key is 10 or fewer characters, fully redact it.
- if license key is empty, redacted license key is also an empty string

## How to Test

Run `npm run unit`

## Related Issues

Closes #3944 