### PR TITLE
feat: Add `span_id` and `trace_id` labels to `CpuProfiler` sample data

### DIFF
--- a/lib/profiling/index.js
+++ b/lib/profiling/index.js
@@ -12,6 +12,7 @@ class ProfilingManager {
     this.logger = logger
     this.metrics = agent.metrics
     this.config = agent.config.profiling
+    this.tracer = agent.tracer
     this.samplingInterval = samplingInterval
     this.profilers = new Map()
     this.startTime = null
@@ -25,7 +26,7 @@ class ProfilingManager {
 
     if (this.config.include.includes('cpu') && !this.profilers.has('CpuProfiler')) {
       const { CpuProfiler } = require('./profilers')
-      this.profilers.set('CpuProfiler', new CpuProfiler({ logger: this.logger, samplingInterval: this.samplingInterval }))
+      this.profilers.set('CpuProfiler', new CpuProfiler({ logger: this.logger, samplingInterval: this.samplingInterval, tracer: this.tracer }))
     }
   }
 

--- a/lib/profiling/profilers/cpu.js
+++ b/lib/profiling/profilers/cpu.js
@@ -4,13 +4,34 @@
  */
 
 'use strict'
+const { AsyncLocalStorage } = require('async_hooks')
 const BaseProfiler = require('./base')
+
+/**
+ * True when V8's AsyncContextFrame is active, detected by whether
+ * `AsyncLocalStorage.run` delegates to `enterWith`. Feature-detected rather than
+ * version-gated so it tracks `--experimental-async-context-frame` (Node 22/23)
+ * and `--no-async-context-frame` (Node 24+).
+ */
+const ASYNC_CONTEXT_FRAME_ACTIVE = (() => {
+  let active = false
+  const als = new AsyncLocalStorage()
+  als.enterWith = () => {
+    active = true
+  }
+  als.run(1, () => {})
+  als.disable()
+  return active
+})()
 
 /**
  * Produces a wall time stack profile via `pprof`.
  * The native sampler fires at a fixed rate against whatever JS is currently
- * on the stack, and the active context is tracked by hooking the agent's
- * `AsyncLocalStorage` (`this.#store`) instance.
+ * on the stack, and the active transaction's trace/span ids are attached to
+ * each sample by hooking the agent's `AsyncLocalStorage` (`this.#store`).
+ *
+ * With AsyncContextFrame active, pprof's `useCPED` carries the context per
+ * async-context-frame; otherwise a single holder is swapped per sample.
  *
  * The wall-clock (or just wall) time for a function measures the time elapsed
  * between entering and exiting a function. Wall time includes all wait time,
@@ -22,26 +43,33 @@ class CpuProfiler extends BaseProfiler {
   #durationMillis
   #intervalMicros = (1e3 / 99) * 1000 // samples at 99hz(99 times per second)
   #kSampleCount
-  // The "context" reference handed to the pprof time profiler. The native
-  // sampler captures whatever `current` holds at the moment a sample is taken,
-  // so we keep it pointed at the active transaction's trace/span ids.
+  #useCPED
+  // (non-CPED) pprof captures this holder by reference at sample time, so we
+  // keep `current` pointed at the active transaction's trace/span ids.
   #context = this.#defaultContext()
   #state
   #lastSampleCount = 0
-  // The agent's `AsyncLocalStorage` instance we use to get the active context.
+  // The agent's `AsyncLocalStorage` instance.
   #store
-  // Caches the resolved transaction name so `getFullName()` (which re-runs the
-  // name normalizer while a transaction is in-flight) isn't called on every
-  // context change.
+  // Caches the resolved transaction name; `getFullName()` re-runs the name
+  // normalizer while a transaction is in-flight, so avoid it per context change.
   #nameCache = { transaction: null, name: '' }
+  // Saved ALS methods, restored by `#unhookContext` on stop.
+  #origRun
+  #origEnterWith
+  // (non-CPED) async hook that refreshes context on async resumption.
+  #asyncHook
 
-  constructor({ logger, samplingInterval, tracer }) {
+  constructor({ logger, samplingInterval, tracer, useCPED = true }) {
     super({ logger })
     this.#pprof = require('@datadog/pprof')
     this.#kSampleCount = this.#pprof.time.constants.kSampleCount
     this.#tracer = tracer
     this.#store = tracer._contextManager._asyncLocalStorage
     this.#durationMillis = samplingInterval
+    // CPED requires AsyncContextFrame. A caller may force the holder strategy
+    // with useCPED: false, but can't force CPED on a runtime that lacks ACF.
+    this.#useCPED = useCPED && ASYNC_CONTEXT_FRAME_ACTIVE
   }
 
   start() {
@@ -55,11 +83,19 @@ class CpuProfiler extends BaseProfiler {
       durationMillis: this.#durationMillis,
       intervalMicros: this.#intervalMicros,
       // needed for trace_id + span_id label
-      withContexts: true
+      withContexts: true,
+      // carry the sample context per async-context-frame when ACF is active
+      useCPED: this.#useCPED
     })
-    this.#state = this.#pprof.time.getState()
-    this.#resetContext()
-    this.#hookContext()
+
+    if (this.#useCPED) {
+      this.#hookEnterWith()
+    } else {
+      this.#state = this.#pprof.time.getState()
+      this.#resetContext()
+      this.#hookRun()
+      this.#hookAsyncResume()
+    }
   }
 
   stop() {
@@ -68,21 +104,27 @@ class CpuProfiler extends BaseProfiler {
       return
     }
 
+    // Restore the wrapped ALS methods before stopping.
+    this.#unhookContext()
     this.#pprof.time.stop(false)
   }
 
   async collect() {
+    if (!this.#useCPED) {
+      // Flush the active span before sampling restarts.
+      this.#updateContext()
+    }
     const profile = this.#pprof.time.stop(true, this.#linkContext)
-    // `stop(true)` restarts sampling, so start a fresh context for the next
-    // collection cycle.
-    this.#resetContext()
+    if (!this.#useCPED) {
+      // `stop(true)` restarts sampling, so start a fresh holder.
+      this.#resetContext()
+    }
     return this.#pprof.encode(profile)
   }
 
   /**
-   * A fresh pprof context holder. Returns a new object on every call: pprof
-   * captures the holder by reference at sample time, so each swap needs its own
-   * object or already-captured samples would pick up later mutations.
+   * A fresh holder on every call: pprof captures it by reference, so each swap
+   * needs its own object or earlier samples would pick up later mutations.
    *
    * @returns {{ current: object }} a new, empty context holder
    */
@@ -91,8 +133,8 @@ class CpuProfiler extends BaseProfiler {
   }
 
   /**
-   * Points the pprof time profiler at a fresh `#context` and resyncs the
-   * sample counter.
+   * (non-CPED) Points the pprof time profiler at a fresh `#context` and resyncs
+   * the sample counter.
    */
   #resetContext() {
     this.#context = this.#defaultContext()
@@ -101,21 +143,53 @@ class CpuProfiler extends BaseProfiler {
   }
 
   /**
-   * pprof's `generateLabels` callback. For each captured sample context it
-   * returns the span label that was active when the sample was taken.
+   * pprof's `generateLabels` callback, returning the span label active when each
+   * sample was taken. With CPED the captured value is the label itself; without
+   * it, the label lives in the holder's `current`.
    *
    * @param {object} params params from pprof
    * @param {object} params.context the captured time profile node context
    * @returns {object} label set applied to the pprof sample
    */
-  #linkContext = ({ context }) => context?.context?.current ?? {}
+  #linkContext = ({ context }) => {
+    const captured = context?.context
+    return (this.#useCPED ? captured : captured?.current) ?? {}
+  }
 
   /**
-   * Writes the active trace/span ids into `#context.current` as one label: a
-   * `span:`-prefixed key and a comma-separated `key=value` value. Uses a fresh
-   * `#context` once a new sample has landed, so earlier samples keep their ids.
+   * Builds the single `span:` label for the active context, or `{}` when there
+   * is none. The value is a comma-separated `span_id=…,trace_id=…` string; the
+   * ids come from `getLinkingMetadata`, which only returns them when both a
+   * segment and transaction are active.
+   *
+   * @returns {object} the label set (at most one `span:` entry)
+   */
+  #buildLabel() {
+    const { 'trace.id': traceId, 'span.id': spanId } = this.#tracer.agent.getLinkingMetadata(true)
+    if (!traceId) {
+      return {}
+    }
+
+    const ids = [`trace_id=${traceId}`]
+    if (spanId) {
+      // Should be in span_id, trace_id order
+      ids.unshift(`span_id=${spanId}`)
+    }
+    return { [this.#spanKey(this.#tracer.getTransaction())]: ids.join(',') }
+  }
+
+  /**
+   * Refreshes the pprof sample context with the active span. With CPED the label
+   * is written straight into the current async-context-frame; otherwise a fresh
+   * holder is swapped in once a sample has landed (so earlier samples keep their
+   * ids) before reassigning its `current`.
    */
   #updateContext = () => {
+    if (this.#useCPED) {
+      this.#pprof.time.setContext(this.#buildLabel())
+      return
+    }
+
     const sampleCount = this.#state?.[this.#kSampleCount]
     if (sampleCount !== this.#lastSampleCount) {
       this.#lastSampleCount = sampleCount
@@ -123,23 +197,7 @@ class CpuProfiler extends BaseProfiler {
       this.#pprof.time.setContext(this.#context)
     }
 
-    // Only returns ids when both a segment and transaction are active.
-    const { 'trace.id': traceId, 'span.id': spanId } = this.#tracer.agent.getLinkingMetadata(true)
-
-    // Assign span_id + trace_id label
-    if (traceId) {
-      const ids = [`trace_id=${traceId}`]
-      if (spanId) {
-        // Should be in span_id, trace_id order
-        ids.unshift(`span_id=${spanId}`)
-      }
-      // Reassign `current` every run() between two samples, because a
-      // sample must reflect only the span active when it was taken, not
-      // every span seen this sample window.
-      this.#context.current = { [this.#spanKey(this.#tracer.getTransaction())]: ids.join(',') }
-    } else {
-      this.#context.current = {}
-    }
+    this.#context.current = this.#buildLabel()
   }
 
   /**
@@ -163,19 +221,31 @@ class CpuProfiler extends BaseProfiler {
   }
 
   /**
-   * Wraps `run` on the agent's single `AsyncLocalStorage` so the pprof holder
-   * is refreshed on every context switch: on `run` entry (the agent propagates
-   * all transaction context through this one instance) and on `run` exit (so a
-   * sibling doesn't inherit a returned child's span). It wraps the instance,
-   * not the prototype, leaves other libraries' ALS untouched.
-   *
-   * @todo On Node 24+ (AsyncContextFrame is on by default), pprof's `useCPED: true`
-   * carries context per-frame and would remove this hook, the `wrapped` frame
-   * in the flame graph UI, and the manual #context.current updates.
+   * (CPED) Wraps `enterWith` on the agent's `AsyncLocalStorage`. Since `run`
+   * delegates to `enterWith` under ACF, this one hook covers every context
+   * switch; we then `setContext` the active span into the current frame, which
+   * pprof propagates to continuations and restores on unwind.
    */
-  #hookContext() {
+  #hookEnterWith() {
     const self = this
-    const origRun = this.#store.run
+    this.#origEnterWith = this.#store.enterWith
+    const origEnterWith = this.#origEnterWith
+    this.#store.enterWith = function (store) {
+      const retVal = origEnterWith.call(this, store)
+      self.#updateContext()
+      return retVal
+    }
+  }
+
+  /**
+   * (non-CPED) Wraps `run` on the agent's `AsyncLocalStorage` to refresh the
+   * holder on `run` entry and exit (so a sibling doesn't inherit a returned
+   * child's span). Wraps the instance, not the prototype.
+   */
+  #hookRun() {
+    const self = this
+    this.#origRun = this.#store.run
+    const origRun = this.#origRun
     this.#store.run = function (store, callback, ...args) {
       function wrapped(...cbArgs) {
         self.#updateContext()
@@ -187,6 +257,35 @@ class CpuProfiler extends BaseProfiler {
         self.#updateContext()
       }
     }
+  }
+
+  /**
+   * (non-CPED) Async resumptions (timer, promise, I/O) restore the active store
+   * without a `run` call, leaving the holder frozen at the last `run`'s span. A
+   * `before` hook refreshes it so those samples get the right span.
+   */
+  #hookAsyncResume() {
+    // eslint-disable-next-line n/no-unsupported-features/node-builtins
+    const { createHook } = require('async_hooks')
+    this.#asyncHook = createHook({ before: () => this.#updateContext() })
+    this.#asyncHook.enable()
+  }
+
+  /**
+   * Restores the original `run`/`enterWith` and disables the async hook so none
+   * fire once the profiler has stopped.
+   */
+  #unhookContext() {
+    if (this.#origRun) {
+      this.#store.run = this.#origRun
+      this.#origRun = null
+    }
+    if (this.#origEnterWith) {
+      this.#store.enterWith = this.#origEnterWith
+      this.#origEnterWith = null
+    }
+    this.#asyncHook?.disable()
+    this.#asyncHook = null
   }
 }
 

