### PR TITLE
Add getBrowserAgentLoader() API and hasToRemoveLoaderScript option to getBrowserTimingHeader()

### DIFF
--- a/api.js
+++ b/api.js
@@ -632,25 +632,34 @@ function _gracefail(errorCode, quiet) {
  * @private
  * @param {object} options Configuration options for RUM
  * @param {string} [options.nonce] Nonce to inject into `<script>` header.
+ * @param {boolean} [options.hasToRemoveLoaderScript] Used to strip loader script. Renders only RUM header.
  * @param {boolean} [options.hasToRemoveScriptWrapper] Used to import agent script without `<script>` tag wrapper.
  * @param {string} metadata Stringified representation of rumHash metadata
  * @param {string} loader Agent Loader script
  * @returns {string} fully formed RUM header
  */
-function _generateRUMHeader(options = {}, metadata, loader) {
-  const formatArgs = []
-
+/**
+ * Wraps `content` in a `<script>` tag, respecting nonce and hasToRemoveScriptWrapper options.
+ *
+ * @param {string} content
+ * @param {object} options
+ * @param {string} [options.nonce]
+ * @param {boolean} [options.hasToRemoveScriptWrapper]
+ * @returns {string}
+ */
+function _wrapScriptTag(content, options = {}) {
   if (options.hasToRemoveScriptWrapper) {
-    formatArgs.push(RUM_STUB)
-  } else if (options.nonce) {
-    formatArgs.push(RUM_STUB_SHELL_WITH_NONCE_PARAM, `nonce="${options.nonce}"`)
-  } else {
-    formatArgs.push(RUM_STUB_SHELL)
+    return content
   }
+  if (options.nonce) {
+    return `<script type='text/javascript' nonce="${options.nonce}">${content}</script>`
+  }
+  return `<script type='text/javascript'>${content}</script>`
+}
 
-  formatArgs.push(metadata, loader)
-
-  return util.format(...formatArgs)
+function _generateRUMHeader(options = {}, metadata, loader) {
+  const body = util.format(RUM_STUB, metadata, options.hasToRemoveLoaderScript ? '' : loader)
+  return _wrapScriptTag(body, options)
 }
 
 /**
@@ -744,6 +753,7 @@ function validateBrowserMonitoring(config, transaction, allowTransactionlessInje
  *
  * @param {object} options configuration options
  * @param {string} [options.nonce] - Nonce to inject into `<script>` header.
+ * @param {boolean} [options.hasToRemoveLoaderScript] Used to strip loader script. Renders only RUM header.
  * @param {boolean} [options.hasToRemoveScriptWrapper] - Used to import agent script without `<script>` tag wrapper.
  * @param {options} [options.allowTransactionlessInjection] Whether or not to allow the Browser Agent to be injected when there is no active transaction
  * @returns {string} The script content to be injected in `<head>` or put inside `<script>` tag (depending on options)
@@ -837,7 +847,7 @@ API.prototype.getBrowserTimingHeader = function getBrowserTimingHeader(options =
 
   // the complete header to be written to the browser
   const out = _generateRUMHeader(
-    { nonce: options.nonce, hasToRemoveScriptWrapper: options.hasToRemoveScriptWrapper },
+    { nonce: options.nonce, hasToRemoveScriptWrapper: options.hasToRemoveScriptWrapper, hasToRemoveLoaderScript: options.hasToRemoveLoaderScript },
     json,
     config.browser_monitoring.js_agent_loader
   )
@@ -845,6 +855,33 @@ API.prototype.getBrowserTimingHeader = function getBrowserTimingHeader(options =
   logger.trace('generating RUM header', out)
 
   return out
+}
+
+/**
+ * Generates the Browser Monitoring agent loader script (excluding configuration metadata).
+ *
+ * @param {object} [options] Configuration options for the loader script
+ * @param {string} [options.nonce] Nonce to inject into `<script>` tag.
+ * @param {boolean} [options.hasToRemoveScriptWrapper] Used to export the script without `<script>` tag wrapper.
+ * @returns {string} The loader script, optionally wrapped in `<script>` tags
+ */
+API.prototype.getBrowserAgentLoader = function getBrowserAgentLoader(options = {}) {
+  const metric = this.agent.metrics.getOrCreateMetric(
+    NAMES.SUPPORTABILITY.API + '/getBrowserAgentLoader'
+  )
+  metric.incrementCallCount()
+
+  const { isValidConfig, failureIdx, quietMode } = validateBrowserMonitoring(
+    this.agent.config,
+    null,
+    true
+  )
+
+  if (!isValidConfig) {
+    return _gracefail(failureIdx, quietMode)
+  }
+
+  return _wrapScriptTag(this.agent.config.browser_monitoring.js_agent_loader, options)
 }
 
 /**

--- a/stub_api.js
+++ b/stub_api.js
@@ -40,6 +40,7 @@ Stub.prototype.startWebTransaction = startWebTransaction
 Stub.prototype.startBackgroundTransaction = startBackgroundTransaction
 Stub.prototype.getTransaction = getTransaction
 Stub.prototype.getBrowserTimingHeader = getBrowserTimingHeader
+Stub.prototype.getBrowserAgentLoader = getBrowserAgentLoader
 Stub.prototype.shutdown = shutdown
 Stub.prototype.setLambdaHandler = setLambdaHandler
 Stub.prototype.getLinkingMetadata = getLinkingMetadata
@@ -49,6 +50,11 @@ Stub.prototype.getTraceMetadata = getTraceMetadata
 // and we don't want it to return undefined/null.
 function getBrowserTimingHeader() {
   logger.debug('Not calling getBrowserTimingHeader because New Relic is disabled.')
+  return ''
+}
+
+function getBrowserAgentLoader() {
+  logger.debug('Not calling getBrowserAgentLoader because New Relic is disabled.')
   return ''
 }
 

--- a/test/unit/api/stub.test.js
+++ b/test/unit/api/stub.test.js
@@ -72,6 +72,14 @@ test('Agent API - Stubbed Agent API', async (t) => {
     end()
   })
 
+  await t.test('should return an empty string when requesting browser monitoring loader script', (t, end) => {
+    const { api } = t.nr
+    const loader = api.getBrowserAgentLoader()
+    assert.equal(loader, '')
+
+    end()
+  })
+
   await t.test('should return a function when calling setLambdaHandler', (t, end) => {
     const { api } = t.nr
     function myNop() {}

--- a/test/unit/rum.test.js
+++ b/test/unit/rum.test.js
@@ -227,6 +227,28 @@ test('the RUM API', async function (t) {
     }
   )
 
+  await t.test(
+    'should get browser agent script without loader script if hasToRemoveLoaderScript passed in options',
+    function (t, end) {
+      const SCRIPT_START = String.raw`<script type='text\/javascript'>`
+      const NREUM_INFO = String.raw`window\.NREUM\|\|\(NREUM=\{\}\);NREUM\.info = \{"licenseKey":1234,"applicationID":12345,"agentToken":null,"applicationTime":\d+(?:\.\d+)?,"transactionName":"OwwBMRwSC1MKBg1JBwJGLQocHgRMAh8cRD0eAExP","queueTime":0,"ttGuid":"[a-f0-9]{16}","atts":"F0sCR1QIR1IOFAxFGxhHFhcHUV8CRA0cTAQDSx4Y"\};`
+      const SCRIPT_END = String.raw`<\/script>`
+
+      const { agent, api } = t.nr
+      helper.runInTransaction(agent, function (tx) {
+        tx.url = '/hello'
+        tx.finalizeNameFromWeb()
+        
+        assert.match(
+          api.getBrowserTimingHeader({ hasToRemoveLoaderScript: true }),
+          new RegExp(`^${SCRIPT_START}${NREUM_INFO}\\s*${SCRIPT_END}$`)
+        )
+  
+        end()
+      })
+    }
+  )
+
   await t.test('should add custom attributes', function (t, end) {
     const { agent, api } = t.nr
     helper.runInTransaction(agent, function (tx) {
@@ -242,5 +264,29 @@ test('the RUM API', async function (t) {
       assert.equal(JSON.parse(deobf).u.hello, 1)
       end()
     })
+  })
+
+  await t.test('getBrowserAgentLoader - should get the loader script with wrapping tag', function (t) {
+    const { api } = t.nr
+    const loader = api.getBrowserAgentLoader()
+    assert.equal(loader, `<script type='text/javascript'>function() {}</script>`)
+  })
+
+  await t.test('getBrowserAgentLoader - should get the loader script with wrapping tag and nonce', function (t) {
+    const { api } = t.nr
+    const loader = api.getBrowserAgentLoader({ nonce: '12345' })
+    assert.equal(loader, `<script type='text/javascript' nonce="12345">function() {}</script>`)
+  })
+
+  await t.test('getBrowserAgentLoader - should get the loader script without wrapping tag when hasToRemoveScriptWrapper is true', function (t) {
+    const { api } = t.nr
+    const loader = api.getBrowserAgentLoader({ hasToRemoveScriptWrapper: true })
+    assert.equal(loader, 'function() {}')
+  })
+
+  await t.test('getBrowserAgentLoader - should return error comment if configuration is disabled', function (t) {
+    const { agent, api } = t.nr
+    agent.config.browser_monitoring.enable = false
+    assert.equal(api.getBrowserAgentLoader(), '<!-- NREUM: (0) -->')
   })
 })


### PR DESCRIPTION
**Background**

The existing `getBrowserTimingHeader()` returns a single `<script>` block combining two conceptually distinct things:
- the NREUM config blob — transaction-specific metadata that is unique per request and must not be cached.
- the agent loader script — a static JS payload (js_agent_loader) that is identical across all requests for a given agent version and is safe to cache aggressively.

Bundling them together forces both to be delivered through the same path, which is either uncacheable (correct for config, wasteful for the loader) or cached (correct for the loader, incorrect for config).

**What this changes**

**New method:** `api.getBrowserAgentLoader(options)`

Returns only the static loader script, optionally wrapped in a `<script>` tag (with nonce support). Because the loader never changes between requests, it can be served through a CDN or long-lived cache, or inlined once into a layout template.

**New option:** `getBrowserTimingHeader({ hasToRemoveLoaderScript: true })`

Returns only the per-request `NREUM` config block — no loader body. This is the piece that must be injected dynamically on each response (e.g. via a reverse proxy inserting it into <head>, or a server-side template). **Change is opt in and non breaking.**

**Internal refactor:** `_wrapScriptTag(content, options)`

The `<script>` wrapping logic (plain / nonce / unwrapped) was duplicated between _generateRUMHeader and the new method. Extracted into a shared private helper.

**Why this matters**

This split enables deployment patterns that weren't previously possible with a single APM-connected Node.js agent:
- cached loader delivery — serve getBrowserAgentLoader() from a caching reverse proxy or CDN; invalidate only on agent upgrades.
- lightweight per-request injection — inject only the small config blob (hasToRemoveLoaderScript: true) via a proxy or template on each request, keeping the response path thin.
- Separation of concerns

**The existing getBrowserTimingHeader() behaviour is unchanged — callers that don't opt in to either new option get the same combined output as before.**