### PR TITLE
test: Added `samples` to prisma and next to cut down on versions under test on packages we recommend using hybrid ageninstrumentation

### DIFF
--- a/test/versioned/nextjs/package.json
+++ b/test/versioned/nextjs/package.json
@@ -9,7 +9,10 @@
         "node": ">=22"
       },
       "dependencies": {
-        "next": ">=14.0.0 <16"
+        "next": {
+          "versions": ">=14.0.0 <16",
+          "samples": 2
+        }
       },
       "files": [
         "app-dir.test.js",

--- a/test/versioned/prisma/package.json
+++ b/test/versioned/prisma/package.json
@@ -18,6 +18,7 @@
         "node": ">=22"
       },
       "groupedDependencies": {
+        "samples": 2,
         "version": ">=5.0.0 <5.9.0 || >=5.9.1 <7.0.0",
         "packages": ["prisma", "@prisma/client"]
       },
@@ -30,6 +31,7 @@
         "node": ">=22"
       },
       "groupedDependencies": {
+        "samples": 5,
         "version": ">=7.0.0",
         "packages": ["prisma", "@prisma/client", "@prisma/adapter-pg"]
       },


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Now that we have sharded versioned tests, there are 2 suites that take much longer than any others:
 nextjs, and prisma.  Prisma takes upwards of 20 mins on node 22 and next takes around 7. Since we recommend our customers rely on native otel instrumentation with hybrid agent, we should reduce the test matrix. I have applied a samples flag to all 3: prisma < 7 sample at 2 because there are only 2 major versions we support, 7+ sample at 5. Nextjs sample at 2 because we only support 2 major versions.
