### PR TITLE
fix: Resolve grpc proto-loader from the running suite's node_modules

### DIFF
--- a/test/versioned/grpc/util.cjs
+++ b/test/versioned/grpc/util.cjs
@@ -9,8 +9,23 @@ const path = require('node:path')
 
 const util = module.exports
 const metricsHelpers = require('../../lib/metrics_helper')
-const protoLoader = require('@grpc/proto-loader')
 const serverImpl = require('./grpc-server.cjs')
+
+// Resolve `@grpc/proto-loader` from the running suite's own `node_modules`
+// (the versioned runner sets cwd to the suite directory) rather than from this
+// file's location. This matters for the `grpc-esm` suite, which imports this
+// helper from the sibling `grpc/` directory: resolving relative to this file
+// would read `grpc/node_modules` while that sibling suite may still be
+// installing into it concurrently, intermittently failing with
+// "Cannot find module './writer'". Anchoring to cwd keeps each suite
+// self-contained. Falls back to normal resolution for non-runner contexts.
+function loadProtoLoader() {
+  try {
+    return require(require.resolve('@grpc/proto-loader', { paths: [process.cwd()] }))
+  } catch {
+    return require('@grpc/proto-loader')
+  }
+}
 const DESTINATIONS = require('../../../lib/config/attribute-filter').DESTINATIONS
 const DESTINATION = DESTINATIONS.TRANS_EVENT | DESTINATIONS.ERROR_EVENT
 
@@ -125,6 +140,7 @@ util.assertMetricsNotExisting = function assertMetricsNotExisting(
  * @returns {object} helloworld protobuf pkg
  */
 function loadProtobufApi(grpc) {
+  const protoLoader = loadProtoLoader()
   const PROTO_PATH = path.join(__dirname, 'example.proto')
   const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
     keepCase: true,


### PR DESCRIPTION
This PR resolves #4109.

-----

## Problem

The `grpc-esm` versioned suite intermittently fails with:

```
Error: Cannot find module './writer'
  ... test/versioned/grpc/node_modules/protobufjs/src/index-minimal.js:13
  ... test/versioned/grpc/node_modules/@grpc/proto-loader/build/src/index.js
  ... test/versioned/grpc/util.cjs
Failed to execute ... test/versioned/grpc-esm/client-unary.test.mjs
```

Root cause: `test/versioned/grpc-esm/*.test.mjs` imports the shared helper
`../grpc/util.cjs`, whose top-level `require('@grpc/proto-loader')` resolves
from `test/versioned/grpc/node_modules` (Node resolves relative to the
requiring file's location). `@grpc/proto-loader` and its `protobufjs`
dependency are installed there transitively by the `grpc` suite's
`@grpc/grpc-js` install.

The versioned runner installs suites concurrently (`--jobs`), and `grpc` +
`grpc-esm` land in the same shard. So a `grpc-esm` test can read
`grpc/node_modules/protobufjs` **while the `grpc` suite is still installing
into it** — `index-minimal.js` is present but `writer.js` is not yet, hence
the `MODULE_NOT_FOUND`. It is a non-deterministic install/read race (observed
failing on 22.x/26.x but passing on 24.x in the same run), more likely under
the `main` regime (`--minor`, `JOBS=16`).

## Fix

Resolve `@grpc/proto-loader` lazily in `util.cjs`, anchored to `process.cwd()`
(the runner sets cwd to the suite directory) instead of this file's location.
Each suite then loads proto-loader from **its own** `node_modules` and never
reads a sibling suite's mid-install tree:

- `grpc` tests (cwd `test/versioned/grpc`) → `grpc/node_modules`
- `grpc-esm` tests (cwd `test/versioned/grpc-esm`) → `grpc-esm/node_modules`

Falls back to normal resolution outside the runner. No suite `package.json`
change is needed: whatever `@grpc/grpc-js` version the suite samples installs
its matching `@grpc/proto-loader` into that suite's own `node_modules` (older
grpc-js pins older proto-loader, so an explicit pin would risk a mismatch).

## Verification

- Simulated end-to-end: `util.cjs` resolves grpc-esm's own proto-loader even
  when `grpc/node_modules` is empty, and proto loading works.
- `npm run lint` passes (0 errors).
- The `grpc` suite continues to resolve proto-loader from its own tree via the
  same cwd anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
