### PR TITLE
test: Added an undici versioned test to assert behavior with using a self signed cert and `undici.Agent`

### DIFF
--- a/test/versioned/undici/requests.test.js
+++ b/test/versioned/undici/requests.test.js
@@ -117,6 +117,33 @@ test('should add HTTPS port to segment name when provided', async (t) => {
   })
 })
 
+test('should handle undici.Agent with rejectUnauthorized', async (t) => {
+  const { agent, undici } = t.nr
+  const { httpsServer } = createHttpsServer()
+  const { port } = httpsServer.address()
+  const customAgent = new undici.Agent({
+    connect: { rejectUnauthorized: false }
+  })
+  t.after(() => {
+    httpsServer.close()
+  })
+
+  await helper.runInTransaction(agent, async (transaction) => {
+    const response = await undici.fetch(`https://localhost:${port}`, {
+      dispatcher: customAgent
+    })
+    assert.equal(response.status, 200)
+    const body = await response.text()
+    assert.equal(body, 'SSL response')
+
+    assertSegments(transaction.trace, transaction.trace.root, [`External/localhost:${port}/`], {
+      exact: false
+    })
+
+    transaction.end()
+  })
+})
+
 test('should add attributes to external segment', async (t) => {
   const { agent, undici, HOST, PORT, REQUEST_URL } = t.nr
   await helper.runInTransaction(agent, async (tx) => {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

A customer using the lambda layer reported an issue with undici hanging, [see](https://github.com/newrelic/newrelic-lambda-extension/issues/390).  I told the serverless team 
that they probably have to do more digging on their end with the layers because a raw agent functions as expected with the test I added, which is a reproduction of the code snippet provided by a customer.
