### PR TITLE
chore: Restructure `aws-sdk-v3` test runner to use `groupedDependencies`

### DIFF
--- a/bin/test/versioned-runner/matrix.test.js
+++ b/bin/test/versioned-runner/matrix.test.js
@@ -138,6 +138,80 @@ test('TestMatrix groupedDependencies intersect matching versions across packages
   )
 })
 
+test('TestMatrix groupedDependencies honors a child `samples` value', function (t) {
+  const matrix = new TestMatrix(
+    [
+      {
+        groupedDependencies: {
+          samples: 3,
+          version: '>=7.0.0',
+          packages: ['prisma', '@prisma/client']
+        },
+        files: ['prisma.test.js']
+      }
+    ],
+    {
+      prisma: {
+        versions: ['7.0.0', '7.1.0', '7.2.0', '7.3.0', '7.4.0', '7.5.0', '7.6.0'],
+        latest: '7.6.0'
+      },
+      '@prisma/client': {
+        versions: ['7.0.0', '7.1.0', '7.2.0', '7.3.0', '7.4.0', '7.5.0', '7.6.0'],
+        latest: '7.6.0'
+      }
+    }
+  )
+
+  const { packages } = matrix._matrix[0]
+  assert.equal(
+    packages[0].versions.length,
+    3,
+    'samples limits the grouped iterator to the requested count'
+  )
+  assert.equal(
+    packages[0].versions[packages[0].versions.length - 1],
+    '7.6.0',
+    'samples always retains the latest matching version'
+  )
+  assert.equal(matrix.length, 3, 'matrix length reflects the sampled grouped versions')
+})
+
+test(
+  'TestMatrix groupedDependencies global samples overrides a larger local samples',
+  function (t) {
+    const matrix = new TestMatrix(
+      [
+        {
+          groupedDependencies: {
+            samples: 5,
+            version: '>=7.0.0',
+            packages: ['prisma', '@prisma/client']
+          },
+          files: ['prisma.test.js']
+        }
+      ],
+      {
+        prisma: {
+          versions: ['7.0.0', '7.1.0', '7.2.0', '7.3.0', '7.4.0'],
+          latest: '7.4.0'
+        },
+        '@prisma/client': {
+          versions: ['7.0.0', '7.1.0', '7.2.0', '7.3.0', '7.4.0'],
+          latest: '7.4.0'
+        }
+      },
+      2
+    )
+
+    const { packages } = matrix._matrix[0]
+    assert.equal(
+      packages[0].versions.length,
+      2,
+      'min(globalSamples, localSamples) is applied to grouped iterators'
+    )
+  }
+)
+
 test('TestMatrix can mix dependencies and groupedDependencies', function (t) {
   const matrix = new TestMatrix(
     [

--- a/bin/versioned-runner/matrix.js
+++ b/bin/versioned-runner/matrix.js
@@ -201,9 +201,10 @@ function TestMatrix(tests, pkgVersions, globalSamples) {
       }
 
       if (test.groupedDependencies && test.groupedDependencies.packages?.length) {
-        const { packages, version } = test.groupedDependencies
+        const { packages, version, samples } = test.groupedDependencies
+        // passing in object as 2nd arg to handle finding minimum of samples vs globalSamples
         task.packages.push(
-          resolveIterator(packages, version, pkgVersions, globalSamples)
+          resolveIterator(packages, { versions: version, samples }, pkgVersions, globalSamples)
         )
       }
 

--- a/test/versioned/aws-sdk-v3/package.json
+++ b/test/versioned/aws-sdk-v3/package.json
@@ -72,9 +72,9 @@
       "engines": {
         "node": ">=22"
       },
-      "comment": "These are sampled at 10 because we have first-class instrumentation for the packages below via middleware in `lib/subscribers/aws-sdk`",
+      "comment": "These are sampled at 7 because we have first-class instrumentation for the packages below via middleware in `lib/subscribers/aws-sdk`",
       "groupedDependencies": {
-        "samples": 10,
+        "samples": 7,
         "version": ">3.377.0 <3.967.0 || >=3.983.0",
         "packages": [
           "@aws-sdk/client-dynamodb",

--- a/test/versioned/aws-sdk-v3/package.json
+++ b/test/versioned/aws-sdk-v3/package.json
@@ -42,153 +42,38 @@
       "engines": {
         "node": ">=22"
       },
-      "dependencies": {
-        "@aws-sdk/client-api-gateway": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
+      "groupedDependencies": {
+        "version": {
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0",
           "samples": 5
-        }
+        },
+        "packages": [
+          "@aws-sdk/client-api-gateway",
+          "@aws-sdk/client-dynamodb",
+          "@aws-sdk/client-elasticache",
+          "@aws-sdk/client-elastic-load-balancing",
+          "@aws-sdk/client-lambda",
+          "@aws-sdk/client-rds",
+          "@aws-sdk/client-redshift",
+          "@aws-sdk/client-rekognition",
+          "@aws-sdk/client-s3",
+          "@aws-sdk/client-ses",
+          "@aws-sdk/client-sns",
+          "@aws-sdk/client-sqs"
+        ]
       },
       "files": [
-        "api-gateway.test.js"
-      ]
-    },
-    {
-      "engines": {
-        "node": ">=22"
-      },
-      "dependencies": {
-        "@aws-sdk/client-elasticache": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
-          "samples": 2
-        }
-      },
-      "files": [
-        "elasticache.test.js"
-      ]
-    },
-    {
-      "engines": {
-        "node": ">=22"
-      },
-      "dependencies": {
-        "@aws-sdk/client-elastic-load-balancing": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
-          "samples": 2
-        }
-      },
-      "files": [
-        "elb.test.js"
-      ]
-    },
-    {
-      "engines": {
-        "node": ">=22"
-      },
-      "dependencies": {
-        "@aws-sdk/client-lambda": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
-          "samples": 2
-        }
-      },
-      "files": [
-        "lambda.test.js"
-      ]
-    },
-    {
-      "engines": {
-        "node": ">=22"
-      },
-      "dependencies": {
-        "@aws-sdk/client-rds": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
-          "samples": 2
-        }
-      },
-      "files": [
-        "rds.test.js"
-      ]
-    },
-    {
-      "engines": {
-        "node": ">=22"
-      },
-      "dependencies": {
-        "@aws-sdk/client-redshift": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
-          "samples": 2
-        }
-      },
-      "files": [
-        "redshift.test.js"
-      ]
-    },
-    {
-      "engines": {
-        "node": ">=22"
-      },
-      "dependencies": {
-        "@aws-sdk/client-rekognition": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
-          "samples": 2
-        }
-      },
-      "files": [
-        "rekognition.test.js"
-      ]
-    },
-    {
-      "engines": {
-        "node": ">=22"
-      },
-      "dependencies": {
-        "@aws-sdk/client-s3": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
-          "samples": 5
-        }
-      },
-      "files": [
-        "s3.test.js"
-      ]
-    },
-    {
-      "engines": {
-        "node": ">=22"
-      },
-      "dependencies": {
-        "@aws-sdk/client-ses": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
-          "samples": 2
-        }
-      },
-      "files": [
-        "ses.test.js"
-      ]
-    },
-    {
-      "engines": {
-        "node": ">=22"
-      },
-      "dependencies": {
-        "@aws-sdk/client-sns": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
-          "samples": 10
-        }
-      },
-      "files": [
-        "sns.test.js"
-      ]
-    },
-    {
-      "engines": {
-        "node": ">=22"
-      },
-      "dependencies": {
-        "@aws-sdk/client-sqs": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
-          "samples": 10
-        }
-      },
-      "files": [
+        "api-gateway.test.js",
+        "client-dynamodb.test.js",
+        "elasticache.test.js",
+        "elb.test.js",
+        "lambda.test.js",
+        "rds.test.js",
+        "redshift.test.js",
+        "rekognition.test.js",
+        "s3.test.js",
+        "ses.test.js",
+        "sns.test.js",
         "sqs.test.js"
       ]
     },
