### PR TITLE
ci: Updated version of `actions/download-artifact` to v8

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -221,7 +221,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
       - name: Post Unit Test Coverage
         uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303
         with:


### PR DESCRIPTION
## Description

This process of updating actions is tedious. I missed one that was still running on node 20