### PR TITLE
test: Removed reliance on `glob` in lieu of `fs.glob`

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -62,7 +62,6 @@ code, the source code can be found at [https://github.com/newrelic/node-newrelic
 * [eslint](#eslint)
 * [express](#express)
 * [git-raw-commits](#git-raw-commits)
-* [glob](#glob)
 * [got](#got)
 * [jsdoc](#jsdoc)
 * [lint-staged](#lint-staged)
@@ -4825,77 +4824,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-```
-
-### glob
-
-This product includes source derived from [glob](https://github.com/isaacs/node-glob) ([v13.0.6](https://github.com/isaacs/node-glob/tree/v13.0.6)), distributed under the [BlueOak-1.0.0 License](https://github.com/isaacs/node-glob/blob/v13.0.6/LICENSE.md):
-
-```
-All packages under `src/` are licensed according to the terms in
-their respective `LICENSE` or `LICENSE.md` files.
-
-The remainder of this project is licensed under the Blue Oak
-Model License, as follows:
-
------
-
-# Blue Oak Model License
-
-Version 1.0.0
-
-## Purpose
-
-This license gives everyone as much permission to work with
-this software as possible, while protecting contributors
-from liability.
-
-## Acceptance
-
-In order to receive this license, you must agree to its
-rules.  The rules of this license are both obligations
-under that agreement and conditions to your license.
-You must not do anything with this software that triggers
-a rule that you cannot or will not follow.
-
-## Copyright
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe that contributor's
-copyright in it.
-
-## Notices
-
-You must ensure that everyone who gets a copy of
-any part of this software from you, with or without
-changes, also gets the text of this license or a link to
-<https://blueoakcouncil.org/license/1.0.0>.
-
-## Excuse
-
-If anyone notifies you in writing that you have not
-complied with [Notices](#notices), you can keep your
-license by taking all practical steps to comply within 30
-days after the notice.  If you do not do so, your license
-ends immediately.
-
-## Patent
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe any patent claims
-they can license or become able to license.
-
-## Reliability
-
-No contributor can revoke this license.
-
-## No Liability
-
-***As far as the law allows, this software comes as is,
-without any warranty or condition, and no contributor
-will be liable to anyone for any damages related to this
-software or this license, under any kind of legal claim.***
 
 ```
 

--- a/bin/run-bench.js
+++ b/bin/run-bench.js
@@ -6,11 +6,11 @@
 
 'use strict'
 
-const cp = require('child_process')
-const { globSync } = require('glob')
-const path = require('path')
+const cp = require('node:child_process')
+const path = require('node:path')
 const { errorAndExit } = require('./utils')
-const fs = require('fs/promises')
+const fs = require('node:fs/promises')
+const { globSync } = require('node:fs')
 const { sendBenchmarkTestMetrics, meterProvider } = require('./otel-metrics-sender')
 
 const cwd = path.resolve(__dirname, '..')

--- a/bin/test/versioned-runner/globber.test.js
+++ b/bin/test/versioned-runner/globber.test.js
@@ -47,7 +47,7 @@ test('resolveGlobs', async (t) => {
   await t.test('resolve asterisk', async (t) => {
     const files = await globber.resolveGlobs([`${TEST_DIR}/*.js`])
     assert.equal(files.length, 2)
-    assert.deepEqual(files, [`${TEST_DIR}/redis.mock.fake-test.js`, `${TEST_DIR}/other.mock.fake-test.js`])
+    assert.deepEqual(files, [`${TEST_DIR}/other.mock.fake-test.js`, `${TEST_DIR}/redis.mock.fake-test.js`])
   })
 
   await t.test('filter out node modules', async (t) => {
@@ -71,6 +71,6 @@ test('resolveGlobs', async (t) => {
   await t.test('handle duplicates', async (t) => {
     const files = await globber.resolveGlobs([`${TEST_DIR}/*.js`, `${TEST_DIR}/*.js`])
     assert.equal(files.length, 2)
-    assert.deepEqual(files, [`${TEST_DIR}/redis.mock.fake-test.js`, `${TEST_DIR}/other.mock.fake-test.js`])
+    assert.deepEqual(files, [`${TEST_DIR}/other.mock.fake-test.js`, `${TEST_DIR}/redis.mock.fake-test.js`])
   })
 })

--- a/bin/versioned-runner/globber.js
+++ b/bin/versioned-runner/globber.js
@@ -6,7 +6,7 @@
 'use strict'
 
 const path = require('path')
-const { glob: globToFiles } = require('glob')
+const { glob: fsGlob } = require('node:fs/promises')
 
 function buildGlobs(testGlobs, patterns = []) {
   // Turn the given globs into searches for package.json files.
@@ -40,30 +40,28 @@ function buildGlobs(testGlobs, patterns = []) {
 }
 
 async function resolveGlobs(globs, skip = []) {
-  // resolve each glob into a list of files
-  const globFiles = []
-  for (const glob of globs) {
-    const files = await globToFiles(glob, { absolute: true })
-    globFiles.push(files)
-  }
-  // flatten and deduplicate our list of lists of files
-  return globFiles.reduce((allFiles, files) => {
-    for (const file of files) {
+  const allFiles = []
+  const seen = new Set()
+
+  for (const pattern of globs) {
+    // Ensure the pattern is absolute so fs.glob returns absolute paths
+    const absPattern = path.isAbsolute(pattern) ? pattern : path.resolve(pattern)
+    for await (const file of fsGlob(absPattern)) {
       // Filter out any package.json files from our `node_modules` directory
       // which aren't from the `@newrelic` scope.
       const inNodeModules = /\/node_modules\/(?!@newrelic\/)/g.test(file)
 
-      if (!inNodeModules) {
-        const shouldSkip = skip.some((s) => file.indexOf(s) >= 0)
-        const isDuplicate = allFiles.includes(file)
-
-        if (!shouldSkip && !isDuplicate) {
+      if (!inNodeModules && !seen.has(file)) {
+        const shouldSkip = skip.some((s) => file.includes(s))
+        if (!shouldSkip) {
+          seen.add(file)
           allFiles.push(file)
         }
       }
     }
-    return allFiles
-  }, [])
+  }
+
+  return allFiles
 }
 
 module.exports = {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -132,9 +132,11 @@ module.exports = [
   jsdocConfig,
   jsdocOverrides,
 
+  // we do not ship `bin/` dir so ignore the node recommended for this but
+  // do not add to test files because we still want to lint them like our other linting rules
   {
     ...sharedConfig.configs.nodeRecommended,
-    ignores: testFiles
+    ignores: [...testFiles, 'bin/**']
   },
   {
     files: ['bin/*.js'],

--- a/package.json
+++ b/package.json
@@ -250,7 +250,6 @@
     "eslint-plugin-jsdoc": "^50.6.1",
     "express": "*",
     "git-raw-commits": "^2.0.11",
-    "glob": "^13.0.6",
     "got": "^11.8.5",
     "jsdoc": "^4.0.0",
     "lint-staged": "^11.0.0",

--- a/test/bin/install_sub_deps
+++ b/test/bin/install_sub_deps
@@ -9,12 +9,12 @@
 'use strict'
 
 const path = require('node:path')
-const { glob } = require('glob')
+const { glob } = require('node:fs/promises')
 const util = require('node:util')
 const exec = util.promisify(require('child_process').exec)
 
 const options = {
-  ignore: '**/test/versioned/**'
+  exclude: (f) => f.includes('test/versioned')
 }
 
 let folder
@@ -59,16 +59,16 @@ function isErrorOutput(text) {
 async function getPackages(folder) {
   if (folder) {
     const commonPackages = await getCommonPackages()
-    const packages = await glob(`**/test/${folder}/**/package.json`, options)
+    const packages = await Array.fromAsync(glob(`**/test/${folder}/**/package.json`, options))
     return commonPackages.concat(packages)
   } else {
-    const packages = await glob('**/test/**/package.json', options)
+    const packages = await Array.fromAsync(glob('**/test/**/package.json', options))
     return packages
   }
 }
 
 async function getCommonPackages() {
-  const packages = await glob('**/test/lib/**/package.json', options)
+  const packages = await Array.fromAsync(glob('**/test/lib/**/package.json', options))
   packages.unshift('test/package.json', 'test/helpers/package.json')
   return packages
 }
@@ -81,7 +81,6 @@ function printError(packagePath, error) {
 }
 
 async function main() {
-  debugger
   const packages = await getPackages(folder)
   const correctPackages = packages.filter(function(line) {
     return !/node_modules|example/.test(line)

--- a/test/integration/utilization/common.js
+++ b/test/integration/utilization/common.js
@@ -6,7 +6,7 @@
 'use strict'
 const assert = require('node:assert')
 const fs = require('fs/promises')
-const { glob } = require('glob')
+const { glob } = fs
 const JSONbig = require('json-bigint')({ useNativeBigInt: true })
 const path = require('path')
 
@@ -40,7 +40,7 @@ async function getTestCases(vendor) {
 
 async function getProcTests(type) {
   const testDir = path.resolve(__dirname, '../../lib/cross_agent_tests', type)
-  return glob(path.join(testDir, '*.txt'))
+  return Array.fromAsync(glob(path.join(testDir, '*.txt')))
 }
 
 module.exports = {

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Mon May 18 2026 16:20:40 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Thu May 21 2026 14:45:39 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -628,20 +628,6 @@
       "publisher": "Steve Mao",
       "email": "maochenyan@gmail.com",
       "url": "https://github.com/stevemao"
-    },
-    "glob@13.0.6": {
-      "name": "glob",
-      "version": "13.0.6",
-      "range": "^13.0.6",
-      "licenses": "BlueOak-1.0.0",
-      "repoUrl": "https://github.com/isaacs/node-glob",
-      "versionedRepoUrl": "https://github.com/isaacs/node-glob/tree/v13.0.6",
-      "licenseFile": "node_modules/glob/LICENSE.md",
-      "licenseUrl": "https://github.com/isaacs/node-glob/blob/v13.0.6/LICENSE.md",
-      "licenseTextSource": "file",
-      "publisher": "Isaac Z. Schlueter",
-      "email": "i@izs.me",
-      "url": "https://blog.izs.me/"
     },
     "got@11.8.6": {
       "name": "got",


### PR DESCRIPTION
## Description
In #4008 I merged it but @jsumners-nr had a good comment about this package is now obsolete. Since we support 22+, I removed `glob` in lieu of `fs.glob`