@@ -196,25 +81,15 @@
       "engines": {
         "node": ">=22"
       },
-      "dependencies": {
-        "@aws-sdk/client-dynamodb": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
-          "samples": 10
-        }
-      },
-      "files": [
-        "client-dynamodb.test.js"
-      ]
-    },
-    {
-      "engines": {
-        "node": ">=22"
-      },
-      "dependencies": {
-        "@aws-sdk/lib-dynamodb": {
+      "groupedDependencies": {
+        "version": {
           "versions": ">3.377.0 <3.967.0 || >=3.983.0",
           "samples": 10
-        }
+        },
+        "packages": [
+          "@aws-sdk/client-dynamodb",
+          "@aws-sdk/lib-dynamodb"
+        ]
       },
       "files": [
         "lib-dynamodb.test.js"

--- a/test/versioned/aws-sdk-v3/package.json
+++ b/test/versioned/aws-sdk-v3/package.json
@@ -42,45 +42,39 @@
       "engines": {
         "node": ">=22"
       },
+      "comment": "These are sampled at 1 because it is a smoke test to verify AWS attributes on generic calls",
       "groupedDependencies": {
         "version": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0",
-          "samples": 5
+          "versions": ">3.377.0",
+          "samples": 1
         },
         "packages": [
           "@aws-sdk/client-api-gateway",
-          "@aws-sdk/client-dynamodb",
           "@aws-sdk/client-elasticache",
           "@aws-sdk/client-elastic-load-balancing",
-          "@aws-sdk/client-lambda",
           "@aws-sdk/client-rds",
           "@aws-sdk/client-redshift",
           "@aws-sdk/client-rekognition",
           "@aws-sdk/client-s3",
-          "@aws-sdk/client-ses",
-          "@aws-sdk/client-sns",
-          "@aws-sdk/client-sqs"
+          "@aws-sdk/client-ses"
         ]
       },
       "files": [
         "api-gateway.test.js",
-        "client-dynamodb.test.js",
         "elasticache.test.js",
         "elb.test.js",
-        "lambda.test.js",
         "rds.test.js",
         "redshift.test.js",
         "rekognition.test.js",
         "s3.test.js",
-        "ses.test.js",
-        "sns.test.js",
-        "sqs.test.js"
+        "ses.test.js"
       ]
     },
     {
       "engines": {
         "node": ">=22"
       },
+      "comment": "These are sampled at 10 because we have first-class instrumentation for the packages below via middleware in `lib/subscribers/aws-sdk`",
       "groupedDependencies": {
         "version": {
           "versions": ">3.377.0 <3.967.0 || >=3.983.0",
@@ -88,25 +82,23 @@
         },
         "packages": [
           "@aws-sdk/client-dynamodb",
-          "@aws-sdk/lib-dynamodb"
+          "@aws-sdk/client-lambda",
+          "@aws-sdk/client-sqs",
+          "@aws-sdk/client-sns",
+          "@aws-sdk/lib-dynamodb",
+          "@aws-sdk/client-bedrock-runtime"
         ]
-      },
-      "files": [
-        "lib-dynamodb.test.js"
-      ]
-    },
-    {
-      "engines": {
-        "node": ">=22"
-      },
-      "dependencies": {
-        "@aws-sdk/client-bedrock-runtime": ">=3.474.0"
       },
       "files": [
         "bedrock-chat-completions.test.js",
         "bedrock-embeddings.test.js",
         "bedrock-negative-tests.test.js",
-        "bedrock-converse-api.test.js"
+        "bedrock-converse-api.test.js",
+        "client-dynamodb.test.js",
+        "lambda.test.js",
+        "lib-dynamodb.test.js",
+        "sns.test.js",
+        "sqs.test.js"
       ]
     }
   ]

