### PR TITLE
chore: Shard versioned tests across CI runners

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -18,6 +18,7 @@ specific functionality
 - After running a specific versioned test suite at least once, individual
 test files in the suite may be run directly as
 `node --test test/versioned/<suite>/<test_file>`
+- When opening Pull Requests, always open them in draft mode
 
 ## Commands
 npm run services:start # start Docker services

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -175,9 +175,31 @@ jobs:
           name: integration-tests-esm-${{ matrix.node-version }}
           path: ./coverage/integration-esm/lcov.info
 
+  # Partition the versioned test suites across shards so the matrix below can
+  # run them on separate runners in parallel. Emits a shard list and a
+  # shard-index -> suite-dirs map consumed by the `versioned` job matrix.
+  versioned-setup:
+    needs:
+      - should_run
+    if: github.event_name == 'workflow_dispatch' ||
+      (needs.should_run.outputs.javascript_changed == 'true' ||
+      needs.should_run.outputs.deps_changed == 'true')
+    runs-on: ubuntu-latest
+    outputs:
+      shards: ${{ steps.plan.outputs.shards }}
+      dirmap: ${{ steps.plan.outputs.dirmap }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Plan versioned shards
+        id: plan
+        run: node ./bin/versioned-runner/shard-plan.js
+        env:
+          SHARD_COUNT: ${{ github.ref == 'refs/heads/main' && 8 || 4 }}
+
   versioned:
     needs:
       - should_run
+      - versioned-setup
     if: github.event_name == 'workflow_dispatch' ||
       (needs.should_run.outputs.javascript_changed == 'true' ||
       needs.should_run.outputs.deps_changed == 'true')
@@ -187,6 +209,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [22.x, 24.x, 26.x]
+        shard: ${{ fromJSON(needs.versioned-setup.outputs.shards) }}
 
     steps:
       - uses: actions/checkout@v6
@@ -210,28 +233,30 @@ jobs:
           # Run more jobs when using larger runner, otherwise 2 per CPU seems to be the sweet spot in GHA default runners(July 2022)
           JOBS: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER && 16 ||  4 }}
           C8_REPORTER: lcovonly
+          # Only run this shard's subset of the versioned suites.
+          VERSIONED_DIRS: ${{ fromJSON(needs.versioned-setup.outputs.dirmap)[matrix.shard] }}
       - name: Archive Versioned Test Coverage
         uses: actions/upload-artifact@v7
         with:
-          name: versioned-tests-${{ matrix.node-version }}
+          name: versioned-tests-${{ matrix.node-version }}-shard-${{ matrix.shard }}
           path: ./coverage/versioned/lcov.info
       - name: Collect docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e
         with:
-          dest: ./logs-${{ matrix.node-version }}
+          dest: ./logs-${{ matrix.node-version }}-shard-${{ matrix.shard }}
       - name: Tar logs
         if: failure()
-        run: tar cvzf ./logs-${{ matrix.node-version }}.tgz ./logs-${{ matrix.node-version }}
+        run: tar cvzf ./logs-${{ matrix.node-version }}-shard-${{ matrix.shard }}.tgz ./logs-${{ matrix.node-version }}-shard-${{ matrix.shard }}
       - name: Upload logs to GitHub
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: logs-${{ matrix.node-version }}.tgz
-          path: ./logs-${{ matrix.node-version }}.tgz
+          name: logs-${{ matrix.node-version }}-shard-${{ matrix.shard }}.tgz
+          path: ./logs-${{ matrix.node-version }}-shard-${{ matrix.shard }}.tgz
 
   codecov:
-    needs: [unit, integration, versioned]
+    needs: [unit, integration, versioned, versioned-setup]
     runs-on: ubuntu-latest
 
     strategy:
@@ -246,6 +271,21 @@ jobs:
           check-latest: true
       - name: Download artifacts
         uses: actions/download-artifact@v8
+      # Versioned coverage is split across one artifact per shard. Build the
+      # comma separated lcov file list for this node-version from the shard list
+      # so codecov can merge them under a single flag.
+      - name: Build versioned coverage file list
+        id: versioned-coverage
+        env:
+          SHARDS: ${{ needs.versioned-setup.outputs.shards }}
+          NODE_VERSION: ${{ matrix.node-version }}
+        run: |
+          files=$(echo "$SHARDS" | node -e '
+            const shards = JSON.parse(require("fs").readFileSync(0, "utf8"))
+            const node = process.env.NODE_VERSION
+            console.log(shards.map((s) => `./versioned-tests-${node}-shard-${s}/lcov.info`).join(","))
+          ')
+          echo "files=${files}" >> "$GITHUB_OUTPUT"
       - name: Post Unit Test Coverage
         # v7.0.0
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
@@ -276,7 +316,7 @@ jobs:
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: versioned-tests-${{ matrix.node-version }}
+          files: ${{ steps.versioned-coverage.outputs.files }}
           flags: versioned-tests-${{ matrix.node-version }}
 
   all-clear:
@@ -287,6 +327,7 @@ jobs:
       - ci
       - unit
       - integration
+      - versioned-setup
       - versioned
     steps:
       - name: All checks passed

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -207,6 +207,10 @@ jobs:
       needs.should_run.outputs.deps_changed == 'true')
     runs-on: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER || 'ubuntu-latest' }}
 
+    # A healthy shard completes well within this; a hung/looping test should fail
+    # its leg fast rather than burning the full GitHub-imposed job limit.
+    timeout-minutes: 8
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -176,8 +176,9 @@ jobs:
           path: ./coverage/integration-esm/lcov.info
 
   # Partition the versioned test suites across shards so the matrix below can
-  # run them on separate runners in parallel. Emits a shard list and a
-  # shard-index -> suite-dirs map consumed by the `versioned` job matrix.
+  # run them on separate runners in parallel. Emits a shard list, a
+  # shard-index -> suite-dirs map, and a shard-index -> docker-services map,
+  # all consumed by the `versioned` job matrix.
   versioned-setup:
     needs:
       - should_run
@@ -188,6 +189,7 @@ jobs:
     outputs:
       shards: ${{ steps.plan.outputs.shards }}
       dirmap: ${{ steps.plan.outputs.dirmap }}
+      servicemap: ${{ steps.plan.outputs.servicemap }}
     steps:
       - uses: actions/checkout@v6
       - name: Plan versioned shards
@@ -225,8 +227,13 @@ jobs:
         run: npm install -g npm@~11.10.0 && npm install -g npm@latest
       - name: Install Dependencies
         run: npm install
+      # Start only the docker services this shard's suites need. Shards whose
+      # suites need no services skip this step entirely (zero containers).
       - name: Run Docker Services
-        run: npm run services
+        if: ${{ fromJSON(needs.versioned-setup.outputs.servicemap)[matrix.shard] != '' }}
+        run: ./bin/start-services.sh $SERVICES
+        env:
+          SERVICES: ${{ fromJSON(needs.versioned-setup.outputs.servicemap)[matrix.shard] }}
       - name: Run Versioned Tests
         run: TEST_CHILD_TIMEOUT=600000 npm run versioned
         env:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -194,7 +194,8 @@ jobs:
         id: plan
         run: node ./bin/versioned-runner/shard-plan.js
         env:
