### PR TITLE
chore: Addressed long standing CI flakes

### DIFF
--- a/test/lib/custom-assertions/assert-segment-duration.js
+++ b/test/lib/custom-assertions/assert-segment-duration.js
@@ -51,12 +51,19 @@
  *   measured from segment.timer.hrstart as the reference point
  * @param {number} [params.threshold] maximum allowed ratio difference between the
  *   two measurements
+ * @param {number} [params.minDelta] absolute difference (in ms) tolerated
+ *   regardless of the ratio. For sub-millisecond operations the fixed
+ *   subscriber/diagnostics-channel overhead between the two measurements can
+ *   dominate the ratio (e.g. a 0.3ms difference on a 0.8ms operation is 36%),
+ *   so a difference this small is treated as measurement noise rather than a
+ *   real discrepancy.
  * @param {object} [params.assert] assertion library to use
  */
 module.exports = function assertSegmentDuration({
   segment,
   actualTime,
   threshold = 0.20,
+  minDelta = 2,
   assert = require('node:assert')
 }) {
   assert.equal(segment._isEnded(), true, 'segment should have ended')
@@ -69,8 +76,9 @@ module.exports = function assertSegmentDuration({
   const ratio = maxDuration > 0 ? diff / maxDuration : 0
 
   assert.ok(
-    ratio <= threshold,
+    diff <= minDelta || ratio <= threshold,
     `segment duration (${segmentDuration}ms) and actual duration (${actualDuration}ms) ` +
-    `differ by ${(ratio * 100).toFixed(1)}% which exceeds the ${threshold * 100}% threshold`
+    `differ by ${diff.toFixed(3)}ms (${(ratio * 100).toFixed(1)}%) which exceeds the ` +
+    `${minDelta}ms / ${threshold * 100}% thresholds`
   )
 }

--- a/test/unit/transaction/trace/segment.test.js
+++ b/test/unit/transaction/trace/segment.test.js
@@ -242,8 +242,12 @@ test('TraceSegment', async (t) => {
     sinon.stub(segment.timer, 'softEnd').returns(true)
     sinon.stub(segment.timer, 'endsAfter').returns(true)
 
-    // Make root duration calculation predictable
+    // Make root duration calculation predictable. The root timer must have a
+    // fixed duration; otherwise it keeps reporting live wall-clock elapsed time,
+    // which makes `_computeTotalTime`'s `rootDuration > root duration` check
+    // (and thus this assertion) flaky on slower machines.
     root.timer.start = 1000
+    root.overwriteDurationInMillis(1)
     segment.timer.start = 1001
     segment.overwriteDurationInMillis(3)
 

--- a/test/versioned/amqplib/callback.test.js
+++ b/test/versioned/amqplib/callback.test.js
@@ -80,7 +80,7 @@ test('amqplib callback instrumentation', async function (t) {
 
   await t.test('sendToQueue', function (t, end) {
     const { agent, channel } = t.nr
-    agent.on('transactionFinished', function (tx) {
+    agent.once('transactionFinished', function (tx) {
       amqpUtils.verifySendToQueue(tx)
       end()
     })
@@ -98,7 +98,7 @@ test('amqplib callback instrumentation', async function (t) {
     const { agent, channel } = t.nr
     const exchange = amqpUtils.FANOUT_EXCHANGE
 
-    agent.on('transactionFinished', function (tx) {
+    agent.once('transactionFinished', function (tx) {
       amqpUtils.verifyProduce(tx, exchange, null, true)
       end()
     })
@@ -131,7 +131,7 @@ test('amqplib callback instrumentation', async function (t) {
     const { agent, channel } = t.nr
     const exchange = amqpUtils.DIRECT_EXCHANGE
 
-    agent.on('transactionFinished', function (tx) {
+    agent.once('transactionFinished', function (tx) {
       amqpUtils.verifyProduce(tx, exchange, 'key1', true)
       end()
     })
@@ -164,7 +164,7 @@ test('amqplib callback instrumentation', async function (t) {
     const exchange = amqpUtils.DIRECT_EXCHANGE
     let queueName = null
 
-    agent.on('transactionFinished', function (tx) {
+    agent.once('transactionFinished', function (tx) {
       amqpUtils.verifyPurge(tx, true)
       end()
     })
@@ -344,7 +344,7 @@ test('amqplib callback instrumentation', async function (t) {
     const exchange = amqpUtils.DIRECT_EXCHANGE
     let queue = null
 
-    agent.on('transactionFinished', function (tx) {
+    agent.once('transactionFinished', function (tx) {
       amqpUtils.verifyConsumeTransaction(tx, exchange, queue, 'consume-tx-key')
       end()
     })
@@ -386,7 +386,7 @@ test('amqplib callback instrumentation', async function (t) {
     const exchange = amqpUtils.DIRECT_EXCHANGE
     let queue = null
 
-    agent.on('transactionFinished', function (tx) {
+    agent.once('transactionFinished', function (tx) {
       assert.equal(
         tx.getFullName(),
         'OtherTransaction/Message/Custom/foobar',
@@ -429,7 +429,7 @@ test('amqplib callback instrumentation', async function (t) {
     const exchange = amqpUtils.DIRECT_EXCHANGE
     let queue = null
 
-    agent.on('transactionFinished', function (tx) {
+    agent.once('transactionFinished', function (tx) {
       amqpUtils.verifyConsumeTransaction(tx, exchange, queue, 'consume-tx-key')
       assert.ok(tx.trace.getDurationInMillis() >= PROMISE_WAIT, 'transaction should account for async work')
 
@@ -475,7 +475,7 @@ test('amqplib callback instrumentation', async function (t) {
     const exchange = amqpUtils.DIRECT_EXCHANGE
     let queue = null
 
-    agent.on('transactionFinished', function (tx) {
+    agent.once('transactionFinished', function (tx) {
       amqpUtils.verifyConsumeTransaction(tx, exchange, queue, 'consume-tx-key')
       assert.ok(tx.trace.getDurationInMillis() >= PROMISE_WAIT, 'transaction should account for async work')
       end()


### PR DESCRIPTION
This PR is an attempt to solve three long running CI flakes. I used the bot to perform the diagnosis and generate the fixes. The justifications it gave are included below.

-----

https://github.com/newrelic/node-newrelic/actions/runs/28800559626/job/85402519493?pr=4084#step:6:11

```
The error: The unit (24.x) CI job failed on an assertion in test/unit/transaction/trace/segment.test.js:253:
  actual: 4.436223, expected: 4, operator: '=='
  in the test should truncate when timer still running.

  Root cause — a flaky test, not a bug in the Node 26 PR (#4084). The PR only adds Node 26 support and touches no timer/trace code. The test itself is
  time-dependent:

  1. The test sets root.timer.start = 1000, segment.timer.start = 1001, segment duration = 3 (so it ends at 1004), expecting the root to be truncated
  to a duration of 4.
  2. finalize() → _computeTotalTime() (in lib/transaction/trace/index.js:364) does:
  if (rootDuration > this.root.getDurationInMillis()) {
    this.root.overwriteDurationInMillis(rootDuration)  // rootDuration = 1004 - 1000 = 4
  }
  3. But the root timer was never stopped — its durationInMillis is null, so root.getDurationInMillis() returns live wall-clock elapsed time.
  4. On a fast machine, elapsed < 4ms, so 4 > elapsed is true → root gets set to 4 → test passes. On the slower CI runner, elapsed grew to 4.436223ms,
  so 4 > 4.436223 is false → the root was never overwritten and still reported the real elapsed time → assertion failed.

  The fix (in the test) pins the root timer to a fixed, small duration before finalize, so the comparison is deterministic:
  root.timer.start = 1000
  root.overwriteDurationInMillis(1)   // added — stops the root timer at a fixed 1ms
  segment.timer.start = 1001
  segment.overwriteDurationInMillis(3)
  Now 4 > 1 is always true, root is always truncated to 4, and the result is independent of machine speed. I verified this holds even with a simulated
  50ms delay, where the old code would fail.

  Since the failure is unrelated to the Node 26 changes and it's a pre-existing flaky test, you may want to land this fix on main separately (or
  cherry-pick into the node-26 branch) rather than bundle it into PR #4084.
```

-----

https://github.com/newrelic/node-newrelic/actions/runs/28800559626/job/85402519414?pr=4084#step:7:164

```
The error (verbatim from the log):
  Error: Test hook "beforeEach" at callback.test.js:23:5 generated asynchronous activity
  after the test ended. This activity created the error "AssertionError [ERR_ASSERTION]:
  base segment should account for async work" and would have caused the test to fail, but
  instead triggered an unhandledRejection event.
  The suite reports pass 14, fail 0 yet the process still exits non-zero, so the versioned runner marks it FAIL (1). The consume async handler test
  logged a runtime of 311207 ms (~311 s).

  Why this is a flaky test, not a code bug (as you noted, it can happen on any Node version — 24.x and 22.x happened to pass this run, but the defect
  is version-independent):

  The consume async handler test (line 427) ends only from inside a transactionFinished listener:
  agent.on('transactionFinished', function (tx) {
    amqpUtils.verifyConsumeTransaction(...)
    assert.ok(tx.trace.getDurationInMillis() >= PROMISE_WAIT, ...)
    assert.ok(tx.baseSegment.getDurationInMillis() >= PROMISE_WAIT, 'base segment should account for async work')  // line 436
    end()
  })

  Two flaky properties combine:

  1. The listener is agent.on, never removed. end() doesn't detach it. So after the test's end() runs, the listener remains live. If RabbitMQ
  redelivers or a straggler transaction finishes late, the listener fires again — now after the test has ended — and assert.ok(...) throws
  asynchronously. Node's runner has no active test to attach it to, so it walks up to the still-open hook context (beforeEach at 23:5) and reports it
  there, then escalates to unhandledRejection.
  2. The message-delivery timing is unbounded. The whole test hinges on the published message being consumed and its transaction finishing promptly.
  When the broker is slow/contended in CI, delivery is delayed (hence the 311 s). A transaction can finish and fire the listener when the base
  segment's duration hasn't yet captured the await setTimeout(100), so baseSegment.getDurationInMillis() >= 100 is false — and because this now
  happens near/after the test boundary, it surfaces as the leaked assertion rather than a clean failure.

  The passing promises.test.js equivalent avoids this: it awaits a promise the handler resolves and asserts once in process.nextTick, with no
  persistent event listener that can re-fire after the test ends.

  The fix is to make the listener single-shot and detach it at test end, so a late/duplicate transactionFinished can never fire an assertion after the
  test boundary. Concretely, in the consume async handler test (and its that rejects sibling), replace agent.on(...) with a guarded one-shot:

  await t.test('consume async handler', function (t, end) {
    const { agent, channel } = t.nr
    const exchange = amqpUtils.DIRECT_EXCHANGE
    let queue = null

    function onFinished(tx) {
      agent.removeListener('transactionFinished', onFinished) // detach so it can't re-fire post-end
      amqpUtils.verifyConsumeTransaction(tx, exchange, queue, 'consume-tx-key')
      assert.ok(tx.trace.getDurationInMillis() >= PROMISE_WAIT, 'transaction should account for async work')
      assert.ok(tx.baseSegment.getDurationInMillis() >= PROMISE_WAIT, 'base segment should account for async work')
      end()
    }
    agent.on('transactionFinished', onFinished)
    // ...rest unchanged
  })

  Using agent.once(...) achieves the same detach guarantee more concisely and is the smallest change. That closes the "async activity after the test
  ended" leak for good; the underlying broker-slowness can still make an individual run slow, but it can no longer corrupt the suite result by leaking
  an assertion into the beforeEach context.
```

-----

https://github.com/newrelic/node-newrelic/actions/runs/28792068889/job/85373059683?pr=4084#step:7:199

```
The error:
  AssertionError: segment duration (0.514959ms) and actual duration (0.80565ms)
  differ by 36.1% which exceeds the 20% threshold
    at assertSegmentDuration (test/lib/custom-assertions/assert-segment-duration.js:71)

  Why it's flaky (same character as your earlier calls — timing-dependent, version-independent): assertSegmentDuration compared the recorded segment
  duration against an independently-measured process.hrtime duration using a pure percentage tolerance (diff / max <= 20%). For sub-millisecond
  operations that's unstable: the two measurements were only ~0.29ms apart (0.51ms vs 0.81ms) — pure measurement noise from
  subscriber/diagnostics-channel overhead in the tiny window between segment.timer.hrstart and the callback — but as a fraction of a 0.8ms operation,
  0.29ms is 36%, blowing past the 20% gate. replace() is one of the fastest memcached ops, so it's the most exposed. The helper's own doc comment
  already flagged that "on constrained CI runners the … overhead … is large enough to make any fixed threshold unreliable."

  The fix (in the shared helper, since 19 call sites share the flaw): added a minDelta = 2 (ms) absolute floor. An assertion now fails only if the
  difference exceeds both the 2ms noise floor and the 20% ratio:
  diff <= minDelta || ratio <= threshold
  This keeps the percentage check strict for meaningful durations while immunizing sub-millisecond operations against jitter. Verified: the CI case
  now passes, a 5ms→50ms discrepancy still fails, and a 3ms/23% drift still fails (the floor forgives ≤2ms noise only, not real drift).

  Verification: memcached versioned suite runs green locally (PASS, 3s). The change is strictly loosening, so it cannot regress the aws-sdk-v3 call
  sites (not run locally — no localstack).
```

