### PR TITLE
chore: Remove the 8 minute versioned shard timeout

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -207,10 +207,6 @@ jobs:
       needs.should_run.outputs.deps_changed == 'true')
     runs-on: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER || 'ubuntu-latest' }}
 
-    # A healthy shard completes well within this; a hung/looping test should fail
-    # its leg fast rather than burning the full GitHub-imposed job limit.
-    timeout-minutes: 8
-
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR fixes the issue where jobs are being canceled when CI is run against the `main` branch. In short, because we test against so many more versions of libraries when running against `main` than we do when running against a PR branch, the 8 minute cap was too low. 

It's not worth trying to figure out a useful cap at this time. We can revisit adding a cap later if we truly desire it. The purpose was only to stop stuck jobs so that we could restart CI quicker.

-----

## What

Removes the `timeout-minutes: 8` cap from the `versioned` job's shard legs.

## Why

The 8-minute cap was sized for the PR regime (`--major`, `JOBS=4`), where shards finish comfortably under it. On `main` the regime is `--minor` + `JOBS=16`, which samples far more package versions — heavier shards legitimately run longer (e.g. the `openai` suite samples ~172 versions). In run [28970211951](https://github.com/newrelic/node-newrelic/actions/runs/28970211951) four shard legs (shard 8 across all Node versions, plus one shard-9 leg) were cancelled at ~8m15s by this cap even though they were progressing normally.

Removing the cap reverts those legs to GitHub's default job limit so heavy `main`-regime shards are no longer cancelled mid-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
