### PR TITLE
test: Added `minSupported` to the nest js versioned tests package.json to ensure the compatibility report will show we support `@nestjs/core`

### DIFF
--- a/test/versioned/nestjs/package.json
+++ b/test/versioned/nestjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-tests",
-  "targets": [{"name":"@nestjs/core","minAgentVersion":"10.1.0"}],
+  "targets": [{"name":"@nestjs/core","minAgentVersion":"10.1.0", "minSupported": "10.0.0"}],
   "version": "0.0.0",
   "private": true,
   "tests": [


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We technically support `@nestjs/core` but we install `@nestjs/cli` for testing.  Our compatibility report will fail to output a line if the packages under tests are not the ones listed in `targets`. Since they are different, we have a way to specify the minimum supported. This PR fixes it for nestjs.
