### PR TITLE
test: Added more scenarios to winston for constructing loggers

### DIFF
--- a/test/versioned/winston/winston.test.js
+++ b/test/versioned/winston/winston.test.js
@@ -408,6 +408,56 @@ test('log forwarding enabled', async (t) => {
     assert.equal(added, 1, 'should add exactly one uncaughtException listener for 25 loggers')
   })
 
+  await t.test('should forward logs from a logger created via `new winston.Logger`', (t, end) => {
+    const { agent, winston } = t.nr
+    const handleMessages = makeStreamTest(() => {
+      const msgs = agent.logs.getEvents()
+      assert.equal(msgs.length, 2)
+      msgs.forEach((msg) => {
+        logForwardingMsgAssertion(msg, agent)
+      })
+      end()
+    })
+
+    const assertFn = originalMsgAssertion.bind(null, {})
+    const jsonStream = concat(handleMessages(assertFn))
+
+    const logger = new winston.Logger({
+      transports: [new winston.transports.Stream({ level: 'info', stream: jsonStream })]
+    })
+
+    // base `Logger` lacks the level convenience methods, so use `.log`
+    // instead of the helper `logWithAggregator`
+    logger.log('info', 'out of trans')
+    helper.runInTransaction(agent, 'test', (tx) => {
+      logger.log('info', 'in trans')
+      tx.end()
+    })
+    jsonStream.end()
+  })
+
+  await t.test('should forward logs from a caller-created `winston.Container`', (t, end) => {
+    const { agent, winston } = t.nr
+    const handleMessages = makeStreamTest(() => {
+      const msgs = agent.logs.getEvents()
+      assert.equal(msgs.length, 2)
+      msgs.forEach((msg) => {
+        logForwardingMsgAssertion(msg, agent)
+      })
+      end()
+    })
+
+    const assertFn = originalMsgAssertion.bind(null, {})
+    const jsonStream = concat(handleMessages(assertFn))
+
+    const container = new winston.Container()
+    const logger = container.add('per-request', {
+      transports: [new winston.transports.Stream({ level: 'info', stream: jsonStream })]
+    })
+
+    logWithAggregator({ loggers: [logger], stream: jsonStream, helper, agent })
+  })
+
   // See: https://github.com/newrelic/node-newrelic/issues/1196
   // This test adds a printf formatter and then asserts that both the log lines
   // in aggregator have keys added in other formatters and that the log line being built


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Although we haven't 100% confirmed yet from customer the theory is that the `NrTransport` leak, fixed in #4108 was never in play for the customer in `newrelic@<13.17.0` because their logger instances weren't getting instrumented.  When we migrated the instrumentation to a subscriber based model, we're instrumenting the underlying `DerivedLogger`, so now their logger constructions were getting instrumented and leaking because of the bug mentioned before.

The theory is that they were constructing loggers like:

```js
 const logger = new winston.Logger({
      transports: [new winston.transports.Stream({ level: 'info', stream: jsonStream })]
    })
    logger.log('info', 'test')
```

which weren't getting instrumented until 13.17.0.  This PR adds more test coverage around 2 other methods of constructing loggers.  If you run these same tests in 13.16.0, `should forward logs from a logger created via new winston.Logger` fails. 

See #4092 for more context of the entire conversation leading to the fix in 14.2.1 and this PR
