### PR TITLE
chore: Updated `sinon` to latest

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -5124,7 +5124,7 @@ THE SOFTWARE.
 
 ### sinon
 
-This product includes source derived from [sinon](https://github.com/sinonjs/sinon) ([v5.1.1](https://github.com/sinonjs/sinon/tree/v5.1.1)), distributed under the [BSD-3-Clause License](https://github.com/sinonjs/sinon/blob/v5.1.1/LICENSE):
+This product includes source derived from [sinon](https://github.com/sinonjs/sinon) ([v22.0.0](https://github.com/sinonjs/sinon/tree/v22.0.0)), distributed under the [BSD-3-Clause License](https://github.com/sinonjs/sinon/blob/v22.0.0/LICENSE):
 
 ```
 (The BSD License)

--- a/bin/test/conventional-changelog.test.js
+++ b/bin/test/conventional-changelog.test.js
@@ -79,7 +79,10 @@ This version of the Node.js agent is a SemVer MAJOR update and contains the foll
 
 test('Conventional Changelog Class', async (t) => {
   t.beforeEach((ctx) => {
-    const clock = sinon.useFakeTimers(new Date('2020-04-03'))
+    const clock = sinon.useFakeTimers({
+      now: new Date('2020-04-03'),
+      toFake: ['Date']
+    })
     const mockGetPrByCommit = sinon.stub()
     const MockGithubSdk = sinon.stub().returns({
       getPullRequestByCommit: mockGetPrByCommit

--- a/package.json
+++ b/package.json
@@ -259,7 +259,7 @@
     "readline": "^1.3.0",
     "self-cert": "^2.0.0",
     "should": "*",
-    "sinon": "^5.1.1"
+    "sinon": "^22.0.0"
   },
   "repository": {
     "type": "git",

--- a/test/unit/shimmer.test.js
+++ b/test/unit/shimmer.test.js
@@ -20,8 +20,8 @@ const symbols = require('../../lib/symbols')
 
 const TEST_MODULE_PATH = 'test-mod/module'
 const TEST_MODULE_RELATIVE_PATH = `../helpers/node_modules/${TEST_MODULE_PATH}`
-const TEST_MODULE = 'sinon'
-const TEST_PATH_WITHIN = `${TEST_MODULE}/lib/sinon/spy`
+const TEST_MODULE = 'c8'
+const TEST_PATH_WITHIN = `${TEST_MODULE}/lib/report.js`
 
 async function makeModuleTests({ moduleName, relativePath, throwsError }, t) {
   t.beforeEach(function (ctx) {

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -748,15 +748,15 @@
       "publisher": "TJ Holowaychuk",
       "email": "tj@vision-media.ca"
     },
-    "sinon@5.1.1": {
+    "sinon@22.0.0": {
       "name": "sinon",
-      "version": "5.1.1",
-      "range": "^5.1.1",
+      "version": "22.0.0",
+      "range": "^22.0.0",
       "licenses": "BSD-3-Clause",
       "repoUrl": "https://github.com/sinonjs/sinon",
-      "versionedRepoUrl": "https://github.com/sinonjs/sinon/tree/v5.1.1",
+      "versionedRepoUrl": "https://github.com/sinonjs/sinon/tree/v22.0.0",
       "licenseFile": "node_modules/sinon/LICENSE",
-      "licenseUrl": "https://github.com/sinonjs/sinon/blob/v5.1.1/LICENSE",
+      "licenseUrl": "https://github.com/sinonjs/sinon/blob/v22.0.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Christian Johansen"
     }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We were very behind on `sinon`. This PR had 2 fix two regressions from updating. `useFakeTimers` in one test to specify to only mock out `Date` and then some reliance on the folder structure for a shimmer test.
