### PR TITLE
test: Removed timing race from common.request unit tests

### DIFF
--- a/test/unit/utilization/common.test.js
+++ b/test/unit/utilization/common.test.js
@@ -84,13 +84,17 @@ test('Utilization Common Components', async function (t) {
   await t.test('common.request', async (t) => {
     t.before(() => {
       nock.disableNetConnect()
-      // We need separate paths for success and failure so that we do not
-      // have to rely on fragile millisecond based timings. While timings of
-      // 100 - 150ms works reliably on individual developer systems, they are
-      // too tight on contendend systems like GitHub Actions.
+      // We use separate paths, each with a delay that is decisively on one side
+      // of its request timeout, so the outcome does not depend on fragile
+      // millisecond margins. The original single interceptor used delay(150)
+      // against timeouts of 150-200ms, which is reliable on a developer machine
+      // but flaky on a contended runner like GitHub Actions.
 
-      // `/success` replies immediately so the success path never times out
-      nock('http://fakedomain').persist().get('/success').reply(200, 'woohoo')
+      // `/success` responds slowly (500ms) but well within its 2000ms request
+      // timeout. This still exercises the "slow response" behavior the success
+      // test cares about -- the client must accept a slow response and must not
+      // treat it as a timeout -- without racing the timeout.
+      nock('http://fakedomain').persist().get('/success').delay(500).reply(200, 'woohoo')
 
       // `/timeout` delays far longer than any request timeout so the socket
       // timeout always fires first.
@@ -115,13 +119,15 @@ test('Utilization Common Components', async function (t) {
     await t.test('should not timeout when request succeeds', (ctx, end) => {
       const agent = ctx.nr.agent
       let invocationCount = 0
+      // The response is slow (500ms) but comfortably within the 2000ms request
+      // timeout. The client must accept the slow response and must not let the
+      // socket timeout fire and invoke the callback a second time (which would
+      // look like a spurious retry).
       common.request(
         {
           method: 'GET',
           host: 'fakedomain',
-          // We set a high timeout here in order to give the request time to
-          // complete on contended systems like GitHub Actions.
-          timeout: 1000,
+          timeout: 2000,
           path: '/success'
         },
         agent,
@@ -132,13 +138,11 @@ test('Utilization Common Components', async function (t) {
         }
       )
 
-      // `common.request` leaves its `timeout`/`error` socket listeners attached
-      // after a successful response, so a late socket event could invoke the
-      // callback a second time. Wait after the request has completed and then
-      // verify it was only invoked once. This window no longer races the
-      // request itself -- `/success` replies immediately -- so it is not timing
-      // sensitive; it is purely an observation period for a stray second call.
-      setTimeout(verifyInvocations, 250)
+      // Verify well after the slow response has arrived (>500ms) so a stray
+      // second invocation would be observed before we assert. The margins are
+      // wide enough (500ms response, 2000ms timeout, 1000ms observation) that
+      // event-loop contention cannot flip the outcome.
+      setTimeout(verifyInvocations, 1000)
 
       function verifyInvocations() {
         assert.equal(invocationCount, 1, 'callback should only be invoked once')

--- a/test/unit/utilization/common.test.js
+++ b/test/unit/utilization/common.test.js
@@ -84,12 +84,16 @@ test('Utilization Common Components', async function (t) {
   await t.test('common.request', async (t) => {
     t.before(() => {
       nock.disableNetConnect()
-      // Two decisive interceptors instead of one delay that races the request
-      // timeout. `/success` replies immediately so the success path never times
-      // out; `/timeout` delays far longer than any request timeout so the socket
-      // timeout always fires first. This keeps both outcomes independent of CI
-      // event-loop jitter (see NR-588003 / #4106).
+      // We need separate paths for success and failure so that we do not
+      // have to rely on fragile millisecond based timings. While timings of
+      // 100 - 150ms works reliably on individual developer systems, they are
+      // too tight on contendend systems like GitHub Actions.
+
+      // `/success` replies immediately so the success path never times out
       nock('http://fakedomain').persist().get('/success').reply(200, 'woohoo')
+
+      // `/timeout` delays far longer than any request timeout so the socket
+      // timeout always fires first.
       nock('http://fakedomain').persist().get('/timeout').delay(10000).reply(200, 'woohoo')
     })
 
@@ -115,6 +119,8 @@ test('Utilization Common Components', async function (t) {
         {
           method: 'GET',
           host: 'fakedomain',
+          // We set a high timeout here in order to give the request time to
+          // complete on contended systems like GitHub Actions.
           timeout: 1000,
           path: '/success'
         },

--- a/test/unit/utilization/common.test.js
+++ b/test/unit/utilization/common.test.js
@@ -84,7 +84,13 @@ test('Utilization Common Components', async function (t) {
   await t.test('common.request', async (t) => {
     t.before(() => {
       nock.disableNetConnect()
-      nock('http://fakedomain').persist().get('/timeout').delay(150).reply(200, 'woohoo')
+      // Two decisive interceptors instead of one delay that races the request
+      // timeout. `/success` replies immediately so the success path never times
+      // out; `/timeout` delays far longer than any request timeout so the socket
+      // timeout always fires first. This keeps both outcomes independent of CI
+      // event-loop jitter (see NR-588003 / #4106).
+      nock('http://fakedomain').persist().get('/success').reply(200, 'woohoo')
+      nock('http://fakedomain').persist().get('/timeout').delay(10000).reply(200, 'woohoo')
     })
 
     t.beforeEach(function (ctx) {
@@ -109,26 +115,20 @@ test('Utilization Common Components', async function (t) {
         {
           method: 'GET',
           host: 'fakedomain',
-          timeout: 200,
-          path: '/timeout'
+          timeout: 1000,
+          path: '/success'
         },
         agent,
         (err, data) => {
+          invocationCount++
           assert.ifError(err)
           assert.equal(data, 'woohoo')
-          invocationCount++
+          assert.equal(invocationCount, 1, 'callback should only be invoked once')
+          // Defer end() by a tick so a stray second invocation would trip the
+          // assertion above rather than being missed by ending immediately.
+          setImmediate(end)
         }
       )
-
-      // need to give enough time for second to have chance to run.
-      // sinon and http don't quite seem to work well enough to do this
-      // totally faked synchronously.
-      setTimeout(verifyInvocations, 250)
-
-      function verifyInvocations() {
-        assert.equal(invocationCount, 1)
-        end()
-      }
     })
 
     await t.test('should not invoke callback multiple times on timeout', (ctx, end) => {
@@ -143,21 +143,17 @@ test('Utilization Common Components', async function (t) {
         },
         agent,
         (err) => {
+          invocationCount++
           assert.ok(err)
           assert.equal(err.code, 'ECONNRESET', 'error should be socket timeout')
-          invocationCount++
+          assert.equal(invocationCount, 1, 'callback should only be invoked once')
+          // The socket timed out and aborted, but nock still has the long
+          // delayed response pending; cancel it so its timer doesn't keep the
+          // event loop alive for the full delay after the test passes.
+          nock.abortPendingRequests()
+          setImmediate(end)
         }
       )
-
-      // need to give enough time for second to have chance to run.
-      // sinon and http don't quite seem to work well enough to do this
-      // totally faked synchronously.
-      setTimeout(verifyInvocations, 200)
-
-      function verifyInvocations() {
-        assert.equal(invocationCount, 1)
-        end()
-      }
     })
   })
 })

--- a/test/unit/utilization/common.test.js
+++ b/test/unit/utilization/common.test.js
@@ -126,15 +126,24 @@ test('Utilization Common Components', async function (t) {
         },
         agent,
         (err, data) => {
-          invocationCount++
           assert.ifError(err)
           assert.equal(data, 'woohoo')
-          assert.equal(invocationCount, 1, 'callback should only be invoked once')
-          // Defer end() by a tick so a stray second invocation would trip the
-          // assertion above rather than being missed by ending immediately.
-          setImmediate(end)
+          invocationCount++
         }
       )
+
+      // `common.request` leaves its `timeout`/`error` socket listeners attached
+      // after a successful response, so a late socket event could invoke the
+      // callback a second time. Wait after the request has completed and then
+      // verify it was only invoked once. This window no longer races the
+      // request itself -- `/success` replies immediately -- so it is not timing
+      // sensitive; it is purely an observation period for a stray second call.
+      setTimeout(verifyInvocations, 250)
+
+      function verifyInvocations() {
+        assert.equal(invocationCount, 1, 'callback should only be invoked once')
+        end()
+      }
     })
 
     await t.test('should not invoke callback multiple times on timeout', (ctx, end) => {
@@ -149,17 +158,26 @@ test('Utilization Common Components', async function (t) {
         },
         agent,
         (err) => {
-          invocationCount++
           assert.ok(err)
           assert.equal(err.code, 'ECONNRESET', 'error should be socket timeout')
-          assert.equal(invocationCount, 1, 'callback should only be invoked once')
+          invocationCount++
           // The socket timed out and aborted, but nock still has the long
           // delayed response pending; cancel it so its timer doesn't keep the
           // event loop alive for the full delay after the test passes.
           nock.abortPendingRequests()
-          setImmediate(end)
         }
       )
+
+      // Wait past the request timeout and then verify the callback fired only
+      // once. The window is not timing sensitive: the socket always times out
+      // at 100ms (the `/timeout` response is delayed far longer), so this just
+      // observes for a stray second invocation after the abort.
+      setTimeout(verifyInvocations, 250)
+
+      function verifyInvocations() {
+        assert.equal(invocationCount, 1, 'callback should only be invoked once')
+        end()
+      }
     })
   })
 })

--- a/test/unit/utilization/common.test.js
+++ b/test/unit/utilization/common.test.js
@@ -86,9 +86,9 @@ test('Utilization Common Components', async function (t) {
       nock.disableNetConnect()
       // We use separate paths, each with a delay that is decisively on one side
       // of its request timeout, so the outcome does not depend on fragile
-      // millisecond margins. The original single interceptor used delay(150)
-      // against timeouts of 150-200ms, which is reliable on a developer machine
-      // but flaky on a contended runner like GitHub Actions.
+      // millisecond margins. Short timeouts of 150-200ms, which is reliable on
+      // a developer machine, are flaky on a contended runner like GitHub
+      // Actions.
 
       // `/success` responds slowly (500ms) but well within its 2000ms request
       // timeout. This still exercises the "slow response" behavior the success
@@ -141,7 +141,7 @@ test('Utilization Common Components', async function (t) {
       // Verify well after the slow response has arrived (>500ms) so a stray
       // second invocation would be observed before we assert. The margins are
       // wide enough (500ms response, 2000ms timeout, 1000ms observation) that
-      // event-loop contention cannot flip the outcome.
+      // event-loop contention does not invalidate the test.
       setTimeout(verifyInvocations, 1000)
 
       function verifyInvocations() {


### PR DESCRIPTION
This PR resolves #4106.

This one was a bit tricky. The flakiness is 100% on the slow GHA system. But the "success" test is rather flaky by design, and I'm not quite sure it provides us with much utility. Getting the bot to not mess up the fix was a chore.

-----

## Problem

The two `common.request` tests in `test/unit/utilization/common.test.js` raced a fixed 150ms `nock` `.delay()` against the request timeout with ~50ms margins:

- **success test**: `timeout: 200` vs `delay(150)` — under CI load the slow response lands after the timeout, the socket aborts, and the test fails with `socket hang up` / `ifError got unwanted exception`.
- **timeout test**: `timeout: 100` vs `delay(150)`, plus a real-clock `setTimeout(..., 200)` observation poll.

These margins are reliable on a developer machine but too tight on a contended runner like GitHub Actions, producing the long-standing intermittent `socket hang up` flake (NR-588003).

## Intent being preserved

The success test is **not** merely "a request succeeds." Its purpose is that a **slow** response — slower than a baseline but still within the timeout — is accepted by the client and does **not** cause the socket timeout to fire and invoke the callback a second time (which would look like a spurious retry). The narrow original timings were deliberately inducing that slow-but-within-timeout condition. The timeout test's purpose is the converse: on an actual timeout, the callback is invoked exactly once with `ECONNRESET`. Both tests issue the request, then wait an observation window and verify the callback fired exactly once.

## Fix

Keep the behaviors and structure; remove only the fragile margins by making each path **decisively** on one side of its timeout, and widening the windows well beyond event-loop jitter:

- **Success path** (`/success`): responds slowly — `delay(500)` — but with a `2000ms` request timeout and a `1000ms` observation window (past the 500ms response). Still exercises "accept a slow response without a spurious timeout/retry," but with ~1.5s of headroom instead of ~50ms.
- **Timeout path** (`/timeout`): `delay(10000)` against a `100ms` timeout, so the socket timeout always fires first and yields `ECONNRESET`. After the abort, `nock.abortPendingRequests()` cancels the still-pending delayed response so its timer doesn't keep the event loop alive for the full delay.
- Both tests retain the original **issue request → wait an observation window → assert callback invoked exactly once** structure. The windows are no longer timing-sensitive because the success/timeout outcome is now decided by the interceptor delays, not by racing the window.

Fake timers were considered but rejected: `nock`'s `.delay()` and the socket `timeout` both use real timers deep in the http/socket machinery — exactly what the old code comment ("sinon and http don't quite seem to work well enough") already found. Making the delays decisive removes the race without fighting that.

## Verification

Test-only change; `lib/utilization/common.js` is untouched and both branches (slow-success acceptance + `ECONNRESET` abort) are still exercised. Ran the file repeatedly, including **25 iterations under full CPU saturation** (the condition that triggers the flake): 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