--- a/lib/profiling/profilers/cpu.js
+++ b/lib/profiling/profilers/cpu.js
@@ -8,6 +8,19 @@ const BaseProfiler = require('./base')
 const semver = require('semver')
 
 /**
+ * (CPED) Key under which each segment caches its sample context, so the same
+ * span always maps to the same object identity.
+ */
+const PROFILING_CONTEXT = Symbol('NewRelicProfilingContext')
+
+/**
+ * (non-CPED) Empty holder for when no span is active. Frozen so it can't be
+ * mutated in place — pprof reads holders by reference, so we swap in a fresh one
+ * per sample.
+ */
+const DEFAULT_CONTEXT = Object.freeze({ current: {} })
+
+/**
  * Produces a wall time stack profile via `pprof`.
  * The native sampler fires at a fixed rate against whatever JS is currently on
  * the stack, and each sample is tagged with the active transaction's trace/span
@@ -26,16 +39,11 @@ class CpuProfiler extends BaseProfiler {
   #intervalMicros = (1e3 / 99) * 1000 // samples at 99hz(99 times per second)
   #kSampleCount
   #useCPED
-  // Readonly so it doesn't get rewritten, without it non-CPED tests fail
-  DEFAULT_CONTEXT = Object.freeze({ current: {} })
   /**
-   * If `#useCPED` is `false`, `pprof` captures this holder by reference at sample
-   * time, so we keep `current` pointed at the active transaction's trace/span ids.
-   *
-   * If `#useCPED` is true, `pprof` handles this for us with `AsyncContextFrame`, so
-   * this property is not used.
+   * (non-CPED) `pprof` captures this holder by reference at sample time, so
+   * we keep `current` pointed at the active transaction's trace/span ids.
    */
-  #context = this.DEFAULT_CONTEXT
+  #context = DEFAULT_CONTEXT
   #state
   #lastSampleCount = 0
   /**
@@ -46,7 +54,7 @@ class CpuProfiler extends BaseProfiler {
   #origRun
   #origEnterWith
   /**
-   * Async hook that refreshes context on async resumption. Only required if `#useCPED` is `false`.
+   * (non-CPED) Async hook that refreshes context on async resumption.
    */
   #asyncHook
 
@@ -58,7 +66,6 @@ class CpuProfiler extends BaseProfiler {
     this.#store = tracer._contextManager._asyncLocalStorage
     this.#durationMillis = samplingInterval
     // CPED requires AsyncContextFrame which is on by default with node >=24
-    // @todo should we account for `--no-async-context-frame`?
     this.#useCPED = semver.satisfies(process.versions.node, '>=24.0.0')
   }
 
@@ -140,16 +147,15 @@ class CpuProfiler extends BaseProfiler {
    * ids) before reassigning its `current`.
    */
   #updateContext = () => {
-    const { 'trace.id': traceId, 'span.id': spanId } = this.#tracer.agent.getLinkingMetadata(true)
-    const spanContext = { traceId, spanId }
-
     if (this.#useCPED) {
-      this.#pprof.time.setContext(spanContext)
+      this.#updateCpedContext()
       return
     }
 
+    const { 'trace.id': traceId, 'span.id': spanId } = this.#tracer.agent.getLinkingMetadata(true)
+    const spanContext = { traceId, spanId }
     const sampleCount = this.#state?.[this.#kSampleCount]
-    if (sampleCount !== this.#lastSampleCount || this.#context === this.DEFAULT_CONTEXT) {
+    if (sampleCount !== this.#lastSampleCount || this.#context === DEFAULT_CONTEXT) {
       this.#lastSampleCount = sampleCount
       this.#context = { current: spanContext }
       this.#pprof.time.setContext(this.#context)
@@ -159,11 +165,34 @@ class CpuProfiler extends BaseProfiler {
   }
 
   /**
+   * (CPED) Installs the active span's context into the current async-context-frame.
+   * Each segment's `{ traceId, spanId }` is built once and cached on the segment
+   * (its ids never change), and `setContext` is only called when the frame isn't
+   * already holding that object, skipping the redundant native write pprof would
+   * otherwise do every time a frame is entered or restored.
+   */
+  #updateCpedContext() {
+    const segment = this.#tracer.getSegment()
+    let spanContext = Object.freeze({})
+    if (segment) {
+      spanContext = segment[PROFILING_CONTEXT]
+      if (spanContext === undefined) {
+        const { 'trace.id': traceId, 'span.id': spanId } = this.#tracer.agent.getLinkingMetadata(true)
+        spanContext = segment[PROFILING_CONTEXT] = { traceId, spanId }
+      }
+    }
+
+    if (this.#pprof.time.getContext() !== spanContext) {
+      this.#pprof.time.setContext(spanContext)
+    }
+  }
+
+  /**
    * (non-CPED) Points the pprof time profiler at a fresh `#context`
    * and resyncs the sample counter.
    */
   #resetContext() {
-    this.#context = this.DEFAULT_CONTEXT
+    this.#context = DEFAULT_CONTEXT
     this.#lastSampleCount = this.#state?.[this.#kSampleCount] ?? 0
     this.#pprof.time.setContext(this.#context)
   }

--- a/lib/profiling/profilers/cpu.js
+++ b/lib/profiling/profilers/cpu.js
@@ -27,13 +27,14 @@ class CpuProfiler extends BaseProfiler {
   #intervalMicros = (1e3 / 99) * 1000 // samples at 99hz(99 times per second)
   #kSampleCount
   #useCPED
-  DEFAULT_CONTEXT = { current: {} }
+  // Readonly so it doesn't get rewritten, without it non-CPED tests fail
+  DEFAULT_CONTEXT = Object.freeze({ current: {} })
   /**
    * If `#useCPED` is `false`, `pprof` captures this holder by reference at sample
    * time, so we keep `current` pointed at the active transaction's trace/span ids.
    *
    * If `#useCPED` is true, `pprof` handles this for us with `AsyncContextFrame`, so
-   * this is field is not used.
+   * this property is not used.
    */
   #context = this.DEFAULT_CONTEXT
   #state
@@ -118,16 +119,6 @@ class CpuProfiler extends BaseProfiler {
   }
 
   /**
-   * (non-CPED) Points the pprof time profiler at a fresh `#context` and resyncs
-   * the sample counter.
-   */
-  #resetContext() {
-    this.#context = this.DEFAULT_CONTEXT
-    this.#lastSampleCount = this.#state?.[this.#kSampleCount] ?? 0
-    this.#pprof.time.setContext(this.#context)
-  }
-
-  /**
    * pprof's `generateLabels` callback, returning the span label active when each
    * sample was taken. With CPED the captured value is the label itself; without
    * it, the label lives in the holder's `current`.
@@ -138,60 +129,70 @@ class CpuProfiler extends BaseProfiler {
    */
   #linkContext = ({ context }) => {
     const captured = context?.context
