### PR TITLE
fix: Updated `tracer.bindFunction` to touch segment if a promise is fulfilled or rejected

### DIFF
--- a/lib/subscribers/aws-sdk/middleware/sqs/index.js
+++ b/lib/subscribers/aws-sdk/middleware/sqs/index.js
@@ -47,7 +47,7 @@ function sqsMiddleware(subscriber, config, next, context) {
   }
 
   subscriber.opaque = true
-  return function nrSqsMiddleware(...args) {
+  return async function nrSqsMiddleware(...args) {
     const ctx = agent.tracer.getContext()
     if (!ctx.transaction || ctx.transaction.isActive() === false) {
       return next(...args)
@@ -84,22 +84,19 @@ function sqsMiddleware(subscriber, config, next, context) {
     segment.addAttribute('messaging.destination.name', queue)
 
     const fn = agent.tracer.bindFunction(next, newCtx, true)
-    const result = fn(...args)
+    const response = await fn(...args)
     if (mode === MessageBrokerDesc.BROKER_MODE_PRODUCE) {
-      return result
+      return response
     }
 
     // aws-sdk@3 only returns promises from `.send`.
-    return result
-      .then((response) => {
-        const message = response?.output?.Messages?.[0] || {}
-        const headers = retrieveHeaders({ message })
-        newCtx.transaction.addDtCatHeaders({
-          headers,
-          transport: MessageBrokerDesc.TRANSPORT_TYPE_QUEUE
-        })
-        return response
-      })
+    const message = response?.output?.Messages?.[0] || {}
+    const headers = retrieveHeaders({ message })
+    newCtx.transaction.addDtCatHeaders({
+      headers,
+      transport: MessageBrokerDesc.TRANSPORT_TYPE_QUEUE
+    })
+    return response
   }
 }
 

--- a/lib/transaction/tracer/index.js
+++ b/lib/transaction/tracer/index.js
@@ -259,6 +259,7 @@ function bindFunction(handler, context, full) {
 
   return _makeWrapped({ tracer: this, handler, context, full: !!full })
 }
+
 function _makeWrapped({ tracer, handler, context, full }) {
   const { segment } = context
   wrapped[symbols.original] = getOriginal(handler)
@@ -272,7 +273,9 @@ function _makeWrapped({ tracer, handler, context, full }) {
     }
 
     try {
-      return tracer._contextManager.runInContext(context, handler, this, arguments)
+      const result = tracer._contextManager.runInContext(context, handler, this, arguments)
+      _maybeBindPromise({ result, tracer, full, segment })
+      return result
     } catch (err) {
       logger.trace(err, 'Error from wrapped function:')
       throw err // Re-throwing application error, this is not an agent error.
@@ -281,6 +284,25 @@ function _makeWrapped({ tracer, handler, context, full }) {
         segment.touch()
       }
     }
+  }
+}
+
+/**
+ * If `full` is true, there is a segment and it is a Promise/thenable,
+ * It will add `onFulfilled` and `onRjected` handlers to touch the segment.
+ *
+ * @param {object} params to function
+ * @param {*} params.result result from wrapped function
+ * @param {boolean} params.full flag to touch segment
+ * @param {TraceSegment} params.segment active segment
+ */
+function _maybeBindPromise({ result, full, segment }) {
+  if (segment && full && typeof result?.then === 'function') {
+    result.then(() => {
+      segment.touch()
+    }, () => {
+      segment.touch()
+    })
   }
 }
 

--- a/test/versioned/aws-sdk-v3/client-dynamodb.test.js
+++ b/test/versioned/aws-sdk-v3/client-dynamodb.test.js
@@ -17,7 +17,7 @@ const {
   SEGMENT_DESTINATION
 } = require('./test-utils/constants.js')
 const { createEmptyResponseServer, FAKE_CREDENTIALS } = require('../../lib/aws-server-stubs')
-const { match } = require('../../lib/custom-assertions')
+const { match, assertSegmentDuration } = require('../../lib/custom-assertions')
 
 const AWS_REGION = 'us-east-1'
 
@@ -83,30 +83,45 @@ test('DynamoDB', async (t) => {
 
   await t.test('commands, promise-style', async (t) => {
     const { agent, commands, client } = t.nr
+    const times = []
     await helper.runInTransaction(agent, async (tx) => {
+      let i = 0
       for (const command of commands) {
         await client.send(command)
+        const children = tx.trace.getChildren(tx.trace.root.id)
+        const actualTime = process.hrtime(children[i].timer.hrstart)
+        times.push(actualTime)
+        i++
       }
       tx.end()
-      finish({ commands, tx })
+      finish({ commands, tx, times })
     })
   })
 
   await t.test('commands, callback-style', async (t) => {
     const { agent, commands, client } = t.nr
+    const times = []
     await helper.runInTransaction(agent, async (tx) => {
+      let i = 0
       for (const command of commands) {
-        await new Promise((resolve) => {
+        const segment = await new Promise((resolve) => {
           client.send(command, (err) => {
             assert.ok(!err)
+            const children = tx.trace.getChildren(tx.trace.root.id)
+            const segment = children[i]
+            i++
 
-            return setImmediate(resolve)
+            setImmediate(() => {
+              resolve(segment)
+            })
           })
         })
+        const actualTime = process.hrtime(segment.timer.hrstart)
+        times.push(actualTime)
       }
 
       tx.end()
-      finish({ commands, tx })
+      finish({ commands, tx, times })
     })
   })
 
@@ -192,7 +207,7 @@ function createCommands({ lib, tableName }) {
   ]
 }
 
-function finish({ commands, tx }) {
+function finish({ commands, tx, times }) {
   const root = tx.trace.root
   const segments = checkAWSAttributes({
     trace: tx.trace,
@@ -215,6 +230,8 @@ function finish({ commands, tx }) {
 
   segments.forEach((segment, i) => {
     const command = commands[i]
+    const actualTime = times[i]
+    assertSegmentDuration({ segment, actualTime })
     assert.ok(command)
     assert.equal(
       segment.name,

--- a/test/versioned/aws-sdk-v3/sns.test.js
+++ b/test/versioned/aws-sdk-v3/sns.test.js
@@ -19,7 +19,7 @@ const {
   SNS_PATTERN
 } = require('./test-utils/constants.js')
 const { createResponseServer, FAKE_CREDENTIALS } = require('../../lib/aws-server-stubs')
-const { match } = require('../../lib/custom-assertions')
+const { match, assertSegmentDuration } = require('../../lib/custom-assertions')
 
 test('SNS', async (t) => {
   const server = createResponseServer()
@@ -43,42 +43,45 @@ test('SNS', async (t) => {
     helper.unloadAgent(agent)
   })
 
-  await t.test('publish with callback', (t, end) => {
+  await t.test('publish with callback', async (t) => {
     const { PublishCommand } = lib
-    helper.runInTransaction(agent, (tx) => {
+    await helper.runInTransaction(agent, async (tx) => {
       const params = { Message: 'Hello!' }
 
       const cmd = new PublishCommand(params)
-      sns.send(cmd, (err) => {
-        assert.ok(!err)
-        tx.end()
-
-        const destName = 'PhoneNumber'
-        const args = [end, tx, destName]
-        setImmediate(finish, ...args)
+      const segment = await new Promise((resolve) => {
+        sns.send(cmd, (err) => {
+          assert.ok(!err)
+          tx.end()
+          const [segment] = tx.trace.getChildren(tx.trace.root.id)
+          resolve(segment)
+        })
       })
+      const actualTime = process.hrtime(segment.timer.hrstart)
+      finish({ tx, destName: 'PhoneNumber', actualTime })
     })
   })
 
-  await t.test('publish with default destination(PhoneNumber)', (t, end) => {
+  await t.test('publish with default destination(PhoneNumber)', async (t) => {
     const { PublishCommand } = lib
-    helper.runInTransaction(agent, async (tx) => {
+    await helper.runInTransaction(agent, async (tx) => {
       const params = { Message: 'Hello!' }
 
       const cmd = new PublishCommand(params)
       await sns.send(cmd)
+      const [segment] = tx.trace.getChildren(tx.trace.root.id)
+      const actualTime = process.hrtime(segment.timer.hrstart)
 
       tx.end()
 
       const destName = 'PhoneNumber'
-      const args = [end, tx, destName]
-      setImmediate(finish, ...args)
+      finish({ tx, destName, actualTime })
     })
   })
 
-  await t.test('publish with TopicArn as destination', (t, end) => {
+  await t.test('publish with TopicArn as destination', async (t) => {
     const { PublishCommand } = lib
-    helper.runInTransaction(agent, async (tx) => {
+    await helper.runInTransaction(agent, async (tx) => {
       const TopicArn = 'TopicArn'
       const params = { TopicArn, Message: 'Hello!' }
 
@@ -87,14 +90,13 @@ test('SNS', async (t) => {
 
       tx.end()
 
-      const args = [end, tx, TopicArn]
-      setImmediate(finish, ...args)
+      finish({ tx, destName: TopicArn })
     })
   })
 
-  await t.test('publish with TargetArn as destination', (t, end) => {
+  await t.test('publish with TargetArn as destination', async (t) => {
     const { PublishCommand } = lib
-    helper.runInTransaction(agent, async (tx) => {
+    await helper.runInTransaction(agent, async (tx) => {
       const TargetArn = 'TargetArn'
       const params = { TargetArn, Message: 'Hello!' }
 
@@ -103,16 +105,15 @@ test('SNS', async (t) => {
 
       tx.end()
 
-      const args = [end, tx, TargetArn]
-      setImmediate(finish, ...args)
+      finish({ tx, destName: TargetArn })
     })
   })
 
   await t.test(
     'publish with TopicArn as destination when both Topic and Target Arn are defined',
-    (t, end) => {
+    async (t) => {
       const { PublishCommand } = lib
-      helper.runInTransaction(agent, async (tx) => {
+      await helper.runInTransaction(agent, async (tx) => {
         const TargetArn = 'TargetArn'
         const TopicArn = 'TopicArn'
         const params = { TargetArn, TopicArn, Message: 'Hello!' }
@@ -121,17 +122,16 @@ test('SNS', async (t) => {
         await sns.send(cmd)
         tx.end()
 
-        const args = [end, tx, TopicArn]
-        setImmediate(finish, ...args)
+        finish({ tx, destName: TopicArn })
       })
     }
   )
 
   await t.test(
     'should record external segment and not a SNS segment for a command that is not PublishCommand',
-    (t, end) => {
+    async (t) => {
       const { ListTopicsCommand } = lib
-      helper.runInTransaction(agent, async (tx) => {
+      await helper.runInTransaction(agent, async (tx) => {
         const TargetArn = 'TargetArn'
         const TopicArn = 'TopicArn'
         const params = { TargetArn, TopicArn, Message: 'Hello!' }
@@ -139,12 +139,8 @@ test('SNS', async (t) => {
         const cmd = new ListTopicsCommand(params)
         await sns.send(cmd)
         tx.end()
-
-        setImmediate(checkExternals, {
-          end,
-          tx,
-          service: 'SNS',
-          operations: ['ListTopicsCommand']
+        checkExternals({
+          tx, service: 'SNS', operations: ['ListTopicsCommand']
         })
       })
     }
@@ -227,7 +223,7 @@ test('SNS', async (t) => {
   })
 })
 
-function finish(end, tx, destName) {
+function finish({ tx, destName, actualTime }) {
   const root = tx.trace.root
 
   const messages = checkAWSAttributes({
@@ -237,6 +233,9 @@ function finish(end, tx, destName) {
   })
   assert.equal(messages.length, 1, 'should have 1 message broker segment')
   assert.ok(messages[0].name.endsWith(destName), 'should have appropriate destination')
+  if (actualTime) {
+    assertSegmentDuration({ actualTime, segment: messages[0] })
+  }
 
   const externalSegments = checkAWSAttributes({
     trace: tx.trace,
@@ -252,5 +251,4 @@ function finish(end, tx, destName) {
     'aws.service': /sns|SNS/,
     'aws.region': 'us-east-1'
   })
-  end()
 }

--- a/test/versioned/aws-sdk-v3/sqs.test.js
+++ b/test/versioned/aws-sdk-v3/sqs.test.js
@@ -18,7 +18,7 @@ const {
   SQS_PATTERN
 } = require('./test-utils/constants.js')
 const { createResponseServer, FAKE_CREDENTIALS } = require('../../lib/aws-server-stubs')
-const { match } = require('../../lib/custom-assertions')
+const { match, assertSegmentDuration } = require('../../lib/custom-assertions')
 
 const AWS_REGION = 'us-east-1'
 
@@ -72,25 +72,32 @@ test('SQS API', async (t) => {
     const { QueueUrl } = await sqs.send(createCommand)
     assert.ok(QueueUrl)
     // run send/receive commands in transaction
+    const times = []
     await helper.runInTransaction(agent, async (transaction) => {
       // send message
       const sendMessageParams = getSendMessageParams(QueueUrl)
       const sendMessageCommand = new SendMessageCommand(sendMessageParams)
       const { MessageId } = await sqs.send(sendMessageCommand)
+      const [sendSegment] = transaction.trace.getChildren(transaction.trace.root.id)
+      times.push(process.hrtime(sendSegment.timer.hrstart))
       assert.ok(MessageId)
       // send message batch
       const sendMessageBatchParams = getSendMessageBatchParams(QueueUrl)
       const sendMessageBatchCommand = new SendMessageBatchCommand(sendMessageBatchParams)
       const { Successful } = await sqs.send(sendMessageBatchCommand)
+      const [, sendBatchSegment] = transaction.trace.getChildren(transaction.trace.root.id)
+      times.push(process.hrtime(sendBatchSegment.timer.hrstart))
       assert.ok(Successful)
       // receive message
       const receiveMessageParams = getReceiveMessageParams(QueueUrl)
       const receiveMessageCommand = new ReceiveMessageCommand(receiveMessageParams)
       const { Messages } = await sqs.send(receiveMessageCommand)
+      const [, , receiveSegment] = transaction.trace.getChildren(transaction.trace.root.id)
+      times.push(process.hrtime(receiveSegment.timer.hrstart))
       assert.ok(Messages)
       // wrap up
       transaction.end()
-      await finish({ transaction, queueName })
+      finish({ transaction, queueName, times })
     })
   })
 
@@ -217,7 +224,7 @@ test('SQS API', async (t) => {
   })
 })
 
-function finish({ transaction, queueName }) {
+function finish({ transaction, queueName, times }) {
   const expectedSegmentCount = 3
 
   const root = transaction.trace.root
@@ -241,6 +248,10 @@ function finish({ transaction, queueName }) {
   assert.equal(externalSegments.length, 0, 'should not have any External segments')
 
   const [sendMessage, sendMessageBatch, receiveMessage] = segments
+  const [sendTime, batchTime, receiveTime] = times
+  assertSegmentDuration({ segment: sendMessage, actualTime: sendTime })
+  assertSegmentDuration({ segment: sendMessageBatch, actualTime: batchTime })
+  assertSegmentDuration({ segment: receiveMessage, actualTime: receiveTime })
 
   checkName(sendMessage.name, 'Produce', queueName)
   checkAttributes(sendMessage, 'SendMessageCommand')

--- a/test/versioned/aws-sdk-v3/test-utils/check-externals.js
+++ b/test/versioned/aws-sdk-v3/test-utils/check-externals.js
@@ -53,5 +53,5 @@ function checkExternals({ service, operations, tx, end }) {
       'aws.region': 'us-east-1'
     })
   })
-  end()
+  end?.()
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

When we started migrating to subscriber based instrumentation, we missed a key bit around duration timing of segment.
Looking at our existing migrations, the only affetcted library is aws-sdk-v3.  We were not touching the segment when a promise is resolved/rejected.
This caused very short durations for sns, sqs, and dynamodb segments.  I added tests that assert the segment durations. Without the code in tracer, they are failing.

**Note**: This logic is identical to `lib/shim/shim.js` `interceptPromise`.  I didn't remove that from shim so it's attaching duplicate `onFulfilled` and `onRejected` handlers.
There was some tests that were failing in shim when I removed it from there.

## How to Test

```sh
npm run versioned
npm run unit
npm run integration
```

## Related Issues
Closes #3966
