### PR TITLE
refactor: Updated MiddlewareWrapper `maybeHandleError` to only mark error as handled if there was a previously stored error

### DIFF
--- a/lib/subscribers/middleware-wrapper.js
+++ b/lib/subscribers/middleware-wrapper.js
@@ -243,7 +243,8 @@ class MiddlewareWrapper {
   /**
    * Errors are handled in `lib/instrumentation/core/http.js` when the
    * http response is ended. This is because it has to check if the status
-   * code is being ignored via config. This handles assigning error but also marking error as handled if
+   * code is being ignored via config.
+   * This handles assigning error but also marking error as handled if
    * a middleware in the chain succeeds after an error.
    *
    * TODO: remove the reliance on `txInfo` and just store on transaction. This is more work than just changing to storing
@@ -255,7 +256,8 @@ class MiddlewareWrapper {
     if (err) {
       txInfo.error = err
       txInfo.errorHandled = txInfo.errorHandled ?? false
-    } else {
+    // a middleware in the chain succeeds after error, mark it as handled
+    } else if (!err && txInfo.error) {
       txInfo.errorHandled = true
     }
   }

--- a/test/unit/lib/subscribers/middleware-wrapper.test.js
+++ b/test/unit/lib/subscribers/middleware-wrapper.test.js
@@ -187,6 +187,32 @@ test('should handle error when passed in to done handler but mark error handled 
   })
 })
 
+test('should handle error when passed in to done handler but subsequent middleware handles error', function (t, end) {
+  t.plan(3)
+  const { agent, wrapper } = t.nr
+  const error = new Error('test error')
+  function handler (req, res, next) {
+    next(error)
+  }
+  const route = '/test/url'
+  const wrapped = wrapper.wrap({ handler, route })
+  const request = {}
+  helper.runInTransaction(agent, function (tx) {
+    tx.type = 'web'
+    tx.url = route
+    wrapped(request, 'one', function(err) {
+      // this middleware essentially swallows error
+      // thus handling it and marking error in txInfo
+      // as handled so it will not report
+      t.assert.equal(err.message, error.message)
+    })
+    t.assert.deepEqual(t.nr.txInfo.error, error)
+    t.assert.equal(t.nr.txInfo.errorHandled, true)
+    tx.end()
+    end()
+  })
+})
+
 test('should not handle error when no error is passed to done handler', function (t, end) {
   const { agent, wrapper } = t.nr
   function handler (req, res, next) {
@@ -199,10 +225,7 @@ test('should not handle error when no error is passed to done handler', function
     tx.type = 'web'
     tx.url = route
     wrapped(request, 'one', function() {})
-    assert.deepEqual(t.nr.txInfo, {
-      errorHandled: true
-    })
-
+    assert.deepEqual(t.nr.txInfo, {})
     tx.end()
     end()
   })
@@ -224,9 +247,7 @@ test('should not handle error when isError is not using default handler', functi
     tx.type = 'web'
     tx.url = route
     wrapped(request, 'one', function() {})
-    assert.deepEqual(t.nr.txInfo, {
-      errorHandled: true
-    })
+    assert.deepEqual(t.nr.txInfo, {})
     tx.end()
     end()
   })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

In #4016 the logic to mark errors was incorrect. We should only mark errors as handled, if there was a previously stored error. 

Resolves #4030