-          SHARD_COUNT: ${{ github.ref == 'refs/heads/main' && 8 || 4 }}
+          # At most 5 suites per shard; the shard count derives from suite count.
+          SHARD_SIZE: 5
 
   versioned:
     needs:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -7,7 +7,6 @@ on:
   push:
   pull_request:
     types:
-      - edited
       - opened
       - reopened
       - synchronize

--- a/bin/run-versioned-tests.sh
+++ b/bin/run-versioned-tests.sh
@@ -38,7 +38,16 @@ fi
 
 set -f
 directories=()
-if [[ "$1" != '' ]];
+if [[ -n "${VERSIONED_DIRS}" ]];
+then
+  # VERSIONED_DIRS is a space separated list of suite subdir names, used by CI
+  # to run a shard (subset) of the versioned suites. Word splitting is safe here
+  # because `set -f` is enabled above and suite names are simple identifiers.
+  for d in ${VERSIONED_DIRS};
+  do
+    directories+=( "test/versioned/${d}" )
+  done
+elif [[ "$1" != '' ]];
 then
   directories=(
     "test/versioned/${1}"

--- a/bin/start-services.sh
+++ b/bin/start-services.sh
@@ -1,0 +1,14 @@
+#! /bin/sh
+
+# Copyright 2026 New Relic Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Start docker-compose services and wait on their healthchecks.
+#
+# With no arguments, ALL services are started -- this is the default used by
+# `npm run services` for local development. When one or more service names are
+# passed, only those services are started; CI uses this to start just the
+# services a given versioned-test shard needs.
+
+export DOCKER_PLATFORM="linux/$(uname -m)"
+docker compose up -d --wait "$@"

--- a/bin/test/versioned-runner/shard-plan.test.js
+++ b/bin/test/versioned-runner/shard-plan.test.js
@@ -31,6 +31,42 @@ test('planShards', async (t) => {
   })
 })
 
