### PR TITLE
ci: Updated `setup-node` job to include `check-latest` to ensure we are getting the latest version of node

### DIFF
--- a/.github/workflows/azure-site-extension.yml
+++ b/.github/workflows/azure-site-extension.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: true
           architecture: ${{ matrix.arch }}
 
       - name: Get local agent version 

--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -28,6 +28,7 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
+        check-latest: true
     # This step can be removed when we drop support for Node 22
     - name: Upgrade npm
       if: matrix.node-version == '22.x'

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -66,6 +66,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: true
       - name: Install Dependencies
         run: npm install
       - name: Run Linting
@@ -90,6 +91,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: true
       - name: Install Dependencies
         run: npm install
       - name: Run CI Script Unit Tests
@@ -106,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.22.3, 24.16.0]
+        node-version: [22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v6
@@ -114,9 +116,10 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: true
       # This step can be removed when we drop support for Node 22
       - name: Upgrade npm
-        if: matrix.node-version == '22.22.3'
+        if: matrix.node-version == '22.x'
         run: npm install -g npm@~11.10.0 && npm install -g npm@latest
       - name: Install Dependencies
         run: npm install
@@ -142,7 +145,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.22.3, 24.16.0]
+        node-version: [22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v6
@@ -150,9 +153,10 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: true
       # This step can be removed when we drop support for Node 22
       - name: Upgrade npm
-        if: matrix.node-version == '22.22.3'
+        if: matrix.node-version == '22.x'
         run: npm install -g npm@~11.10.0 && npm install -g npm@latest
       - name: Install Dependencies
         run: npm install
@@ -182,7 +186,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.22.3, 24.16.0]
+        node-version: [22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v6
@@ -190,9 +194,10 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: true
       # This step can be removed when we drop support for Node 22
       - name: Upgrade npm
-        if: matrix.node-version == '22.22.3'
+        if: matrix.node-version == '22.x'
         run: npm install -g npm@~11.10.0 && npm install -g npm@latest
       - name: Install Dependencies
         run: npm install
@@ -231,13 +236,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.22.3, 24.16.0]
+        node-version: [22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
+          check-latest: true
       - name: Download artifacts
         uses: actions/download-artifact@v8
       - name: Post Unit Test Coverage

--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -19,6 +19,7 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: lts/*
+        check-latest: true
     - name: Install Dependencies
       run: npm install
     - name: Check for PRs not yet released

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
+          check-latest: true
       - run: npm install
       - run: |
           git config user.name ${GITHUB_ACTOR}
@@ -60,6 +61,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
+          check-latest: true
       - run: npm install
       - run: |
           git config user.name ${GITHUB_ACTOR}

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -46,6 +46,7 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
+        check-latest: true
     # Only need to install deps in agent-repo because of the bin scripts
     - name: Install Dependencies
       run: npm install --prefix agent-repo

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/setup-node@v6 # https://github.com/actions/setup-node
       with:
         node-version: ${{ matrix.node-version }}
+        check-latest: true
         registry-url: 'https://registry.npmjs.org'
     - name: Install Dependencies
       run: npm install

--- a/.github/workflows/release-creation.yml
+++ b/.github/workflows/release-creation.yml
@@ -49,6 +49,7 @@ jobs:
         # Once v24 is the minimum LTS release, we can revert this back to
         # utilizing the matrix defined version.
         node-version: 24.16.0
+        check-latest: true
         registry-url: 'https://registry.npmjs.org'
     # Only need to install deps in agent-repo because of the bin scripts
     - name: Install Dependencies

--- a/.github/workflows/smoke-test-workflow.yml
+++ b/.github/workflows/smoke-test-workflow.yml
@@ -35,6 +35,7 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
+        check-latest: true
     # This step can be removed when we drop support for Node 22
     - name: Upgrade npm
       if: matrix.node-version == '22.x'

--- a/.github/workflows/update-snyk-prs.yml
+++ b/.github/workflows/update-snyk-prs.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: lts/*
+          check-latest: true
       - name: Install Dependencies
         run: npm install
       - name: Update Snyk PR Title

--- a/.github/workflows/versioned-security-agent.yml
+++ b/.github/workflows/versioned-security-agent.yml
@@ -77,6 +77,7 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
+        check-latest: true
     # This step can be removed when we drop support for Node 22
     - name: Upgrade npm
       if: matrix.node-version == '22.x'


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This specifies `check-latest` on setup node to ensure we get the latest released version of node for a given major version.
This also reverts the pinning of 22/24 as the fix for `node-fetch` was made and released in [24.18.0](https://github.com/nodejs/node/releases/tag/v24.18.0) 
and [22.23.1](https://github.com/nodejs/node/releases/tag/v22.23.1)
