### PR TITLE
chore: Fix issue with amqplib tests

### DIFF
--- a/test/versioned/amqplib/callback.test.js
+++ b/test/versioned/amqplib/callback.test.js
@@ -4,16 +4,23 @@
  */
 
 'use strict'
+
 const assert = require('node:assert')
 const test = require('node:test')
+const path = require('node:path')
 const amqpUtils = require('./amqp-utils')
 const API = require('../../../api')
 const helper = require('../../lib/agent_helper')
 const { removeMatchedModules } = require('../../lib/cache-buster')
 const promiseResolvers = require('../../lib/promise-resolvers')
-const { version } = require('amqplib/package.json')
+const getPackageVersion = require('../../../lib/util/get-package-version')
+
 const { assertPackageMetrics } = require('../../lib/custom-assertions')
 const PROMISE_WAIT = 100
+
+const version = getPackageVersion(
+  path.join(__dirname, 'node_modules', 'amqplib')
+)
 
 test('amqplib callback instrumentation', async function (t) {
   t.beforeEach(async function (ctx) {

--- a/test/versioned/amqplib/promises.test.js
+++ b/test/versioned/amqplib/promises.test.js
@@ -4,17 +4,23 @@
  */
 
 'use strict'
+
 const assert = require('node:assert')
 const test = require('node:test')
+const path = require('node:path')
 const amqpUtils = require('./amqp-utils')
 const API = require('../../../api')
 const helper = require('../../lib/agent_helper')
 const { removeMatchedModules } = require('../../lib/cache-buster')
 const promiseResolvers = require('../../lib/promise-resolvers')
+const getPackageVersion = require('../../../lib/util/get-package-version')
 const metrics = require('../../lib/metrics_helper')
 const { assertPackageMetrics, assertMetrics, assertSegments } = require('./../../lib/custom-assertions')
-const { version } = require('amqplib/package.json')
 const PROMISE_WAIT = 100
+
+const version = getPackageVersion(
+  path.join(__dirname, 'node_modules', 'amqplib')
+)
 
 test('amqplib promise instrumentation', async function (t) {
   t.beforeEach(async function (ctx) {


### PR DESCRIPTION
Something changed and caused the way we retrieved the `amqplib` version in the tests started triggering the subpath import branch in the Node.js module loader. This PR avoids that by directly accessing the `package.json` file.