--- a/test/versioned/aws-sdk-v3/package.json
+++ b/test/versioned/aws-sdk-v3/package.json
@@ -44,10 +44,8 @@
       },
       "comment": "These are sampled at 1 because it is a smoke test to verify AWS attributes on generic calls",
       "groupedDependencies": {
-        "version": {
-          "versions": ">3.377.0",
-          "samples": 1
-        },
+        "samples": 1,
+        "version": ">3.377.0",
         "packages": [
           "@aws-sdk/client-api-gateway",
           "@aws-sdk/client-elasticache",
@@ -76,10 +74,8 @@
       },
       "comment": "These are sampled at 10 because we have first-class instrumentation for the packages below via middleware in `lib/subscribers/aws-sdk`",
       "groupedDependencies": {
-        "version": {
-          "versions": ">3.377.0 <3.967.0 || >=3.983.0",
-          "samples": 10
-        },
+        "samples": 10,
+        "version": ">3.377.0 <3.967.0 || >=3.983.0",
         "packages": [
           "@aws-sdk/client-dynamodb",
           "@aws-sdk/client-lambda",


### PR DESCRIPTION
## Description

- Smoke test block (samples: 1) — 8 generic-call AWS clients with a wider >3.377.0 range
- 1st-class instrumentation block (samples: 10) — DynamoDB, Lambda, SQS, SNS, lib-dynamodb, and bedrock-runtime, all co-pinned at the same version

## How to Test

```
npm run versioned aws-sdk-v3
```

## Related Issues

Closes #3979 