### PR TITLE
fix: Updated tracer, middleware wrapper, and wrapPromise to properly run promise context propagating outside current context to avoid leaking objects on promises that are never fulfilled

### DIFF
--- a/lib/context-manager/async-local-context-manager.js
+++ b/lib/context-manager/async-local-context-manager.js
@@ -56,6 +56,17 @@ class AsyncLocalContextManager {
   runInContext(context, callback, cbThis, args = []) {
     return this._asyncLocalStorage.run(context, Reflect.apply, callback, cbThis, args)
   }
+
+  /**
+   * Run a function outside the current context. The primary use case is to ensure
+   * objects are not being held and not able to GC if the function never finishes.
+   *
+   * @param {Function} callback to run outside the current async context
+   * @returns {*} Returns the value returned by the callback function.
+   */
+  runOutOfContext(callback) {
+    return this._asyncLocalStorage.exit(callback)
+  }
 }
 
 module.exports = AsyncLocalContextManager

--- a/lib/subscribers/middleware-wrapper.js
+++ b/lib/subscribers/middleware-wrapper.js
@@ -128,14 +128,25 @@ class MiddlewareWrapper {
       try {
         const result = self.agent.tracer.runInContext({ handler, context: newCtx, thisArg: this, args, full: true })
         if (result?.then) {
-          return result.then(function onThen(val) {
-            self.maybeHandleError(txInfo)
+          // Hold `txInfo` (which stores the transaction object) weakly and run the propgation
+          // outside the current context.  This is to prevent a middleware promise that
+          // settles late or is never resolved to not retain the transaction (see issue #4092), and cause a possible leak.
+          // If `txInfo` has been collected by the time the promise settles there
+          // is no longer a transaction to record an error against.
+          const txInfoRef = new WeakRef(txInfo)
+          return self.agent.tracer._contextManager.runOutOfContext(() => result.then(function onThen(val) {
+            const info = txInfoRef.deref()
+            if (info) {
+              self.maybeHandleError(info)
+            }
             return val
-          },
-          function onCatch(err) {
-            self.maybeHandleError(txInfo, err)
+          }, function onCatch(err) {
+            const info = txInfoRef.deref()
+            if (info) {
+              self.maybeHandleError(info, err)
+            }
             throw err
-          })
+          }))
         }
         return result
       } catch (err) {

--- a/lib/subscribers/utils.js
+++ b/lib/subscribers/utils.js
@@ -4,6 +4,7 @@
  */
 
 'use strict'
+
 /**
  * Temporary fix as `tracePromise` wraps the promise in a native one.
  * Certain 3rd party library functions are wrapped in a `traceSync` call,
@@ -11,6 +12,13 @@
  * Then we attach resolve/rejection handlers to indicate a promise is finished.
  * We are not re-throwing the error because that would create an unhandled promise rejection, since the error is getting handled in 3rd party code.
  * ioredis has broken the promise chain and uses this instead, [see](https://github.com/redis/ioredis/blob/d5f5b407bd1287fd86d2ca5df7a10c50c9702305/lib/Pipeline.ts#L218)
+ *
+ * The promise is registered out of context and holds the context weakly so an
+ * application that never awaits the command promise to completion cannot retain
+ * the transaction (see issue #4092) and cause a leak. `asyncEnd` reads the active context to find
+ * the segment, so we re-establish the captured context while publishing. If the
+ * context has been collected by the time the promise settles there is nothing
+ * left to touch.
  *
  * see: https://github.com/newrelic/node-newrelic/issues/3379
  * see: https://github.com/nodejs/node/issues/59936
@@ -23,13 +31,25 @@ function wrapPromise(data) {
     return promise
   }
 
-  promise.then((result) => {
+  const tracer = this.agent.tracer
+  const ctxRef = new WeakRef(tracer.getContext())
+  const publishAsyncEnd = () => {
+    const ctx = ctxRef.deref()
+    if (!ctx) {
+      return
+    }
+    tracer._contextManager.runInContext(ctx, () => {
+      this.channel.asyncEnd.publish(data)
+    })
+  }
+
+  tracer._contextManager.runOutOfContext(() => promise.then((result) => {
     data.result = result
-    this.channel.asyncEnd.publish(data)
+    publishAsyncEnd()
   }, (err) => {
     data.error = err
-    this.channel.asyncEnd.publish(data)
-  })
+    publishAsyncEnd()
+  }))
 }
 
 module.exports = {

--- a/lib/transaction/tracer/index.js
+++ b/lib/transaction/tracer/index.js
@@ -274,7 +274,7 @@ function _makeWrapped({ tracer, handler, context, full }) {
 
     try {
       const result = tracer._contextManager.runInContext(context, handler, this, arguments)
-      _maybeBindPromise({ result, full, segment })
+      _maybeBindPromise({ tracer, result, full, segment })
       return result
     } catch (err) {
       logger.trace({ error: err }, 'Error from wrapped function:')
@@ -289,19 +289,36 @@ function _makeWrapped({ tracer, handler, context, full }) {
 
 /**
  * If `full` is true, there is a segment and it is a Promise/thenable,
- * It will add `onFulfilled` and `onRjected` handlers to touch the segment.
+ * it will add `onFulfilled` and `onRejected` handlers to touch the segment
+ * when the promise settles.
+ *
+ * The agent does not own `result`; an application may hold onto a promise that
+ * settles late or never resolves/rejects. Two things are required so a pending promise cannot
+ * retain the transaction (see issue #4092):
+ *   1. The propagation closes over a `WeakRef` to the segment, not the segment
+ *      itself, so it cannot keep the segment alive on its own.
+ *   2. The propagation is done outside the current context. Attaching a
+ *      link of the promise inside the active context pins the promise's async-context
+ *      frame, which references the whole transaction, for the life of the
+ *      promise, thus creating a possible leak.
+ * If the segment has already been collected when the promise settles the
+ * propagation is a no-op.
  *
  * @param {object} params to function
+ * @param {Tracer} params.tracer the active tracer
  * @param {*} params.result result from wrapped function
  * @param {boolean} params.full flag to touch segment
  * @param {TraceSegment} params.segment active segment
  */
-function _maybeBindPromise({ result, full, segment }) {
+function _maybeBindPromise({ tracer, result, full, segment }) {
   if (segment && full && typeof result?.then === 'function') {
-    result.then(() => {
-      segment.touch()
-    }, () => {
-      segment.touch()
+    const segmentRef = new WeakRef(segment)
+    const touch = () => {
+      segmentRef.deref()?.touch()
+    }
+
+    tracer._contextManager.runOutOfContext(() => {
+      result.then(touch, touch)
     })
   }
 }
@@ -330,7 +347,7 @@ function runInContext({ handler, context, full, thisArg, args }) {
 
   try {
     const result = this._contextManager.runInContext(context, handler, thisArg, args)
-    _maybeBindPromise({ result, full, segment })
+    _maybeBindPromise({ tracer: this, result, full, segment })
     return result
   } catch (err) {
     logger.trace({ error: err }, 'Error from wrapped function:')

--- a/test/unit/lib/subscribers/middleware-wrapper.test.js
+++ b/test/unit/lib/subscribers/middleware-wrapper.test.js
@@ -6,6 +6,7 @@
 'use strict'
 const assert = require('node:assert')
 const test = require('node:test')
+const semver = require('semver')
 const loggerMock = require('../../mocks/logger')
 const MwWrapper = require('#agentlib/subscribers/middleware-wrapper.js')
 const helper = require('#testlib/agent_helper.js')
@@ -251,4 +252,79 @@ test('should not handle error when isError is not using default handler', functi
     tx.end()
     end()
   })
+})
+
+test('should record error from a rejected promise handler', async function (t) {
+  const { agent, wrapper } = t.nr
+  const error = new Error('async failure')
+  async function handler() {
+    throw error
+  }
+  const wrapped = wrapper.wrap({ handler, route: '/promise' })
+  await helper.runInTransaction(agent, async function (tx) {
+    tx.type = 'web'
+    await assert.rejects(wrapped({}, 'one', 'two'), error)
+    assert.equal(t.nr.txInfo.error, error, 'error from settled promise should be recorded on txInfo')
+    tx.end()
+  })
+})
+
+test('should pass through resolved value from a promise handler', async function (t) {
+  const { agent, wrapper } = t.nr
+  async function handler() {
+    return 'resolved'
+  }
+  const wrapped = wrapper.wrap({ handler, route: '/promise' })
+  await helper.runInTransaction(agent, async function (tx) {
+    tx.type = 'web'
+    assert.equal(await wrapped({}, 'one', 'two'), 'resolved')
+    tx.end()
+  })
+})
+
+// see: https://github.com/newrelic/node-newrelic/issues/4092.
+// A wrapped middleware handler that returns a promise gets a `.then`
+// link so errors can be recorded when it settles. That propagation must not
+// pin the transaction: an application-held promise that settles late or never
+// would otherwise keep the segment (and its parent transaction) alive forever.
+//
+// This test is only valid where AsyncContextFrame is enabled(Node's default from v24),
+// so they are skipped below v24 where a held pending promise pins the async
+// context regardless of the agent. See the tracer suite for the same rationale.
+test('should not retain the segment for a pending promise handler', { skip: semver.lt(process.version, '24.0.0') }, async function (t) {
+  const { agent, wrapper } = t.nr
+  const v8 = require('node:v8')
+  const vm = require('node:vm')
+  v8.setFlagsFromString('--expose-gc')
+  const gc = vm.runInNewContext('gc')
+  v8.setFlagsFromString('--no-expose-gc')
+
+  async function collect() {
+    for (let i = 0; i < 30; i++) {
+      gc()
+      await new Promise((resolve) => setImmediate(resolve))
+    }
+  }
+
+  const held = []
+  function handler() {
+    const promise = new Promise(() => {})
+    held.push(promise)
+    return promise
+  }
+  const wrapped = wrapper.wrap({ handler, route: '/leak' })
+
+  let ref
+  helper.runInTransaction(agent, function (tx) {
+    tx.type = 'web'
+    held.push(wrapped({}, 'one', 'two'))
+    const [segment] = tx.trace.getChildren(tx.trace.root.id)
+    ref = new WeakRef(segment)
+    tx.end()
+  })
+
+  await collect()
+
+  assert.equal(held.length, 2, 'application still holds the pending promises')
+  assert.equal(ref.deref(), undefined, 'segment should be collected even though the middleware promise never settled')
 })

--- a/test/unit/lib/subscribers/utils.test.js
+++ b/test/unit/lib/subscribers/utils.test.js
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const assert = require('node:assert')
+const test = require('node:test')
+const semver = require('semver')
+const helper = require('#testlib/agent_helper.js')
+const { wrapPromise } = require('#agentlib/subscribers/utils.js')
+
+test.beforeEach((ctx) => {
+  ctx.nr = {}
+  ctx.nr.agent = helper.loadMockedAgent()
+})
+
+test.afterEach((ctx) => {
+  helper.unloadAgent(ctx.nr.agent)
+})
+
+// Builds a minimal subscriber-like `this` for `wrapPromise`. It only needs a
+// tracer (via `agent`) and a `channel.asyncEnd.publish` to forward to.
+function makeSubscriber(agent, published) {
+  return {
+    agent,
+    channel: {
+      asyncEnd: {
+        publish(data) {
+          published.push(data)
+          agent.tracer.getSegment()?.touch()
+        }
+      }
+    }
+  }
+}
+
+test('returns non-thenable results untouched', function (t) {
+  const { agent } = t.nr
+  const sub = makeSubscriber(agent, [])
+  assert.equal(wrapPromise.call(sub, { result: 42 }), 42)
+  assert.equal(wrapPromise.call(sub, undefined), undefined)
+})
+
+test('publishes asyncEnd with the result when the promise resolves', async function (t) {
+  const { agent } = t.nr
+  const published = []
+  const sub = makeSubscriber(agent, published)
+
+  await helper.runInTransaction(agent, async function (tx) {
+    const segment = agent.tracer.getSegment()
+    let resolveFn
+    const promise = new Promise((resolve) => {
+      resolveFn = resolve
+    })
+    const data = { result: promise, segment }
+    wrapPromise.call(sub, data)
+    resolveFn('ok')
+    await promise
+
+    assert.equal(published.length, 1, 'asyncEnd should be published once')
+    assert.equal(published[0].result, 'ok', 'settled value should be stored on data')
+    tx.end()
+  })
+})
+
+test('publishes asyncEnd with the error when the promise rejects', async function (t) {
+  const { agent } = t.nr
+  const published = []
+  const sub = makeSubscriber(agent, published)
+  const error = new Error('boom')
+
+  await helper.runInTransaction(agent, async function (tx) {
+    const promise = Promise.reject(error)
+    const data = { result: promise }
+    wrapPromise.call(sub, data)
+    await promise.catch(() => {})
+
+    assert.equal(published.length, 1, 'asyncEnd should be published once')
+    assert.equal(published[0].error, error, 'rejection should be stored on data')
+    tx.end()
+  })
+})
+
+// see: https://github.com/newrelic/node-newrelic/issues/4092.
+// `wrapPromise` attaches a link to a promise that publishes `asyncEnd` (touching the
+// segment) when a command promise settles. The propagation must not pin the async
+// context frame, otherwise a command promise the application never awaits to
+// completion keeps the segment (and its transaction) alive forever, thus leaks memory because it cannot be freed.
+//
+// This test is only valid where AsyncContextFrame is enabled(Node's default from v24),
+// so they are skipped below v24 where a held pending promise pins the async
+// context regardless of the agent. See the tracer suite for the same rationale.
+test('does not retain the segment for a pending command promise', { skip: semver.lt(process.version, '24.0.0') }, async function (t) {
+  const { agent } = t.nr
+  const tracer = agent.tracer
+  const sub = makeSubscriber(agent, [])
+
+  const v8 = require('node:v8')
+  const vm = require('node:vm')
+  v8.setFlagsFromString('--expose-gc')
+  const gc = vm.runInNewContext('gc')
+  v8.setFlagsFromString('--no-expose-gc')
+
+  async function collect() {
+    for (let i = 0; i < 30; i++) {
+      gc()
+      await new Promise((resolve) => setImmediate(resolve))
+    }
+  }
+
+  const held = []
+  let ref
+  helper.runInTransaction(agent, function (tx) {
+    tracer.addSegment('command', null, tracer.getSegment(), false, function task() {
+      ref = new WeakRef(tracer.getSegment())
+      const promise = new Promise(() => {})
+      held.push(promise)
+      wrapPromise.call(sub, { result: promise })
+    })
+    tx.end()
+  })
+
+  await collect()
+
+  assert.equal(held.length, 1, 'application still holds the pending promise')
+  assert.equal(ref.deref(), undefined, 'segment should be collected even though the command promise never settled')
+})

--- a/test/unit/transaction/tracer.test.js
+++ b/test/unit/transaction/tracer.test.js
@@ -7,6 +7,7 @@
 const assert = require('node:assert')
 const test = require('node:test')
 const sinon = require('sinon')
+const semver = require('semver')
 const proxyquire = require('proxyquire')
 const helper = require('#testlib/agent_helper.js')
 const Segment = require('#agentlib/transaction/trace/segment.js')
@@ -287,6 +288,101 @@ test('Tracer', async function (t) {
 
       const logCalls = loggerStub.trace.args.filter(([msg]) => typeof msg === 'string' && msg.includes('has exceeded its max segment limit'))
       assert.ok(logCalls.length > 0, 'should log trace message when max_trace_segments is exceeded')
+    })
+  })
+
+  // see: https://github.com/newrelic/node-newrelic/issues/4092.
+  // `_maybeBindPromise` attaches a `.then()` link to the promise to touch a segment when
+  // a promise resolves/rejects.
+  // The propagation must not hold a strong reference to the segment, otherwise a
+  // pending/never-settled promise the application retains keeps the segment (and
+  // its parent) alive forever, producing volume-scaled heap growth.
+  //
+  // The "never settles" assertions only apply to AsyncContextFrame, Node's
+  // default from v24 on. Under the pre-v24 async_hooks `AsyncLocalStorage`, a
+  // promise created inside `runInContext` captures the async resource, so an
+  // application-held pending promise pins the context (and thus the transaction)
+  // regardless of the agent -- the `full: false` case, which attaches no agent
+  // binding at all, leaks just the same. Those cases are therefore skipped below
+  // v24, where the leak this fix targets is neither observable nor fixable.
+  const skipPreAcf = semver.lt(process.version, '24.0.0')
+  await t.test('#addSegment promise binding does not leak segments', async (t) => {
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    // Obtain a callable gc() without requiring the `--expose-gc` CLI flag so this
+    // suite runs under a plain `node --test`.
+    const v8 = require('node:v8')
+    const vm = require('node:vm')
+    v8.setFlagsFromString('--expose-gc')
+    const gc = vm.runInNewContext('gc')
+    v8.setFlagsFromString('--no-expose-gc')
+
+    // Pre-ACF async_hooks (Node's default before v24) needs several ticks for
+    // `destroy` hooks to fire and release retained resources, so give GC ample
+    // cycles to keep this deterministic across Node versions.
+    async function collect() {
+      for (let i = 0; i < 30; i++) {
+        gc()
+        await new Promise((resolve) => setImmediate(resolve))
+      }
+    }
+
+    // Runs one "request": a `full`-wrapped task returns a promise. The test only
+    // keeps a WeakRef to the created segment; when `settle` is false the returned
+    // promise is pushed into `held` so it stays pending and reachable, exactly
+    // like an application holding an in-flight promise.
+    function makeRequest({ agent, tracer, full, settle, held }) {
+      let ref
+      helper.runInTransaction(agent, function (tx) {
+        const parent = tracer.getSegment()
+        tracer.addSegment('segment', null, parent, full, function task() {
+          ref = new WeakRef(tracer.getSegment())
+          let resolveFn
+          const promise = new Promise((resolve) => {
+            resolveFn = resolve
+          })
+          if (settle) {
+            resolveFn()
+          } else {
+            held.push(promise)
+          }
+          return promise
+        })
+        tx.end()
+      })
+      return ref
+    }
+
+    await t.test('releases the segment for a pending, application-held promise', { skip: skipPreAcf }, async (t) => {
+      const { agent, tracer } = t.nr
+      const held = []
+      const ref = makeRequest({ agent, tracer, full: true, settle: false, held })
+
+      await collect()
+
+      assert.equal(held.length, 1, 'application still holds the pending promise')
+      assert.equal(ref.deref(), undefined, 'segment should be collected even though the promise never settled')
+    })
+
+    await t.test('releases the segment for a settled promise', async (t) => {
+      const { agent, tracer } = t.nr
+      const ref = makeRequest({ agent, tracer, full: true, settle: true, held: [] })
+
+      await collect()
+
+      assert.equal(ref.deref(), undefined, 'segment should be collected after the promise settles')
+    })
+
+    await t.test('does not retain the segment when full is false', { skip: skipPreAcf }, async (t) => {
+      const { agent, tracer } = t.nr
+      const held = []
+      const ref = makeRequest({ agent, tracer, full: false, settle: false, held })
+
+      await collect()
+
+      assert.equal(held.length, 1, 'application still holds the pending promise')
+      assert.equal(ref.deref(), undefined, 'segment should be collected when no promise binding is attached')
     })
   })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We had a report in #4092 of memory leaks since 13.20.0. We're still trying to confirm that is the version introduced, but there was a pattern in 3 different places where we were attaching logic to a promise chain and actioning on NR primitives from context manager.  The theory is a promise could never be fulfilled, thus leaving references to segments, or transactions that can never be GCd, and create a memory leak.

A lot of the analysis, and fixes were done by claude with refactoring from me to keep a consistent API in our context manager.

I think we should ask the issue author to test this PR to ensure leaks are no longer present before merging.


## Related Issues
Closes #4092
