### PR TITLE
chore: Added baseline instructions for Claude bot

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,30 @@
+# newrelic instrumentation agent
+
+`newrelic` is an observability instrumentation agent. It hooks and traces
+third party modules.
+
+## Conventions
+- Code style is enforced using eslint and should be written according to its configuration
+- Tests are written using the `node:test` module
+
+## Important
+- Unit tests live in `test/unit/`
+- When verifying new unit tests, run the test directly as `node --test <test_file>`
+- Agent integration tests live in `test/integration/` and verify agent
+specific functionality
+- Instrumentation of third party modules is verified by "versioned tests"
+- Versioned tests live in `test/versioned/`
+- Docker services should be running for versioned tests to succeed
+- After running a specific versioned test suite at least once, individual
+test files in the suite may be run directly as
+`node --test test/versioned/<suite>/<test_file>`
+
+## Commands
+npm run services:start # start Docker services
+npm run services:stop # stop Docker services
+npm run versioned:major # run all versioned tests
+npm run versioned:major <suite_name> # run specific versioned test suite
+npm run unit # run all unit tests
+npm run lint # verify code style
+npm run lint:verbose # show all code style errors
+npm run lint:fix # automatically fix incorrect code style

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ bin/.env
 
 # Local developer resources:
 local/
+# .gitignore - Claude Code personal files
+# per https://computingforgeeks.com/claude-code-dot-claude-directory-guide/
+CLAUDE.local.md
+.claude/settings.local.json
+.claude/agent-memory-local/


### PR DESCRIPTION
If we are going to keep using this tool, we should add some common baseline instructions for it. This PR enables the following prompts to work correctly:

- `How would you run a new unit test?`
- `run tests for the fastify instrumentation`
- `run the fastify "add hook" tests`