### PR TITLE
feat: Add new GCP Cloud Run hostname logic to include `K_REVISION`

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -555,6 +555,19 @@ defaultConfig.definition = () => {
       gcp_use_instance_as_host: {
         default: true,
         formatter: boolean
+      },
+
+      gcp_cloud_run: {
+        /**
+         * When enabled, and `gcp_use_instance_as_host` is also enabled, the
+         * GCP Cloud Run revision (`K_REVISION`) will be prepended to the
+         * instance id when setting the hostname of the running application,
+         * resulting in a hostname of `${K_REVISION}-${instance_id}`.
+         */
+        include_revision_in_host: {
+          default: false,
+          formatter: boolean
+        }
       }
     },
     transaction_tracer: {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -959,6 +959,27 @@ Config.prototype.getIPAddresses = function getIPAddresses() {
 }
 
 /**
+ * Determines the GCP Cloud Run host name from the instance id. When
+ * `utilization.gcp_cloud_run.include_revision_in_host` is enabled and the
+ * `K_REVISION` env var is present, the revision is prepended to the instance
+ * id, resulting in a host name of `${K_REVISION}-${gcpId}`.
+ *
+ * @param {object} config agent config
+ * @param {string} gcpId GCP metadata ID
+ * @returns {string} host name
+ */
+function getGcpHostname(config, gcpId) {
+  if (config.utilization.gcp_cloud_run?.include_revision_in_host && process.env.K_REVISION) {
+    const hostname = `${process.env.K_REVISION}-${gcpId}`
+    logger.info('Using GCP revision and instance ID for host name: %s', hostname)
+    return hostname
+  }
+
+  logger.info('Using GCP instance ID for host name: %s', gcpId)
+  return gcpId
+}
+
+/**
  * Gets the system's host name. If that fails, it just returns ipv4/6
  * based on the user's process_host.ipv_preference setting.
  * @param {string} gcpId GCP metadata ID
@@ -991,8 +1012,7 @@ function getHostnameSafe(gcpId = null) {
       _hostname = process.env.DYNO || os.hostname()
       logger.info('Using Heroku dyno name for host name: %s', _hostname)
     } else if (config.utilization.gcp_use_instance_as_host && process.env.K_SERVICE && gcpId) {
-      _hostname = gcpId
-      logger.info('Using GCP instance ID for host name: %s', _hostname)
+      _hostname = getGcpHostname(config, gcpId)
     } else {
       _hostname = os.hostname()
       logger.info('Using OS hostname for host name: %s', _hostname)

--- a/test/unit/collector/facts.test.js
+++ b/test/unit/collector/facts.test.js
@@ -846,6 +846,7 @@ test('host facts', async (t) => {
   t.afterEach((ctx) => {
     helper.unloadAgent(ctx.nr.agent)
     delete process.env.K_SERVICE
+    delete process.env.K_REVISION
 
     // Restore system-info cache
     if (ctx.systemInfoPath) {
@@ -910,6 +911,65 @@ test('host facts', async (t) => {
 
     facts(agent, (result) => {
       assert.equal(result.host, os.hostname(), 'Hostname should not be set to GCP instance ID')
+      end()
+    })
+  })
+
+  await t.test('should be K_REVISION-GCPid when gcp_cloud_run.include_revision_in_host is true', (t, end) => {
+    const { agent, facts } = t.nr
+
+    agent.config.utilization = {
+      gcp_use_instance_as_host: true,
+      gcp_cloud_run: { include_revision_in_host: true }
+    }
+    process.env.K_SERVICE = 'mock-service'
+    process.env.K_REVISION = 'mock-revision'
+
+    facts(agent, (result) => {
+      assert.equal(
+        result.host,
+        'mock-revision-mock-gcp-instance-id',
+        'Hostname should include the GCP revision and instance ID'
+      )
+      end()
+    })
+  })
+
+  await t.test('should be GCP id when gcp_cloud_run.include_revision_in_host is true but K_REVISION is not set', (t, end) => {
+    const { agent, facts } = t.nr
+
+    agent.config.utilization = {
+      gcp_use_instance_as_host: true,
+      gcp_cloud_run: { include_revision_in_host: true }
+    }
+    process.env.K_SERVICE = 'mock-service'
+
+    facts(agent, (result) => {
+      assert.equal(
+        result.host,
+        'mock-gcp-instance-id',
+        'Hostname should fall back to the GCP instance ID when K_REVISION is absent'
+      )
+      end()
+    })
+  })
+
+  await t.test('should be GCP id when K_REVISION is set but gcp_cloud_run.include_revision_in_host is false', (t, end) => {
+    const { agent, facts } = t.nr
+
+    agent.config.utilization = {
+      gcp_use_instance_as_host: true,
+      gcp_cloud_run: { include_revision_in_host: false }
+    }
+    process.env.K_SERVICE = 'mock-service'
+    process.env.K_REVISION = 'mock-revision'
+
+    facts(agent, (result) => {
+      assert.equal(
+        result.host,
+        'mock-gcp-instance-id',
+        'Hostname should be set to the GCP instance ID only'
+      )
       end()
     })
   })


### PR DESCRIPTION
## Description

Implements the updated GCP Cloud Run hostname construction from agent spec PR 809. This PR adds a new config option, `utilization.gcp_cloud_run.include_revision_in_host`, which when enabled, will prepend the Cloud Run revision number (`K_REVISION`) to the instance id. 

Behavior when `gcp_use_instance_as_host` is `true` (default):

| `include_revision_in_host` | `K_REVISION` | hostname                      |
| -------------------------- | ------------ | ----------------------------- |
| `false` (default)          | —            | `${instance_id}` (unchanged)  |
| `true`                     | set          | `${K_REVISION}-${instance_id}`|
| `true`                     | unset        | `${instance_id}` (fallback)   |

## How to Test

```
npm run unit
# or more specifically
node --test test/unit/collector/facts.test.js
```

## Related Issues

Closes #4068 