### PR TITLE
fix: Updated label parser to handle empty values in an object key

### DIFF
--- a/lib/util/label-parser.js
+++ b/lib/util/label-parser.js
@@ -80,9 +80,10 @@ function fromMap(map) {
     const type = truncate(key, 255)
 
     if (!val || typeof val !== 'string') {
-      return warnings.push(
-        'Label value for ' + type + 'should be a string with a length between 1 and 255 characters'
+      warnings.push(
+        `Label value for '${type}' should be a string with a length between 1 and 255 characters`
       )
+      continue
     }
 
     const value = truncate(val, 255)

--- a/test/unit/collector/facts.test.js
+++ b/test/unit/collector/facts.test.js
@@ -204,7 +204,8 @@ test('fun facts about apps that New Relic is interested in including', async (t)
     agent.config.parsedLabels = parseLabels(
       {
         a: 'b',
-        [longKey]: longValue
+        [longKey]: longValue,
+        c: undefined
       },
       { child: () => logger }
     )
@@ -214,6 +215,21 @@ test('fun facts about apps that New Relic is interested in including', async (t)
         { label_type: '€'.repeat(255), label_value: '𝌆'.repeat(255) }
       ]
       assert.deepEqual(result.labels, expected)
+      end()
+    })
+  })
+
+  await t.test('should not convert label object if empty values', (t, end) => {
+    const { agent, logger, facts } = t.nr
+    agent.config.parsedLabels = parseLabels(
+      {
+        a: undefined,
+        b: undefined
+      },
+      { child: () => logger }
+    )
+    facts(agent, (result) => {
+      assert.deepEqual(result.labels, [])
       end()
     })
   })

--- a/test/unit/config/config.test.js
+++ b/test/unit/config/config.test.js
@@ -151,6 +151,19 @@ test('parsedLabels', () => {
   ])
 })
 
+test('parsedLabels object', () => {
+  const configuration = Config.initialize({ labels: { foo: 'bar', bar: 'baz' } })
+  assert.deepEqual(configuration.parsedLabels, [
+    { label_type: 'foo', label_value: 'bar' },
+    { label_type: 'bar', label_value: 'baz' },
+  ])
+})
+
+test('parsedLabels empty values in object', () => {
+  const configuration = Config.initialize({ labels: { foo: undefined, bar: undefined } })
+  assert.deepEqual(configuration.parsedLabels, [])
+})
+
 test('loggingLabels', async (t) => {
   await t.test('should exclude labels regardless of case', () => {
     const config = {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

It looks like in #3440 we had a regression that was uncaught. We lacked tests for the scenario where a `config.lablels` is an object and a value is not a string.

## Related Issues
Closes #3997
