### PR TITLE
chore: Added OTEL rule to support Prisma 7

### DIFF
--- a/documentation/otel/otel-transformation-rules.md
+++ b/documentation/otel/otel-transformation-rules.md
@@ -41,6 +41,12 @@ Each item in the array is a rule object with the following properties:
 - **attribute_conditions** (`object`, optional):  
   An object where each key is an attribute name and the value is an array of allowed values for that attribute.
 
+- **scope_name** (`string`, optional):
+  Indicates that the span's `instrumentationScope.name` must be set to the  specified value.
+
+- **scope_version** (`string`, optional):
+  Indicates that the span's `instrumentationScope.version` must satisfy the provided version range. For example, the value in the rule may be `^1.0.0` and the value in the span may be `1.5.0`.
+
 ---
 
 ### attributes

--- a/lib/otel/traces/rules.js
+++ b/lib/otel/traces/rules.js
@@ -5,8 +5,36 @@
 
 'use strict'
 
+const semver = require('semver')
 const { SpanKind } = require('@opentelemetry/api')
 const srcJson = require('./transformation-rules/index.js')()
+
+/**
+ * An OtelRuleMatcher object defines how the rules engine will decide if a
+ * rule matches an OTEL span. See {@link Rule#matches} to learn how the
+ * matcher properties are evaluated and in what priority.
+ *
+ * @typedef {object} OtelRuleMatcher
+ * @property {string[]} required_span_kinds List of OTEL span kinds that
+ * this rule will match. Possible values are "server", "client", and "internal".
+ * @property {string[]} required_attribute_keys List of OTEL span
+ * attributes that must be present for the rule to match. Each value is a dot
+ * separated path.
+ * @property {object} [attribute_conditions] List of OTEL span attributes that
+ * must contain a value in the array. For example, if the
+ * `required_attribute_keys` list contains `"db.system"`, this object may
+ * contain a field named `db.system` with a value like `["mongodb"]` to
+ * ensure that the rule only matches when the database system is defined to
+ * be "mongodb" by the OTEL instrumentation.
+ * @property {string} [scope_name] Indicates that the span's
+ * `instrumentationScope.name` must be set to the specified value.
+ * https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_sdk-node.core.InstrumentationScope.html
+ * @property {string} [scope_version] Indicates that the span's
+ * `instrumentationScope.version` must satisfy the provided version range.
+ * For example, the value in the rule may be `^1.0.0` and the value in the
+ * span may be `1.5.0`.
+ * https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_sdk-node.core.InstrumentationScope.html
+ */
 
 /**
  * Mapping rules are stored, and provided to the agent, as JSON. We call these
@@ -16,19 +44,14 @@ const srcJson = require('./transformation-rules/index.js')()
  * @typedef {object} SerializedOtelMappingRule
  * @property {string} name The name of the rule. This will be used to detect
  * @property {string} type The type of the rule. This will be used to detect the type of segment/transaction to create.
- * @property {object} matcher Defines the required properties of the OTEL span
- * that are needed in order for the rule to match.
- * @property {string[]} matcher.required_span_kinds List of OTEL span kinds that
- * this rule will match. Possible values are "server", "client", and "internal".
- * @property {string[]} matcher.required_attribute_keys List of OTEL span
- * attributes that must be present for the rule to match. Each value is a dot
- * separated path.
- * @property {object} matcher.attribute_conditions List of OTEL span
- * attributes that must contain a value in the array.
- * separated path.
+ * @property {OtelRuleMatcher} matcher Defines the required properties of the
+ * OTEL span that are needed in order for the rule to match.
  * @property {Array} attributes The attributes to map to a given target(segment/transaction/trace).
  * @property {object} transaction The transformation to apply to the transaction.
- * @property {object} segment The transformation to apply to the segment.
+ * @property {object} segment The transformation to apply to the segment. Keys
+ * in this object map to {@link TraceSegment} attributes. Values are either
+ * a string pointing to the OTEL span attribute to use for the value, or an
+ * object as described in `documentation/otel/otel-transformation-rules.md`.
  */
 
 /**
@@ -49,6 +72,7 @@ class Rule {
   #attributes
   #segmentTransformation
   #txTransformation
+  #scope = { name: undefined, version: undefined }
 
   /**
    * @param {SerializedOtelMappingRule} input A serialized rule to parse.
@@ -69,6 +93,8 @@ class Rule {
     this.#spanKinds = input?.matcher?.required_span_kinds?.map((v) => v.toLowerCase()) ?? []
     this.#requiredAttributes = input?.matcher?.required_attribute_keys ?? []
     this.#requiredConditions = input?.matcher?.attribute_conditions ?? {}
+    this.#scope.name = input?.matcher?.scope_name
+    this.#scope.version = input?.matcher?.scope_version
   }
 
   get name() {
@@ -125,6 +151,20 @@ class Rule {
   matches(span) {
     let result = false
 
+    // If the rule has defined either scope name or version requirements,
+    // evaluate them first so that we avoid iterating attributes in the case
+    // of a rule mismatch.
+    const { name: scopeName, version: scopeVersion } = span.instrumentationScope || {}
+    if (this.#scope.name && scopeName !== this.#scope.name) {
+      return result
+    }
+    if (
+      (this.#scope.version && scopeVersion) &&
+      semver.satisfies(scopeVersion, this.#scope.version) === false
+    ) {
+      return result
+    }
+
     let attrCount = 0
     let attrConditions = 0
     for (const attr of this.#requiredAttributes) {
@@ -134,12 +174,18 @@ class Rule {
     }
 
     for (const [key, value] of Object.entries(this.#requiredConditions)) {
-      if ((Array.isArray(value) && value.includes(span.attributes[key])) || span.attributes[key] === value) {
+      if (
+        (Array.isArray(value) && value.includes(span.attributes[key])) ||
+        span.attributes[key] === value
+      ) {
         attrConditions += 1
       }
     }
 
-    if (attrCount === this.#requiredAttributes.length && attrConditions === Object.keys(this.#requiredConditions).length) {
+    if (
+      attrCount === this.#requiredAttributes.length &&
+      attrConditions === Object.keys(this.#requiredConditions).length
+    ) {
       result = true
     }
 
@@ -158,8 +204,8 @@ class RulesEngine {
   #fallbackInternalRules = new Map()
   #fallbackProducerRules = new Map()
 
-  constructor() {
-    for (const inputRule of srcJson) {
+  constructor({ rules = srcJson } = {}) {
+    for (const inputRule of rules) {
       const rule = new Rule(inputRule)
 
       if (/fallback/i.test(rule.name) === true) {

--- a/lib/otel/traces/transformation-rules/311-OtelDbClientPrisma1_40.json
+++ b/lib/otel/traces/transformation-rules/311-OtelDbClientPrisma1_40.json
@@ -1,0 +1,28 @@
+{
+  "name": "OtelDbClientPrisma1_40",
+  "comment": "This rule supports the JS variant of Prisma 7. Their @prisma/instrumentation otel spans only include `db.system.name` and `db.query.text`. This means we were unable to match the standard rule.",
+  "type": "db",
+  "matcher": {
+    "required_span_kinds": [
+      "client"
+    ],
+    "required_attribute_keys": [
+      "db.system.name"
+    ],
+    "scope_name": "prisma"
+  },
+  "attributes": [
+    {
+      "key": "db.system.name",
+      "target": "segment",
+      "name": "product"
+    }
+  ],
+  "segment": {
+    "statement": "db.query.text",
+    "type": "db.system.name",
+    "name": {
+      "template": "Datastore/statement/${type}/${collection}/${operation}"
+    }
+  }
+}

--- a/test/unit/lib/otel/traces/rules.test.js
+++ b/test/unit/lib/otel/traces/rules.test.js
@@ -131,3 +131,28 @@ test('scope_version matching rule is met', () => {
   assert.notEqual(foundRule, undefined)
   assert.equal(foundRule.name, rule.name)
 })
+
+test('scope_version does not satisfy', () => {
+  const rule = {
+    name: 'test-rule',
+    type: 'db',
+    matcher: {
+      required_span_kinds: ['client'],
+      required_attribute_keys: ['db.system'],
+      scope_version: '^1.0.0'
+    },
+    attributes: [{
+      key: 'db.system',
+      target: 'segment',
+      name: 'product'
+    }]
+  }
+  const engine = new RulesEngine({ rules: [rule] })
+  const span = tracer.startSpan('test-span', { kind: SpanKind.CLIENT }, ROOT_CONTEXT)
+  span.setAttribute('db.system', 'test-db')
+  span.instrumentationScope = { version: '2.0.0' }
+  span.end()
+
+  const foundRule = engine.test(span)
+  assert.equal(foundRule, undefined)
+})

--- a/test/unit/lib/otel/traces/rules.test.js
+++ b/test/unit/lib/otel/traces/rules.test.js
@@ -93,3 +93,41 @@ test('fallback internal rule is met', () => {
   assert.notEqual(rule, undefined)
   assert.equal(rule.name, 'Fallback')
 })
+
+test('scope_name rule is met', () => {
+  const engine = new RulesEngine()
+  const span = tracer.startSpan('test-span', { kind: SpanKind.CLIENT }, ROOT_CONTEXT)
+  span.setAttribute('db.system.name', 'postgresql')
+  span.instrumentationScope = { name: 'prisma' }
+  span.end()
+
+  const rule = engine.test(span)
+  assert.notEqual(rule, undefined)
+  assert.equal(rule.name, 'OtelDbClientPrisma1_40')
+})
+
+test('scope_version matching rule is met', () => {
+  const rule = {
+    name: 'test-rule',
+    type: 'db',
+    matcher: {
+      required_span_kinds: ['client'],
+      required_attribute_keys: ['db.system'],
+      scope_version: '^1.0.0'
+    },
+    attributes: [{
+      key: 'db.system',
+      target: 'segment',
+      name: 'product'
+    }]
+  }
+  const engine = new RulesEngine({ rules: [rule] })
+  const span = tracer.startSpan('test-span', { kind: SpanKind.CLIENT }, ROOT_CONTEXT)
+  span.setAttribute('db.system', 'test-db')
+  span.instrumentationScope = { version: '1.2.3' }
+  span.end()
+
+  const foundRule = engine.test(span)
+  assert.notEqual(foundRule, undefined)
+  assert.equal(foundRule.name, rule.name)
+})

--- a/test/unit/lib/otel/traces/transformation-rules/index.test.js
+++ b/test/unit/lib/otel/traces/transformation-rules/index.test.js
@@ -83,8 +83,8 @@ test('transformation rules module', async (t) => {
     }
   })
 
-  await t.test('should contain 31 rules', () => {
-    assert.equal(rules.length, 31, 'should have exactly 31 rules')
+  await t.test('should contain 32 rules', () => {
+    assert.equal(rules.length, 32, 'should have exactly 32 rules')
   })
 
   await t.test('should load rules in correct order', () => {
@@ -108,6 +108,7 @@ test('transformation rules module', async (t) => {
       'OtelDbClientDynamo1_40',
       'OtelDbClientDynamo1_17',
       'OtelDbClient1_17',
+      'OtelDbClientPrisma1_40',
       'OtelHttpClient1_23',
       'OtelHttpClient1_17',
       'OtelRpcClient1_23',
@@ -150,7 +151,7 @@ test('transformation rules module', async (t) => {
         'OtelDbClient1_40', 'OtelDbClient1_24',
         'OtelDbClientRedis1_17', 'OtelDbClientMongo1_17',
         'OtelDbClientDynamo1_40', 'OtelDbClientDynamo1_17',
-        'OtelDbClient1_17'
+        'OtelDbClient1_17', 'OtelDbClientPrisma1_40'
       ],
       external: [
         'OtelHttpClient1_23', 'OtelHttpClient1_17',


### PR DESCRIPTION
This PR is part of solving #3525. In order to utilize `@prisma/instrumentation` effectively, we have to add a rule that matches Prisma's incomplete spans. Specifically, they only attach the `db.system.name` and `db.query.text` attributes to their spans. Which means the lack the required attributes to match the `OtelDbClient1_40` rule (i.e. they are not fully following OTEL's semantic conventions).

With this PR merged, and a new agent version released, I will be able to add an example app that shows how to use our OTEL support to instrument `prisma@7` via their JavaScript variant and get dashboard results like:

<img width="1317" height="864" alt="image" src="https://github.com/user-attachments/assets/a91ae8b2-ff93-4b06-b754-3d1ba5779b6e" />
