### PR TITLE
test: Updated undici.Agent versioned test to skip using custom dispatcher on versions <5.2.0 as it was not supported

### DIFF
--- a/test/versioned/undici/requests.test.js
+++ b/test/versioned/undici/requests.test.js
@@ -117,7 +117,7 @@ test('should add HTTPS port to segment name when provided', async (t) => {
   })
 })
 
-test('should handle undici.Agent with rejectUnauthorized', async (t) => {
+test('should handle undici.Agent with rejectUnauthorized', { skip: semver.lt(pkgVersion, '5.2.0') }, async (t) => {
   const { agent, undici } = t.nr
   const { httpsServer } = createHttpsServer()
   const { port } = httpsServer.address()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

In #4026 I added a test to verify that self signed certs with undici.Agent work. However, I didnt' test on all supported versions of undici.
It doesn't support a custom dispatcher to fetch until 5.2.0, [see](https://github.com/nodejs/undici/pull/1411). This PR adds a skip for versions <5.2.0 for this test.

