### PR TITLE
chore: Fixed package version resolution on Node 26

### DIFF
--- a/lib/subscribers/resolve-package-version.js
+++ b/lib/subscribers/resolve-package-version.js
@@ -16,6 +16,22 @@ const modPathReg = /at .+ \((.+):\d+:\d+\)/
 module.exports = resolveModuleVersion
 
 /**
+ * Captures the current call stack, dropping frames up to and including the
+ * `Channel.publish` frame so that the first returned frame belongs to the
+ * module that published the diagnostics channel event.
+ *
+ * @returns {string[]} The remaining stack frames.
+ */
+function defaultGetStack() {
+  const err = Error()
+  const stack = err.stack.split('\n')
+  do {
+    stack.shift()
+  } while (dcFuncFrame.test(stack[0]) === false && stack.length > 0)
+  return stack
+}
+
+/**
  * Given a module name, attempt to read the version string from its
  * associated package manifest. If the module is a built-in, or one that has
  * been bundled with Node.js (e.g. `undici`), a package manifest will not be
@@ -32,30 +48,44 @@ module.exports = resolveModuleVersion
  * @param {string} moduleSpecifier What would be passed to `resolve()`.
  * @param {object} [deps] Optional dependencies.
  * @param {object} [deps.logger] Agent logger instance.
+ * @param {Function} [deps.getStack] Returns the current call stack as an array
+ * of frame strings. Exposed for testing so a synthetic publisher frame can be
+ * supplied.
  *
  * @returns {string} The version string from the package manifest or "unknown".
  */
-function resolveModuleVersion(moduleSpecifier, { logger = defaultLogger } = {}) {
+function resolveModuleVersion(
+  moduleSpecifier,
+  { logger = defaultLogger, getStack = defaultGetStack } = {}
+) {
   let pkgPath
   // We'd prefer to use `require.resolve(moduleSpecifier)` here, but it gets
   // a bit confused when there are non-standard module directories in play.
   // Once we are able to refactor our "on require" metric recording to
   // utilize `module.registerHooks`, we should be able to eliminate this
   // slow algorithm.
-  const err = Error()
-  const stack = err.stack.split('\n')
-  do {
-    stack.shift()
-  } while (dcFuncFrame.test(stack[0]) === false && stack.length > 0)
+  const stack = getStack()
   const matches = modPathReg.exec(stack[1])
   pkgPath = matches?.[1]
 
-  if (!pkgPath) {
-    logger.warn(
-      { moduleSpecifier },
-      'Could not resolve module path. Possibly a built-in or Node.js bundled module.'
-    )
-    return 'unknown'
+  // When the diagnostics channel event is published by a Node.js built-in or
+  // bundled module (e.g. `node:internal/deps/undici/undici`), `pkgPath` is not
+  // a real filesystem path, so the directory walk below cannot use it. This
+  // happens on modern Node.js versions where userland `undici` reuses Node's
+  // internally bundled undici channels. In that case, resolve the userland
+  // package manifest directly to report the version the application installed.
+  if (!pkgPath || pkgPath.startsWith('node:')) {
+    try {
+      const { version } = require(`${moduleSpecifier}/package.json`)
+      logger.trace({ moduleSpecifier, version }, 'Resolved package version.')
+      return version ?? 'unknown'
+    } catch {
+      logger.warn(
+        { moduleSpecifier },
+        'Could not resolve module path. Possibly a built-in or Node.js bundled module.'
+      )
+      return 'unknown'
+    }
   }
 
   const cwd = process.cwd()

--- a/test/unit/lib/subscribers/resolve-package-version.test.js
+++ b/test/unit/lib/subscribers/resolve-package-version.test.js
@@ -103,6 +103,37 @@ test('returns unknown if app root does not have manifest', (t) => {
   t.assert.equal(result.stdout.toString(), 'unknown\n')
 })
 
+// Simulates a stack where the diagnostics channel event was published from a
+// Node.js bundled module (e.g. modern Node's internal undici), so the publisher
+// frame is a `node:internal` path rather than a real filesystem path.
+const bundledPublisherStack = () => [
+  '    at Channel.publish (node:diagnostics_channel:186:9)',
+  '    at new Request (node:internal/deps/undici/undici:2914:27)'
+]
+
+test('resolves userland package when published from a Node.js bundled module', (t) => {
+  const result = resolvePackageVersion('semver', {
+    ...t.nr,
+    getStack: bundledPublisherStack
+  })
+  t.assert.equal(result, require('semver/package.json').version)
+  t.assert.deepStrictEqual(t.nr.logs.warn, [])
+})
+
+test('returns unknown when bundled module has no userland install', (t) => {
+  const result = resolvePackageVersion('not-a-real-package', {
+    ...t.nr,
+    getStack: bundledPublisherStack
+  })
+  t.assert.equal(result, 'unknown')
+  t.assert.deepStrictEqual(t.nr.logs.warn, [
+    [
+      { moduleSpecifier: 'not-a-real-package' },
+      'Could not resolve module path. Possibly a built-in or Node.js bundled module.'
+    ]
+  ])
+})
+
 test('returns version', (t) => {
   t.plan(2)
 


### PR DESCRIPTION
This solves our newly broken CI on Node 26. When running `npm run versioned:major undici` the issue does not present itself. But when running `npm run versioned undici`, we trigger [this prophecy](https://github.com/nodejs/node/issues/61149). So we have to be a bit more creative with our stack inspection to resolve the _user_ installed version of `undici`.