### PR TITLE
test: Added skip for winston test for ranges that do not support it

### DIFF
--- a/test/versioned/winston/winston.test.js
+++ b/test/versioned/winston/winston.test.js
@@ -10,9 +10,9 @@ const assert = require('node:assert')
 const semver = require('semver')
 const { Writable } = require('node:stream')
 
-const { version: pkgVersion } = require('winston/package')
-
 const helper = require('../../lib/agent_helper')
+const pkgVersion = helper.readPackageVersion(__dirname, 'winston')
+
 const { removeMatchedModules } = require('../../lib/cache-buster')
 const { LOGGING } = require('../../../lib/metrics/names')
 const {

--- a/test/versioned/winston/winston.test.js
+++ b/test/versioned/winston/winston.test.js
@@ -7,7 +7,10 @@
 
 const test = require('node:test')
 const assert = require('node:assert')
+const semver = require('semver')
 const { Writable } = require('node:stream')
+
+const { version: pkgVersion } = require('winston/package')
 
 const helper = require('../../lib/agent_helper')
 const { removeMatchedModules } = require('../../lib/cache-buster')
@@ -408,7 +411,11 @@ test('log forwarding enabled', async (t) => {
     assert.equal(added, 1, 'should add exactly one uncaughtException listener for 25 loggers')
   })
 
-  await t.test('should forward logs from a logger created via `new winston.Logger`', (t, end) => {
+  // The `winston.Logger` constructor was removed in winston@3.0.0 and
+  // reintroduced in winston@3.10.0
+  await t.test('should forward logs from a logger created via `new winston.Logger`', {
+    skip: semver.lt(pkgVersion, '3.10.0')
+  }, (t, end) => {
     const { agent, winston } = t.nr
     const handleMessages = makeStreamTest(() => {
       const msgs = agent.logs.getEvents()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

In #4120 I added more winston tests. Turns out the one `new winston.Logger` is invalid for a range between 3.0.0-3.9.x. This Pr updates that check.