-    return (this.#useCPED ? captured : captured?.current) ?? {}
+    return this.#buildLabel(this.#useCPED ? captured : captured?.current)
   }
 
   /**
-   * Builds the single `span:` label for the active context, or `{}` when there
-   * is none. The value is a comma-separated `span_id=…,trace_id=…` string; the
-   * ids come from `getLinkingMetadata`, which only returns them when both a
-   * segment and transaction are active.
-   *
-   * @returns {object} the label set (at most one `span:` entry)
-   */
-  #buildLabel() {
-    const { 'trace.id': traceId, 'span.id': spanId } = this.#tracer.agent.getLinkingMetadata(true)
-    if (!traceId) {
-      return {}
-    }
-
-    const ids = [`trace_id=${traceId}`]
-    if (spanId) {
-      // Should be in span_id, trace_id order
-      ids.unshift(`span_id=${spanId}`)
-    }
-    return { [this.#generateKey(this.#tracer.getTransaction())]: ids.join(',') }
-  }
-
-  /**
-   * Refreshes the pprof sample context with the active span. With CPED the label
+   * Refreshes the pprof sample context with the active span. With CPED, the label
    * is written straight into the current async-context-frame; otherwise a fresh
    * holder is swapped in once a sample has landed (so earlier samples keep their
    * ids) before reassigning its `current`.
    */
   #updateContext = () => {
+    const { 'trace.id': traceId, 'span.id': spanId } = this.#tracer.agent.getLinkingMetadata(true)
+    const spanContext = { traceId, spanId, transaction: this.#tracer.getTransaction() }
+
     if (this.#useCPED) {
-      this.#pprof.time.setContext(this.#buildLabel())
+      this.#pprof.time.setContext(spanContext)
       return
     }
 
     const sampleCount = this.#state?.[this.#kSampleCount]
-    if (sampleCount !== this.#lastSampleCount) {
+    if (sampleCount !== this.#lastSampleCount || this.#context === this.DEFAULT_CONTEXT) {
       this.#lastSampleCount = sampleCount
-      this.#context = this.DEFAULT_CONTEXT
+      this.#context = spanContext ? { current: spanContext } : this.DEFAULT_CONTEXT
       this.#pprof.time.setContext(this.#context)
+    } else {
+      this.#context.current = spanContext
+    }
+  }
+
+  /**
+   * (non-CPED) Points the pprof time profiler at a fresh `#context`
+   * and resyncs the sample counter.
+   */
+  #resetContext() {
+    this.#context = this.DEFAULT_CONTEXT
+    this.#lastSampleCount = this.#state?.[this.#kSampleCount] ?? 0
+    this.#pprof.time.setContext(this.#context)
+  }
+
+  /**
+   * Builds the single `span:` label for the active context, or `{}` when there
+   * is none. The value is a comma-separated `span_id=…,trace_id=…` string.
+   *
+   * @todo what is the intended behavior if trace.id is unavailable? span.id? both?
+   *    currently we omit one of them if it's unavailable but keep the other one.
+   * @todo should we do two KVPs/labels instead? e.g. "trace_id": "xxx", "span_id": "yyy"
+   *
+   * @param {object} [spanContext] the captured trace/span ids and transaction
+   * @returns {object} the label set (at most one `span:` entry)
+   */
+  #buildLabel(spanContext) {
+    if (!spanContext?.traceId) {
+      return {}
     }
 
-    this.#context.current = this.#buildLabel()
+    const { traceId, spanId } = spanContext
+    // Should be in span_id, trace_id order
+    const value = spanId ? `span_id=${spanId},trace_id=${traceId}` : `trace_id=${traceId}`
+    return { [this.#generateKey(spanContext.transaction)]: value }
   }
 
   /**
    * Builds the `span:` label key: the first 16 chars of the trace id plus the
    * transaction name (`span:<traceId[0:16]>:<name>`) to match other language
    * agents' implementation.
-   *
-   * The backend only cares about the `span:` prefix. Anything after that is just
-   * a unique identifier format that other language agents have agreed upon.
    *
    * @todo should we do two KVPs/labels instead? e.g. "trace_id": "xxx", "span_id": "yyy"
    *

--- a/lib/profiling/profilers/cpu.js
+++ b/lib/profiling/profilers/cpu.js
@@ -9,12 +9,11 @@ const semver = require('semver')
 
 /**
  * Produces a wall time stack profile via `pprof`.
- * The native sampler fires at a fixed rate against whatever JS is currently
- * on the stack, and the active transaction's trace/span ids are attached to
- * each sample by hooking the agent's `AsyncLocalStorage` (`this.#store`).
- *
- * With AsyncContextFrame active, pprof's `useCPED` carries the context per
- * async-context-frame; otherwise a single holder is swapped per sample.
+ * The native sampler fires at a fixed rate against whatever JS is currently on
+ * the stack, and each sample is tagged with the active transaction's trace/span
+ * ids. We capture those ids by hooking the agent's `AsyncLocalStorage`; pprof
+ * then carries them per sample via CPED when `AsyncContextFrame` is active, or
+ * in a holder we swap per sample otherwise.
  *
  * The wall-clock (or just wall) time for a function measures the time elapsed
  * between entering and exiting a function. Wall time includes all wait time,
@@ -43,11 +42,6 @@ class CpuProfiler extends BaseProfiler {
    * The agent's `AsyncLocalStorage` instance.
    */
   #store
-  /**
-   * Caches the resolved transaction name; `getFullName()` re-runs the name
-   * normalizer while a transaction is in-flight, so avoid it per context change.
-   */
-  #nameCache = { transaction: null, name: '' }
   // Saved ALS methods, restored by `#unhookContext` on stop.
   #origRun
   #origEnterWith
@@ -110,7 +104,7 @@ class CpuProfiler extends BaseProfiler {
       // Flush the active span before sampling restarts.
       this.#updateContext()
     }
-    const profile = this.#pprof.time.stop(true, this.#linkContext)
+    const profile = this.#pprof.time.stop(true, this.#generateLabels)
     if (!this.#useCPED) {
       // `stop(true)` restarts sampling, so start a fresh holder.
       this.#resetContext()
@@ -119,17 +113,24 @@ class CpuProfiler extends BaseProfiler {
   }
 
   /**
-   * pprof's `generateLabels` callback, returning the span label active when each
-   * sample was taken. With CPED the captured value is the label itself; without
-   * it, the label lives in the holder's `current`.
+   * Callback that returns the `span_id` and `trace_id`
+   * labels active when each sample was taken.
    *
    * @param {object} params params from pprof
    * @param {object} params.context the captured time profile node context
    * @returns {object} label set applied to the pprof sample
    */
-  #linkContext = ({ context }) => {
-    const captured = context?.context
-    return this.#buildLabel(this.#useCPED ? captured : captured?.current)
+  #generateLabels = ({ context }) => {
+    const capturedContext = context?.context
+    // With CPED the captured value is the label itself; without it,
+    // the label lives in the holder's `current`.
+    const { traceId, spanId } = (this.#useCPED ? capturedContext : capturedContext?.current) ?? {}
+    // A span id only exists when a trace id does, so trace_id anchors the label set:
+    // no trace id means no active span, and span_id is added only when present.
+    if (!traceId) {
+      return {}
+    }
+    return spanId ? { span_id: spanId, trace_id: traceId } : { trace_id: traceId }
   }
 
   /**
@@ -140,7 +141,7 @@ class CpuProfiler extends BaseProfiler {
    */
   #updateContext = () => {
     const { 'trace.id': traceId, 'span.id': spanId } = this.#tracer.agent.getLinkingMetadata(true)
-    const spanContext = { traceId, spanId, transaction: this.#tracer.getTransaction() }
+    const spanContext = { traceId, spanId }
 
     if (this.#useCPED) {
       this.#pprof.time.setContext(spanContext)
@@ -165,47 +166,6 @@ class CpuProfiler extends BaseProfiler {
     this.#context = this.DEFAULT_CONTEXT
     this.#lastSampleCount = this.#state?.[this.#kSampleCount] ?? 0
     this.#pprof.time.setContext(this.#context)
-  }
-
-  /**
-   * Builds the single `span:` label for the active context, or `{}` when there
-   * is none. The value is a comma-separated `span_id=…,trace_id=…` string.
-   *
-   * @todo what is the intended behavior if trace.id is unavailable? span.id? both?
-   *    currently we omit one of them if it's unavailable but keep the other one.
-   * @todo should we do two KVPs/labels instead? e.g. "trace_id": "xxx", "span_id": "yyy"
-   *
-   * @param {object} [spanContext] the captured trace/span ids and transaction
-   * @returns {object} the label set (at most one `span:` entry)
-   */
-  #buildLabel(spanContext) {
-    if (!spanContext?.traceId) {
-      return {}
-    }
-
-    const { traceId, spanId } = spanContext
-    // Should be in span_id, trace_id order
-    const value = spanId ? `span_id=${spanId},trace_id=${traceId}` : `trace_id=${traceId}`
-    return { [this.#generateKey(spanContext.transaction)]: value }
-  }
-
-  /**
-   * Builds the `span:` label key: the first 16 chars of the trace id plus the
-   * transaction name (`span:<traceId[0:16]>:<name>`) to match other language
-   * agents' implementation.
-   *
-   * @todo should we do two KVPs/labels instead? e.g. "trace_id": "xxx", "span_id": "yyy"
-   *
-   * @param {Transaction} transaction the active transaction
-   * @returns {string} the label key
-   */
-  #generateKey(transaction) {
-    if (transaction !== this.#nameCache.transaction || !this.#nameCache.name) {
-      this.#nameCache = { transaction, name: transaction.getFullName() || '' }
-    }
-
-    const prefix = `span:${transaction.traceId.slice(0, 16)}`
-    return this.#nameCache.name ? `${prefix}:${this.#nameCache.name}` : prefix
   }
 
   /**

--- a/lib/profiling/profilers/cpu.js
+++ b/lib/profiling/profilers/cpu.js
@@ -112,10 +112,8 @@ class CpuProfiler extends BaseProfiler {
       this.#pprof.time.setContext(this.#context)
     }
 
-    const ctx = this.#tracer.getContext()
-    const transaction = ctx?.transaction
-    const traceId = transaction?.traceId
-    const spanId = ctx?.segment?.getSpanId?.()
+    // Only returns ids when both a segment and transaction are active.
+    const { 'trace.id': traceId, 'span.id': spanId } = this.#tracer.agent.getLinkingMetadata(true)
 
     // Assign span_id + trace_id label
     if (traceId) {
@@ -127,17 +125,19 @@ class CpuProfiler extends BaseProfiler {
       // Reassign `current` every run() between two samples, because a
       // sample must reflect only the span active when it was taken, not
       // every span seen this sample window.
-      this.#context.current = { [this.#spanKey(transaction)]: ids.join(',') }
+      this.#context.current = { [this.#spanKey(this.#tracer.getTransaction())]: ids.join(',') }
     } else {
       this.#context.current = {}
     }
   }
 
   /**
-   * Builds the `span:` label key. The portion after `span:` is not consumed
-   * externally; we'll use internal transaction id + transaction name for the key:
-   * `span:<transaction.id>:<name>` to match other language agents' implementation.
-   * The name is resolved (and cached per transaction) via `getFullName()`.
+   * Builds the `span:` label key: the first 16 chars of the trace id plus the
+   * transaction name (`span:<traceId[0:16]>:<name>`) to match other language
+   * agents' implementation.
+   *
+   * The backend only cares about the `span:` prefix. Anything after that is just
+   * a unique identifier format that other language agents have agreed upon.
    *
    * @param {Transaction} transaction the active transaction
    * @returns {string} the label key
@@ -147,7 +147,7 @@ class CpuProfiler extends BaseProfiler {
       this.#nameCache = { transaction, name: transaction.getFullName() || '' }
     }
 
-    const prefix = `span:${transaction.id}`
+    const prefix = `span:${transaction.traceId.slice(0, 16)}`
     return this.#nameCache.name ? `${prefix}:${this.#nameCache.name}` : prefix
   }
 

--- a/lib/profiling/profilers/cpu.js
+++ b/lib/profiling/profilers/cpu.js
@@ -25,7 +25,7 @@ class CpuProfiler extends BaseProfiler {
   // The "context" reference handed to the pprof time profiler. The native
   // sampler captures whatever `current` holds at the moment a sample is taken,
   // so we keep it pointed at the active transaction's trace/span ids.
-  #context = { current: {} }
+  #context = this.#defaultContext()
   #state
   #lastSampleCount = 0
   // The agent's `AsyncLocalStorage` instance we use to get the active context.
@@ -80,11 +80,22 @@ class CpuProfiler extends BaseProfiler {
   }
 
   /**
+   * A fresh pprof context holder. Returns a new object on every call: pprof
+   * captures the holder by reference at sample time, so each swap needs its own
+   * object or already-captured samples would pick up later mutations.
+   *
+   * @returns {{ current: object }} a new, empty context holder
+   */
+  #defaultContext() {
+    return { current: {} }
+  }
+
+  /**
    * Points the pprof time profiler at a fresh `#context` and resyncs the
    * sample counter.
    */
   #resetContext() {
-    this.#context = { current: {} }
+    this.#context = this.#defaultContext()
     this.#lastSampleCount = this.#state?.[this.#kSampleCount] ?? 0
     this.#pprof.time.setContext(this.#context)
   }
@@ -108,7 +119,7 @@ class CpuProfiler extends BaseProfiler {
     const sampleCount = this.#state?.[this.#kSampleCount]
     if (sampleCount !== this.#lastSampleCount) {
       this.#lastSampleCount = sampleCount
-      this.#context = { current: {} }
+      this.#context = this.#defaultContext()
       this.#pprof.time.setContext(this.#context)
     }
 

--- a/lib/profiling/profilers/cpu.js
+++ b/lib/profiling/profilers/cpu.js
@@ -6,13 +6,41 @@
 'use strict'
 const BaseProfiler = require('./base')
 
+/**
+ * Produces a wall time stack profile via `pprof`.
+ * The native sampler fires at a fixed rate against whatever JS is currently
+ * on the stack, and the active context is tracked by hooking the agent's
+ * `AsyncLocalStorage` (`this.#store`) instance.
+ *
+ * The wall-clock (or just wall) time for a function measures the time elapsed
+ * between entering and exiting a function. Wall time includes all wait time,
+ * including that for locks and thread synchronization.
+ */
 class CpuProfiler extends BaseProfiler {
   #pprof
+  #tracer
   #durationMillis
   #intervalMicros = (1e3 / 99) * 1000 // samples at 99hz(99 times per second)
-  constructor({ logger, samplingInterval }) {
+  #kSampleCount
+  // The "context" reference handed to the pprof time profiler. The native
+  // sampler captures whatever `current` holds at the moment a sample is taken,
+  // so we keep it pointed at the active transaction's trace/span ids.
+  #context = { current: {} }
+  #state
+  #lastSampleCount = 0
+  // The agent's `AsyncLocalStorage` instance we use to get the active context.
+  #store
+  // Caches the resolved transaction name so `getFullName()` (which re-runs the
+  // name normalizer while a transaction is in-flight) isn't called on every
+  // context change.
+  #nameCache = { transaction: null, name: '' }
+
+  constructor({ logger, samplingInterval, tracer }) {
     super({ logger })
     this.#pprof = require('@datadog/pprof')
+    this.#kSampleCount = this.#pprof.time.constants.kSampleCount
+    this.#tracer = tracer
+    this.#store = tracer._contextManager._asyncLocalStorage
     this.#durationMillis = samplingInterval
   }
 
@@ -25,8 +53,13 @@ class CpuProfiler extends BaseProfiler {
     this.logger.trace(`Starting CpuProfiler, sample every ${this.#intervalMicros}hz for ${this.#durationMillis} ms.`)
     this.#pprof.time.start({
       durationMillis: this.#durationMillis,
-      intervalMicros: this.#intervalMicros
+      intervalMicros: this.#intervalMicros,
+      // needed for trace_id + span_id label
+      withContexts: true
     })
+    this.#state = this.#pprof.time.getState()
+    this.#resetContext()
+    this.#hookContext()
   }
 
   stop() {
@@ -39,8 +72,110 @@ class CpuProfiler extends BaseProfiler {
   }
 
   async collect() {
-    const profile = this.#pprof.time.stop(true)
+    const profile = this.#pprof.time.stop(true, this.#linkContext)
+    // `stop(true)` restarts sampling, so start a fresh context for the next
+    // collection cycle.
+    this.#resetContext()
     return this.#pprof.encode(profile)
+  }
+
+  /**
+   * Points the pprof time profiler at a fresh `#context` and resyncs the
+   * sample counter.
+   */
+  #resetContext() {
+    this.#context = { current: {} }
+    this.#lastSampleCount = this.#state?.[this.#kSampleCount] ?? 0
+    this.#pprof.time.setContext(this.#context)
+  }
+
+  /**
+   * pprof's `generateLabels` callback. For each captured sample context it
+   * returns the span label that was active when the sample was taken.
+   *
+   * @param {object} params params from pprof
+   * @param {object} params.context the captured time profile node context
+   * @returns {object} label set applied to the pprof sample
+   */
+  #linkContext = ({ context }) => context?.context?.current ?? {}
+
+  /**
+   * Writes the active trace/span ids into `#context.current` as one label: a
+   * `span:`-prefixed key and a comma-separated `key=value` value. Uses a fresh
+   * `#context` once a new sample has landed, so earlier samples keep their ids.
+   */
+  #updateContext = () => {
+    const sampleCount = this.#state?.[this.#kSampleCount]
+    if (sampleCount !== this.#lastSampleCount) {
+      this.#lastSampleCount = sampleCount
+      this.#context = { current: {} }
+      this.#pprof.time.setContext(this.#context)
+    }
+
+    const ctx = this.#tracer.getContext()
+    const transaction = ctx?.transaction
+    const traceId = transaction?.traceId
+    const spanId = ctx?.segment?.getSpanId?.()
+
+    // Assign span_id + trace_id label
+    if (traceId) {
+      const ids = [`trace_id=${traceId}`]
+      if (spanId) {
+        // Should be in span_id, trace_id order
+        ids.unshift(`span_id=${spanId}`)
+      }
+      // Reassign `current` every run() between two samples, because a
+      // sample must reflect only the span active when it was taken, not
+      // every span seen this sample window.
+      this.#context.current = { [this.#spanKey(transaction)]: ids.join(',') }
+    } else {
+      this.#context.current = {}
+    }
+  }
+
+  /**
+   * Builds the `span:` label key. The portion after `span:` is not consumed
+   * externally; we'll use internal transaction id + transaction name for the key:
+   * `span:<transaction.id>:<name>` to match other language agents' implementation.
+   * The name is resolved (and cached per transaction) via `getFullName()`.
+   *
+   * @param {Transaction} transaction the active transaction
+   * @returns {string} the label key
+   */
+  #spanKey(transaction) {
+    if (transaction !== this.#nameCache.transaction || !this.#nameCache.name) {
+      this.#nameCache = { transaction, name: transaction.getFullName() || '' }
+    }
+
+    const prefix = `span:${transaction.id}`
+    return this.#nameCache.name ? `${prefix}:${this.#nameCache.name}` : prefix
+  }
+
+  /**
+   * Wraps `run` on the agent's single `AsyncLocalStorage` so the pprof holder
+   * is refreshed on every context switch: on `run` entry (the agent propagates
+   * all transaction context through this one instance) and on `run` exit (so a
+   * sibling doesn't inherit a returned child's span). It wraps the instance,
+   * not the prototype, leaves other libraries' ALS untouched.
+   *
+   * @todo On Node 24+ (AsyncContextFrame is on by default), pprof's `useCPED: true`
+   * carries context per-frame and would remove this hook, the `wrapped` frame
+   * in the flame graph UI, and the manual #context.current updates.
+   */
+  #hookContext() {
+    const self = this
+    const origRun = this.#store.run
+    this.#store.run = function (store, callback, ...args) {
+      function wrapped(...cbArgs) {
+        self.#updateContext()
+        return callback.apply(this, cbArgs)
+      }
+      try {
+        return origRun.call(this, store, wrapped, ...args)
+      } finally {
+        self.#updateContext()
+      }
+    }
   }
 }
 

