### PR TITLE
chore: Fixed `test/lib/get-package-version.js`

### DIFF
--- a/test/lib/get-package-version.js
+++ b/test/lib/get-package-version.js
@@ -34,13 +34,14 @@ module.exports = function getPackageVersion({
   const root = path.dirname(baseDir) === 'node_modules'
     ? baseDir
     : path.join(baseDir, 'node_modules')
-  const resolvedPath = path.resolve(path.join(root, pkgName, 'package.js'))
+  const resolvedPath = path.resolve(path.join(root, pkgName, 'package.json'))
   try {
     // We cannot `require(json)` here because some packages defined an exports
     // map which prohibits access to the manifest file. We need to
     // circumvent that.
     const pkg = fs.readFileSync(resolvedPath)
-    return pkg.version
+    const { version } = JSON.parse(pkg)
+    return version
   } catch {
     return returnProcessVersion === true
       ? process.version.slice(1)

--- a/test/versioned/aws-sdk-v3/bedrock-converse-api.test.js
+++ b/test/versioned/aws-sdk-v3/bedrock-converse-api.test.js
@@ -62,10 +62,11 @@ test('Converse API', { skip: semver.lt(bedrockVersion, '3.587.0') }, async (t) =
       pkgName: pkg,
       baseDir: __dirname
     })
-    if (version === undefined) {
+
+    if (version === undefined || semver.gte(version, '4.13.0')) {
       pkg = '@smithy/core'
       version = getPackageVersion({
-        pkgName: '@smithy/core',
+        pkgName: pkg,
         baseDir: __dirname
       })
     }


### PR DESCRIPTION
The asserting of tracking metric for bedrock depends on the version of `@smithy/smithy-client`.  In 4.13.0 the instrumentation we rely on moved to `@smithy/core`. And then in `3.1046.0` of any packages it appears that `@smithy/smithy-client` was removed in favor of `@smithy/core`. This PR addresses all of that.

Full versioned test run:

```sh
Folder: aws-sdk-v3
	 * @aws-sdk/client-api-gateway(1): 3.1046.0
	 * @aws-sdk/client-elasticache(1): 3.1046.0
	 * @aws-sdk/client-elastic-load-balancing(1): 3.1046.0
	 * @aws-sdk/client-rds(1): 3.1046.0
	 * @aws-sdk/client-redshift(1): 3.1046.0
	 * @aws-sdk/client-rekognition(1): 3.1046.0
	 * @aws-sdk/client-s3(1): 3.1046.0
	 * @aws-sdk/client-ses(1): 3.1046.0
	 * @aws-sdk/client-dynamodb(7): 3.423.0, 3.525.0, 3.662.0, 3.806.0, 3.914.0, 3.996.0, 3.1046.0
	 * @aws-sdk/client-lambda(7): 3.423.0, 3.525.0, 3.662.0, 3.806.0, 3.914.0, 3.996.0, 3.1046.0
	 * @aws-sdk/client-sqs(7): 3.423.0, 3.525.0, 3.662.0, 3.806.0, 3.914.0, 3.996.0, 3.1046.0
	 * @aws-sdk/client-sns(7): 3.423.0, 3.525.0, 3.662.0, 3.806.0, 3.914.0, 3.996.0, 3.1046.0
	 * @aws-sdk/lib-dynamodb(7): 3.423.0, 3.525.0, 3.662.0, 3.806.0, 3.914.0, 3.996.0, 3.1046.0
	 * @aws-sdk/client-bedrock-runtime(7): 3.423.0, 3.525.0, 3.662.0, 3.806.0, 3.914.0, 3.996.0, 3.1046.0
===============================================================
PASS

real	1m35.912s
user	1m20.109s
sys	0m35.655s

```