### PR TITLE
chore: Updated a few versioned test stanzas to reduce the number of combinations it runs

### DIFF
--- a/bin/versioned-runner/matrix.js
+++ b/bin/versioned-runner/matrix.js
@@ -201,7 +201,7 @@ function TestMatrix(tests, pkgVersions, globalSamples) {
       }
 
       if (test.groupedDependencies && test.groupedDependencies.packages?.length) {
-        const { packages, version, samples } = test.groupedDependencies
+        const { packages, version, samples = Infinity } = test.groupedDependencies
         // passing in object as 2nd arg to handle finding minimum of samples vs globalSamples
         task.packages.push(
           resolveIterator(packages, { versions: version, samples }, pkgVersions, globalSamples)

--- a/test/versioned/aws-sdk-v2/package.json
+++ b/test/versioned/aws-sdk-v2/package.json
@@ -26,7 +26,7 @@
       "dependencies": {
         "aws-sdk": {
           "versions": ">=2.463.0",
-          "samples": 10
+          "samples": 1 
         }
       },
       "files": [
@@ -44,7 +44,10 @@
         "node": ">=22.0"
       },
       "dependencies": {
-        "amazon-dax-client": ">=1.2.5"
+        "amazon-dax-client": {
+         "versions": ">=1.2.5",
+         "samples": 1
+        }
       },
       "files": [
         "amazon-dax-client.test.js"

--- a/test/versioned/fastify/package.json
+++ b/test/versioned/fastify/package.json
@@ -29,7 +29,10 @@
         "node": ">=22"
       },
       "dependencies": {
-        "fastify": "^4.0.0",
+        "fastify": {
+          "versions": "^4.0.0",
+          "samples": 1 
+        },
         "@fastify/middie": ">=7.0.0 && <9.0.0"
       },
       "files": [

--- a/test/versioned/openai/chat-completions-res-api.test.js
+++ b/test/versioned/openai/chat-completions-res-api.test.js
@@ -7,6 +7,7 @@
 
 const test = require('node:test')
 const assert = require('node:assert')
+const semver = require('semver')
 const { tspl } = require('@matteo.collina/tspl')
 
 const { removeModules } = require('../../lib/cache-buster')
@@ -25,7 +26,7 @@ const TRACKING_METRIC = `Supportability/Nodejs/ML/OpenAI/${pkgVersion}`
 const responses = require('./mock-responses-api-responses')
 const { assertChatCompletionMessages, assertChatCompletionSummary } = require('./common-responses-api')
 
-test('responses.create', async (t) => {
+test('responses.create', { skip: semver.lte(pkgVersion, '4.87.0') }, async (t) => {
   t.beforeEach(async (ctx) => {
     ctx.nr = {}
     const { host, port, server } = await createOpenAIMockServer(responses)

--- a/test/versioned/openai/package.json
+++ b/test/versioned/openai/package.json
@@ -16,19 +16,9 @@
       },
       "files": [
         "chat-completions.test.js",
+        "chat-completions-res-api.test.js",
         "embeddings.test.js",
         "feedback-messages.test.js"
-      ]
-    },
-    {
-      "engines": {
-        "node": ">=22"
-      },
-      "dependencies": {
-        "openai": ">=4.87.0"
-      },
-      "files": [
-        "chat-completions-res-api.test.js"
       ]
     }
   ]

--- a/test/versioned/undici/package.json
+++ b/test/versioned/undici/package.json
@@ -9,7 +9,10 @@
         "node": ">=22"
       },
       "dependencies": {
-        "undici": ">=5.0.0 <8.0.0"
+        "undici": {
+          "versions": ">=5.0.0 <8.0.0",
+          "samples": 4
+        }
       },
       "files": [
         "requests.test.js"

--- a/test/versioned/undici/package.json
+++ b/test/versioned/undici/package.json
@@ -9,22 +9,7 @@
         "node": ">=22"
       },
       "dependencies": {
-        "undici": {
-          "versions": ">=5.0.0 <8.0.0",
-          "samples": 4
-        }
-      },
-      "files": [
-        "requests.test.js"
-      ]
-    },
-
-    {
-      "engines": {
-        "node": ">=22"
-      },
-      "dependencies": {
-        "undici": ">=8.0.0"
+        "undici": ">=5.0.0"
       },
       "files": [
         "requests.test.js"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This PR reduces the test matrix by applying sampling, or combining tests into one stanza.
I also fixed a bug with `samples` on `groupedDependencies`. It wasn't using the min because if samples wasn't defined it was not sampling at all.
By defaulting the samples to `Infinity` it resolves the issue.  

After this PR we went from:

prisma: 52 different versions to 19
openai: 19 to 10
fastify: 20 to 12
undici: 13 to 10
aws sdk v2: 11 to 2

The idea is for 3rd party libraries that have multiple test stanzas and those versions are EOLd, I'm sampling at a low rate because they are not changing.