--- a/lib/profiling/profilers/cpu.js
+++ b/lib/profiling/profilers/cpu.js
@@ -4,25 +4,8 @@
  */
 
 'use strict'
-const { AsyncLocalStorage } = require('async_hooks')
 const BaseProfiler = require('./base')
-
-/**
- * True when V8's AsyncContextFrame is active, detected by whether
- * `AsyncLocalStorage.run` delegates to `enterWith`. Feature-detected rather than
- * version-gated so it tracks `--experimental-async-context-frame` (Node 22/23)
- * and `--no-async-context-frame` (Node 24+).
- */
-const ASYNC_CONTEXT_FRAME_ACTIVE = (() => {
-  let active = false
-  const als = new AsyncLocalStorage()
-  als.enterWith = () => {
-    active = true
-  }
-  als.run(1, () => {})
-  als.disable()
-  return active
-})()
+const semver = require('semver')
 
 /**
  * Produces a wall time stack profile via `pprof`.
@@ -45,20 +28,31 @@ class CpuProfiler extends BaseProfiler {
   #kSampleCount
   #useCPED
   DEFAULT_CONTEXT = { current: {} }
-  // (non-CPED) pprof captures this holder by reference at sample time, so we
-  // keep `current` pointed at the active transaction's trace/span ids.
+  /**
+   * If `#useCPED` is `false`, `pprof` captures this holder by reference at sample
+   * time, so we keep `current` pointed at the active transaction's trace/span ids.
+   *
+   * If `#useCPED` is true, `pprof` handles this for us with `AsyncContextFrame`, so
+   * this is field is not used.
+   */
   #context = this.DEFAULT_CONTEXT
   #state
   #lastSampleCount = 0
-  // The agent's `AsyncLocalStorage` instance.
+  /**
+   * The agent's `AsyncLocalStorage` instance.
+   */
   #store
-  // Caches the resolved transaction name; `getFullName()` re-runs the name
-  // normalizer while a transaction is in-flight, so avoid it per context change.
+  /**
+   * Caches the resolved transaction name; `getFullName()` re-runs the name
+   * normalizer while a transaction is in-flight, so avoid it per context change.
+   */
   #nameCache = { transaction: null, name: '' }
   // Saved ALS methods, restored by `#unhookContext` on stop.
   #origRun
   #origEnterWith