+test('orderSuites', async (t) => {
+  const services = {
+    zebra: ['redis'],
+    apple: [],
+    mango: ['mysql'],
+    banana: [],
+    cherry: ['pg']
+  }
+  const getServices = (dir) => services[dir]
+
+  await t.test('puts docker-requiring suites first, each group alphabetical', () => {
+    const ordered = shardPlan.orderSuites(Object.keys(services), getServices)
+    assert.deepEqual(ordered, [
+      // docker-requiring, alphabetical
+      'cherry',
+      'mango',
+      'zebra',
+      // docker-free, alphabetical
+      'apple',
+      'banana'
+    ])
+  })
+
+  await t.test('preserves every suite exactly once', () => {
+    const suites = Object.keys(services)
+    const ordered = shardPlan.orderSuites(suites, getServices)
+    assert.equal(ordered.length, suites.length)
+    assert.deepEqual([...ordered].sort(), [...suites].sort())
+  })
+
+  await t.test('handles all-docker and all-docker-free inputs', () => {
+    assert.deepEqual(shardPlan.orderSuites(['b', 'a'], () => []), ['a', 'b'])
+    assert.deepEqual(shardPlan.orderSuites(['b', 'a'], () => ['redis']), ['a', 'b'])
+  })
+})
+
 test('planServices', async (t) => {
   const dirmap = {
     0: ['redis', 'disabled-instrumentation'],

--- a/bin/test/versioned-runner/shard-plan.test.js
+++ b/bin/test/versioned-runner/shard-plan.test.js
@@ -31,42 +31,6 @@ test('planShards', async (t) => {
   })
 })
 
-test('orderSuites', async (t) => {
-  const services = {
-    zebra: ['redis'],
-    apple: [],
-    mango: ['mysql'],
-    banana: [],
-    cherry: ['pg']
-  }
-  const getServices = (dir) => services[dir]
-
-  await t.test('puts docker-requiring suites first, each group alphabetical', () => {
-    const ordered = shardPlan.orderSuites(Object.keys(services), getServices)
-    assert.deepEqual(ordered, [
-      // docker-requiring, alphabetical
-      'cherry',
-      'mango',
-      'zebra',
-      // docker-free, alphabetical
-      'apple',
-      'banana'
-    ])
-  })
-
-  await t.test('preserves every suite exactly once', () => {
-    const suites = Object.keys(services)
-    const ordered = shardPlan.orderSuites(suites, getServices)
-    assert.equal(ordered.length, suites.length)
-    assert.deepEqual([...ordered].sort(), [...suites].sort())
-  })
-
-  await t.test('handles all-docker and all-docker-free inputs', () => {
-    assert.deepEqual(shardPlan.orderSuites(['b', 'a'], () => []), ['a', 'b'])
-    assert.deepEqual(shardPlan.orderSuites(['b', 'a'], () => ['redis']), ['a', 'b'])
-  })
-})
-
 test('planServices', async (t) => {
   const dirmap = {
     0: ['redis', 'disabled-instrumentation'],

--- a/bin/test/versioned-runner/shard-plan.test.js
+++ b/bin/test/versioned-runner/shard-plan.test.js
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const test = require('node:test')
+const assert = require('node:assert')
+const os = require('node:os')
+const fs = require('node:fs')
+const path = require('node:path')
+const shardPlan = require('../../versioned-runner/shard-plan')
+
+test('planShards', async (t) => {
+  await t.test('splits into contiguous chunks of at most shardSize', () => {
+    const suites = ['a', 'b', 'c', 'd', 'e']
+    const dirmap = shardPlan.planShards(suites, 2)
+    assert.deepEqual(dirmap, {
+      0: ['a', 'b'],
+      1: ['c', 'd'],
+      2: ['e']
+    })
+  })
+
+  await t.test('covers every suite exactly once', () => {
+    const suites = Array.from({ length: 13 }, (_, i) => `suite-${i}`)
+    const dirmap = shardPlan.planShards(suites, 5)
+    const assigned = Object.values(dirmap).flat()
+    assert.equal(assigned.length, suites.length)
+    assert.deepEqual([...assigned].sort(), [...suites].sort())
+  })
+})
+
+test('planServices', async (t) => {
+  const dirmap = {
+    0: ['redis', 'disabled-instrumentation'],
+    1: ['kafkajs'],
+    2: ['express', 'koa']
+  }
+  const services = {
+    redis: ['redis'],
+    'disabled-instrumentation': ['redis', 'mongodb_5'],
+    kafkajs: ['kafka', 'zookeeper'],
+    express: [],
+    koa: []
+  }
+  const getServices = (dir) => services[dir]
+
+  await t.test('unions and dedupes services within a shard', () => {
+    const servicemap = shardPlan.planServices(dirmap, getServices)
+    // redis appears in both suites of shard 0 -> deduped.
+    assert.equal(servicemap['0'], 'mongodb_5 redis')
+  })
+
+  await t.test('lists all services a shard needs, sorted', () => {
+    const servicemap = shardPlan.planServices(dirmap, getServices)
+    assert.equal(servicemap['1'], 'kafka zookeeper')
+  })
+
+  await t.test('emits empty string for a service-free shard', () => {
+    const servicemap = shardPlan.planServices(dirmap, getServices)
+    assert.equal(servicemap['2'], '')
+  })
+})
+
+test('readServices', async (t) => {
+  const known = shardPlan.knownServices()
+
+  await t.test('reads a real suite declaration', () => {
+    // kafkajs declares both kafka and zookeeper.
+    assert.deepEqual(shardPlan.readServices('kafkajs', known), ['kafka', 'zookeeper'])
+  })
+
+  await t.test('returns empty for a suite that declares nothing', () => {
+    // express is a pure HTTP framework; no dockerServices field.
+    assert.deepEqual(shardPlan.readServices('express', known), [])
+  })
+
+  await t.test('throws on an unknown service name', () => {
+    const known = new Set(['redis'])
+    assert.throws(
+      () => shardPlan.readServices('kafkajs', known),
+      /declares unknown docker service/
+    )
+  })
+})
+
+test('knownServices', async (t) => {
+  await t.test('reads the service names from docker-compose.yml', () => {
+    const known = shardPlan.knownServices()
+    // Spot-check a representative set; all must be present.
+    for (const name of ['redis', 'mongodb_5', 'kafka', 'zookeeper', 'pg', 'pg_prisma', 'rmq']) {
+      assert.ok(known.has(name), `expected known service "${name}"`)
+    }
+  })
+})
+
+test('main writes shards, dirmap, and servicemap to GITHUB_OUTPUT', () => {
+  const outFile = path.join(os.tmpdir(), `shard-plan-out-${process.pid}`)
+  fs.writeFileSync(outFile, '')
+  const prevOutput = process.env.GITHUB_OUTPUT
+  process.env.GITHUB_OUTPUT = outFile
+
+  try {
+    shardPlan.main()
+  } finally {
+    if (prevOutput === undefined) {
+      delete process.env.GITHUB_OUTPUT
+    } else {
+      process.env.GITHUB_OUTPUT = prevOutput
+    }
+  }
+
+  const written = fs.readFileSync(outFile, 'utf8')
+  fs.rmSync(outFile, { force: true })
+
+  assert.match(written, /^shards=\[/m)
+  assert.match(written, /^dirmap=\{/m)
+  assert.match(written, /^servicemap=\{/m)
+
+  // The servicemap values must be valid JSON and every value a string.
+  const servicemapLine = written.split('\n').find((l) => l.startsWith('servicemap='))
+  const servicemap = JSON.parse(servicemapLine.slice('servicemap='.length))
+  for (const value of Object.values(servicemap)) {
+    assert.equal(typeof value, 'string')
+  }
+})

--- a/bin/versioned-runner/shard-plan.js
+++ b/bin/versioned-runner/shard-plan.js
@@ -9,10 +9,13 @@
 
 // Partitions the versioned test suites in `test/versioned/` across a number of
 // shards so that CI can run them on separate runners in parallel. The suite
-// directories are listed in alphabetical order and split into contiguous chunks
-// of at most SHARD_SIZE suites; the number of shards is derived from that. Each
-// shard therefore holds an alphabetically adjacent run of suites. New suites are
-// picked up automatically.
+// directories are ordered with all docker-requiring suites first (alphabetical
+// among themselves) followed by all docker-free suites (alphabetical among
+// themselves), then split into contiguous chunks of at most SHARD_SIZE suites;
+// the number of shards is derived from that. Clustering the docker-requiring
+// suites into the earliest shards means the later shards are entirely
+// docker-free and skip the Docker startup step. New suites are picked up
+// automatically.
 //
 // Outputs three values, written to `$GITHUB_OUTPUT` when present (otherwise
 // stdout for local inspection):
@@ -92,11 +95,31 @@ function readServices(dir, known) {
   return services
 }
 
+// Orders suites so every docker-requiring suite comes before every docker-free
+// suite, with each group sorted alphabetically. Chunking this list clusters the
+// docker-requiring suites into the earliest shards, leaving the later shards
+// docker-free. `getServices` maps a suite dir to its service list (injectable
+// for testing).
+function orderSuites(suites, getServices) {
+  const withDocker = []
+  const withoutDocker = []
+  for (const suite of suites) {
+    if (getServices(suite).length > 0) {
+      withDocker.push(suite)
+    } else {
+      withoutDocker.push(suite)
+    }
+  }
+  withDocker.sort()
+  withoutDocker.sort()
+  return [...withDocker, ...withoutDocker]
+}
+
 function planShards(suites, shardSize) {
   const dirmap = {}
 
-  // Split the alphabetically sorted list into contiguous chunks of at most
-  // `shardSize` suites. The number of shards falls out of the suite count.
+  // Split the ordered list into contiguous chunks of at most `shardSize`
+  // suites. The number of shards falls out of the suite count.
   for (let i = 0; i < suites.length; i += shardSize) {
     const shard = String(i / shardSize)
     dirmap[shard] = suites.slice(i, i + shardSize)
@@ -146,8 +169,10 @@ function main() {
   }
 
   const known = knownServices()
-  const dirmap = planShards(suites, SHARD_SIZE)
-  const servicemap = planServices(dirmap, (dir) => readServices(dir, known))
+  const getServices = (dir) => readServices(dir, known)
+  const ordered = orderSuites(suites, getServices)
+  const dirmap = planShards(ordered, SHARD_SIZE)
+  const servicemap = planServices(dirmap, getServices)
   const shards = Object.keys(dirmap)
 
   const dirmapOut = {}
@@ -177,6 +202,7 @@ module.exports = {
   knownServices,
   listSuites,
   readServices,
+  orderSuites,
   planShards,
   planServices,
   main

--- a/bin/versioned-runner/shard-plan.js
+++ b/bin/versioned-runner/shard-plan.js
@@ -9,13 +9,10 @@
 
 // Partitions the versioned test suites in `test/versioned/` across a number of
 // shards so that CI can run them on separate runners in parallel. The suite
-// directories are ordered with all docker-requiring suites first (alphabetical
-// among themselves) followed by all docker-free suites (alphabetical among
-// themselves), then split into contiguous chunks of at most SHARD_SIZE suites;
-// the number of shards is derived from that. Clustering the docker-requiring
-// suites into the earliest shards means the later shards are entirely
-// docker-free and skip the Docker startup step. New suites are picked up
-// automatically.
+// directories are listed in alphabetical order and split into contiguous chunks
+// of at most SHARD_SIZE suites; the number of shards is derived from that. Each
+// shard therefore holds an alphabetically adjacent run of suites. New suites are
+// picked up automatically.
 //
 // Outputs three values, written to `$GITHUB_OUTPUT` when present (otherwise
 // stdout for local inspection):
@@ -95,31 +92,11 @@ function readServices(dir, known) {
   return services
 }
 
-// Orders suites so every docker-requiring suite comes before every docker-free
-// suite, with each group sorted alphabetically. Chunking this list clusters the
-// docker-requiring suites into the earliest shards, leaving the later shards
-// docker-free. `getServices` maps a suite dir to its service list (injectable
-// for testing).
-function orderSuites(suites, getServices) {
-  const withDocker = []
-  const withoutDocker = []
-  for (const suite of suites) {
-    if (getServices(suite).length > 0) {
-      withDocker.push(suite)
-    } else {
-      withoutDocker.push(suite)
-    }
-  }
-  withDocker.sort()
-  withoutDocker.sort()
-  return [...withDocker, ...withoutDocker]
-}
-
 function planShards(suites, shardSize) {
   const dirmap = {}
 
-  // Split the ordered list into contiguous chunks of at most `shardSize`
-  // suites. The number of shards falls out of the suite count.
+  // Split the alphabetically sorted list into contiguous chunks of at most
+  // `shardSize` suites. The number of shards falls out of the suite count.
   for (let i = 0; i < suites.length; i += shardSize) {
     const shard = String(i / shardSize)
     dirmap[shard] = suites.slice(i, i + shardSize)
@@ -169,10 +146,8 @@ function main() {
   }
 
   const known = knownServices()
-  const getServices = (dir) => readServices(dir, known)
-  const ordered = orderSuites(suites, getServices)
-  const dirmap = planShards(ordered, SHARD_SIZE)
-  const servicemap = planServices(dirmap, getServices)
+  const dirmap = planShards(suites, SHARD_SIZE)
+  const servicemap = planServices(dirmap, (dir) => readServices(dir, known))
   const shards = Object.keys(dirmap)
 
   const dirmapOut = {}
@@ -202,7 +177,6 @@ module.exports = {
   knownServices,
   listSuites,
   readServices,
-  orderSuites,
   planShards,
   planServices,
   main

--- a/bin/versioned-runner/shard-plan.js
+++ b/bin/versioned-runner/shard-plan.js
@@ -8,9 +8,11 @@
 /* eslint-disable no-console */
 
 // Partitions the versioned test suites in `test/versioned/` across a number of
-// shards so that CI can run them on separate runners in parallel. Suites are
-// assigned round-robin (`shard = index % SHARD_COUNT`) over a deterministic,
-// sorted listing of suite directories. New suites are picked up automatically.
+// shards so that CI can run them on separate runners in parallel. The suite
+// directories are listed in alphabetical order and split into contiguous chunks
+// of at most SHARD_SIZE suites; the number of shards is derived from that. Each
+// shard therefore holds an alphabetically adjacent run of suites. New suites are
+// picked up automatically.
 //
 // Outputs two values, written to `$GITHUB_OUTPUT` when present (otherwise
 // stdout for local inspection):
@@ -24,7 +26,7 @@ const fs = require('fs')
 const path = require('path')
 
 const VERSIONED_DIR = path.join(process.cwd(), 'test', 'versioned')
-const SHARD_COUNT = parseInt(process.env.SHARD_COUNT, 10) || 4
+const SHARD_SIZE = parseInt(process.env.SHARD_SIZE, 10) || 5
 
 function listSuites() {
   return fs
@@ -39,15 +41,15 @@ function listSuites() {
     .sort()
 }
 
-function planShards(suites, shardCount) {
+function planShards(suites, shardSize) {
   const dirmap = {}
-  for (let i = 0; i < shardCount; i++) {
-    dirmap[String(i)] = []
-  }
 
-  suites.forEach((suite, index) => {
-    dirmap[String(index % shardCount)].push(suite)
-  })
+  // Split the alphabetically sorted list into contiguous chunks of at most
+  // `shardSize` suites. The number of shards falls out of the suite count.
+  for (let i = 0; i < suites.length; i += shardSize) {
+    const shard = String(i / shardSize)
+    dirmap[shard] = suites.slice(i, i + shardSize)
+  }
 
   // Safety check: `--strict` in the versioned runner only flags files within a
   // listed suite dir; it does NOT catch an entire suite that no shard runs. So
@@ -75,7 +77,7 @@ function main() {
     throw new Error(`No versioned test suites found in ${VERSIONED_DIR}`)
   }
 
-  const dirmap = planShards(suites, SHARD_COUNT)
+  const dirmap = planShards(suites, SHARD_SIZE)
   const shards = Object.keys(dirmap)
 
   const dirmapOut = {}

--- a/bin/versioned-runner/shard-plan.js
+++ b/bin/versioned-runner/shard-plan.js
@@ -1,0 +1,98 @@
+#! /usr/bin/env node
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+/* eslint-disable no-console */
+
+// Partitions the versioned test suites in `test/versioned/` across a number of
+// shards so that CI can run them on separate runners in parallel. Suites are
+// assigned round-robin (`shard = index % SHARD_COUNT`) over a deterministic,
+// sorted listing of suite directories. New suites are picked up automatically.
+//
+// Outputs two values, written to `$GITHUB_OUTPUT` when present (otherwise
+// stdout for local inspection):
+//   - shards: a JSON array of shard index strings, e.g. ["0","1","2","3"]
+//   - dirmap: a JSON object of shard index -> space separated suite dir names
+//
+// A suite dir qualifies if it is a directory containing a `package.json`. This
+// naturally excludes stray files such as the `*.md` notes in `test/versioned/`.
+
+const fs = require('fs')
+const path = require('path')
+
+const VERSIONED_DIR = path.join(process.cwd(), 'test', 'versioned')
+const SHARD_COUNT = parseInt(process.env.SHARD_COUNT, 10) || 4
+
+function listSuites() {
+  return fs
+    .readdirSync(VERSIONED_DIR, { withFileTypes: true })
+    .filter((entry) => {
+      if (!entry.isDirectory()) {
+        return false
+      }
+      return fs.existsSync(path.join(VERSIONED_DIR, entry.name, 'package.json'))
+    })
+    .map((entry) => entry.name)
+    .sort()
+}
+
+function planShards(suites, shardCount) {
+  const dirmap = {}
+  for (let i = 0; i < shardCount; i++) {
+    dirmap[String(i)] = []
+  }
+
+  suites.forEach((suite, index) => {
+    dirmap[String(index % shardCount)].push(suite)
+  })
+
+  // Safety check: `--strict` in the versioned runner only flags files within a
+  // listed suite dir; it does NOT catch an entire suite that no shard runs. So
+  // verify every suite is assigned exactly once before we hand the plan to CI.
+  const assigned = Object.values(dirmap).flat()
+  if (assigned.length !== suites.length) {
+    throw new Error(
+      `Shard plan covers ${assigned.length} suites but found ${suites.length}. ` +
+        'Every suite must be assigned exactly once.'
+    )
+  }
+  const assignedSet = new Set(assigned)
+  for (const suite of suites) {
+    if (!assignedSet.has(suite)) {
+      throw new Error(`Suite "${suite}" was not assigned to any shard.`)
+    }
+  }
+
+  return dirmap
+}
+
+function main() {
+  const suites = listSuites()
+  if (!suites.length) {
+    throw new Error(`No versioned test suites found in ${VERSIONED_DIR}`)
+  }
+
+  const dirmap = planShards(suites, SHARD_COUNT)
+  const shards = Object.keys(dirmap)
+
+  const dirmapOut = {}
+  for (const shard of shards) {
+    dirmapOut[shard] = dirmap[shard].join(' ')
+  }
+
+  const shardsLine = `shards=${JSON.stringify(shards)}`
+  const dirmapLine = `dirmap=${JSON.stringify(dirmapOut)}`
+
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${shardsLine}\n${dirmapLine}\n`)
+  }
+
+  // Always echo for logs / local inspection.
+  console.log(shardsLine)
+  console.log(dirmapLine)
+}
+
+main()

--- a/bin/versioned-runner/shard-plan.js
+++ b/bin/versioned-runner/shard-plan.js
@@ -27,16 +27,22 @@
 // A suite declares its docker service needs via a top-level `dockerServices`
 // array in its package.json; absence means the suite needs no services.
 
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 
 const VERSIONED_DIR = path.join(process.cwd(), 'test', 'versioned')
 const COMPOSE_FILE = path.join(process.cwd(), 'docker-compose.yml')
 const SHARD_SIZE = parseInt(process.env.SHARD_SIZE, 10) || 5
 
-// The set of valid docker service names, read from docker-compose.yml so the
-// allowlist can never drift from what actually exists. Service names are the
-// keys directly under the top-level `services:` block.
+/**
+ * Parses a `docker-compose.yml` to build an allow list of available Docker
+ * services. Services are defined by the key name for each service defined
+ * in the `services:` block.
+ *
+ * @param {string} composeFile File system path to the file to parse.
+ *
+ * @returns {Set<string>} List of discovered service names.
+ */
 function knownServices(composeFile = COMPOSE_FILE) {
   const lines = fs.readFileSync(composeFile, 'utf8').split('\n')
   const services = new Set()
@@ -62,6 +68,13 @@ function knownServices(composeFile = COMPOSE_FILE) {
   return services
 }
 
+/**
+ * Reads the VERSIONED_DIR directory to discover the available test suites.
+ * A test suite is a directory that contains a `package.json` manifest as
+ * documented in `test/versioned/Readme.md`.
+ *
+ * @returns {string[]} List of test suites.
+ */
 function listSuites() {
   return fs
     .readdirSync(VERSIONED_DIR, { withFileTypes: true })
@@ -75,11 +88,23 @@ function listSuites() {
     .sort()
 }
 
-// Reads a suite's declared docker service dependencies, validating each against
-// the known service set to catch typos (an unknown name would silently never
-// start, hanging the suite). Absent `dockerServices` means no services.
+/**
+ * Reads the defined `dockerServices` in a test suite's manifest.
+ *
+ * @param {string} dir Path to the test suite.
+ * @param {Set<string>} known List of known Docker services as provided
+ * by `knownServices`.
+ *
+ * @returns {string[]} List of Docker services the suite requires.
+ * @throws Error When an unknown Docker service is encountered.
+ */
 function readServices(dir, known) {
-  const pkg = JSON.parse(fs.readFileSync(path.join(VERSIONED_DIR, dir, 'package.json'), 'utf8'))
+  const pkg = JSON.parse(
+    fs.readFileSync(
+      path.join(VERSIONED_DIR, dir, 'package.json'),
+      'utf8'
+    )
+  )
   const services = pkg.dockerServices ?? []
   for (const service of services) {
     if (!known.has(service)) {
@@ -92,6 +117,25 @@ function readServices(dir, known) {
   return services
 }
 
+/**
+ * The `suites` property is really a repeated key-value pair like
+ * `0: ['a', 'b', 'c']`.
+ *
+ * @typedef {object} Shard
+ * @property {string[]} suites List of suites.
+ */
+
+/**
+ * Builds a mapping of shard number to suites in the shard.
+ *
+ * @param {string[]} suites List of available test suites as returned by
+ * `listSuites`.
+ * @param {number} shardSize The maximum number of suites to include in
+ * each shard.
+ *
+ * @returns {Shard} Built shards map.
+ * @throws Error When a suite has not been assigned to any shards.
+ */
 function planShards(suites, shardSize) {
   const dirmap = {}
 
@@ -122,9 +166,24 @@ function planShards(suites, shardSize) {
   return dirmap
 }
 
-// For each shard, computes the deduped, sorted union of docker services its
-// suites need. `getServices` maps a suite dir to its service list (injectable
-// for testing); it defaults to reading each suite's package.json.
+/**
+ * The `serivces` property is really a repeated key-value pair that looks like
+ * `0: ['svc1', 'svc2', 'svc3']`.
+ *
+ * @typedef {object} ServiceMap
+ * @property {string[]} services List of services for the shard.
+ */
+
+/**
+ * Iterates the shards and suites to build a mapping that indicates which
+ * shards needs which Docker services running in order to function correctly.
+ *
+ * @param {Shard} dirmap Shard as planned by `planShards`.
+ * @param {Function} getServices Function the returns the list of services
+ * required by the provided suite. Accepts a string suite name.
+ *
+ * @returns {ServiceMap} The list of services mapped to shards.
+ */
 function planServices(dirmap, getServices) {
   const servicemap = {}
   for (const [shard, suites] of Object.entries(dirmap)) {

--- a/bin/versioned-runner/shard-plan.js
+++ b/bin/versioned-runner/shard-plan.js
@@ -14,19 +14,53 @@
 // shard therefore holds an alphabetically adjacent run of suites. New suites are
 // picked up automatically.
 //
-// Outputs two values, written to `$GITHUB_OUTPUT` when present (otherwise
+// Outputs three values, written to `$GITHUB_OUTPUT` when present (otherwise
 // stdout for local inspection):
 //   - shards: a JSON array of shard index strings, e.g. ["0","1","2","3"]
 //   - dirmap: a JSON object of shard index -> space separated suite dir names
+//   - servicemap: a JSON object of shard index -> space separated docker-compose
+//     service names that shard's suites need (empty string when none). CI uses
+//     this to start only the required services per shard, or skip Docker entirely.
 //
 // A suite dir qualifies if it is a directory containing a `package.json`. This
 // naturally excludes stray files such as the `*.md` notes in `test/versioned/`.
+// A suite declares its docker service needs via a top-level `dockerServices`
+// array in its package.json; absence means the suite needs no services.
 
 const fs = require('fs')
 const path = require('path')
 
 const VERSIONED_DIR = path.join(process.cwd(), 'test', 'versioned')
+const COMPOSE_FILE = path.join(process.cwd(), 'docker-compose.yml')
 const SHARD_SIZE = parseInt(process.env.SHARD_SIZE, 10) || 5
+
+// The set of valid docker service names, read from docker-compose.yml so the
+// allowlist can never drift from what actually exists. Service names are the
+// keys directly under the top-level `services:` block.
+function knownServices(composeFile = COMPOSE_FILE) {
+  const lines = fs.readFileSync(composeFile, 'utf8').split('\n')
+  const services = new Set()
+  let inServices = false
+  for (const line of lines) {
+    if (/^services:\s*$/.test(line)) {
+      inServices = true
+      continue
+    }
+    if (!inServices) {
+      continue
+    }
+    // A non-indented, non-blank line ends the services block.
+    if (/^\S/.test(line)) {
+      break
+    }
+    // Service names are keys indented exactly two spaces: `  <name>:`.
+    const match = line.match(/^ {2}([a-zA-Z0-9_-]+):\s*$/)
+    if (match) {
+      services.add(match[1])
+    }
+  }
+  return services
+}
 
 function listSuites() {
   return fs
@@ -39,6 +73,23 @@ function listSuites() {
     })
     .map((entry) => entry.name)
     .sort()
+}
+
+// Reads a suite's declared docker service dependencies, validating each against
+// the known service set to catch typos (an unknown name would silently never
+// start, hanging the suite). Absent `dockerServices` means no services.
+function readServices(dir, known) {
+  const pkg = JSON.parse(fs.readFileSync(path.join(VERSIONED_DIR, dir, 'package.json'), 'utf8'))
+  const services = pkg.dockerServices ?? []
+  for (const service of services) {
+    if (!known.has(service)) {
+      throw new Error(
+        `Suite "${dir}" declares unknown docker service "${service}". ` +
+          `Known services: ${[...known].sort().join(', ')}.`
+      )
+    }
+  }
+  return services
 }
 
 function planShards(suites, shardSize) {
@@ -71,13 +122,32 @@ function planShards(suites, shardSize) {
   return dirmap
 }
 
+// For each shard, computes the deduped, sorted union of docker services its
+// suites need. `getServices` maps a suite dir to its service list (injectable
+// for testing); it defaults to reading each suite's package.json.
+function planServices(dirmap, getServices) {
+  const servicemap = {}
+  for (const [shard, suites] of Object.entries(dirmap)) {
+    const services = new Set()
+    for (const suite of suites) {
+      for (const service of getServices(suite)) {
+        services.add(service)
+      }
+    }
+    servicemap[shard] = [...services].sort().join(' ')
+  }
+  return servicemap
+}
+
 function main() {
   const suites = listSuites()
   if (!suites.length) {
     throw new Error(`No versioned test suites found in ${VERSIONED_DIR}`)
   }
 
+  const known = knownServices()
   const dirmap = planShards(suites, SHARD_SIZE)
+  const servicemap = planServices(dirmap, (dir) => readServices(dir, known))
   const shards = Object.keys(dirmap)
 
   const dirmapOut = {}
@@ -87,14 +157,27 @@ function main() {
 
   const shardsLine = `shards=${JSON.stringify(shards)}`
   const dirmapLine = `dirmap=${JSON.stringify(dirmapOut)}`
+  const servicemapLine = `servicemap=${JSON.stringify(servicemap)}`
 
   if (process.env.GITHUB_OUTPUT) {
-    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${shardsLine}\n${dirmapLine}\n`)
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${shardsLine}\n${dirmapLine}\n${servicemapLine}\n`)
   }
 
   // Always echo for logs / local inspection.
   console.log(shardsLine)
   console.log(dirmapLine)
+  console.log(servicemapLine)
 }
 
-main()
+if (require.main === module) {
+  main()
+}
+
+module.exports = {
+  knownServices,
+  listSuites,
+  readServices,
+  planShards,
+  planServices,
+  main
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,11 +192,22 @@ services:
     ports:
       - "5672:5672"
       - "15672:15672"
-    environment:
-      # Provide the Erlang cookie via the environment so the node never reads
-      # the on-disk .erlang.cookie, which the image writes with a permission
-      # race that intermittently crashes boot with "eacces".
-      RABBITMQ_ERLANG_COOKIE: "nr-node-test-cookie"
+    # The Erlang VM auto-generates /var/lib/rabbitmq/.erlang.cookie on boot and
+    # chmods it; on a loaded runner the distribution layer occasionally reads it
+    # mid-write and crashes with "eacces" (BOOT FAILED). Pre-create the cookie
+    # file with a static value and correct owner/mode *before* the server starts
+    # so the read never races, then hand off to the normal entrypoint. The value
+    # is arbitrary -- these are single-node test brokers that never cluster.
+    command:
+      - bash
+      - -c
+      - >
+        install -o rabbitmq -g rabbitmq -m 0400
+        <(printf %s nr-node-test-cookie) /var/lib/rabbitmq/.erlang.cookie
+        && exec docker-entrypoint.sh rabbitmq-server
+    # Backstop: if a boot still fails transiently, restart rather than failing
+    # the whole shard; the healthcheck retries below give it time to come up.
+    restart: on-failure:3
     healthcheck:
       # `ping` only confirms the node is up; `check_port_connectivity` gates on
       # the AMQP listener actually accepting connections, which is what tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,11 @@ services:
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "2181"]
+      interval: 1s
+      timeout: 10s
+      retries: 30
   kafka:
     container_name: nr_node_kafka
     image: confluentinc/cp-kafka:7.9.1
@@ -81,6 +86,14 @@ services:
     image: memcached
     ports:
       - "11211:11211"
+    healthcheck:
+      # The memcached image is minimal (no shell utilities), but it ships a
+      # bash that can open a TCP socket to verify the daemon is accepting
+      # connections.
+      test: ["CMD", "bash", "-c", "printf 'stats\\r\\nquit\\r\\n' > /dev/tcp/127.0.0.1/11211"]
+      interval: 1s
+      timeout: 10s
+      retries: 30
 
   mongodb_5:
     container_name: nr_node_mongodb_5
@@ -147,12 +160,17 @@ services:
       timeout: 10s
       retries: 20
 
-  # pg 9.2 has built in healthcheck
   pg:
     container_name: nr_node_postgres
     image: postgres:9.2
     ports:
       - "5432:5432"
+    healthcheck:
+      # postgres:9.2 predates `pg_isready` (added in 9.3), so probe with psql.
+      test: ["CMD", "psql", "-U", "postgres", "-c", "select 1"]
+      interval: 1s
+      timeout: 10s
+      retries: 30
 
   pg_prisma:
     container_name: nr_node_postgres_prisma
@@ -174,3 +192,11 @@ services:
     ports:
       - "5672:5672"
       - "15672:15672"
+    healthcheck:
+      # `ping` only confirms the node is up; `check_port_connectivity` gates on
+      # the AMQP listener actually accepting connections, which is what tests
+      # need (the node reports up before the listener is ready).
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "check_port_connectivity"]
+      interval: 2s
+      timeout: 10s
+      retries: 30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,6 +198,11 @@ services:
     # file with a static value and correct owner/mode *before* the server starts
     # so the read never races, then hand off to the normal entrypoint. The value
     # is arbitrary -- these are single-node test brokers that never cluster.
+    #
+    # Note: we are able to pre-create this file because, according to
+    # https://web.archive.org/web/20260620031421/https://www.erlang.org/doc/system/distributed.html#security,
+    # the contents are not necessarily unique to the running instance. It will
+    # use an existing cookie if one exists, or create one if not.
     command:
       - bash
       - -c

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,6 +192,11 @@ services:
     ports:
       - "5672:5672"
       - "15672:15672"
+    environment:
+      # Provide the Erlang cookie via the environment so the node never reads
+      # the on-disk .erlang.cookie, which the image writes with a permission
+      # race that intermittently crashes boot with "eacces".
+      RABBITMQ_ERLANG_COOKIE: "nr-node-test-cookie"
     healthcheck:
       # `ping` only confirms the node is up; `check_port_connectivity` gates on
       # the AMQP listener actually accepting connections, which is what tests

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "lint:fix": "eslint --fix .",
     "public-docs": "jsdoc -c ./jsdoc-conf.jsonc",
     "publish-docs": "./bin/publish-docs.sh",
-    "services": "DOCKER_PLATFORM=linux/$(uname -m) docker compose up -d --wait",
+    "services": "./bin/start-services.sh",
     "services:start": "npm run services",
     "services:stop": "docker compose down",
     "smoke": "time borp --timeout 180000 --reporter ./test/lib/test-reporter.mjs 'test/smoke/**/*.test.js'",

--- a/test/versioned/Readme.md
+++ b/test/versioned/Readme.md
@@ -11,6 +11,9 @@ a version for each minor between `0` and `10`, then our versioned test runner
 will run the test suite across a sampling of versions in that range, e.g.
 versions `1.0.0`, `1.3.0`, and `1.10.0`.
 
+Important: do not nest suites. For example, do not create `foo/one`, `foo/two`.
+Instead, create `foo-one/` and `foo-two/`.
+
 ## Versioned Tests `npm-env.json`
 We have a few npm config options in `node-newrelic/.npmrc`. These options are intended
 to harden our security posture, however they may conflict with how our versioned test runner

--- a/test/versioned/Readme.md
+++ b/test/versioned/Readme.md
@@ -72,6 +72,21 @@ that are specific to our versioned test runner. The following is a
     }
   ],
   
+  // `dockerServices` lists the docker-compose services (by their service name
+  // in the repo-root `docker-compose.yml`) that this suite needs in order to
+  // run. CI uses this to start only the required services for a given batch of
+  // suites, and to skip starting docker entirely for suites that need none.
+  //
+  // Omit this property (or use an empty array) when the suite needs no backing
+  // service -- e.g. pure HTTP frameworks, or SDKs whose backend is mocked.
+  // List every service the suite connects to, including ones reached through a
+  // helper imported from a sibling suite. Under-declaring will cause the suite
+  // to fail in CI because the service it expects will not be running; an
+  // unknown service name fails the shard-planning step. Some examples:
+  //   - `kafkajs` needs both `kafka` and `zookeeper`.
+  //   - `prisma` needs `pg_prisma` (a dedicated postgres), not `pg`.
+  "dockerServices": ["service-name"],
+
   // `version` is ignored.
   "version": "0.0.0",
   

--- a/test/versioned/amqplib-esm/package.json
+++ b/test/versioned/amqplib-esm/package.json
@@ -1,5 +1,6 @@
 {
   "name": "amqplib-esm-tests",
+  "dockerServices": ["rmq"],
   "version": "0.0.0",
   "type": "module",
   "private": true,

--- a/test/versioned/amqplib/package.json
+++ b/test/versioned/amqplib/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ampqlib-tests",
   "targets": [{ "name": "amqplib", "minAgentVersion": "2.0.0" }],
+  "dockerServices": ["rmq"],
   "version": "0.0.0",
   "private": true,
   "tests": [

--- a/test/versioned/cassandra-driver/package.json
+++ b/test/versioned/cassandra-driver/package.json
@@ -1,6 +1,7 @@
 {
   "name": "cassandra-driver-tests",
   "targets": [{"name":"cassandra-driver","minAgentVersion": "1.7.1"}],
+  "dockerServices": ["cassandra"],
   "version": "0.0.0",
   "private": true,
   "tests": [

--- a/test/versioned/disabled-instrumentation/package.json
+++ b/test/versioned/disabled-instrumentation/package.json
@@ -1,6 +1,7 @@
 {
   "name": "disabled-instrumentation-tests",
   "targets": [],
+  "dockerServices": ["redis", "mongodb_5"],
   "version": "0.0.0",
   "private": true,
   "tests": [

--- a/test/versioned/elastic/package.json
+++ b/test/versioned/elastic/package.json
@@ -1,6 +1,7 @@
 {
   "name": "elasticsearch-tests",
   "targets": [{"name":"@elastic/elasticsearch","minAgentVersion":"11.9.0"}],
+  "dockerServices": ["elasticsearch"],
   "version": "0.0.0",
   "private": true,
   "engines": {

--- a/test/versioned/ioredis-esm/package.json
+++ b/test/versioned/ioredis-esm/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ioredis-test",
   "targets": [{"name":"ioredis","minAgentVersion":"1.26.2"}],
+  "dockerServices": ["redis"],
   "version": "0.0.0",
   "type": "module",
   "private": true,

--- a/test/versioned/ioredis/package.json
+++ b/test/versioned/ioredis/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ioredis-test",
   "targets": [{"name":"ioredis","minAgentVersion":"1.26.2"}],
+  "dockerServices": ["redis"],
   "version": "0.0.0",
   "private": true,
   "tests": [

--- a/test/versioned/iovalkey/package.json
+++ b/test/versioned/iovalkey/package.json
@@ -1,6 +1,7 @@
 {
   "name": "iovalkey-test",
   "targets": [{"name":"iovalkey","minAgentVersion":"13.9.0"}],
+  "dockerServices": ["redis"],
   "version": "0.0.0",
   "private": true,
   "tests": [

--- a/test/versioned/kafkajs/package.json
+++ b/test/versioned/kafkajs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "kafka-tests",
   "targets": [{"name":"kafkajs","minAgentVersion":"11.19.0"}],
+  "dockerServices": ["kafka", "zookeeper"],
   "version": "0.0.0",
   "private": true,
   "tests": [

--- a/test/versioned/memcached/package.json
+++ b/test/versioned/memcached/package.json
@@ -1,6 +1,7 @@
 {
   "name": "memcached-test",
   "targets": [{"name":"memcached","minAgentVersion":"1.26.2"}],
+  "dockerServices": ["memcached"],
   "version": "0.0.0",
   "private": true,
   "tests": [

--- a/test/versioned/mongodb-esm/package.json
+++ b/test/versioned/mongodb-esm/package.json
@@ -1,5 +1,6 @@
 {
   "name": "mongodb-esm-tests",
+  "dockerServices": ["mongodb_5"],
   "version": "0.0.0",
   "type": "module",
   "private": true,

--- a/test/versioned/mongodb/package.json
+++ b/test/versioned/mongodb/package.json
@@ -7,6 +7,7 @@
       "minAgentVersion": "1.32.0"
     }
   ],
+  "dockerServices": ["mongodb_5"],
   "version": "0.0.0",
   "private": true,
   "tests": [

--- a/test/versioned/mysql/package.json
+++ b/test/versioned/mysql/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mysql-tests",
   "targets": [{"name":"mysql","minAgentVersion":"1.32.0"}],
+  "dockerServices": ["mysql"],
   "version": "0.0.0",
   "private": true,
   "tests": [

--- a/test/versioned/mysql2/package.json
+++ b/test/versioned/mysql2/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mysql2-tests",
   "targets": [{"name":"mysql2","minAgentVersion":"1.32.0"}],
+  "dockerServices": ["mysql"],
   "version": "0.0.0",
   "private": true,
   "tests": [

--- a/test/versioned/opensearch/package.json
+++ b/test/versioned/opensearch/package.json
@@ -1,6 +1,7 @@
 {
   "name": "opensearch-tests",
   "targets": [{"name":"@opensearch-project/opensearch","minAgentVersion":"12.10.0"}],
+  "dockerServices": ["opensearch"],
   "version": "0.0.0",
   "private": true,
   "engines": {

--- a/test/versioned/otel-bridge/package.json
+++ b/test/versioned/otel-bridge/package.json
@@ -1,5 +1,6 @@
 {
   "name": "otel-tests",
+  "dockerServices": ["rmq"],
   "version": "0.0.0",
   "private": true,
   "tests": [

--- a/test/versioned/pg-esm/package.json
+++ b/test/versioned/pg-esm/package.json
@@ -2,6 +2,7 @@
   "name": "pg-esm-tests",
   "targets": [{"name":"pg","minAgentVersion":"9.0.0"},{"name":"pg-native","minAgentVersion":"9.0.0"}],
   "type": "module",
+  "dockerServices": ["pg"],
   "version": "0.0.0",
   "private": true,
   "tests": [

--- a/test/versioned/pg/package.json
+++ b/test/versioned/pg/package.json
@@ -1,6 +1,7 @@
 {
   "name": "pg-tests",
   "targets": [{"name":"pg","minAgentVersion":"9.0.0"},{"name":"pg-native","minAgentVersion":"9.0.0"}],
+  "dockerServices": ["pg"],
   "version": "0.0.0",
   "private": true,
   "tests": [

--- a/test/versioned/prisma/package.json
+++ b/test/versioned/prisma/package.json
@@ -6,6 +6,7 @@
       "minAgentVersion": "11.0.0"
     }
   ],
+  "dockerServices": ["pg_prisma"],
   "version": "0.0.0",
   "private": true,
   "engines": {

--- a/test/versioned/redis/package.json
+++ b/test/versioned/redis/package.json
@@ -1,6 +1,7 @@
 {
   "name": "redis-tests",
   "targets": [{"name":"redis","minAgentVersion":"1.31.0"}],
+  "dockerServices": ["redis"],
   "version": "0.0.0",
   "private": true,
   "tests": [


### PR DESCRIPTION
This PR resolves #4104.

This significantly reduces the amount of time needed to run our versioned tests in CI. The only other thing I can think of that we could do would be to add a pre-tests step that installs the agent dependencies and caches them for all of the various shards to re-use. But I think this complicates the workflow enough, and the dependencies step is short compared to everything else. So I am omitting it for now.

The big problem is all of the Docker services we rely upon. I tried loading them up in to groups at the top (i.e. group all Docker dependent services, then alphabetize, and then shard), but that resulted in test timeouts. It seems best to leave them in a somewhat random configuration.

-----

## Motivation

Measured per-step timings showed the **entire CI critical path was a single job leg: `versioned`**. Everything else (lint, ci, unit, integration) finished 10+ minutes earlier and did not gate completion.

Breakdown of the slowest PR versioned leg (~17m24s):
- checkout + setup Node: ~10s
- `npm install`: 33s
- `docker compose up --wait` (all 12 services): ~2m14s
- **Run Versioned Tests: ~14m20s** ← the long pole

The three `node-version` legs already ran in parallel, so the slowest leg alone set the finish, bottlenecked by `JOBS=4` on a 2-vCPU runner.

## What this does

1. **Shards the versioned suites across the matrix.** A new `versioned-setup` job runs `bin/versioned-runner/shard-plan.js`, which lists the suites under `test/versioned/` alphabetically and splits them into contiguous chunks of at most `SHARD_SIZE` (5) suites — 57 suites → **12 shards**. The `versioned` job gains a `shard` matrix dimension (3 node-versions × 12 shards = **36 legs**), each running its subset via a new `VERSIONED_DIRS` env var. Contiguous alphabetical chunks keep adjacent suites together and balance far better than round-robin (which interleaved the sorted list and produced a straggler shard).

2. **Starts only the docker services each shard needs.** Each service-using suite declares a top-level `dockerServices` array in its `package.json` (~20 suites; absent means none). `shard-plan.js` computes the per-shard service union and emits a `servicemap`; the `versioned` job starts only those services via a new arg-aware `bin/start-services.sh`, and **skips the Docker step entirely** for service-free shards (5 of 12). An unknown service name fails the setup job. `npm run services` with no args still starts everything (local dev unchanged).

3. **Fixes latent service-readiness flakes exposed by scoping.** Starting all 12 services previously blocked ~2m14s on the slow ones, which incidentally gave gate-less services time to become ready. With per-shard startup that grace period is gone, so:
   - Added healthchecks to `rmq`, `zookeeper`, `memcached`, and `pg` (they had none, so `--wait` returned before they accepted connections). `rmq` uses `check_port_connectivity` to gate on the AMQP listener; `pg` (9.2, predates `pg_isready`) probes with `psql`.
   - Set `RABBITMQ_ERLANG_COOKIE` so RabbitMQ skips the on-disk `.erlang.cookie` whose permission race intermittently crashed boot with `eacces`.

Coverage: each shard uploads `versioned-tests-${node}-shard-${i}`; the `codecov` job builds a per-node file list across shards and posts them under the unchanged `versioned-tests-${node}` flag (Codecov merges them), preserving `fail_ci_if_error: true`.

## Results (measured)

End-to-end CI time on a clean single-attempt run ([run 28892475586](https://github.com/newrelic/node-newrelic/actions/runs/28892475586), 50/50 jobs green): **~5m20s**, down from **13–18m** — roughly a **65–70% reduction**.

| Stage | End-to-end |
|---|---|
| Baseline (no sharding) | 13–18m |
| Sharding (contiguous chunks, 12 shards) | ~7m42s |
| + per-shard services, healthchecks, rmq cookie fix | **~5m20s** |

The 36 legs land between ~47s (`winston`/`winston-esm` — now skips Docker) and ~4m30s (`memcached mongodb mongodb-esm mysql mysql2` — DB-heavy, still starts its services).

## Commits

- `chore: Shard versioned tests across CI runners` — setup job, shard matrix, `VERSIONED_DIRS`, sharded coverage artifacts
- `chore: Shard versioned suites into contiguous alphabetical chunks` — `SHARD_SIZE`-based contiguous chunking (replaces round-robin) for balance
- `chore: Start only the docker services each versioned shard needs` — `dockerServices` field, `servicemap`, `bin/start-services.sh`, conditional Docker step
- `fix: Add healthchecks to rmq, zookeeper, memcached, and pg` — so `--wait` gates on real readiness
- `fix: Set RabbitMQ Erlang cookie via environment to avoid boot crash` — removes the `.erlang.cookie` `eacces` race

## Why directory-based sharding

- The runner already accepts multiple positional suite directories; only the shell wrapper needed a change.
- `--strict` only flags files within a listed suite dir, not wholly-omitted suites — verified — so a shard subset is safe. `shard-plan.js` self-verifies full coverage to guard against a silent drop.
- `--pattern` is a fragile substring match (`pg` matches `pg-esm`), so sharding by directory is the robust choice.

## Notes

- 36 legs vs the previous 3 — more runner-minutes, but the goal was wall-clock; runner cost was accepted.
- Under-declaring a suite's services would fail loudly on its shard (no blanket "start everything" fallback). The `dockerServices` mapping is evidence-backed from each suite's real connections.
- Out of scope: a pre-existing `amqplib/promises.test.js` wall-clock timing assertion can flake under CPU contention (did not fire on the final run); tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
