### PR TITLE
chore: Updated codecov action

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -238,28 +238,32 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v8
       - name: Post Unit Test Coverage
-        uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303
+        # v6.0.1
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: unit-tests-${{ matrix.node-version }}
           flags: unit-tests-${{ matrix.node-version }}
       - name: Post Integration CJS Test Coverage
-        uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303
+        # v6.0.1
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: integration-tests-cjs-${{ matrix.node-version }}
           flags: integration-tests-cjs-${{ matrix.node-version }}
       - name: Post Integration ESM Test Coverage
-        uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303
+        # v6.0.1
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: integration-tests-esm-${{ matrix.node-version }}
           flags: integration-tests-esm-${{ matrix.node-version }}
       - name: Post Versioned Test Coverage
-        uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303
+        # v6.0.1
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -235,6 +235,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts
       - name: Download artifacts
         uses: actions/download-artifact@v8
       - name: Post Unit Test Coverage


### PR DESCRIPTION
This PR updates the codecov action to the latest version: https://github.com/codecov/codecov-action/releases/tag/v6.0.1.

While the issues that release address do not seem applicable to our workflow, it seems like a good idea to update regardless. 