### PR TITLE
ci: Added `contents: write` to `post-release` to allow commit/push of api docs

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -24,6 +24,9 @@ on:
 
 jobs:
   local:
+    # `public-docs` commits/pushes the docs to the `gh-pages` branch
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     if:
       (github.event.workflow_run && github.event.workflow_run.conclusion == 'success') ||


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

The `local` post-release job failed [here](https://github.com/newrelic/node-newrelic/actions/runs/25741147874/job/75591558139) with 403. I assume it is because it does not have `contents: write`