-  // (non-CPED) async hook that refreshes context on async resumption.
+  /**
+   * Async hook that refreshes context on async resumption. Only required if `#useCPED` is `false`.
+   */
   #asyncHook
 
   constructor({ logger, samplingInterval, tracer, useCPED = true }) {
@@ -68,9 +62,9 @@ class CpuProfiler extends BaseProfiler {
     this.#tracer = tracer
     this.#store = tracer._contextManager._asyncLocalStorage
     this.#durationMillis = samplingInterval
-    // CPED requires AsyncContextFrame. A caller may force the holder strategy
-    // with useCPED: false, but can't force CPED on a runtime that lacks ACF.
-    this.#useCPED = useCPED && ASYNC_CONTEXT_FRAME_ACTIVE
+    // CPED requires AsyncContextFrame which is on by default with node >=24
+    // @todo should we account for `--no-async-context-frame`?
+    this.#useCPED = useCPED && semver.satisfies(process.versions.node, '>=24.0.0')
   }
 
   start() {

--- a/lib/profiling/profilers/cpu.js
+++ b/lib/profiling/profilers/cpu.js
@@ -50,7 +50,7 @@ class CpuProfiler extends BaseProfiler {
    */
   #asyncHook
 
-  constructor({ logger, samplingInterval, tracer, useCPED = true }) {
+  constructor({ logger, samplingInterval, tracer }) {
     super({ logger })
     this.#pprof = require('@datadog/pprof')
     this.#kSampleCount = this.#pprof.time.constants.kSampleCount
@@ -59,7 +59,7 @@ class CpuProfiler extends BaseProfiler {
     this.#durationMillis = samplingInterval
     // CPED requires AsyncContextFrame which is on by default with node >=24
     // @todo should we account for `--no-async-context-frame`?
-    this.#useCPED = useCPED && semver.satisfies(process.versions.node, '>=24.0.0')
+    this.#useCPED = semver.satisfies(process.versions.node, '>=24.0.0')
   }
 
   start() {
@@ -151,7 +151,7 @@ class CpuProfiler extends BaseProfiler {
     const sampleCount = this.#state?.[this.#kSampleCount]
     if (sampleCount !== this.#lastSampleCount || this.#context === this.DEFAULT_CONTEXT) {
       this.#lastSampleCount = sampleCount
-      this.#context = spanContext ? { current: spanContext } : this.DEFAULT_CONTEXT
+      this.#context = { current: spanContext }
       this.#pprof.time.setContext(this.#context)
     } else {
       this.#context.current = spanContext

--- a/lib/profiling/profilers/cpu.js
+++ b/lib/profiling/profilers/cpu.js
@@ -44,9 +44,10 @@ class CpuProfiler extends BaseProfiler {
   #intervalMicros = (1e3 / 99) * 1000 // samples at 99hz(99 times per second)
   #kSampleCount
   #useCPED
+  DEFAULT_CONTEXT = { current: {} }
   // (non-CPED) pprof captures this holder by reference at sample time, so we
   // keep `current` pointed at the active transaction's trace/span ids.
-  #context = this.#defaultContext()
+  #context = this.DEFAULT_CONTEXT
   #state
   #lastSampleCount = 0
   // The agent's `AsyncLocalStorage` instance.
@@ -123,21 +124,11 @@ class CpuProfiler extends BaseProfiler {
   }
 
   /**
-   * A fresh holder on every call: pprof captures it by reference, so each swap
-   * needs its own object or earlier samples would pick up later mutations.
-   *
-   * @returns {{ current: object }} a new, empty context holder
-   */
-  #defaultContext() {
-    return { current: {} }
-  }
-
-  /**
    * (non-CPED) Points the pprof time profiler at a fresh `#context` and resyncs
    * the sample counter.
    */
   #resetContext() {
-    this.#context = this.#defaultContext()
+    this.#context = this.DEFAULT_CONTEXT
     this.#lastSampleCount = this.#state?.[this.#kSampleCount] ?? 0
     this.#pprof.time.setContext(this.#context)
   }
@@ -175,7 +166,7 @@ class CpuProfiler extends BaseProfiler {
       // Should be in span_id, trace_id order
       ids.unshift(`span_id=${spanId}`)
     }
-    return { [this.#spanKey(this.#tracer.getTransaction())]: ids.join(',') }
+    return { [this.#generateKey(this.#tracer.getTransaction())]: ids.join(',') }
   }
 
   /**
@@ -193,7 +184,7 @@ class CpuProfiler extends BaseProfiler {
     const sampleCount = this.#state?.[this.#kSampleCount]
     if (sampleCount !== this.#lastSampleCount) {
       this.#lastSampleCount = sampleCount
-      this.#context = this.#defaultContext()
+      this.#context = this.DEFAULT_CONTEXT
       this.#pprof.time.setContext(this.#context)
     }
 
@@ -208,10 +199,12 @@ class CpuProfiler extends BaseProfiler {
    * The backend only cares about the `span:` prefix. Anything after that is just
    * a unique identifier format that other language agents have agreed upon.
    *
+   * @todo should we do two KVPs/labels instead? e.g. "trace_id": "xxx", "span_id": "yyy"
+   *
    * @param {Transaction} transaction the active transaction
    * @returns {string} the label key
    */
-  #spanKey(transaction) {
+  #generateKey(transaction) {
     if (transaction !== this.#nameCache.transaction || !this.#nameCache.name) {
       this.#nameCache = { transaction, name: transaction.getFullName() || '' }
     }

--- a/test/integration/profiling/cpu.test.js
+++ b/test/integration/profiling/cpu.test.js
@@ -36,28 +36,29 @@ function burnCpu(ms) {
 
 /**
  * Decodes the gzipped pprof buffer returned by the profiler and collects, per
- * sample, the `span:`-prefixed labels. The label value is a comma-separated
- * list of `key=value` pairs (e.g. `span_id=...,trace_id=...`) which is parsed
- * into an `extracted` object.
+ * sample, the `span_id` and `trace_id` label values. Node only ever has one
+ * span per sample, so each appears at most once.
  *
  * @param {Buffer} encoded gzipped, protobuf-encoded pprof profile
- * @returns {object} the per-sample span labels
+ * @returns {object} the per-sample span and trace ids
  */
 function decodeSamples(encoded) {
   const profile = Profile.decode(zlib.gunzipSync(encoded))
   const str = (i) => profile.stringTable.strings[i]
 
   const samples = profile.sample.map((sample) => {
-    const spanLabels = []
+    const spanIds = []
+    const traceIds = []
     for (const label of sample.label || []) {
       const key = str(label.key)
-      if (key.startsWith('span:')) {
-        const extracted = Object.fromEntries(str(label.str).split(',').map((pair) => pair.split('=')))
-        spanLabels.push({ key, extracted })
+      if (key === 'span_id') {
+        spanIds.push(str(label.str))
+      } else if (key === 'trace_id') {
+        traceIds.push(str(label.str))
       }
     }
 
-    return { spanLabels }
+    return { spanIds, traceIds }
   })
 
   return { samples }
@@ -105,14 +106,11 @@ for (const variant of variants) {
       helper.unloadAgent(agent)
     })
 
-    test('attaches a span: label with the active span_id and trace_id to CPU samples', async () => {
+    test('attaches span_id and trace_id labels for the active span to CPU samples', async () => {
       profiler.start()
 
-      const name = 'TestTransaction/profiling'
       let expected
       await helper.runInTransaction(agent, 'test', async (transaction) => {
-        // Set a finalized transaction name so the span key includes it.
-        transaction.name = name
         const parent = agent.tracer.getSegment()
         agent.tracer.addSegment('burnCpu', null, parent, false, (segment) => {
           burnCpu(500)
@@ -121,21 +119,18 @@ for (const variant of variants) {
       })
 
       const { samples } = decodeSamples(await profiler.collect())
-      const labelled = samples.filter((s) => s.spanLabels.length > 0)
+      const labelled = samples.filter((s) => s.traceIds.length > 0)
 
       assert.ok(samples.length > 0, 'should have collected samples')
-      assert.ok(labelled.length > 0, 'at least some samples should carry a span: label')
+      assert.ok(labelled.length > 0, 'at least some samples should carry span labels')
 
-      const expectedKey = `span:${expected.traceId.slice(0, 16)}:${name}`
       for (const sample of labelled) {
-        const [{ key, extracted }] = sample.spanLabels
-        assert.equal(key, expectedKey, 'label key should be span:<traceId[0:16]>:<name>')
-        assert.equal(extracted.trace_id, expected.traceId, 'trace_id should match the active transaction')
-        assert.equal(extracted.span_id, expected.spanId, 'span_id should match the active segment')
+        assert.equal(sample.traceIds[0], expected.traceId, 'trace_id should match the active transaction')
+        assert.equal(sample.spanIds[0], expected.spanId, 'span_id should match the active segment')
       }
     })
 
-    test('attaches at most one `span:` label per sample', async () => {
+    test('attaches at most one span_id and one trace_id label per sample', async () => {
       profiler.start()
 
       await helper.runInTransaction(agent, 'web', async () => {
@@ -146,7 +141,8 @@ for (const variant of variants) {
 
       assert.ok(samples.length > 0, 'should have collected samples')
       for (const sample of samples) {
-        assert.ok(sample.spanLabels.length <= 1, 'a sample should never have more than one `span:` label')
+        assert.ok(sample.spanIds.length <= 1, 'a sample should never have more than one span_id label')
+        assert.ok(sample.traceIds.length <= 1, 'a sample should never have more than one trace_id label')
       }
     })
 
@@ -157,10 +153,8 @@ for (const variant of variants) {
 
       profiler.start()
 
-      const name = 'TestTransaction/profiling'
       let expected
       await helper.runInTransaction(agent, 'test', async (transaction) => {
-        transaction.name = name
         const parent = agent.tracer.getSegment()
         agent.tracer.addSegment('burnCpu', null, parent, false, (segment) => {
           burnCpu(500)
@@ -171,35 +165,30 @@ for (const variant of variants) {
       assert.equal(expected.spanId, null, 'sanity: getSpanId() should be null when span events are disabled')
 
       const { samples } = decodeSamples(await profiler.collect())
-      const labelled = samples.filter((s) => s.spanLabels.length > 0)
-      assert.ok(labelled.length > 0, 'at least some samples should carry a span: label')
+      const labelled = samples.filter((s) => s.traceIds.length > 0)
+      assert.ok(labelled.length > 0, 'at least some samples should carry a trace_id label')
 
-      const expectedKey = `span:${expected.traceId.slice(0, 16)}:${name}`
       for (const sample of labelled) {
-        const [{ key, extracted }] = sample.spanLabels
-        assert.equal(key, expectedKey, 'label key should be span:<traceId[0:16]>:<name>')
-        assert.equal(extracted.trace_id, expected.traceId, 'trace_id should match the active transaction')
-        assert.equal(extracted.span_id, undefined, 'no span_id should be present when span events are disabled')
+        assert.equal(sample.traceIds[0], expected.traceId, 'trace_id should match the active transaction')
+        assert.equal(sample.spanIds.length, 0, 'no span_id should be present when span events are disabled')
       }
     })
 
-    test('produces no `span:` labels when no transaction is active', async () => {
+    test('produces no span labels when no transaction is active', async () => {
       profiler.start()
       burnCpu(300)
 
       const { samples } = decodeSamples(await profiler.collect())
 
-      const labelled = samples.filter((s) => s.spanLabels.length > 0)
-      assert.equal(labelled.length, 0, 'samples outside a transaction should not carry `span:` labels')
+      const labelled = samples.filter((s) => s.traceIds.length > 0 || s.spanIds.length > 0)
+      assert.equal(labelled.length, 0, 'samples outside a transaction should not carry span labels')
     })
 
     test('attributes samples to the correct span id for sibling segments', async () => {
       profiler.start()
 
-      const name = 'TestTransaction/siblings'
       let expected
       await helper.runInTransaction(agent, 'test', async (transaction) => {
-        transaction.name = name
         const root = agent.tracer.getSegment()
 
         let first
@@ -222,20 +211,17 @@ for (const variant of variants) {
       })
 
       const { samples } = decodeSamples(await profiler.collect())
-      const labelled = samples.filter((s) => s.spanLabels.length > 0)
-      assert.ok(labelled.length > 0, 'at least some samples should carry a span: label')
+      const labelled = samples.filter((s) => s.traceIds.length > 0)
+      assert.ok(labelled.length > 0, 'at least some samples should carry span labels')
 
-      const expectedKey = `span:${expected.traceId.slice(0, 16)}:${name}`
       const seen = new Set()
       for (const sample of labelled) {
-        const [{ key, extracted }] = sample.spanLabels
-        assert.equal(key, expectedKey, 'label key should be span:<traceId[0:16]>:<name>')
-        assert.equal(extracted.trace_id, expected.traceId, 'all samples share the transaction trace_id')
+        assert.equal(sample.traceIds[0], expected.traceId, 'all samples share the transaction trace_id')
         assert.ok(
-          expected.created.has(extracted.span_id),
-          `span_id ${extracted.span_id} should belong to a segment created in this transaction`
+          expected.created.has(sample.spanIds[0]),
+          `span_id ${sample.spanIds[0]} should belong to a segment created in this transaction`
         )
-        seen.add(extracted.span_id)
+        seen.add(sample.spanIds[0])
       }
 
       assert.ok(seen.has(expected.first), 'first sibling segment should own some samples')
@@ -245,10 +231,8 @@ for (const variant of variants) {
     test('attributes samples to a child segment and restores the parent after it completes', async () => {
       profiler.start()
 
-      const name = 'TestTransaction/nested'
       let expected
       await helper.runInTransaction(agent, 'test', async (transaction) => {
-        transaction.name = name
         const root = agent.tracer.getSegment()
 
         let parentId
@@ -278,20 +262,17 @@ for (const variant of variants) {
       })
 
       const { samples } = decodeSamples(await profiler.collect())
-      const labelled = samples.filter((s) => s.spanLabels.length > 0)
-      assert.ok(labelled.length > 0, 'at least some samples should carry a span: label')
+      const labelled = samples.filter((s) => s.traceIds.length > 0)
+      assert.ok(labelled.length > 0, 'at least some samples should carry span labels')
 
-      const expectedKey = `span:${expected.traceId.slice(0, 16)}:${name}`
       const seen = new Set()
       for (const sample of labelled) {
-        const [{ key, extracted }] = sample.spanLabels
-        assert.equal(key, expectedKey, 'label key should be span:<traceId[0:16]>:<name>')
-        assert.equal(extracted.trace_id, expected.traceId, 'all samples share the transaction trace_id')
+        assert.equal(sample.traceIds[0], expected.traceId, 'all samples share the transaction trace_id')
         assert.ok(
-          expected.created.has(extracted.span_id),
-          `span_id ${extracted.span_id} should belong to a segment created in this transaction`
+          expected.created.has(sample.spanIds[0]),
+          `span_id ${sample.spanIds[0]} should belong to a segment created in this transaction`
         )
-        seen.add(extracted.span_id)
+        seen.add(sample.spanIds[0])
       }
 
       assert.ok(seen.has(expected.child), 'child segment should own some samples')
@@ -304,36 +285,27 @@ for (const variant of variants) {
     test('attributes samples to the correct trace_id across separate transactions', async () => {
       profiler.start()
 
-      // Map each trace-id slice (the label key's id portion) to its full trace
-      // id so we can cross-check the key against the sampled trace_id.
-      const traceBySlice = new Map()
-
+      const traceIds = new Set()
       for (const suffix of ['one', 'two']) {
         await helper.runInTransaction(agent, 'test', async (transaction) => {
           transaction.name = `TestTransaction/${suffix}`
-          traceBySlice.set(transaction.traceId.slice(0, 16), transaction.traceId)
+          traceIds.add(transaction.traceId)
           burnCpu(400)
         })
       }
 
       const { samples } = decodeSamples(await profiler.collect())
-      const labelled = samples.filter((s) => s.spanLabels.length > 0)
-      assert.ok(labelled.length > 0, 'at least some samples should carry a span: label')
+      const labelled = samples.filter((s) => s.traceIds.length > 0)
+      assert.ok(labelled.length > 0, 'at least some samples should carry a trace_id label')
 
-      const seenSlices = new Set()
+      const seen = new Set()
       for (const sample of labelled) {
-        const [{ key, extracted }] = sample.spanLabels
-        const idPart = key.split(':')[1]
-        assert.ok(traceBySlice.has(idPart), `sample key should reference a known transaction (${idPart})`)
-        assert.equal(
-          extracted.trace_id,
-          traceBySlice.get(idPart),
-          'trace_id must match the transaction referenced by the label key'
-        )
-        seenSlices.add(idPart)
+        const traceId = sample.traceIds[0]
+        assert.ok(traceIds.has(traceId), `sample trace_id should reference a known transaction (${traceId})`)
+        seen.add(traceId)
       }
 
-      assert.equal(seenSlices.size, 2, 'samples from both transactions should be present with distinct trace ids')
+      assert.equal(seen.size, 2, 'samples from both transactions should be present with distinct trace ids')
     })
   })
 }

--- a/test/integration/profiling/cpu.test.js
+++ b/test/integration/profiling/cpu.test.js
@@ -5,9 +5,10 @@
 
 'use strict'
 
-const test = require('node:test')
+const { test, describe, beforeEach, afterEach } = require('node:test')
 const assert = require('node:assert')
 const zlib = require('node:zlib')
+const { AsyncLocalStorage } = require('node:async_hooks')
 
 const helper = require('../../lib/agent_helper')
 const CpuProfiler = require('../../../lib/profiling/profilers/cpu')
@@ -37,7 +38,7 @@ function burnCpu(ms) {
  * Decodes the gzipped pprof buffer returned by the profiler and collects, per
  * sample, the `span:`-prefixed labels. The label value is a comma-separated
  * list of `key=value` pairs (e.g. `span_id=...,trace_id=...`) which is parsed
- * into a `fields` object.
+ * into an `extracted` object.
  *
  * @param {Buffer} encoded gzipped, protobuf-encoded pprof profile
  * @returns {object} the per-sample span labels
@@ -51,7 +52,6 @@ function decodeSamples(encoded) {
     for (const label of sample.label || []) {
       const key = str(label.key)
       if (key.startsWith('span:')) {
-        // Extract trace_id and span_id into a separate object for easier assertions
         const extracted = Object.fromEntries(str(label.str).split(',').map((pair) => pair.split('=')))
         spanLabels.push({ key, extracted })
       }
@@ -63,124 +63,277 @@ function decodeSamples(encoded) {
   return { samples }
 }
 
-test.beforeEach((ctx) => {
-  const agent = helper.instrumentMockedAgent({
-    distributed_tracing: { enabled: true },
-    profiling: { enabled: true, include: ['cpu'] }
-  })
-  const profiler = new CpuProfiler({ logger, samplingInterval: 60_000, tracer: agent.tracer })
-  ctx.nr = { agent, profiler }
-})
-
-test.afterEach((ctx) => {
-  if (ctx.nr.profiler) {
-    ctx.nr.profiler.stop()
+// AsyncContextFrame is active when `AsyncLocalStorage.run` delegates to
+// `enterWith` — the same check CpuProfiler uses. CPED is only exercisable then.
+const asyncContextFrameActive = (() => {
+  let active = false
+  const als = new AsyncLocalStorage()
+  als.enterWith = () => {
+    active = true
   }
-  helper.unloadAgent(ctx.nr.agent)
-})
+  als.run(1, () => {})
+  als.disable()
+  return active
+})()
 
-test('attaches a span: label with the active span_id and trace_id to CPU samples', async (t) => {
-  const { agent, profiler } = t.nr
+// The holder path runs on any runtime; CPED only when AsyncContextFrame is active.
+const variants = [{ label: 'non-CPED (holder + run hook)', useCPED: false }]
+if (asyncContextFrameActive) {
+  variants.push({ label: 'CPED (per async-context-frame)', useCPED: true })
+}
 
-  profiler.start()
+for (const variant of variants) {
+  describe(`CpuProfiler span labels — ${variant.label}`, () => {
+    let agent
+    let profiler
 
-  const name = 'TestTransaction/profiling'
-  let expected
-  await helper.runInTransaction(agent, 'test', async (transaction) => {
-    // Set a finalized transaction name so the span key includes it.
-    transaction.name = name
-    const parent = agent.tracer.getSegment()
-    agent.tracer.addSegment('burnCpu', null, parent, false, (segment) => {
-      burnCpu(500)
-      expected = { traceId: transaction.traceId, spanId: segment.getSpanId() }
+    beforeEach(() => {
+      agent = helper.instrumentMockedAgent({
+        distributed_tracing: { enabled: true },
+        profiling: { enabled: true, include: ['cpu'] }
+      })
+      profiler = new CpuProfiler({
+        logger,
+        samplingInterval: 60_000,
+        tracer: agent.tracer,
+        useCPED: variant.useCPED
+      })
+    })
+
+    afterEach(() => {
+      profiler?.stop()
+      helper.unloadAgent(agent)
+    })
+
+    test('attaches a span: label with the active span_id and trace_id to CPU samples', async () => {
+      profiler.start()
+
+      const name = 'TestTransaction/profiling'
+      let expected
+      await helper.runInTransaction(agent, 'test', async (transaction) => {
+        // Set a finalized transaction name so the span key includes it.
+        transaction.name = name
+        const parent = agent.tracer.getSegment()
+        agent.tracer.addSegment('burnCpu', null, parent, false, (segment) => {
+          burnCpu(500)
+          expected = { traceId: transaction.traceId, spanId: segment.getSpanId() }
+        })
+      })
+
+      const { samples } = decodeSamples(await profiler.collect())
+      const labelled = samples.filter((s) => s.spanLabels.length > 0)
+
+      assert.ok(samples.length > 0, 'should have collected samples')
+      assert.ok(labelled.length > 0, 'at least some samples should carry a span: label')
+
+      const expectedKey = `span:${expected.traceId.slice(0, 16)}:${name}`
+      for (const sample of labelled) {
+        const [{ key, extracted }] = sample.spanLabels
+        assert.equal(key, expectedKey, 'label key should be span:<traceId[0:16]>:<name>')
+        assert.equal(extracted.trace_id, expected.traceId, 'trace_id should match the active transaction')
+        assert.equal(extracted.span_id, expected.spanId, 'span_id should match the active segment')
+      }
+    })
+
+    test('attaches at most one `span:` label per sample', async () => {
+      profiler.start()
+
+      await helper.runInTransaction(agent, 'web', async () => {
+        burnCpu(500)
+      })
+
+      const { samples } = decodeSamples(await profiler.collect())
+
+      assert.ok(samples.length > 0, 'should have collected samples')
+      for (const sample of samples) {
+        assert.ok(sample.spanLabels.length <= 1, 'a sample should never have more than one `span:` label')
+      }
+    })
+
+    test('emits trace_id only when span events are disabled so the segment has no span id', async () => {
+      // Disable before the transaction is built: `spansEnabled` is read at
+      // segment construction, and a null span id yields trace_id without span_id.
+      agent.config.span_events.enabled = false
+
+      profiler.start()
+
+      const name = 'TestTransaction/profiling'
+      let expected
+      await helper.runInTransaction(agent, 'test', async (transaction) => {
+        transaction.name = name
+        const parent = agent.tracer.getSegment()
+        agent.tracer.addSegment('burnCpu', null, parent, false, (segment) => {
+          burnCpu(500)
+          expected = { traceId: transaction.traceId, spanId: segment.getSpanId() }
+        })
+      })
+
+      assert.equal(expected.spanId, null, 'sanity: getSpanId() should be null when span events are disabled')
+
+      const { samples } = decodeSamples(await profiler.collect())
+      const labelled = samples.filter((s) => s.spanLabels.length > 0)
+      assert.ok(labelled.length > 0, 'at least some samples should carry a span: label')
+
+      const expectedKey = `span:${expected.traceId.slice(0, 16)}:${name}`
+      for (const sample of labelled) {
+        const [{ key, extracted }] = sample.spanLabels
+        assert.equal(key, expectedKey, 'label key should be span:<traceId[0:16]>:<name>')
+        assert.equal(extracted.trace_id, expected.traceId, 'trace_id should match the active transaction')
+        assert.equal(extracted.span_id, undefined, 'no span_id should be present when span events are disabled')
+      }
+    })
+
+    test('produces no `span:` labels when no transaction is active', async () => {
+      profiler.start()
+      burnCpu(300)
+
+      const { samples } = decodeSamples(await profiler.collect())
+
+      const labelled = samples.filter((s) => s.spanLabels.length > 0)
+      assert.equal(labelled.length, 0, 'samples outside a transaction should not carry `span:` labels')
+    })
+
+    test('attributes samples to the correct span id for sibling segments', async () => {
+      profiler.start()
+
+      const name = 'TestTransaction/siblings'
+      let expected
+      await helper.runInTransaction(agent, 'test', async (transaction) => {
+        transaction.name = name
+        const root = agent.tracer.getSegment()
+
+        let first
+        let second
+        agent.tracer.addSegment('first', null, root, false, (segment) => {
+          first = segment.getSpanId()
+          burnCpu(400)
+        })
+        agent.tracer.addSegment('second', null, root, false, (segment) => {
+          second = segment.getSpanId()
+          burnCpu(400)
+        })
+
+        expected = {
+          traceId: transaction.traceId,
+          created: new Set([root.getSpanId(), first, second]),
+          first,
+          second
+        }
+      })
+
+      const { samples } = decodeSamples(await profiler.collect())
+      const labelled = samples.filter((s) => s.spanLabels.length > 0)
+      assert.ok(labelled.length > 0, 'at least some samples should carry a span: label')
+
+      const expectedKey = `span:${expected.traceId.slice(0, 16)}:${name}`
+      const seen = new Set()
+      for (const sample of labelled) {
+        const [{ key, extracted }] = sample.spanLabels
+        assert.equal(key, expectedKey, 'label key should be span:<traceId[0:16]>:<name>')
+        assert.equal(extracted.trace_id, expected.traceId, 'all samples share the transaction trace_id')
+        assert.ok(
+          expected.created.has(extracted.span_id),
+          `span_id ${extracted.span_id} should belong to a segment created in this transaction`
+        )
+        seen.add(extracted.span_id)
+      }
+
+      assert.ok(seen.has(expected.first), 'first sibling segment should own some samples')
+      assert.ok(seen.has(expected.second), 'second sibling segment should own some samples')
+    })
+
+    test('attributes samples to a child segment and restores the parent after it completes', async () => {
+      profiler.start()
+
+      const name = 'TestTransaction/nested'
+      let expected
+      await helper.runInTransaction(agent, 'test', async (transaction) => {
+        transaction.name = name
+        const root = agent.tracer.getSegment()
+
+        let parentId
+        let childId
+        agent.tracer.addSegment('parent', null, root, false, (parentSegment) => {
+          parentId = parentSegment.getSpanId()
+
+          // Nest a child segment and do all of its CPU work inside it.
+          agent.tracer.addSegment('child', null, parentSegment, false, (childSegment) => {
+            childId = childSegment.getSpanId()
+            burnCpu(400)
+          })
+
+          // The child segment has ended, so the active context is restored to
+          // `parent`. CPU burned here can only be attributed to `parent`; seeing
+          // the parent span id below proves the child's span id did not leak past
+          // its scope.
+          burnCpu(400)
+        })
+
+        expected = {
+          traceId: transaction.traceId,
+          created: new Set([root.getSpanId(), parentId, childId]),
+          parent: parentId,
+          child: childId
+        }
+      })
+
+      const { samples } = decodeSamples(await profiler.collect())
+      const labelled = samples.filter((s) => s.spanLabels.length > 0)
+      assert.ok(labelled.length > 0, 'at least some samples should carry a span: label')
+
+      const expectedKey = `span:${expected.traceId.slice(0, 16)}:${name}`
+      const seen = new Set()
+      for (const sample of labelled) {
+        const [{ key, extracted }] = sample.spanLabels
+        assert.equal(key, expectedKey, 'label key should be span:<traceId[0:16]>:<name>')
+        assert.equal(extracted.trace_id, expected.traceId, 'all samples share the transaction trace_id')
+        assert.ok(
+          expected.created.has(extracted.span_id),
+          `span_id ${extracted.span_id} should belong to a segment created in this transaction`
+        )
+        seen.add(extracted.span_id)
+      }
+
+      assert.ok(seen.has(expected.child), 'child segment should own some samples')
+      assert.ok(
+        seen.has(expected.parent),
+        'parent segment should own samples after the child completes (context restored)'
+      )
+    })
+
+    test('attributes samples to the correct trace_id across separate transactions', async () => {
+      profiler.start()
+
+      // Map each trace-id slice (the label key's id portion) to its full trace
+      // id so we can cross-check the key against the sampled trace_id.
+      const traceBySlice = new Map()
+
+      for (const suffix of ['one', 'two']) {
+        await helper.runInTransaction(agent, 'test', async (transaction) => {
+          transaction.name = `TestTransaction/${suffix}`
+          traceBySlice.set(transaction.traceId.slice(0, 16), transaction.traceId)
+          burnCpu(400)
+        })
+      }
+
+      const { samples } = decodeSamples(await profiler.collect())
+      const labelled = samples.filter((s) => s.spanLabels.length > 0)
+      assert.ok(labelled.length > 0, 'at least some samples should carry a span: label')
+
+      const seenSlices = new Set()
+      for (const sample of labelled) {
+        const [{ key, extracted }] = sample.spanLabels
+        const idPart = key.split(':')[1]
+        assert.ok(traceBySlice.has(idPart), `sample key should reference a known transaction (${idPart})`)
+        assert.equal(
+          extracted.trace_id,
+          traceBySlice.get(idPart),
+          'trace_id must match the transaction referenced by the label key'
+        )
+        seenSlices.add(idPart)
+      }
+
+      assert.equal(seenSlices.size, 2, 'samples from both transactions should be present with distinct trace ids')
     })
   })
-
-  const encoded = await profiler.collect()
-  const { samples } = decodeSamples(encoded)
-
-  const labelled = samples.filter((s) => s.spanLabels.length > 0)
-
-  assert.ok(samples.length > 0, 'should have collected samples')
-  assert.ok(labelled.length > 0, 'at least some samples should carry a span: label')
-
-  // Assert that `span:` key and value contains correct trace_id and span_id
-  const expectedKey = `span:${expected.traceId.slice(0, 16)}:${name}`
-  for (const sample of labelled) {
-    const [{ key, extracted }] = sample.spanLabels
-    assert.equal(key, expectedKey, 'label key should be span:<transaction.id>:<name>')
-    assert.equal(extracted.trace_id, expected.traceId, 'trace_id should match the active transaction')
-    assert.equal(extracted.span_id, expected.spanId, 'span_id should match the active segment')
-  }
-})
-
-test('attaches at most one `span:` label per sample', async (t) => {
-  const { agent, profiler } = t.nr
-
-  profiler.start()
-
-  await helper.runInTransaction(agent, 'web', async () => {
-    burnCpu(500)
-  })
-
-  const encoded = await profiler.collect()
-  const { samples } = decodeSamples(encoded)
-
-  assert.ok(samples.length > 0, 'should have collected samples')
-  for (const sample of samples) {
-    assert.ok(sample.spanLabels.length <= 1, 'a sample should never have more than one `span:` label')
-  }
-})
-
-test('emits trace_id only when span events are disabled so the segment has no span id', async (t) => {
-  const { agent, profiler } = t.nr
-
-  // With span events disabled, a segment is still active but `getSpanId()`
-  // returns null, so `getLinkingMetadata` yields trace.id without span.id.
-  // `spansEnabled` is read when the segment is built, so disable before the
-  // transaction (and its segments) are created.
-  agent.config.span_events.enabled = false
-
-  profiler.start()
-
-  const name = 'TestTransaction/profiling'
-  let expected
-  await helper.runInTransaction(agent, 'test', async (transaction) => {
-    transaction.name = name
-    const parent = agent.tracer.getSegment()
-    agent.tracer.addSegment('burnCpu', null, parent, false, (segment) => {
-      burnCpu(500)
-      expected = { traceId: transaction.traceId, spanId: segment.getSpanId() }
-    })
-  })
-
-  assert.equal(expected.spanId, null, 'sanity: getSpanId() should be null when span events are disabled')
-
-  const encoded = await profiler.collect()
-  const { samples } = decodeSamples(encoded)
-
-  const labelled = samples.filter((s) => s.spanLabels.length > 0)
-  assert.ok(labelled.length > 0, 'at least some samples should carry a span: label')
-
-  const expectedKey = `span:${expected.traceId.slice(0, 16)}:${name}`
-  for (const sample of labelled) {
-    const [{ key, extracted }] = sample.spanLabels
-    assert.equal(key, expectedKey, 'label key should be span:<transaction.id>:<name>')
-    assert.equal(extracted.trace_id, expected.traceId, 'trace_id should match the active transaction')
-    assert.equal(extracted.span_id, undefined, 'no span_id should be present when span events are disabled')
-  }
-})
-
-test('produces no `span:` labels when no transaction is active', async (t) => {
-  const { profiler } = t.nr
-
-  profiler.start()
-  // Burn CPU with no active transaction context.
-  burnCpu(300)
-
-  const encoded = await profiler.collect()
-  const { samples } = decodeSamples(encoded)
-
-  const labelled = samples.filter((s) => s.spanLabels.length > 0)
-  assert.equal(labelled.length, 0, 'samples outside a transaction should not carry `span:` labels')
-})
+}

--- a/test/integration/profiling/cpu.test.js
+++ b/test/integration/profiling/cpu.test.js
@@ -8,7 +8,6 @@
 const { test, describe, beforeEach, afterEach } = require('node:test')
 const assert = require('node:assert')
 const zlib = require('node:zlib')
-const { AsyncLocalStorage } = require('node:async_hooks')
 
 const helper = require('../../lib/agent_helper')
 const CpuProfiler = require('../../../lib/profiling/profilers/cpu')
@@ -64,248 +63,229 @@ function decodeSamples(encoded) {
   return { samples }
 }
 
-// AsyncContextFrame is active when `AsyncLocalStorage.run` delegates to
-// `enterWith` — the same check CpuProfiler uses. CPED is only exercisable then.
-const asyncContextFrameActive = (() => {
-  let active = false
-  const als = new AsyncLocalStorage()
-  als.enterWith = () => {
-    active = true
-  }
-  als.run(1, () => {})
-  als.disable()
-  return active
-})()
+// CpuProfiler picks its context-tracking strategy from the runtime: CPED on
+// Node 24+ (where AsyncContextFrame is on), the holder + run hook otherwise. CI
+// runs both Node 22 and 24, so each path is exercised by the matching runtime.
+describe('CpuProfiler span labels', () => {
+  let agent
+  let profiler
 
-// The holder path runs on any runtime; CPED only when AsyncContextFrame is active.
-const variants = [{ label: 'non-CPED (holder + run hook)', useCPED: false }]
-if (asyncContextFrameActive) {
-  variants.push({ label: 'CPED (per async-context-frame)', useCPED: true })
-}
-
-for (const variant of variants) {
-  describe(`CpuProfiler span labels — ${variant.label}`, () => {
-    let agent
-    let profiler
-
-    beforeEach(() => {
-      agent = helper.instrumentMockedAgent({
-        distributed_tracing: { enabled: true },
-        profiling: { enabled: true, include: ['cpu'] }
-      })
-      profiler = new CpuProfiler({
-        logger,
-        samplingInterval: 60_000,
-        tracer: agent.tracer,
-        useCPED: variant.useCPED
-      })
+  beforeEach(() => {
+    agent = helper.instrumentMockedAgent({
+      distributed_tracing: { enabled: true },
+      profiling: { enabled: true, include: ['cpu'] }
     })
-
-    afterEach(() => {
-      profiler?.stop()
-      helper.unloadAgent(agent)
-    })
-
-    test('attaches span_id and trace_id labels for the active span to CPU samples', async () => {
-      profiler.start()
-
-      let expected
-      await helper.runInTransaction(agent, 'test', async (transaction) => {
-        const parent = agent.tracer.getSegment()
-        agent.tracer.addSegment('burnCpu', null, parent, false, (segment) => {
-          burnCpu(500)
-          expected = { traceId: transaction.traceId, spanId: segment.getSpanId() }
-        })
-      })
-
-      const { samples } = decodeSamples(await profiler.collect())
-      const labelled = samples.filter((s) => s.traceIds.length > 0)
-
-      assert.ok(samples.length > 0, 'should have collected samples')
-      assert.ok(labelled.length > 0, 'at least some samples should carry span labels')
-
-      for (const sample of labelled) {
-        assert.equal(sample.traceIds[0], expected.traceId, 'trace_id should match the active transaction')
-        assert.equal(sample.spanIds[0], expected.spanId, 'span_id should match the active segment')
-      }
-    })
-
-    test('attaches at most one span_id and one trace_id label per sample', async () => {
-      profiler.start()
-
-      await helper.runInTransaction(agent, 'web', async () => {
-        burnCpu(500)
-      })
-
-      const { samples } = decodeSamples(await profiler.collect())
-
-      assert.ok(samples.length > 0, 'should have collected samples')
-      for (const sample of samples) {
-        assert.ok(sample.spanIds.length <= 1, 'a sample should never have more than one span_id label')
-        assert.ok(sample.traceIds.length <= 1, 'a sample should never have more than one trace_id label')
-      }
-    })
-
-    test('emits trace_id only when span events are disabled so the segment has no span id', async () => {
-      // Disable before the transaction is built: `spansEnabled` is read at
-      // segment construction, and a null span id yields trace_id without span_id.
-      agent.config.span_events.enabled = false
-
-      profiler.start()
-
-      let expected
-      await helper.runInTransaction(agent, 'test', async (transaction) => {
-        const parent = agent.tracer.getSegment()
-        agent.tracer.addSegment('burnCpu', null, parent, false, (segment) => {
-          burnCpu(500)
-          expected = { traceId: transaction.traceId, spanId: segment.getSpanId() }
-        })
-      })
-
-      assert.equal(expected.spanId, null, 'sanity: getSpanId() should be null when span events are disabled')
-
-      const { samples } = decodeSamples(await profiler.collect())
-      const labelled = samples.filter((s) => s.traceIds.length > 0)
-      assert.ok(labelled.length > 0, 'at least some samples should carry a trace_id label')
-
-      for (const sample of labelled) {
-        assert.equal(sample.traceIds[0], expected.traceId, 'trace_id should match the active transaction')
-        assert.equal(sample.spanIds.length, 0, 'no span_id should be present when span events are disabled')
-      }
-    })
-
-    test('produces no span labels when no transaction is active', async () => {
-      profiler.start()
-      burnCpu(300)
-
-      const { samples } = decodeSamples(await profiler.collect())
-
-      const labelled = samples.filter((s) => s.traceIds.length > 0 || s.spanIds.length > 0)
-      assert.equal(labelled.length, 0, 'samples outside a transaction should not carry span labels')
-    })
-
-    test('attributes samples to the correct span id for sibling segments', async () => {
-      profiler.start()
-
-      let expected
-      await helper.runInTransaction(agent, 'test', async (transaction) => {
-        const root = agent.tracer.getSegment()
-
-        let first
-        let second
-        agent.tracer.addSegment('first', null, root, false, (segment) => {
-          first = segment.getSpanId()
-          burnCpu(400)
-        })
-        agent.tracer.addSegment('second', null, root, false, (segment) => {
-          second = segment.getSpanId()
-          burnCpu(400)
-        })
-
-        expected = {
-          traceId: transaction.traceId,
-          created: new Set([root.getSpanId(), first, second]),
-          first,
-          second
-        }
-      })
-
-      const { samples } = decodeSamples(await profiler.collect())
-      const labelled = samples.filter((s) => s.traceIds.length > 0)
-      assert.ok(labelled.length > 0, 'at least some samples should carry span labels')
-
-      const seen = new Set()
-      for (const sample of labelled) {
-        assert.equal(sample.traceIds[0], expected.traceId, 'all samples share the transaction trace_id')
-        assert.ok(
-          expected.created.has(sample.spanIds[0]),
-          `span_id ${sample.spanIds[0]} should belong to a segment created in this transaction`
-        )
-        seen.add(sample.spanIds[0])
-      }
-
-      assert.ok(seen.has(expected.first), 'first sibling segment should own some samples')
-      assert.ok(seen.has(expected.second), 'second sibling segment should own some samples')
-    })
-
-    test('attributes samples to a child segment and restores the parent after it completes', async () => {
-      profiler.start()
-
-      let expected
-      await helper.runInTransaction(agent, 'test', async (transaction) => {
-        const root = agent.tracer.getSegment()
-
-        let parentId
-        let childId
-        agent.tracer.addSegment('parent', null, root, false, (parentSegment) => {
-          parentId = parentSegment.getSpanId()
-
-          // Nest a child segment and do all of its CPU work inside it.
-          agent.tracer.addSegment('child', null, parentSegment, false, (childSegment) => {
-            childId = childSegment.getSpanId()
-            burnCpu(400)
-          })
-
-          // The child segment has ended, so the active context is restored to
-          // `parent`. CPU burned here can only be attributed to `parent`; seeing
-          // the parent span id below proves the child's span id did not leak past
-          // its scope.
-          burnCpu(400)
-        })
-
-        expected = {
-          traceId: transaction.traceId,
-          created: new Set([root.getSpanId(), parentId, childId]),
-          parent: parentId,
-          child: childId
-        }
-      })
-
-      const { samples } = decodeSamples(await profiler.collect())
-      const labelled = samples.filter((s) => s.traceIds.length > 0)
-      assert.ok(labelled.length > 0, 'at least some samples should carry span labels')
-
-      const seen = new Set()
-      for (const sample of labelled) {
-        assert.equal(sample.traceIds[0], expected.traceId, 'all samples share the transaction trace_id')
-        assert.ok(
-          expected.created.has(sample.spanIds[0]),
-          `span_id ${sample.spanIds[0]} should belong to a segment created in this transaction`
-        )
-        seen.add(sample.spanIds[0])
-      }
-
-      assert.ok(seen.has(expected.child), 'child segment should own some samples')
-      assert.ok(
-        seen.has(expected.parent),
-        'parent segment should own samples after the child completes (context restored)'
-      )
-    })
-
-    test('attributes samples to the correct trace_id across separate transactions', async () => {
-      profiler.start()
-
-      const traceIds = new Set()
-      for (const suffix of ['one', 'two']) {
-        await helper.runInTransaction(agent, 'test', async (transaction) => {
-          transaction.name = `TestTransaction/${suffix}`
-          traceIds.add(transaction.traceId)
-          burnCpu(400)
-        })
-      }
-
-      const { samples } = decodeSamples(await profiler.collect())
-      const labelled = samples.filter((s) => s.traceIds.length > 0)
-      assert.ok(labelled.length > 0, 'at least some samples should carry a trace_id label')
-
-      const seen = new Set()
-      for (const sample of labelled) {
-        const traceId = sample.traceIds[0]
-        assert.ok(traceIds.has(traceId), `sample trace_id should reference a known transaction (${traceId})`)
-        seen.add(traceId)
-      }
-
-      assert.equal(seen.size, 2, 'samples from both transactions should be present with distinct trace ids')
+    profiler = new CpuProfiler({
+      logger,
+      samplingInterval: 60_000,
+      tracer: agent.tracer
     })
   })
-}
+
+  afterEach(() => {
+    profiler?.stop()
+    helper.unloadAgent(agent)
+  })
+
+  test('attaches span_id and trace_id labels for the active span to CPU samples', async () => {
+    profiler.start()
+
+    let expected
+    await helper.runInTransaction(agent, 'test', async (transaction) => {
+      const parent = agent.tracer.getSegment()
+      agent.tracer.addSegment('burnCpu', null, parent, false, (segment) => {
+        burnCpu(500)
+        expected = { traceId: transaction.traceId, spanId: segment.getSpanId() }
+      })
+    })
+
+    const { samples } = decodeSamples(await profiler.collect())
+    const labelled = samples.filter((s) => s.traceIds.length > 0)
+
+    assert.ok(samples.length > 0, 'should have collected samples')
+    assert.ok(labelled.length > 0, 'at least some samples should carry span labels')
+
+    for (const sample of labelled) {
+      assert.equal(sample.traceIds[0], expected.traceId, 'trace_id should match the active transaction')
+      assert.equal(sample.spanIds[0], expected.spanId, 'span_id should match the active segment')
+    }
+  })
+
+  test('attaches at most one span_id and one trace_id label per sample', async () => {
+    profiler.start()
+
+    await helper.runInTransaction(agent, 'web', async () => {
+      burnCpu(500)
+    })
+
+    const { samples } = decodeSamples(await profiler.collect())
+
+    assert.ok(samples.length > 0, 'should have collected samples')
+    for (const sample of samples) {
+      assert.ok(sample.spanIds.length <= 1, 'a sample should never have more than one span_id label')
+      assert.ok(sample.traceIds.length <= 1, 'a sample should never have more than one trace_id label')
+    }
+  })
+
+  test('emits trace_id only when span events are disabled so the segment has no span id', async () => {
+    // Disable before the transaction is built: `spansEnabled` is read at
+    // segment construction, and a null span id yields trace_id without span_id.
+    agent.config.span_events.enabled = false
+
+    profiler.start()
+
+    let expected
+    await helper.runInTransaction(agent, 'test', async (transaction) => {
+      const parent = agent.tracer.getSegment()
+      agent.tracer.addSegment('burnCpu', null, parent, false, (segment) => {
+        burnCpu(500)
+        expected = { traceId: transaction.traceId, spanId: segment.getSpanId() }
+      })
+    })
+
+    assert.equal(expected.spanId, null, 'sanity: getSpanId() should be null when span events are disabled')
+
+    const { samples } = decodeSamples(await profiler.collect())
+    const labelled = samples.filter((s) => s.traceIds.length > 0)
+    assert.ok(labelled.length > 0, 'at least some samples should carry a trace_id label')
+
+    for (const sample of labelled) {
+      assert.equal(sample.traceIds[0], expected.traceId, 'trace_id should match the active transaction')
+      assert.equal(sample.spanIds.length, 0, 'no span_id should be present when span events are disabled')
+    }
+  })
+
+  test('produces no span labels when no transaction is active', async () => {
+    profiler.start()
+    burnCpu(300)
+
+    const { samples } = decodeSamples(await profiler.collect())
+
+    const labelled = samples.filter((s) => s.traceIds.length > 0 || s.spanIds.length > 0)
+    assert.equal(labelled.length, 0, 'samples outside a transaction should not carry span labels')
+  })
+
+  test('attributes samples to the correct span id for sibling segments', async () => {
+    profiler.start()
+
+    let expected
+    await helper.runInTransaction(agent, 'test', async (transaction) => {
+      const root = agent.tracer.getSegment()
+
+      let first
+      let second
+      agent.tracer.addSegment('first', null, root, false, (segment) => {
+        first = segment.getSpanId()
+        burnCpu(400)
+      })
+      agent.tracer.addSegment('second', null, root, false, (segment) => {
+        second = segment.getSpanId()
+        burnCpu(400)
+      })
+
+      expected = {
+        traceId: transaction.traceId,
+        created: new Set([root.getSpanId(), first, second]),
+        first,
+        second
+      }
+    })
+
+    const { samples } = decodeSamples(await profiler.collect())
+    const labelled = samples.filter((s) => s.traceIds.length > 0)
+    assert.ok(labelled.length > 0, 'at least some samples should carry span labels')
+
+    const seen = new Set()
+    for (const sample of labelled) {
+      assert.equal(sample.traceIds[0], expected.traceId, 'all samples share the transaction trace_id')
+      assert.ok(
+        expected.created.has(sample.spanIds[0]),
+        `span_id ${sample.spanIds[0]} should belong to a segment created in this transaction`
+      )
+      seen.add(sample.spanIds[0])
+    }
+
+    assert.ok(seen.has(expected.first), 'first sibling segment should own some samples')
+    assert.ok(seen.has(expected.second), 'second sibling segment should own some samples')
+  })
+
+  test('attributes samples to a child segment and restores the parent after it completes', async () => {
+    profiler.start()
+
+    let expected
+    await helper.runInTransaction(agent, 'test', async (transaction) => {
+      const root = agent.tracer.getSegment()
+
+      let parentId
+      let childId
+      agent.tracer.addSegment('parent', null, root, false, (parentSegment) => {
+        parentId = parentSegment.getSpanId()
+
+        // Nest a child segment and do all of its CPU work inside it.
+        agent.tracer.addSegment('child', null, parentSegment, false, (childSegment) => {
+          childId = childSegment.getSpanId()
+          burnCpu(400)
+        })
+
+        // The child segment has ended, so the active context is restored to
+        // `parent`. CPU burned here can only be attributed to `parent`; seeing
+        // the parent span id below proves the child's span id did not leak past
+        // its scope.
+        burnCpu(400)
+      })
+
+      expected = {
+        traceId: transaction.traceId,
+        created: new Set([root.getSpanId(), parentId, childId]),
+        parent: parentId,
+        child: childId
+      }
+    })
+
+    const { samples } = decodeSamples(await profiler.collect())
+    const labelled = samples.filter((s) => s.traceIds.length > 0)
+    assert.ok(labelled.length > 0, 'at least some samples should carry span labels')
+
+    const seen = new Set()
+    for (const sample of labelled) {
+      assert.equal(sample.traceIds[0], expected.traceId, 'all samples share the transaction trace_id')
+      assert.ok(
+        expected.created.has(sample.spanIds[0]),
+        `span_id ${sample.spanIds[0]} should belong to a segment created in this transaction`
+      )
+      seen.add(sample.spanIds[0])
+    }
+
+    assert.ok(seen.has(expected.child), 'child segment should own some samples')
+    assert.ok(
+      seen.has(expected.parent),
+      'parent segment should own samples after the child completes (context restored)'
+    )
+  })
+
+  test('attributes samples to the correct trace_id across separate transactions', async () => {
+    profiler.start()
+
+    const traceIds = new Set()
+    for (const suffix of ['one', 'two']) {
+      await helper.runInTransaction(agent, 'test', async (transaction) => {
+        transaction.name = `TestTransaction/${suffix}`
+        traceIds.add(transaction.traceId)
+        burnCpu(400)
+      })
+    }
+
+    const { samples } = decodeSamples(await profiler.collect())
+    const labelled = samples.filter((s) => s.traceIds.length > 0)
+    assert.ok(labelled.length > 0, 'at least some samples should carry a trace_id label')
+
+    const seen = new Set()
+    for (const sample of labelled) {
+      const traceId = sample.traceIds[0]
+      assert.ok(traceIds.has(traceId), `sample trace_id should reference a known transaction (${traceId})`)
+      seen.add(traceId)
+    }
+
+    assert.equal(seen.size, 2, 'samples from both transactions should be present with distinct trace ids')
+  })
+})

--- a/test/integration/profiling/cpu.test.js
+++ b/test/integration/profiling/cpu.test.js
@@ -11,7 +11,6 @@ const zlib = require('node:zlib')
 
 const helper = require('../../lib/agent_helper')
 const CpuProfiler = require('../../../lib/profiling/profilers/cpu')
-const Context = require('../../../lib/context-manager/context')
 const { Profile } = require('pprof-format')
 
 const logger = { trace() {}, debug() {}, error() {} }
@@ -93,7 +92,7 @@ test('attaches a span: label with the active span_id and trace_id to CPU samples
     const parent = agent.tracer.getSegment()
     agent.tracer.addSegment('burnCpu', null, parent, false, (segment) => {
       burnCpu(500)
-      expected = { id: transaction.id, traceId: transaction.traceId, spanId: segment.getSpanId() }
+      expected = { traceId: transaction.traceId, spanId: segment.getSpanId() }
     })
   })
 
@@ -106,7 +105,7 @@ test('attaches a span: label with the active span_id and trace_id to CPU samples
   assert.ok(labelled.length > 0, 'at least some samples should carry a span: label')
 
   // Assert that `span:` key and value contains correct trace_id and span_id
-  const expectedKey = `span:${expected.id}:${name}`
+  const expectedKey = `span:${expected.traceId.slice(0, 16)}:${name}`
   for (const sample of labelled) {
     const [{ key, extracted }] = sample.spanLabels
     assert.equal(key, expectedKey, 'label key should be span:<transaction.id>:<name>')
@@ -133,8 +132,14 @@ test('attaches at most one `span:` label per sample', async (t) => {
   }
 })
 
-test('emits trace_id only when a transaction is active but there is no segment', async (t) => {
+test('emits trace_id only when span events are disabled so the segment has no span id', async (t) => {
   const { agent, profiler } = t.nr
+
+  // With span events disabled, a segment is still active but `getSpanId()`
+  // returns null, so `getLinkingMetadata` yields trace.id without span.id.
+  // `spansEnabled` is read when the segment is built, so disable before the
+  // transaction (and its segments) are created.
+  agent.config.span_events.enabled = false
 
   profiler.start()
 
@@ -142,12 +147,14 @@ test('emits trace_id only when a transaction is active but there is no segment',
   let expected
   await helper.runInTransaction(agent, 'test', async (transaction) => {
     transaction.name = name
-    expected = { id: transaction.id, traceId: transaction.traceId }
-    // Run with a context that carries the transaction but no active segment, so
-    // `getSpanId()` is never reached and the label omits `span_id`.
-    const context = new Context({ transaction, segment: null })
-    agent.tracer.runInContext({ handler: () => burnCpu(500), context })
+    const parent = agent.tracer.getSegment()
+    agent.tracer.addSegment('burnCpu', null, parent, false, (segment) => {
+      burnCpu(500)
+      expected = { traceId: transaction.traceId, spanId: segment.getSpanId() }
+    })
   })
+
+  assert.equal(expected.spanId, null, 'sanity: getSpanId() should be null when span events are disabled')
 
   const encoded = await profiler.collect()
   const { samples } = decodeSamples(encoded)
@@ -155,12 +162,12 @@ test('emits trace_id only when a transaction is active but there is no segment',
   const labelled = samples.filter((s) => s.spanLabels.length > 0)
   assert.ok(labelled.length > 0, 'at least some samples should carry a span: label')
 
-  const expectedKey = `span:${expected.id}:${name}`
+  const expectedKey = `span:${expected.traceId.slice(0, 16)}:${name}`
   for (const sample of labelled) {
     const [{ key, extracted }] = sample.spanLabels
     assert.equal(key, expectedKey, 'label key should be span:<transaction.id>:<name>')
     assert.equal(extracted.trace_id, expected.traceId, 'trace_id should match the active transaction')
-    assert.equal(extracted.span_id, undefined, 'no span_id should be present without an active segment')
+    assert.equal(extracted.span_id, undefined, 'no span_id should be present when span events are disabled')
   }
 })
 

--- a/test/integration/profiling/cpu.test.js
+++ b/test/integration/profiling/cpu.test.js
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert')
+const zlib = require('node:zlib')
+
+const helper = require('../../lib/agent_helper')
+const CpuProfiler = require('../../../lib/profiling/profilers/cpu')
+const Context = require('../../../lib/context-manager/context')
+const { Profile } = require('pprof-format')
+
+const logger = { trace() {}, debug() {}, error() {} }
+
+/**
+ * Burns CPU synchronously for at least `ms` milliseconds so the time profiler
+ * has a chance to take samples while a context is active.
+ *
+ * @param {number} ms minimum time to burn
+ * @returns {number} an accumulated value, to keep the loop from being optimized away
+ */
+function burnCpu(ms) {
+  const end = Date.now() + ms
+  let x = 0
+  while (Date.now() < end) {
+    for (let i = 0; i < 1e5; i++) {
+      x += Math.sqrt(i)
+    }
+  }
+  return x
+}
+
+/**
+ * Decodes the gzipped pprof buffer returned by the profiler and collects, per
+ * sample, the `span:`-prefixed labels. The label value is a comma-separated
+ * list of `key=value` pairs (e.g. `span_id=...,trace_id=...`) which is parsed
+ * into a `fields` object.
+ *
+ * @param {Buffer} encoded gzipped, protobuf-encoded pprof profile
+ * @returns {object} the per-sample span labels
+ */
+function decodeSamples(encoded) {
+  const profile = Profile.decode(zlib.gunzipSync(encoded))
+  const str = (i) => profile.stringTable.strings[i]
+
+  const samples = profile.sample.map((sample) => {
+    const spanLabels = []
+    for (const label of sample.label || []) {
+      const key = str(label.key)
+      if (key.startsWith('span:')) {
+        // Extract trace_id and span_id into a separate object for easier assertions
+        const extracted = Object.fromEntries(str(label.str).split(',').map((pair) => pair.split('=')))
+        spanLabels.push({ key, extracted })
+      }
+    }
+
+    return { spanLabels }
+  })
+
+  return { samples }
+}
+
+test.beforeEach((ctx) => {
+  const agent = helper.instrumentMockedAgent({
+    distributed_tracing: { enabled: true },
+    profiling: { enabled: true, include: ['cpu'] }
+  })
+  const profiler = new CpuProfiler({ logger, samplingInterval: 60_000, tracer: agent.tracer })
+  ctx.nr = { agent, profiler }
+})
+
+test.afterEach((ctx) => {
+  if (ctx.nr.profiler) {
+    ctx.nr.profiler.stop()
+  }
+  helper.unloadAgent(ctx.nr.agent)
+})
+
+test('attaches a span: label with the active span_id and trace_id to CPU samples', async (t) => {
+  const { agent, profiler } = t.nr
+
+  profiler.start()
+
+  const name = 'TestTransaction/profiling'
+  let expected
+  await helper.runInTransaction(agent, 'test', async (transaction) => {
+    // Set a finalized transaction name so the span key includes it.
+    transaction.name = name
+    const parent = agent.tracer.getSegment()
+    agent.tracer.addSegment('burnCpu', null, parent, false, (segment) => {
+      burnCpu(500)
+      expected = { id: transaction.id, traceId: transaction.traceId, spanId: segment.getSpanId() }
+    })
+  })
+
+  const encoded = await profiler.collect()
+  const { samples } = decodeSamples(encoded)
+
+  const labelled = samples.filter((s) => s.spanLabels.length > 0)
+
+  assert.ok(samples.length > 0, 'should have collected samples')
+  assert.ok(labelled.length > 0, 'at least some samples should carry a span: label')
+
+  // Assert that `span:` key and value contains correct trace_id and span_id
+  const expectedKey = `span:${expected.id}:${name}`
+  for (const sample of labelled) {
+    const [{ key, extracted }] = sample.spanLabels
+    assert.equal(key, expectedKey, 'label key should be span:<transaction.id>:<name>')
+    assert.equal(extracted.trace_id, expected.traceId, 'trace_id should match the active transaction')
+    assert.equal(extracted.span_id, expected.spanId, 'span_id should match the active segment')
+  }
+})
+
+test('attaches at most one `span:` label per sample', async (t) => {
+  const { agent, profiler } = t.nr
+
+  profiler.start()
+
+  await helper.runInTransaction(agent, 'web', async () => {
+    burnCpu(500)
+  })
+
+  const encoded = await profiler.collect()
+  const { samples } = decodeSamples(encoded)
+
+  assert.ok(samples.length > 0, 'should have collected samples')
+  for (const sample of samples) {
+    assert.ok(sample.spanLabels.length <= 1, 'a sample should never have more than one `span:` label')
+  }
+})
+
+test('emits trace_id only when a transaction is active but there is no segment', async (t) => {
+  const { agent, profiler } = t.nr
+
+  profiler.start()
+
+  const name = 'TestTransaction/profiling'
+  let expected
+  await helper.runInTransaction(agent, 'test', async (transaction) => {
+    transaction.name = name
+    expected = { id: transaction.id, traceId: transaction.traceId }
+    // Run with a context that carries the transaction but no active segment, so
+    // `getSpanId()` is never reached and the label omits `span_id`.
+    const context = new Context({ transaction, segment: null })
+    agent.tracer.runInContext({ handler: () => burnCpu(500), context })
+  })
+
+  const encoded = await profiler.collect()
+  const { samples } = decodeSamples(encoded)
+
+  const labelled = samples.filter((s) => s.spanLabels.length > 0)
+  assert.ok(labelled.length > 0, 'at least some samples should carry a span: label')
+
+  const expectedKey = `span:${expected.id}:${name}`
+  for (const sample of labelled) {
+    const [{ key, extracted }] = sample.spanLabels
+    assert.equal(key, expectedKey, 'label key should be span:<transaction.id>:<name>')
+    assert.equal(extracted.trace_id, expected.traceId, 'trace_id should match the active transaction')
+    assert.equal(extracted.span_id, undefined, 'no span_id should be present without an active segment')
+  }
+})
+
+test('produces no `span:` labels when no transaction is active', async (t) => {
+  const { profiler } = t.nr
+
+  profiler.start()
+  // Burn CPU with no active transaction context.
+  burnCpu(300)
+
+  const encoded = await profiler.collect()
+  const { samples } = decodeSamples(encoded)
+
+  const labelled = samples.filter((s) => s.spanLabels.length > 0)
+  assert.equal(labelled.length, 0, 'samples outside a transaction should not carry `span:` labels')
+})


### PR DESCRIPTION
## Description

This PR tags each `pprof` sample with the active code's `span_id` and `trace_id`, attached as two separate `pprof` labels: `"span_id": <span id>` and `"trace_id": <trace id>`.

We capture the active ids by setting `withContexts: true` in `pprof` and hooking the agent's ALS instance. We wrap the instance rather than the ALS prototype, so other libraries aren't affected.

How those ids get carried per sample depends on the runtime:
- **AsyncContextFrame active (Node 24+):** `pprof` carries the context per async-context-frame via CPED. We hook `enterWith` and write the active ids straight into the current frame.
- **Older Node:** `pprof` captures a context holder by reference, so we wrap the ALS instance's `run` and reset the holder's `current` to the active ids on each context switch.

### To Do

## How to Test

```
npm run integration
```

## Related Issues

Closes #3964