### PR TITLE
chore: Fixed node-version in CI workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -237,7 +237,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: lts
+          node-version: 'lts/*'
       - name: Download artifacts
         uses: actions/download-artifact@v8
       - name: Post Unit Test Coverage


### PR DESCRIPTION
The docs are so bad.

Verifying with run https://github.com/newrelic/node-newrelic/actions/runs/26644676240