### PR TITLE
fix: Updated aws sdk v3 instrumentation to handle using `@smithy/smithy-client` 4.13.0+

### DIFF
--- a/lib/subscribers/aws-sdk/config.js
+++ b/lib/subscribers/aws-sdk/config.js
@@ -3,13 +3,48 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+const coreSendConfig = {
+  path: './aws-sdk/core-send.js',
+  instrumentations: [
+    // CJS
+    {
+      channelName: 'nr_send',
+      module: { name: '@smithy/core', versionRange: '>=3.24.0', filePath: 'dist-cjs/submodules/client/index.js' },
+      functionQuery: {
+        className: 'Client',
+        methodName: 'send',
+        kind: 'Sync'
+      }
+    },
+    // ESM
+    {
+      channelName: 'nr_send',
+      module: { name: '@smithy/core', versionRange: '>=3.24.0', filePath: 'dist-es/submodules/client/smithy-client/client.js' },
+      functionQuery: {
+        className: 'Client',
+        methodName: 'send',
+        kind: 'Sync'
+      }
+    }
+  ]
+}
+
 const sendConfig = {
   path: './aws-sdk/send.js',
   instrumentations: [
     // CJS
     {
       channelName: 'nr_send',
-      module: { name: '@smithy/smithy-client', versionRange: '>=4.0.0', filePath: 'dist-cjs/index.js' },
+      module: { name: '@smithy/smithy-client', versionRange: '>=4.0.0 <4.13.0', filePath: 'dist-cjs/index.js' },
+      functionQuery: {
+        className: 'Client',
+        methodName: 'send',
+        kind: 'Sync'
+      }
+    },
+    {
+      channelName: 'nr_send',
+      module: { name: '@smithy/smithy-client', versionRange: '>=4.0.0 <4.13.0', filePath: 'dist-cjs/index.js' },
       functionQuery: {
         className: 'Client',
         methodName: 'send',
@@ -28,7 +63,7 @@ const sendConfig = {
     // ESM
     {
       channelName: 'nr_send',
-      module: { name: '@smithy/smithy-client', versionRange: '>=4.0.0', filePath: 'dist-es/index.js' },
+      module: { name: '@smithy/smithy-client', versionRange: '>=4.0.0 <4.13.0', filePath: 'dist-es/index.js' },
       functionQuery: {
         className: 'Client',
         methodName: 'send',
@@ -99,5 +134,8 @@ module.exports = {
   '@aws-sdk/smithy-client':
     [
       legacySendConfig
-    ]
+    ],
+  '@smithy/core': [
+    coreSendConfig
+  ]
 }

--- a/lib/subscribers/aws-sdk/core-send.js
+++ b/lib/subscribers/aws-sdk/core-send.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+'use strict'
+const SmithyClientSendSubscriber = require('./send')
+
+/**
+ * Extends SmithyClientSendSubscriber to handle the new Client.send in `@smithy/core`
+ * package, which newer versions of AWS SDK v3 versions depend on instead of `@smithy/smithy-client`.
+ */
+module.exports = class CoreClientSendSubscriber extends SmithyClientSendSubscriber {
+  constructor({ agent, logger }) {
+    super({ agent, logger, packageName: '@smithy/core' })
+  }
+}

--- a/test/versioned/aws-sdk-v3/bedrock-converse-api.test.js
+++ b/test/versioned/aws-sdk-v3/bedrock-converse-api.test.js
@@ -54,7 +54,13 @@ test('Converse API', { skip: semver.lt(bedrockVersion, '3.587.0') }, async (t) =
   })
 
   await t.test('should properly create completion segment', async (t) => {
-    const { version } = require('@smithy/smithy-client/package.json')
+    // the package we subscribe to changes in `4.13.0` of `@smithy/smithy-client` to `@smithy/core`
+    let { version } = require('@smithy/smithy-client/package.json')
+    let pkg = '@smithy/smithy-client'
+    if (semver.gte(version, '4.13.0')) {
+      ;({ version } = require('@smithy/core/package.json'))
+      pkg = '@smithy/core'
+    }
     const prompt = 'text converse ultimate question'
     const input = {
       modelId,
@@ -76,7 +82,7 @@ test('Converse API', { skip: semver.lt(bedrockVersion, '3.587.0') }, async (t) =
         ['Llm/completion/Bedrock/ConverseCommand', [expectedExternalPath(modelId)]],
         { exact: false }
       )
-      assertPackageMetrics({ agent, pkg: '@smithy/smithy-client', version, subscriberType: true })
+      assertPackageMetrics({ agent, pkg, version, subscriberType: true })
       tx.end()
     })
   })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

AWS sdk restructured their code, yet again.  In 4.13.0+ of `@smithy/smithy-client`. The code we need to rewrite and subscribed moved to `@smithy/core`. This PR addresses it.

## How to Test

```sh
npm run versioned:internal aws-sdk-v3
```

## Related Issues
Closes #3963
