### PR TITLE
fix: Updated `winston` instrumenting to assign `handleExceptions` to the first NrTransport to avoid registering duplicate `uncaughtException` handlers

### DIFF
--- a/lib/subscribers/winston/configure.js
+++ b/lib/subscribers/winston/configure.js
@@ -17,6 +17,9 @@ module.exports = class WinstonConfigure extends ApplicationLogsSubscriber {
   constructor({ agent, logger }) {
     super({ agent, logger, channelName: 'nr_configure', packageName: 'winston' })
     this.events = ['end']
+    // we only want to assign `handleExceptions` to the first NrTransport
+    // customers could be constructing multiple logger instances
+    this.handlingExceptions = false
   }
 
   handler(data, ctx) {
@@ -39,11 +42,12 @@ module.exports = class WinstonConfigure extends ApplicationLogsSubscriber {
     const hasNrTransport = logger.transports?.some((t) => t.name === 'newrelic')
     if (!hasNrTransport) {
       const nrTransport = new NrTransport({ agent: this.agent })
-      // Only handle exceptions if the logger has user-configured transports.
-      // This prevents the default logger (created during require('winston')
-      // module init with no transports) from double-handling exceptions.
-      if (logger.transports.length === 0) {
-        nrTransport.handleExceptions = false
+      // assigning `transport.handleExceptions` adds a global `process.on('uncaughtException')`
+      // handler. Doing it for more than one NrTransport instance will cause duplicate log lines
+      if (this.handlingExceptions === false && logger.transports.length > 0) {
+        // See: https://github.com/winstonjs/winston#handling-uncaught-exceptions-with-winston
+        nrTransport.handleExceptions = true
+        this.handlingExceptions = true
       }
       logger.add(nrTransport)
     }

--- a/lib/subscribers/winston/configure.js
+++ b/lib/subscribers/winston/configure.js
@@ -12,6 +12,10 @@ const NrTransport = require('./nr-winston-transport.js')
  * during initial construction and on any subsequent reconfiguration.
  *
  * Handles `NrTransport` injection (after `configure` runs, via `end`).
+ *
+ * @property {boolean} handlingExceptions Indicates if this instrumentation has
+ * already registered a global exception handler or not. We only need a single
+ * exception handler per process.
  */
 module.exports = class WinstonConfigure extends ApplicationLogsSubscriber {
   constructor({ agent, logger }) {

--- a/lib/subscribers/winston/nr-winston-transport.js
+++ b/lib/subscribers/winston/nr-winston-transport.js
@@ -17,9 +17,6 @@ const { truncate } = require('../../util/application-logging')
  */
 class NrTransport extends TransportStream {
   constructor(opts = {}) {
-    // set this option to have winston handle uncaught exceptions
-    // See: https://github.com/winstonjs/winston#handling-uncaught-exceptions-with-winston
-    opts.handleExceptions = true
     super(opts)
     this.name = 'newrelic'
     this.agent = opts.agent

--- a/lib/subscribers/winston/nr-winston-transport.js
+++ b/lib/subscribers/winston/nr-winston-transport.js
@@ -14,6 +14,12 @@ const { truncate } = require('../../util/application-logging')
  *
  * Note*: This copies the log line so no other transports will get the
  * mutated data.
+ *
+ * @property {string} name name of the transport
+ * @property {Agent} agent the instance of agent
+ * @property {object} config the agent configuration
+ * @property {boolean} handleExceptions set in `lib/subscribers/winston/configure.js` for the first NrTransport instance
+ * to ensure that only one is handling uncaught exceptions in winston transports
  */
 class NrTransport extends TransportStream {
   constructor(opts = {}) {

--- a/test/versioned/winston/winston.test.js
+++ b/test/versioned/winston/winston.test.js
@@ -320,7 +320,7 @@ test('log forwarding enabled', async (t) => {
 
     const handleMessages = makeStreamTest(() => {
       const msgs = agent.logs.getEvents()
-      assert.equal(msgs.length, 1, 'should add error line to aggregator')
+      assert.equal(msgs.length, 1)
       const [msg] = msgs
       assert.equal(msg['error.message'], errorMsg, 'error.message should match')
       assert.equal(msg['error.class'], name, 'error.class should match')
@@ -333,22 +333,29 @@ test('log forwarding enabled', async (t) => {
     const err = new TestError(errorMsg)
 
     const assertFn = originalMsgAssertion.bind(null, { level: 'error' })
-    const jsonStream = concat(handleMessages(assertFn))
 
-    // Example Winston setup to test
-    winston.createLogger({
-      transports: [
-        // Log to a stream so we can test the output
-        new winston.transports.Stream({
-          level: 'info',
-          stream: jsonStream
-        })
-      ],
-      exitOnError: false
-    })
+    // Register multiple loggers, each with its own user transport, to mirror an
+    // app that creates a logger per request.
+    const streams = []
+    for (let i = 0; i < 5; i++) {
+      const jsonStream = concat(handleMessages(assertFn))
+      streams.push(jsonStream)
+
+      // Example Winston setup to test
+      winston.createLogger({
+        transports: [
+          // Log to a stream so we can test the output
+          new winston.transports.Stream({
+            level: 'info',
+            stream: jsonStream
+          })
+        ],
+        exitOnError: false
+      })
+    }
 
     process.emit('uncaughtException', err)
-    jsonStream.end()
+    streams.forEach((stream) => stream.end())
   })
 
   await t.test('should not double log nor instrument composed logger', (t, end) => {
@@ -378,6 +385,27 @@ test('log forwarding enabled', async (t) => {
     const subLogger = winston.createLogger(logger)
 
     logWithAggregator({ loggers: [logger, subLogger], stream: simpleStream, helper, agent })
+  })
+
+  // Winston's `Logger.add()` registers a per-logger `uncaughtException` process
+  // listener for every transport with `handleExceptions: true`. Since we attach
+  // an NrTransport to every logger, apps that create a logger per request would
+  // leak a listener (and the logger/transport graph it retains) per logger.
+  // Only the first NrTransport should carry exception handling.
+  await t.test('should only register one uncaughtException listener across many loggers', (t) => {
+    const { winston } = t.nr
+    const before = process.listenerCount('uncaughtException')
+
+    for (let i = 0; i < 25; i++) {
+      // Each logger has a user transport, so this mirrors a per-request logger
+      // (the transport-count carve-out does not apply).
+      winston.createLogger({
+        transports: [new winston.transports.Console({ silent: true })]
+      })
+    }
+
+    const added = process.listenerCount('uncaughtException') - before
+    assert.equal(added, 1, 'should add exactly one uncaughtException listener for 25 loggers')
   })
 
   // See: https://github.com/newrelic/node-newrelic/issues/1196


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

In #4092 a customer was reporting linear growth.  Although they haven't found the root cause, they pointed to a possible leak in our agent.
We do not handle where a customer is registering more than 1 winston logger instance and our `NrTransport` is assigning an uncaughtException handler 
n times.  We should only be creating one `NrTransport` for an agent instance to handle and forward uncaught exceptions.  This PR addresses that and adds
tests to ensure it is functioning as expected.

## How to Test

```sh
npm run versioned winston
```

