### PR TITLE
chore: Deprecate `instrumentLoadedModule` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ We support the following custom instrumentation API methods in ES module apps:
 * `newrelic.instrumentMessages`
 * `newrelic.instrumentWebframework`
 
-Note that we _do not_ support `newrelic.instrumentLoadedModule`, for the same issue of immutability mentioned above.
+Note that `newrelic.instrumentLoadedModule` is deprecated and scheduled for removal in v15. It was never supported in ES module apps, and in CommonJS it only existed to retrofit instrumentation when the agent was loaded after user modules, which is no longer supported.
 
 If you want to see an example of how to write custom instrumentation in an ES module app, check out our [examples](https://github.com/newrelic/newrelic-node-examples/tree/main/esm-app) repo for a working demo.
 

--- a/api.js
+++ b/api.js
@@ -1493,6 +1493,10 @@ API.prototype.instrumentMessages = function instrumentMessages(moduleName, onReq
  * Applies an instrumentation to an already loaded CommonJs module.
  *
  * Note: This function will not work for ESM packages.
+ *
+ * @deprecated Scheduled for removal in v15. Load the agent via
+ * `node -r newrelic` (or `NODE_OPTIONS='-r newrelic'`), so the agent is active
+ * before user modules resolve.
  * @example
  *
  * // oh no, express was loaded before newrelic
@@ -1511,6 +1515,12 @@ API.prototype.instrumentMessages = function instrumentMessages(moduleName, onReq
  * @returns {boolean} Whether or not the module was successfully instrumented
  */
 API.prototype.instrumentLoadedModule = function instrumentLoadedModule(moduleName, module) {
+  logger.warn(
+    'newrelic.instrumentLoadedModule is deprecated and will be removed in v15. ' +
+      'Load the agent via `node -r newrelic` (or NODE_OPTIONS=\'-r newrelic\'), ' +
+      'so it is active before user modules resolve.'
+  )
+
   const metric = this.agent.metrics.getOrCreateMetric(
     NAMES.SUPPORTABILITY.API + '/instrumentLoadedModule'
   )

--- a/api.js
+++ b/api.js
@@ -1515,11 +1515,11 @@ API.prototype.instrumentMessages = function instrumentMessages(moduleName, onReq
  * @returns {boolean} Whether or not the module was successfully instrumented
  */
 API.prototype.instrumentLoadedModule = function instrumentLoadedModule(moduleName, module) {
-  logger.warn(
-    'newrelic.instrumentLoadedModule is deprecated and will be removed in v15. ' +
-      'Load the agent via `node -r newrelic` (or NODE_OPTIONS=\'-r newrelic\'), ' +
+  const warningMsg = 'newrelic.instrumentLoadedModule is deprecated and will be removed in v15. ' +
+      'Load the agent via `node -r newrelic` (or NODE_OPTIONS=\'-r newrelic\') ' +
       'so it is active before user modules resolve.'
-  )
+  logger.warn(warningMsg)
+  process.emitWarning(warningMsg, { type: 'DeprecationWarning' })
 
   const metric = this.agent.metrics.getOrCreateMetric(
     NAMES.SUPPORTABILITY.API + '/instrumentLoadedModule'

--- a/test/unit/api/api-instrument-loaded-module.test.js
+++ b/test/unit/api/api-instrument-loaded-module.test.js
@@ -6,6 +6,8 @@
 'use strict'
 const test = require('node:test')
 const assert = require('node:assert')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
 const API = require('../../../api')
 const agentHelper = require('../../lib/agent_helper')
 const symbols = require('../../../lib/symbols')
@@ -108,5 +110,39 @@ test('Agent API - instrumentLoadedModule', async (t) => {
     assert.doesNotThrow(() => {
       api.instrumentLoadedModule('mysql', mod)
     })
+  })
+})
+
+test('Agent API - instrumentLoadedModule deprecation warning', async (t) => {
+  t.beforeEach((ctx) => {
+    ctx.nr = {}
+    const loggerMock = require('../mocks/logger')()
+    const DeprecatingAPI = proxyquire('../../../api', {
+      './lib/logger': {
+        child: sinon.stub().callsFake(() => loggerMock)
+      }
+    })
+    const agent = agentHelper.instrumentMockedAgent()
+    ctx.nr.api = new DeprecatingAPI(agent)
+    ctx.nr.agent = agent
+    ctx.nr.loggerMock = loggerMock
+  })
+
+  t.afterEach((ctx) => {
+    agentHelper.unloadAgent(ctx.nr.agent)
+  })
+
+  await t.test('logs the deprecation warning on every call', (t) => {
+    const { api, loggerMock } = t.nr
+
+    api.instrumentLoadedModule('myTestModule')
+    api.instrumentLoadedModule('myTestModule')
+    api.instrumentLoadedModule('anotherModule')
+
+    const deprecationCalls = loggerMock.warn
+      .getCalls()
+      .filter((call) => /instrumentLoadedModule is deprecated/.test(call.args[0]))
+    assert.equal(deprecationCalls.length, 3)
+    assert.match(deprecationCalls[0].args[0], /removed in v15/)
   })
 })

--- a/test/unit/api/api-instrument-loaded-module.test.js
+++ b/test/unit/api/api-instrument-loaded-module.test.js
@@ -132,6 +132,21 @@ test('Agent API - instrumentLoadedModule deprecation warning', async (t) => {
     agentHelper.unloadAgent(ctx.nr.agent)
   })
 
+  await t.test('emits a user-visible DeprecationWarning via process.emitWarning', async (t) => {
+    const { api } = t.nr
+    const warnings = []
+    const onWarning = (warning) => warnings.push(warning)
+    process.on('warning', onWarning)
+    t.after(() => process.off('warning', onWarning))
+
+    api.instrumentLoadedModule('myTestModule')
+    await new Promise((resolve) => setImmediate(resolve))
+
+    const deprecation = warnings.find((w) => /instrumentLoadedModule is deprecated/.test(w.message))
+    assert.ok(deprecation, 'expected a DeprecationWarning to be emitted')
+    assert.equal(deprecation.name, 'DeprecationWarning')
+  })
+
   await t.test('logs the deprecation warning on every call', (t) => {
     const { api, loggerMock } = t.nr
 


### PR DESCRIPTION
## Description

Deprecates `newrelic.instrumentLoadedModule` effective next release. We will completely remove it next major release (v15).

## How to Test

```
npm run unit
```

## Related Issues

Closes #4031