### PR TITLE
test: Add stable `http.request` shim so AWS test agent setup works with smithy >=4.7.3

### DIFF
--- a/test/lib/agent_helper.js
+++ b/test/lib/agent_helper.js
@@ -193,8 +193,28 @@ helper.instrumentMockedAgent = (conf, setState = true, shimmer = require('../../
   shimmer.bootstrapInstrumentation(agent)
   shimmer.registerHooks(agent)
   helper.maybeLoadSecurityAgent(agent)
+  installStableHttpRequest()
 
   return agent
+}
+
+// @smithy/node-http-handler ≥ 4.7.3 captures http.request via
+// `await import('node:http')`, which snapshots the ESM namespace at first
+// import. Subsequent shimmer.unwrap/re-wrap cycles (per-test agent setup)
+// are invisible to that snapshot, leaving smithy bound to a defunct agent.
+// Install a stable forwarding shim once; each instrumentMockedAgent call
+// just updates what it delegates to.
+let _activeHttpRequest = null
+let _stableHttpRequest = null
+function installStableHttpRequest() {
+  _activeHttpRequest = http.request
+  if (!_stableHttpRequest) {
+    // Name mirrors shimmer's wrapper so http.request.name assertions still hold.
+    _stableHttpRequest = function wrappedRequest(...args) {
+      return _activeHttpRequest.apply(this, args)
+    }
+  }
+  http.request = _stableHttpRequest
 }
 
 /**

--- a/test/versioned/aws-sdk-v3/bedrock-chat-completions.test.js
+++ b/test/versioned/aws-sdk-v3/bedrock-chat-completions.test.js
@@ -9,6 +9,7 @@ const assert = require('node:assert')
 const test = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
 
+const afterEach = require('./test-utils/after-each.js')
 const assertChatCompletionMessage = require('./test-utils/assert-chat-completion-message.js')
 const assertChatCompletionMessages = require('./test-utils/assert-chat-completion-messages.js')
 const assertChatCompletionSummary = require('./test-utils/assert-chat-completion-summary.js')
@@ -83,31 +84,30 @@ const requests = {
 }
 
 test('Chat completions', async (t) => {
-  const agent = helper.instrumentMockedAgent({
-    ai_monitoring: {
-      enabled: true
-    }
-  })
-  const bedrock = require('@aws-sdk/client-bedrock-runtime')
+  t.beforeEach(async (ctx) => {
+    ctx.nr = {}
+    ctx.nr.agent = helper.instrumentMockedAgent({
+      ai_monitoring: {
+        enabled: true
+      }
+    })
+    const bedrock = require('@aws-sdk/client-bedrock-runtime')
+    ctx.nr.bedrock = bedrock
 
-  const { server, baseUrl, responses, host, port } = await createAiResponseServer()
-  const expectedExternalPath = (modelId, method = 'invoke') => `External/${host}:${port}/model/${encodeURIComponent(modelId)}/${method}`
+    const { server, baseUrl, responses, host, port } = await createAiResponseServer()
+    ctx.nr.server = server
+    ctx.nr.responses = responses
+    ctx.nr.expectedExternalPath = (modelId, method = 'invoke') => `External/${host}:${port}/model/${encodeURIComponent(modelId)}/${method}`
 
-  const client = new bedrock.BedrockRuntimeClient({
-    region: 'us-east-1',
-    credentials: FAKE_CREDENTIALS,
-    endpoint: baseUrl,
-    maxAttempts: 1
-  })
-  test.after(() => {
-    server.destroy()
-    helper.unloadAgent(agent)
+    ctx.nr.client = new bedrock.BedrockRuntimeClient({
+      region: 'us-east-1',
+      credentials: FAKE_CREDENTIALS,
+      endpoint: baseUrl,
+      maxAttempts: 1
+    })
   })
 
-  test.afterEach(() => {
-    agent.customEventAggregator.clear()
-    agent.llm.tokenCountCallback = null
-  })
+  t.afterEach(afterEach)
 
   const tests = [
     { modelId: 'amazon.titan-text-express-v1', resKey: 'amazon' },
@@ -122,6 +122,7 @@ test('Chat completions', async (t) => {
   for (const data of tests) {
     const { modelId, resKey } = data
     await t.test(`${modelId}: should properly create completion segment`, async (t) => {
+      const { agent, bedrock, client, responses, expectedExternalPath } = t.nr
       const prompt = `text ${resKey} ultimate question`
       const input = requests[resKey](prompt, modelId)
 
@@ -144,6 +145,7 @@ test('Chat completions', async (t) => {
     })
 
     await t.test(`${modelId}:  properly create the LlmChatCompletionMessage(s) and LlmChatCompletionSummary events`, async (t) => {
+      const { agent, bedrock, client } = t.nr
       const prompt = `text ${resKey} ultimate question`
       const input = requests[resKey](prompt, modelId)
       const command = new bedrock.InvokeModelCommand(input)
@@ -176,6 +178,7 @@ test('Chat completions', async (t) => {
     })
 
     await t.test(`${modelId}:  supports custom attributes on LlmChatCompletionMessage(s) and LlmChatCompletionSummary events`, async (t) => {
+      const { agent, bedrock, client } = t.nr
       const { promise, resolve } = promiseResolvers()
       const prompt = `text ${resKey} ultimate question`
       const input = requests[resKey](prompt, modelId)
@@ -200,6 +203,7 @@ test('Chat completions', async (t) => {
     })
 
     await t.test(`${modelId}:  supports assigning token counts in callback`, async (t) => {
+      const { agent, bedrock, client } = t.nr
       const { promise, resolve } = promiseResolvers()
       const prompt = `text ${resKey} ultimate question`
       const input = requests[resKey](prompt, modelId)
@@ -242,6 +246,7 @@ test('Chat completions', async (t) => {
     })
 
     await t.test(`${modelId}: text answer (streamed)`, async (t) => {
+      const { agent, bedrock, client } = t.nr
       const prompt = `text ${resKey} ultimate question streamed`
       const input = requests[resKey](prompt, modelId)
       const command = new bedrock.InvokeModelWithResponseStreamCommand(input)
@@ -273,7 +278,6 @@ test('Chat completions', async (t) => {
         assertChatCompletionSummary({ tx, modelId, chatSummary, numMsgs: events.length - 1 })
 
         const timeToFirstToken = chatSummary?.[1]?.['time_to_first_token']
-        assert.ok(timeToFirstToken, 'time_to_first_token should exist')
         assert.equal(typeof timeToFirstToken, 'number', 'time_to_first_token should be a number')
         assert.ok(timeToFirstToken >= 0, 'time_to_first_token should be >= 0')
 
@@ -282,6 +286,7 @@ test('Chat completions', async (t) => {
     })
 
     await t.test('should record feedback message accordingly', async (t) => {
+      const { agent, bedrock, client } = t.nr
       const prompt = `text ${resKey} ultimate question`
       const input = requests[resKey](prompt, modelId)
       const command = new bedrock.InvokeModelCommand(input)
@@ -315,6 +320,7 @@ test('Chat completions', async (t) => {
     })
 
     await t.test(`${modelId}: should increment tracking metric for each chat completion event`, async (t) => {
+      const { agent, bedrock, client } = t.nr
       const prompt = `text ${resKey} ultimate question`
       const input = requests[resKey](prompt, modelId)
       const command = new bedrock.InvokeModelCommand(input)
@@ -330,6 +336,7 @@ test('Chat completions', async (t) => {
     })
 
     await t.test(`${modelId}: should properly create errors on create completion`, async (t) => {
+      const { agent, bedrock, client, expectedExternalPath } = t.nr
       const prompt = `text ${resKey} ultimate question error`
       const input = requests[resKey](prompt, modelId)
 
@@ -390,6 +397,7 @@ test('Chat completions', async (t) => {
     })
 
     await t.test(`{${modelId}:}: should add llm attribute to transaction`, async (t) => {
+      const { agent, bedrock, client } = t.nr
       const prompt = `text ${resKey} ultimate question`
       const input = requests[resKey](prompt, modelId)
       const command = new bedrock.InvokeModelCommand(input)
@@ -404,6 +412,7 @@ test('Chat completions', async (t) => {
     })
 
     await t.test(`${modelId}: should decorate messages with custom attrs`, async (t) => {
+      const { agent, bedrock, client } = t.nr
       const prompt = `text ${resKey} ultimate question`
       const input = requests[resKey](prompt, modelId)
       const command = new bedrock.InvokeModelCommand(input)
@@ -433,6 +442,7 @@ test('Chat completions', async (t) => {
   }
 
   await t.test('cohere embedding streaming works', async (t) => {
+    const { agent, bedrock, client } = t.nr
     const prompt = 'embed text cohere stream'
     const input = {
       body: JSON.stringify({
@@ -464,6 +474,7 @@ test('Chat completions', async (t) => {
   })
 
   await t.test('anthropic-claude-3: should properly create events for chunked messages', async (t) => {
+    const { agent, bedrock, client } = t.nr
     const modelId = 'anthropic.claude-3-5-sonnet-20240620-v1:0'
     const prompt = 'text claude3 ultimate question chunked'
     const promptFollowUp = 'And please include an image in the response'
@@ -537,6 +548,7 @@ test('Chat completions', async (t) => {
   })
 
   await t.test('region specific anthropic-claude-3: should properly create events for chunked messages', async (t) => {
+    const { agent, bedrock, client } = t.nr
     const modelId = 'us.anthropic.claude-3-5-sonnet-20240620-v1:0'
     const prompt = 'text claude3 ultimate question chunked'
     const promptFollowUp = 'And please include an image in the response'
@@ -610,6 +622,7 @@ test('Chat completions', async (t) => {
   })
 
   await t.test('models that do not support streaming should be handled', async (t) => {
+    const { agent, bedrock, client, expectedExternalPath } = t.nr
     const modelId = 'amazon.titan-embed-text-v1'
     const prompt = 'embed text amazon error streamed'
     const input = requests.amazon(prompt, modelId)
@@ -665,6 +678,7 @@ test('Chat completions', async (t) => {
   })
 
   await t.test('models should properly create errors on stream interruption', async (t) => {
+    const { agent, bedrock, client } = t.nr
     const modelId = 'amazon.titan-text-express-v1'
     const prompt = 'text amazon bad stream'
     const input = requests.amazon(prompt, modelId)
@@ -707,6 +721,7 @@ test('Chat completions', async (t) => {
   })
 
   await t.test('should not instrument stream when disabled', async (t) => {
+    const { agent, bedrock, client } = t.nr
     const modelId = 'amazon.titan-text-express-v1'
     agent.config.ai_monitoring.streaming.enabled = false
     const prompt = 'text amazon ultimate question streamed'
@@ -768,6 +783,7 @@ test('Chat completions', async (t) => {
   })
 
   await t.test('should utilize tokenCountCallback when set', async (t) => {
+    const { agent, bedrock, client } = t.nr
     const plan = tspl(t, { plan: 13 })
 
     const prompt = 'text amazon user token count callback response'

--- a/test/versioned/aws-sdk-v3/bedrock-converse-api.test.js
+++ b/test/versioned/aws-sdk-v3/bedrock-converse-api.test.js
@@ -10,6 +10,7 @@ const test = require('node:test')
 const semver = require('semver')
 
 const getPackageVersion = require('../../lib/get-package-version.js')
+const afterEach = require('./test-utils/after-each.js')
 const assertChatCompletionMessages = require('./test-utils/assert-chat-completion-messages.js')
 const assertChatCompletionSummary = require('./test-utils/assert-chat-completion-summary.js')
 const helper = require('../../lib/agent_helper')
@@ -27,34 +28,32 @@ const modelId = 'anthropic.claude-instant-v1'
 const { version: bedrockVersion } = require('@aws-sdk/client-bedrock-runtime/package.json')
 
 test('Converse API', { skip: semver.lt(bedrockVersion, '3.587.0') }, async (t) => {
-  const agent = helper.instrumentMockedAgent({
-    ai_monitoring: {
-      enabled: true
-    }
-  })
-  const bedrock = require('@aws-sdk/client-bedrock-runtime')
+  t.beforeEach(async (ctx) => {
+    ctx.nr = {}
+    ctx.nr.agent = helper.instrumentMockedAgent({
+      ai_monitoring: {
+        enabled: true
+      }
+    })
+    const bedrock = require('@aws-sdk/client-bedrock-runtime')
+    ctx.nr.bedrock = bedrock
 
-  const { server, baseUrl, host, port } = await createAiResponseServer()
-  const expectedExternalPath = (modelId, method = 'converse') => `External/${host}:${port}/model/${encodeURIComponent(modelId)}/${method}`
+    const { server, baseUrl, host, port } = await createAiResponseServer()
+    ctx.nr.server = server
+    ctx.nr.expectedExternalPath = (modelId, method = 'converse') => `External/${host}:${port}/model/${encodeURIComponent(modelId)}/${method}`
 
-  const client = new bedrock.BedrockRuntimeClient({
-    region: 'us-east-1',
-    credentials: FAKE_CREDENTIALS,
-    endpoint: baseUrl,
-    maxAttempts: 1
+    ctx.nr.client = new bedrock.BedrockRuntimeClient({
+      region: 'us-east-1',
+      credentials: FAKE_CREDENTIALS,
+      endpoint: baseUrl,
+      maxAttempts: 1
+    })
   })
 
-  test.after(() => {
-    server.destroy()
-    helper.unloadAgent(agent)
-  })
-
-  test.afterEach(() => {
-    agent.customEventAggregator.clear()
-    agent.llm.tokenCountCallback = null
-  })
+  t.afterEach(afterEach)
 
   await t.test('should properly create completion segment', async (t) => {
+    const { agent, bedrock, client, expectedExternalPath } = t.nr
     // the package we subscribe to changes in `4.13.0` from
     // `@smithy/smithy-client` to `@smithy/core`
     let pkg = '@smithy/smithy-client'
@@ -98,6 +97,7 @@ test('Converse API', { skip: semver.lt(bedrockVersion, '3.587.0') }, async (t) =
   })
 
   await t.test('properly create the LlmChatCompletionMessage(s) and LlmChatCompletionSummary events', async (t) => {
+    const { agent, bedrock, client } = t.nr
     const prompt = 'text converse ultimate question'
     const input = {
       modelId,
@@ -140,6 +140,7 @@ test('Converse API', { skip: semver.lt(bedrockVersion, '3.587.0') }, async (t) =
   })
 
   await t.test('supports custom attributes on LlmChatCompletionMessage(s) and LlmChatCompletionSummary events', async (t) => {
+    const { agent, bedrock, client } = t.nr
     const { promise, resolve } = promiseResolvers()
     const prompt = 'text converse ultimate question'
     const input = {
@@ -169,6 +170,7 @@ test('Converse API', { skip: semver.lt(bedrockVersion, '3.587.0') }, async (t) =
   })
 
   await t.test('should record feedback message accordingly', async (t) => {
+    const { agent, bedrock, client } = t.nr
     const prompt = 'text converse ultimate question'
     const input = {
       modelId,
@@ -207,6 +209,7 @@ test('Converse API', { skip: semver.lt(bedrockVersion, '3.587.0') }, async (t) =
   })
 
   await t.test('should increment tracking metric for each chat completion event', async (t) => {
+    const { agent, bedrock, client } = t.nr
     const prompt = 'text converse ultimate question'
     const input = {
       modelId,
@@ -227,6 +230,7 @@ test('Converse API', { skip: semver.lt(bedrockVersion, '3.587.0') }, async (t) =
   })
 
   await t.test('should properly create errors on create completion', async (t) => {
+    const { agent, bedrock, client, expectedExternalPath } = t.nr
     const prompt = 'text converse ultimate question error'
     const input = {
       modelId,
@@ -297,6 +301,7 @@ test('Converse API', { skip: semver.lt(bedrockVersion, '3.587.0') }, async (t) =
   })
 
   await t.test('should add llm attribute to transaction', async (t) => {
+    const { agent, bedrock, client } = t.nr
     const prompt = 'text converse ultimate question'
     const input = {
       modelId,
@@ -316,6 +321,7 @@ test('Converse API', { skip: semver.lt(bedrockVersion, '3.587.0') }, async (t) =
   })
 
   await t.test('should decorate messages with custom attrs', async (t) => {
+    const { agent, bedrock, client } = t.nr
     const prompt = 'text converse ultimate question'
     const input = {
       modelId,
@@ -349,6 +355,7 @@ test('Converse API', { skip: semver.lt(bedrockVersion, '3.587.0') }, async (t) =
   })
 
   await t.test('should instrument text stream', async (t) => {
+    const { agent, bedrock, client } = t.nr
     const prompt = 'text converse ultimate question streamed'
     const input = {
       modelId,
@@ -389,7 +396,6 @@ test('Converse API', { skip: semver.lt(bedrockVersion, '3.587.0') }, async (t) =
 
       assertChatCompletionSummary({ tx, modelId, tokenUsage: true, chatSummary, numMsgs: events.length - 1 })
       const timeToFirstToken = chatSummary?.[1]?.['time_to_first_token']
-      assert.ok(timeToFirstToken, 'time_to_first_token should exist')
       assert.equal(typeof timeToFirstToken, 'number', 'time_to_first_token should be a number')
       assert.ok(timeToFirstToken >= 0, 'time_to_first_token should be >= 0')
 
@@ -398,6 +404,7 @@ test('Converse API', { skip: semver.lt(bedrockVersion, '3.587.0') }, async (t) =
   })
 
   await t.test('should not instrument stream when disabled', async (t) => {
+    const { agent, bedrock, client } = t.nr
     agent.config.ai_monitoring.streaming.enabled = false
     const prompt = 'text converse ultimate question streamed'
     const input = {

--- a/test/versioned/aws-sdk-v3/bedrock-embeddings.test.js
+++ b/test/versioned/aws-sdk-v3/bedrock-embeddings.test.js
@@ -10,6 +10,7 @@ const helper = require('../../lib/agent_helper')
 const { assertSegments, match } = require('../../lib/custom-assertions')
 const { FAKE_CREDENTIALS, getAiResponseServer } = require('../../lib/aws-server-stubs')
 const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
+const afterEach = require('./test-utils/after-each.js')
 const createAiResponseServer = getAiResponseServer(__dirname)
 const requests = {
   amazon: (prompt, modelId) => {
@@ -27,30 +28,30 @@ const requests = {
 }
 
 test('Embeddings', async (t) => {
-  const agent = helper.instrumentMockedAgent({
-    ai_monitoring: {
-      enabled: true
-    }
+  t.beforeEach(async (ctx) => {
+    ctx.nr = {}
+    ctx.nr.agent = helper.instrumentMockedAgent({
+      ai_monitoring: {
+        enabled: true
+      }
+    })
+
+    const bedrock = require('@aws-sdk/client-bedrock-runtime')
+    ctx.nr.bedrock = bedrock
+
+    const { server, baseUrl, responses, host, port } = await createAiResponseServer()
+    ctx.nr.server = server
+    ctx.nr.responses = responses
+    ctx.nr.expectedExternalPath = (modelId) => `External/${host}:${port}/model/${modelId}/invoke`
+
+    ctx.nr.client = new bedrock.BedrockRuntimeClient({
+      region: 'us-east-1',
+      credentials: FAKE_CREDENTIALS,
+      endpoint: baseUrl
+    })
   })
 
-  const bedrock = require('@aws-sdk/client-bedrock-runtime')
-  const { server, baseUrl, responses, host, port } = await createAiResponseServer()
-  const expectedExternalPath = (modelId) => `External/${host}:${port}/model/${modelId}/invoke`
-
-  const client = new bedrock.BedrockRuntimeClient({
-    region: 'us-east-1',
-    credentials: FAKE_CREDENTIALS,
-    endpoint: baseUrl
-  })
-  test.after(() => {
-    server.destroy()
-    helper.unloadAgent(agent)
-  })
-
-  test.afterEach(() => {
-    agent.customEventAggregator.clear()
-    agent.llm.tokenCountCallback = null
-  })
+  t.afterEach(afterEach)
 
   const tests = [
     { modelId: 'amazon.titan-embed-text-v1', resKey: 'amazon' },
@@ -60,6 +61,7 @@ test('Embeddings', async (t) => {
   for (const data of tests) {
     const { modelId, resKey } = data
     await t.test(`${modelId}: should properly create embedding segment`, async (t) => {
+      const { agent, bedrock, client, responses, expectedExternalPath } = t.nr
       const prompt = `text ${resKey} ultimate question`
       const input = requests[resKey](prompt, modelId)
 
@@ -82,6 +84,7 @@ test('Embeddings', async (t) => {
     })
 
     await t.test(`${modelId}: should properly create the LlmEmbedding event`, async (t) => {
+      const { agent, bedrock, client } = t.nr
       const prompt = `embed text ${resKey} success`
       const input = requests[resKey](prompt, modelId)
       const command = new bedrock.InvokeModelCommand(input)
@@ -116,6 +119,7 @@ test('Embeddings', async (t) => {
     // Amazon Bedrock does not currently support streaming responses for amazon titan embeddings
     // See: https://docs.aws.amazon.com/bedrock/latest/userguide/service_code_examples_bedrock-runtime_amazon_titan_text_embeddings.html
     await t.test(`${modelId}: text answer (streamed)`, { skip: resKey === 'amazon' }, async (t) => {
+      const { agent, bedrock, client } = t.nr
       const prompt = `text ${resKey} ultimate question streamed`
       const input = requests[resKey](prompt, modelId)
       const command = new bedrock.InvokeModelWithResponseStreamCommand(input)
@@ -156,6 +160,7 @@ test('Embeddings', async (t) => {
     })
 
     await t.test(`${modelId}: should properly create errors on embeddings`, async (t) => {
+      const { agent, bedrock, client, expectedExternalPath } = t.nr
       const prompt = `embed text ${resKey} error`
       const input = requests[resKey](prompt, modelId)
       const command = new bedrock.InvokeModelCommand(input)
@@ -219,6 +224,7 @@ test('Embeddings', async (t) => {
     })
 
     await t.test(`${modelId}: should add llm attribute to transaction`, async (t) => {
+      const { agent, bedrock, client } = t.nr
       const prompt = `embed text ${resKey} success`
       const input = requests[resKey](prompt, modelId)
       const command = new bedrock.InvokeModelCommand(input)
@@ -233,6 +239,7 @@ test('Embeddings', async (t) => {
     })
 
     await t.test(`${modelId}: should decorate messages with custom attrs`, async (t) => {
+      const { agent, bedrock, client } = t.nr
       const prompt = `embed text ${resKey} success`
       const input = requests[resKey](prompt, modelId)
       const command = new bedrock.InvokeModelCommand(input)

--- a/test/versioned/aws-sdk-v3/lambda.test.js
+++ b/test/versioned/aws-sdk-v3/lambda.test.js
@@ -9,12 +9,13 @@ const test = require('node:test')
 const assert = require('node:assert')
 
 const helper = require('../../lib/agent_helper')
+const afterEach = require('./test-utils/after-each.js')
+const checkAWSAttributes = require('./test-utils/check-aws-attributes.js')
+const checkExternals = require('./test-utils/check-externals.js')
 const {
   EXTERN_PATTERN,
   SEGMENT_DESTINATION
 } = require('./test-utils/constants.js')
-const checkAWSAttributes = require('./test-utils/check-aws-attributes.js')
-const checkExternals = require('./test-utils/check-externals.js')
 const { createEmptyResponseServer, FAKE_CREDENTIALS } = require('../../lib/aws-server-stubs')
 const { match } = require('../../lib/custom-assertions')
 
@@ -71,37 +72,37 @@ function checkNonLinkableSegments({ operations, tx, end }) {
     match(attrs, {
       'aws.operation': operations[0],
       'aws.requestId': String,
-      'aws.region': 'us-east-1',
-      'aws.service': String
+      'aws.service': String,
+      'aws.region': 'us-east-1'
     })
   })
   end()
 }
 
-// Note: Not running this in a beforEach/afterEach because of a refactor
-// @smithy/node-http-handler. They are importing `node:http` and it was
-// always picking up the instrumented http code from the first test run
 test('LambdaClient', async (t) => {
-  const server = createEmptyResponseServer()
-  await new Promise((resolve) => {
-    server.listen(0, resolve)
-  })
-  const agent = helper.instrumentMockedAgent()
-  const { LambdaClient, ...lib } = require('@aws-sdk/client-lambda')
-  const { AddLayerVersionPermissionCommand, InvokeCommand } = lib
-  const endpoint = `http://localhost:${server.address().port}`
-  const service = new LambdaClient({
-    credentials: FAKE_CREDENTIALS,
-    endpoint,
-    region: 'us-east-1'
+  t.beforeEach(async (ctx) => {
+    ctx.nr = {}
+    const server = createEmptyResponseServer()
+    await new Promise((resolve) => {
+      server.listen(0, resolve)
+    })
+    ctx.nr.server = server
+    ctx.nr.agent = helper.instrumentMockedAgent()
+    const { LambdaClient, ...lib } = require('@aws-sdk/client-lambda')
+    ctx.nr.AddLayerVersionPermissionCommand = lib.AddLayerVersionPermissionCommand
+    ctx.nr.InvokeCommand = lib.InvokeCommand
+    const endpoint = `http://localhost:${server.address().port}`
+    ctx.nr.service = new LambdaClient({
+      credentials: FAKE_CREDENTIALS,
+      endpoint,
+      region: 'us-east-1'
+    })
   })
 
-  t.after(() => {
-    server.destroy()
-    helper.unloadAgent(agent)
-  })
+  t.afterEach(afterEach)
 
   await t.test('AddLayerVersionPermissionCommand', (t, end) => {
+    const { service, agent, AddLayerVersionPermissionCommand } = t.nr
     helper.runInTransaction(agent, async (tx) => {
       const cmd = new AddLayerVersionPermissionCommand({
         Action: 'lambda:GetLayerVersion' /* required */,
@@ -124,6 +125,7 @@ test('LambdaClient', async (t) => {
   })
 
   await t.test('InvokeCommand', (t, end) => {
+    const { service, agent, InvokeCommand } = t.nr
     agent.config.cloud.aws.account_id = 123456789123
     helper.runInTransaction(agent, async (tx) => {
       const cmd = new InvokeCommand({
@@ -141,6 +143,7 @@ test('LambdaClient', async (t) => {
   })
 
   await t.test('InvokeCommand without account ID defined', (t, end) => {
+    const { service, agent, InvokeCommand } = t.nr
     agent.config.cloud.aws.account_id = null
     helper.runInTransaction(agent, async (tx) => {
       const cmd = new InvokeCommand({

--- a/test/versioned/aws-sdk-v3/sns.test.js
+++ b/test/versioned/aws-sdk-v3/sns.test.js
@@ -10,6 +10,7 @@ const test = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
 
 const helper = require('../../lib/agent_helper')
+const afterEach = require('./test-utils/after-each.js')
 const awsEcho = require('./test-utils/aws-echo.js')
 const checkAWSAttributes = require('./test-utils/check-aws-attributes.js')
 const checkExternals = require('./test-utils/check-externals.js')
@@ -22,29 +23,31 @@ const { createResponseServer, FAKE_CREDENTIALS } = require('../../lib/aws-server
 const { match, assertSegmentDuration } = require('../../lib/custom-assertions')
 
 test('SNS', async (t) => {
-  const server = createResponseServer()
+  t.beforeEach(async (ctx) => {
+    ctx.nr = {}
+    const server = createResponseServer()
 
-  await new Promise((resolve) => {
-    server.listen(0, resolve)
+    await new Promise((resolve) => {
+      server.listen(0, resolve)
+    })
+
+    ctx.nr.server = server
+    ctx.nr.agent = helper.instrumentMockedAgent()
+    ctx.nr.http = require('node:http')
+    const lib = require('@aws-sdk/client-sns')
+    const SNSClient = lib.SNSClient
+    ctx.nr.lib = lib
+    ctx.nr.sns = new SNSClient({
+      credentials: FAKE_CREDENTIALS,
+      endpoint: `http://localhost:${server.address().port}`,
+      region: 'us-east-1'
+    })
   })
 
-  const agent = helper.instrumentMockedAgent()
-  const http = require('node:http')
-  const lib = require('@aws-sdk/client-sns')
-  const SNSClient = lib.SNSClient
-  const sns = new SNSClient({
-    credentials: FAKE_CREDENTIALS,
-    endpoint: `http://localhost:${server.address().port}`,
-    region: 'us-east-1'
-  })
-
-  t.after(() => {
-    server.destroy()
-    helper.unloadAgent(agent)
-  })
+  t.afterEach(afterEach)
 
   await t.test('publish with callback', async (t) => {
-    const { PublishCommand } = lib
+    const { agent, sns, lib: { PublishCommand } } = t.nr
     await helper.runInTransaction(agent, async (tx) => {
       const params = { Message: 'Hello!' }
 
@@ -63,7 +66,7 @@ test('SNS', async (t) => {
   })
 
   await t.test('publish with default destination(PhoneNumber)', async (t) => {
-    const { PublishCommand } = lib
+    const { agent, sns, lib: { PublishCommand } } = t.nr
     await helper.runInTransaction(agent, async (tx) => {
       const params = { Message: 'Hello!' }
 
@@ -80,7 +83,7 @@ test('SNS', async (t) => {
   })
 
   await t.test('publish with TopicArn as destination', async (t) => {
-    const { PublishCommand } = lib
+    const { agent, sns, lib: { PublishCommand } } = t.nr
     await helper.runInTransaction(agent, async (tx) => {
       const TopicArn = 'TopicArn'
       const params = { TopicArn, Message: 'Hello!' }
@@ -95,7 +98,7 @@ test('SNS', async (t) => {
   })
 
   await t.test('publish with TargetArn as destination', async (t) => {
-    const { PublishCommand } = lib
+    const { agent, sns, lib: { PublishCommand } } = t.nr
     await helper.runInTransaction(agent, async (tx) => {
       const TargetArn = 'TargetArn'
       const params = { TargetArn, Message: 'Hello!' }
@@ -112,7 +115,7 @@ test('SNS', async (t) => {
   await t.test(
     'publish with TopicArn as destination when both Topic and Target Arn are defined',
     async (t) => {
-      const { PublishCommand } = lib
+      const { agent, sns, lib: { PublishCommand } } = t.nr
       await helper.runInTransaction(agent, async (tx) => {
         const TargetArn = 'TargetArn'
         const TopicArn = 'TopicArn'
@@ -130,7 +133,7 @@ test('SNS', async (t) => {
   await t.test(
     'should record external segment and not a SNS segment for a command that is not PublishCommand',
     async (t) => {
-      const { ListTopicsCommand } = lib
+      const { agent, sns, lib: { ListTopicsCommand } } = t.nr
       await helper.runInTransaction(agent, async (tx) => {
         const TargetArn = 'TargetArn'
         const TopicArn = 'TopicArn'
@@ -147,8 +150,8 @@ test('SNS', async (t) => {
   )
 
   await t.test('should mark requests to be dt-disabled', async (t) => {
+    const { agent, sns, lib: { ListTopicsCommand } } = t.nr
     const plan = tspl(t, { plan: 2 })
-    const { ListTopicsCommand } = lib
 
     await helper.runInTransaction(agent, async (tx) => {
       const params = { Message: 'Hiya' }
@@ -170,6 +173,7 @@ test('SNS', async (t) => {
   })
 
   await t.test('attaches distributed trace headers when sending messages', async (t) => {
+    const { http, sns, lib } = t.nr
     const params = { TargetArn: 'TargetArn', Message: 'Hello!' }
     const { server, address } = await awsEcho({
       http,
@@ -198,7 +202,7 @@ test('SNS', async (t) => {
   })
 
   await t.test('does not attach distributed trace headers when disabled', async (t) => {
-    // This is a race condition waiting to happen.
+    const { agent, http, sns, lib } = t.nr
     agent.config.distributed_tracing.enabled = false
 
     const params = { TargetArn: 'TargetArn', Message: 'Hello!' }
@@ -209,7 +213,6 @@ test('SNS', async (t) => {
       CreateCommand: lib.PublishCommand
     })
     t.after(() => {
-      agent.config.distributed_tracing.enabled = true
       server.close()
     })
 


### PR DESCRIPTION
## Description

Restores the per-test agent setup pattern (`beforeEach`/`afterEach`) for the AWS SDK v3 lambda, sns, and bedrock versioned tests, reverting the structural workarounds introduced in #3836 and #3838.

### Problem
The aforementioned PRs collapsed those specific AWS tests' setup into a single agent-per-file because of a bug surfaced by `@smithy/node-http-handler` ≥ 4.7.3 (ships with `@aws-sdk/*` ≥ ~3.700). At that version smithy lazily resolves `node:http` via:
```
const { Agent, request } = await import('node:http')
```

Node's ESM loader snapshots namespace bindings at first import, so once smithy captures `http.request`, subsequent `shimmer.unwrap` / re-wrap cycles are invisible to it. The second test in a `beforeEach` pattern would call into a wrapper bound to the first (now-unloaded) agent, which short-circuits to the un-instrumented request and produces no segments which will fail the tests.

### Fix

Adds a stable forwarding shim for `http.request` in `agent_helper.instrumentMockedAgent`. Installed once per process, the shim never changes, so smithy's ESM-snapshotted reference always resolves to it. Each `instrumentMockedAgent` call only swaps `_activeHttpRequest` to point at the current shimmer-wrapped function. We could probably remove this when we move over `core` instrumentation to subscriber-based.

With the shim in place, all five test files are restored to per-test agent construction.

## How to Test

```
npm run versioned aws-sdk-v3
```

## Related Issues

Closes #3837 