### PR TITLE
chore: Updated test runner to accept suites as positional parameters

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -233,15 +233,15 @@ jobs:
         run: ./bin/start-services.sh $SERVICES
         env:
           SERVICES: ${{ fromJSON(needs.versioned-setup.outputs.servicemap)[matrix.shard] }}
+      # The suite names for this shard are passed as positional arguments so the
+      # runner only executes this shard's subset of the versioned suites.
       - name: Run Versioned Tests
-        run: TEST_CHILD_TIMEOUT=600000 npm run versioned
+        run: TEST_CHILD_TIMEOUT=600000 npm run versioned ${{ fromJSON(needs.versioned-setup.outputs.dirmap)[matrix.shard] }}
         env:
           VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}
           # Run more jobs when using larger runner, otherwise 2 per CPU seems to be the sweet spot in GHA default runners(July 2022)
           JOBS: ${{ github.ref == 'refs/heads/main' && vars.NR_RUNNER && 16 ||  4 }}
           C8_REPORTER: lcovonly
-          # Only run this shard's subset of the versioned suites.
-          VERSIONED_DIRS: ${{ fromJSON(needs.versioned-setup.outputs.dirmap)[matrix.shard] }}
       - name: Archive Versioned Test Coverage
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -236,7 +236,10 @@ jobs:
       # The suite names for this shard are passed as positional arguments so the
       # runner only executes this shard's subset of the versioned suites.
       - name: Run Versioned Tests
-        run: TEST_CHILD_TIMEOUT=600000 npm run versioned ${{ fromJSON(needs.versioned-setup.outputs.dirmap)[matrix.shard] }}
+        run: |
+          TEST_CHILD_TIMEOUT=600000 \
+          npm run versioned \
+          ${{ fromJSON(needs.versioned-setup.outputs.dirmap)[matrix.shard] }}
         env:
           VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}
           # Run more jobs when using larger runner, otherwise 2 per CPU seems to be the sweet spot in GHA default runners(July 2022)

--- a/bin/run-versioned-tests.sh
+++ b/bin/run-versioned-tests.sh
@@ -38,20 +38,15 @@ fi
 
 set -f
 directories=()
-if [[ -n "${VERSIONED_DIRS}" ]];
+if [[ "$#" -gt 0 ]];
 then
-  # VERSIONED_DIRS is a space separated list of suite subdir names, used by CI
-  # to run a shard (subset) of the versioned suites. Word splitting is safe here
-  # because `set -f` is enabled above and suite names are simple identifiers.
-  for d in ${VERSIONED_DIRS};
+  # Each positional argument is a suite subdir name to run, e.g.
+  # `npm run versioned:major amqplib pino winston`. CI uses this to run a shard
+  # (subset) of the versioned suites.
+  for d in "$@";
   do
     directories+=( "test/versioned/${d}" )
   done
-elif [[ "$1" != '' ]];
-then
-  directories=(
-    "test/versioned/${1}"
-  )
 else
   directories=(
     "test/versioned/"


### PR DESCRIPTION
This PR resolves #4105.

https://github.com/newrelic/node-newrelic/actions/runs/29034218785 shows the changes work as expected. Shards still get created and run with subsets of the overall versioned tests suites.

-----

## What

Run a subset of versioned suites by passing suite names as **positional arguments**:

```
npm run versioned:major amqplib pino winston
```

This replaces the `VERSIONED_DIRS` environment variable that previously carried the shard's suite list.

## Why

Positional arguments are the natural CLI form and match how a single suite was already invoked (`npm run versioned:major <suite>`). The env var was an extra, less discoverable mechanism.

## Changes

- **`bin/run-versioned-tests.sh`**: build the `directories` list from all positional arguments (`"$@"`) when any are given; otherwise run the whole tree. Previously only `$1` was honored, so `npm run versioned:major amqplib pino winston` would have silently dropped all but the first suite — that's now fixed, and the separate single-`$1` branch is subsumed by the loop.
- **`.github/workflows/ci-workflow.yml`**: the `versioned` job passes the shard's suite list as arguments (`npm run versioned <dirs>`) instead of via `VERSIONED_DIRS`.

## Verification

- `npm run versioned:major amqplib pino winston` → all three suites reach the runner; single-suite and no-arg (whole tree) invocations still work.
- npm forwards trailing args through the full `versioned:major` → `versioned` → script chain (verified).
- No remaining `VERSIONED_DIRS` references; every shard's suite list is non-empty (whole-tree fallback cannot be accidentally triggered); scripts unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
