### PR TITLE
chore: Decrease smoke-like esm tests' sample size

### DIFF
--- a/test/versioned/amqplib-esm/package.json
+++ b/test/versioned/amqplib-esm/package.json
@@ -9,7 +9,10 @@
         "node": ">=22"
       },
       "dependencies": {
-        "amqplib": ">=0.5.0"
+        "amqplib": {
+          "versions": ">=0.5.0",
+          "samples": 2
+        }
       },
       "files": [
         "issue-2663.test.mjs"

--- a/test/versioned/amqplib-esm/package.json
+++ b/test/versioned/amqplib-esm/package.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "amqplib": {
           "versions": ">=0.5.0",
-          "samples": 2
+          "samples": 1
         }
       },
       "files": [

--- a/test/versioned/esm-package/package.json
+++ b/test/versioned/esm-package/package.json
@@ -12,7 +12,7 @@
         "dependencies": {
           "parse-json": {
             "versions": "6.0.2",
-            "samples": 2
+            "samples": 1
           }
         },
         "files": [

--- a/test/versioned/esm-package/package.json
+++ b/test/versioned/esm-package/package.json
@@ -10,7 +10,10 @@
           "node": ">=22"
         },
         "dependencies": {
-          "parse-json": "6.0.2"
+          "parse-json": {
+            "versions": "6.0.2",
+            "samples": 2
+          }
         },
         "files": [
           "parse-json.test.mjs"

--- a/test/versioned/express-esm/package.json
+++ b/test/versioned/express-esm/package.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "express": {
           "versions": ">=4.15.0",
-          "samples": 5
+          "samples": 2
         }
       },
       "files": [

--- a/test/versioned/express-esm/package.json
+++ b/test/versioned/express-esm/package.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "express": {
           "versions": ">=4.15.0",
-          "samples": 2
+          "samples": 1
         }
       },
       "files": [

--- a/test/versioned/grpc-esm/package.json
+++ b/test/versioned/grpc-esm/package.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@grpc/grpc-js": {
           "versions": ">=1.4.0",
-          "samples": 2
+          "samples": 1
         }
       },
       "files": [

--- a/test/versioned/grpc-esm/package.json
+++ b/test/versioned/grpc-esm/package.json
@@ -10,7 +10,10 @@
         "node": ">=22"
       },
       "dependencies": {
-        "@grpc/grpc-js": ">=1.4.0"
+        "@grpc/grpc-js": {
+          "versions": ">=1.4.0",
+          "samples": 2
+        }
       },
       "files": [
         "client-unary.test.mjs",

--- a/test/versioned/ioredis-esm/package.json
+++ b/test/versioned/ioredis-esm/package.json
@@ -10,7 +10,10 @@
         "node": ">=22"
       },
       "dependencies": {
-        "ioredis": ">=4.0.0"
+        "ioredis": {
+          "versions": ">=4.0.0",
+          "samples": 2
+        }
       },
       "files": [
         "ioredis.test.js"

--- a/test/versioned/ioredis-esm/package.json
+++ b/test/versioned/ioredis-esm/package.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "ioredis": {
           "versions": ">=4.0.0",
-          "samples": 2
+          "samples": 1
         }
       },
       "files": [

--- a/test/versioned/mongodb-esm/package.json
+++ b/test/versioned/mongodb-esm/package.json
@@ -9,7 +9,10 @@
         "node": ">=22"
       },
       "dependencies": {
-        "mongodb": ">=4.1.4 < 5"
+        "mongodb": {
+          "versions": ">=4.1.4 < 5",
+          "samples": 1
+        }
       },
       "files": [
         "bulk.test.mjs",

--- a/test/versioned/pg-esm/package.json
+++ b/test/versioned/pg-esm/package.json
@@ -10,7 +10,10 @@
         "node": ">=22"
       },
       "dependencies": {
-        "pg": ">=8.2.0"
+        "pg": {
+          "versions": ">=8.2.0",
+          "samples": 1
+        }
       },
       "files": [
         "pg.test.mjs"
@@ -21,8 +24,14 @@
         "node": ">=22 <24"
       },
       "dependencies": {
-        "pg": ">=8.2.0",
-        "pg-native": ">=3.0.0 <3.4.0 || >=3.4.5"
+        "pg": {
+          "versions": ">=8.2.0",
+          "samples": 1
+        },
+        "pg-native": {
+          "versions": ">=3.0.0 <3.4.0 || >=3.4.5",
+          "samples": 1
+        }
       },
       "files": [
         "force-native.test.mjs",
@@ -34,8 +43,14 @@
         "node": ">=24"
       },
       "dependencies": {
-        "pg": ">=8.16.0",
-        "pg-native": ">=3.5.0"
+        "pg": {
+          "versions": ">=8.16.0",
+          "samples": 1
+        },
+        "pg-native": {
+          "versions": ">=3.5.0",
+          "samples": 1
+        }
       },
       "files": [
         "force-native.test.mjs",

--- a/test/versioned/winston-esm/package.json
+++ b/test/versioned/winston-esm/package.json
@@ -10,8 +10,14 @@
         "node": ">=22"
       },
       "dependencies": {
-        "winston": ">=3.0.0",
-        "winston-transport": ">=4.0.0"
+        "winston": {
+          "versions": ">=3.0.0",
+          "samples": 2
+        },
+        "winston-transport": {
+          "versions": ">=4.0.0",
+          "samples": 2
+        }
       },
       "files": [
         "winston.test.mjs"

--- a/test/versioned/winston-esm/package.json
+++ b/test/versioned/winston-esm/package.json
@@ -12,11 +12,11 @@
       "dependencies": {
         "winston": {
           "versions": ">=3.0.0",
-          "samples": 2
+          "samples": 1
         },
         "winston-transport": {
           "versions": ">=4.0.0",
-          "samples": 2
+          "samples": 1
         }
       },
       "files": [


### PR DESCRIPTION
## Description

We have a few smoke-like ESM tests that just test that ESM instrumentation was loaded correctly or minimal instrumentation cases. The default sample size of 10 is not necessary for these tests. This PR reduces the sample size for applicable ESM test suites down to 1.

## How to Test

```
npm run versioned
```

## Related Issues

None