### PR TITLE
fix: Fixed Azure functions crashing when they include response headers

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -182,7 +182,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [22.22.3, 24.16.0]
 
     steps:
       - uses: actions/checkout@v6

--- a/lib/subscribers/azure-functions/azure-handler-base.js
+++ b/lib/subscribers/azure-functions/azure-handler-base.js
@@ -42,9 +42,22 @@ module.exports = class AzureHandler {
     const newCtx = this.createTransaction({ handlerArgs, ctx })
     const transaction = newCtx?.transaction
     this.addFaasAttributes(transaction, context)
-    const result = await this.runHandlerInContext({ originalHandler, ctx: newCtx, thisArg, handlerArgs })
-    this.handleColdStart(transaction)
-    return this.finalizeTransaction({ result, transaction })
+
+    // We need to wrap up all of our operations into a function that we
+    // can execute within the same context. If we only run the original handler
+    // in the context, then when we try to finalize the transaction we will
+    // not have access to the segment.
+    const wrappedHandler = async (...args) => {
+      const result = await originalHandler.apply(thisArg, args)
+      this.handleColdStart(transaction)
+      return this.finalizeTransaction({ result, transaction })
+    }
+    return await this.runHandlerInContext({
+      originalHandler: wrappedHandler,
+      ctx: newCtx,
+      thisArg,
+      handlerArgs
+    })
   }
 
   runHandlerInContext({ originalHandler, ctx, thisArg, handlerArgs }) {

--- a/test/versioned/azure-functions/http.test.js
+++ b/test/versioned/azure-functions/http.test.js
@@ -387,3 +387,40 @@ test('ends transaction on stream close', async (t) => {
     })
   })
 })
+
+test('collects response headers', async (t) => {
+  bootstrapModule({ t })
+  const { agent, mockApi } = t.nr
+  agent.config.allow_all_headers = true
+
+  const handler = async function () {
+    const response = new AzureFunctionHttpResponse()
+    response.body = 'ok'
+    response.status = 200
+    response.headers = {
+      'content-type': 'application/json',
+      'x-custom-header': 'custom-value'
+    }
+    return response
+  }
+  const options = { handler }
+
+  const txFinished = once(agent, 'transactionFinished')
+  mockApi.app.get('a-test', options)
+  const wrappedHandler = global.azure.handlers.at(-1)
+  const response = await mockApi.httpRequest('get', wrappedHandler)
+  assert.equal(response.body, 'ok')
+
+  const [tx] = await txFinished
+  assert.ok(tx)
+
+  // Verify response headers were collected as transaction attributes
+  const attributes = tx.trace.attributes.get(DESTS.TRANS_COMMON)
+  assert.equal(attributes['response.headers.contentType'], 'application/json')
+  assert.equal(attributes['response.headers.xCustomHeader'], 'custom-value')
+
+  // Verify response headers were also added to the base segment as span attributes
+  const spanAttributes = tx.baseSegment.attributes.get(DESTS.SPAN_EVENT)
+  assert.equal(spanAttributes['response.headers.contentType'], 'application/json')
+  assert.equal(spanAttributes['response.headers.xCustomHeader'], 'custom-value')
+})


### PR DESCRIPTION
When an Azure function includes headers in the response object, our instrumentation was crashing at:

https://github.com/newrelic/node-newrelic/blob/0ae24b865d61b0035cffdafbcfc6543cd7dce27d/lib/header-attributes.js#L137

This is because the `segment` was unavailable at:

https://github.com/newrelic/node-newrelic/blob/0ae24b865d61b0035cffdafbcfc6543cd7dce27d/lib/header-attributes.js#L120

The root cause is that our transaction finalization was not happening within the right context.