### PR TITLE
feat: Added support for `ai_monitoring.enabled`,`ai_monitoring.streaming.enabled`, and `ai_monitoring.record_content.enabled` to be assigned via server-side config

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -578,18 +578,16 @@ Config.prototype._fromServer = function _fromServer(params, key) {
       break
 
     // interpret AI Monitoring account setting.
-    // `ai_monitoring.enabled` from the connect response takes precedence over
+    // `ai_monitoring.enabled` from the connect response server-side config(SSC) takes precedence over
+    // SSC settings come in an `agent_config` object
     // `collect_ai`; collect_ai is only the fallback when it is absent.
     case 'collect_ai':
-      if (!('ai_monitoring.enabled' in params)) {
+      if (!params?.agent_config?.['ai_monitoring.enabled']) {
         this._disableOption(params.collect_ai, 'ai_monitoring')
         this.emit('change', this)
       }
       break
     case 'ai_monitoring.enabled':
-      // HSM safeguard is enforced here: `ai_monitoring.enabled` is a
-      // HIGH_SECURITY_KEY, so _updateNestedIfChanged refuses to enable AIM
-      // when high_security is on.
       this._updateNestedIfChanged(
         params,
         this.ai_monitoring,

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -357,12 +357,6 @@ Config.prototype._fromServer = function _fromServer(params, key) {
     case 'high_security':
       break
 
-    // interpret AI Monitoring account setting
-    case 'collect_ai':
-      this._disableOption(params.collect_ai, 'ai_monitoring')
-      this.emit('change', this)
-      break
-
     // always accept these settings
     case 'encoding_key':
       this._alwaysUpdateIfChanged(params, key)
@@ -581,6 +575,43 @@ Config.prototype._fromServer = function _fromServer(params, key) {
       this.span_event_harvest_config = {
         ...params[key]
       }
+      break
+
+    // interpret AI Monitoring account setting.
+    // `ai_monitoring.enabled` from the connect response takes precedence over
+    // `collect_ai`; collect_ai is only the fallback when it is absent.
+    case 'collect_ai':
+      if (!('ai_monitoring.enabled' in params)) {
+        this._disableOption(params.collect_ai, 'ai_monitoring')
+        this.emit('change', this)
+      }
+      break
+    case 'ai_monitoring.enabled':
+      // HSM safeguard is enforced here: `ai_monitoring.enabled` is a
+      // HIGH_SECURITY_KEY, so _updateNestedIfChanged refuses to enable AIM
+      // when high_security is on.
+      this._updateNestedIfChanged(
+        params,
+        this.ai_monitoring,
+        'ai_monitoring.enabled',
+        'enabled'
+      )
+      break
+    case 'ai_monitoring.streaming.enabled':
+      this._updateNestedIfChanged(
+        params,
+        this.ai_monitoring.streaming,
+        'ai_monitoring.streaming.enabled',
+        'enabled'
+      )
+      break
+    case 'ai_monitoring.record_content.enabled':
+      this._updateNestedIfChanged(
+        params,
+        this.ai_monitoring.record_content,
+        'ai_monitoring.record_content.enabled',
+        'enabled'
+      )
       break
 
     case 'profiling.enabled':

--- a/lib/subscribers/ai-monitoring/base.js
+++ b/lib/subscribers/ai-monitoring/base.js
@@ -26,8 +26,14 @@ class AiMonitoringSubscriber extends Subscriber {
     this.trackingPrefix = trackingPrefix
   }
 
-  get enabled() {
-    return super.enabled && this.agent.config.ai_monitoring.enabled === true
+  /**
+   * Checks if AI monitoring is enabled. The subscriber itself is registered
+   * regardless of this value (gated only by `instrumentation.<lib>.enabled`),
+   * but AI monitoring behavior (segments, events, metrics) is gated on this.
+   * @returns {boolean} if AI monitoring is enabled
+   */
+  get aiEnabled() {
+    return this.agent.config.ai_monitoring.enabled === true
   }
 
   set name(name) {
@@ -96,7 +102,7 @@ class AiMonitoringSubscriber extends Subscriber {
    * @returns {Context} either new context or existing
    */
   handler(data, ctx) {
-    if (!this.enabled) {
+    if (!this.aiEnabled) {
       this.logger.debug('`ai_monitoring.enabled` is set to false, not creating segment.')
       return ctx
     }

--- a/lib/subscribers/ai-monitoring/base.js
+++ b/lib/subscribers/ai-monitoring/base.js
@@ -36,6 +36,15 @@ class AiMonitoringSubscriber extends Subscriber {
     return this.agent.config.ai_monitoring.enabled === true
   }
 
+  /**
+   * Checks if AI monitoring streaming is enabled.  It is predicated on AI monitoring being enabled
+   * as if it isn't, no instrumentation should occur
+   * @returns {boolean} if we should be instrumenting streams
+   */
+  get streamingEnabled() {
+    return this.aiEnabled && this.agent.config.ai_monitoring.streaming.enabled === true
+  }
+
   set name(name) {
     if (!name) {
       throw new Error('subscriber must pass in `name`')

--- a/lib/subscribers/ai-monitoring/chat.js
+++ b/lib/subscribers/ai-monitoring/chat.js
@@ -24,7 +24,7 @@ class AiMonitoringChatSubscriber extends AiMonitoringSubscriber {
   }
 
   get streamingEnabled() {
-    return this.agent.config.ai_monitoring.streaming.enabled === true
+    return this.aiEnabled && this.agent.config.ai_monitoring.streaming.enabled === true
   }
 
   /**
@@ -86,7 +86,7 @@ class AiMonitoringChatSubscriber extends AiMonitoringSubscriber {
    * @param {Array} params.tags used only for langchain events at the moment
    */
   recordChatCompletionEvents({ ctx, request, response, err, timeOfFirstToken, metadata = {}, tags = [] }) {
-    if (!this.enabled) {
+    if (!this.aiEnabled) {
       this.logger.debug('config.ai_monitoring.enabled is set to false, not creating chat completion events.')
       return
     }

--- a/lib/subscribers/ai-monitoring/chat.js
+++ b/lib/subscribers/ai-monitoring/chat.js
@@ -23,10 +23,6 @@ class AiMonitoringChatSubscriber extends AiMonitoringSubscriber {
     super({ agent, logger, packageName, channelName, name, trackingPrefix })
   }
 
-  get streamingEnabled() {
-    return this.aiEnabled && this.agent.config.ai_monitoring.streaming.enabled === true
-  }
-
   /**
    * Function that must be implemented by inherited subscriber to create an llm completion message.
    *

--- a/lib/subscribers/ai-monitoring/embedding.js
+++ b/lib/subscribers/ai-monitoring/embedding.js
@@ -46,7 +46,7 @@ class AiMonitoringEmbeddingSubscriber extends AiMonitoringSubscriber {
    * @param {object} params.err error if present
    */
   recordEmbedding({ ctx, request, response, err }) {
-    if (!this.enabled) {
+    if (!this.aiEnabled) {
       this.logger.debug('config.ai_monitoring.enabled is set to false, not creating embedding event.')
       return
     }

--- a/lib/subscribers/anthropic-sdk/create.js
+++ b/lib/subscribers/anthropic-sdk/create.js
@@ -25,7 +25,7 @@ module.exports = class AnthropicChatCreateSubscriber extends AiMonitoringChatSub
 
   asyncEnd(data) {
     const { agent, logger } = this
-    if (!this.enabled) {
+    if (!this.aiEnabled) {
       logger.debug('`ai_monitoring.enabled` is set to false, not creating chat completion events.')
       return
     }

--- a/lib/subscribers/google-adk/agent-run-async.js
+++ b/lib/subscribers/google-adk/agent-run-async.js
@@ -33,7 +33,7 @@ module.exports = class GoogleAdkAgentRunSubscriber extends AiMonitoringSubscribe
   // generator is created but before it is consumed by the caller.
   end(data) {
     const { agent, logger } = this
-    if (!this.enabled) {
+    if (!this.aiEnabled) {
       logger.debug('Google ADK instrumentation is disabled, not instrumenting runAsync.')
       return
     }

--- a/lib/subscribers/google-adk/tool-run-async.js
+++ b/lib/subscribers/google-adk/tool-run-async.js
@@ -36,7 +36,7 @@ module.exports = class GoogleAdkToolRunSubscriber extends AiMonitoringSubscriber
 
   asyncEnd(data) {
     const { agent, logger, toolName, toolInput } = this
-    if (!this.enabled) {
+    if (!this.aiEnabled) {
       logger.debug('Google ADK instrumentation is disabled, not instrumenting FunctionTool.runAsync.')
       return
     }

--- a/lib/subscribers/google-genai/generate-content-stream.js
+++ b/lib/subscribers/google-genai/generate-content-stream.js
@@ -76,11 +76,6 @@ class GoogleGenAIGenerateContentStreamSubscriber extends GoogleGenAIGenerateCont
   }
 
   asyncEnd(data) {
-    // Check config to see if ai_monitoring is still enabled
-    if (!this.aiEnabled) {
-      this.logger.debug('`ai_monitoring.enabled` is set to false, stream will not be instrumented.')
-      return
-    }
     if (!this.streamingEnabled) {
       this.logger.warn(
         '`ai_monitoring.streaming.enabled` is set to `false`, stream will not be instrumented.'

--- a/lib/subscribers/google-genai/generate-content-stream.js
+++ b/lib/subscribers/google-genai/generate-content-stream.js
@@ -77,7 +77,7 @@ class GoogleGenAIGenerateContentStreamSubscriber extends GoogleGenAIGenerateCont
 
   asyncEnd(data) {
     // Check config to see if ai_monitoring is still enabled
-    if (!this.enabled) {
+    if (!this.aiEnabled) {
       this.logger.debug('`ai_monitoring.enabled` is set to false, stream will not be instrumented.')
       return
     }

--- a/lib/subscribers/langchain/runnable-stream.js
+++ b/lib/subscribers/langchain/runnable-stream.js
@@ -12,7 +12,7 @@ class LangchainRunnableStreamSubscriber extends LangchainRunnableSubscriber {
   }
 
   asyncEnd(data) {
-    if (!this.enabled) {
+    if (!this.aiEnabled) {
       this.logger.debug('`ai_monitoring.enabled` is set to false, stream will not be instrumented.')
       return
     }

--- a/lib/subscribers/langchain/runnable-stream.js
+++ b/lib/subscribers/langchain/runnable-stream.js
@@ -12,10 +12,6 @@ class LangchainRunnableStreamSubscriber extends LangchainRunnableSubscriber {
   }
 
   asyncEnd(data) {
-    if (!this.aiEnabled) {
-      this.logger.debug('`ai_monitoring.enabled` is set to false, stream will not be instrumented.')
-      return
-    }
     if (!this.streamingEnabled) {
       this.logger.debug('`ai_monitoring.streaming.enabled` is set to false, stream will not be instrumented.')
       this.agent.metrics.getOrCreateMetric(STREAMING_DISABLED).incrementCallCount()

--- a/lib/subscribers/langchain/tool.js
+++ b/lib/subscribers/langchain/tool.js
@@ -27,7 +27,7 @@ class LangchainToolSubscriber extends AiMonitoringSubscriber {
   asyncEnd(data) {
     // Extract data and exit early if need be.
     const { agent, logger } = this
-    if (!this.enabled) {
+    if (!this.aiEnabled) {
       logger.debug('Langchain instrumentation is disabled, not recording Llm events.')
       return
     }

--- a/lib/subscribers/langchain/vectorstore.js
+++ b/lib/subscribers/langchain/vectorstore.js
@@ -84,7 +84,7 @@ class LangchainVectorstoreSubscriber extends AiMonitoringSubscriber {
   }
 
   asyncEnd(data) {
-    if (!this.enabled) {
+    if (!this.aiEnabled) {
       this.logger.debug('Langchain instrumentation is disabled, not recording Llm events.')
       return
     }

--- a/lib/subscribers/langgraph/graph-stream.js
+++ b/lib/subscribers/langgraph/graph-stream.js
@@ -22,7 +22,7 @@ class LangGraphStreamSubscriber extends AiMonitoringSubscriber {
   }
 
   get streamingEnabled() {
-    return this.agent.config.ai_monitoring.streaming.enabled
+    return this.aiEnabled && this.agent.config.ai_monitoring.streaming.enabled
   }
 
   handler(data, ctx) {
@@ -35,7 +35,7 @@ class LangGraphStreamSubscriber extends AiMonitoringSubscriber {
 
   asyncEnd(data) {
     const { agent, logger, aiAgentName } = this
-    if (!this.enabled) {
+    if (!this.aiEnabled) {
       logger.debug('LangGraph instrumentation is disabled, not instrumenting stream.')
       return
     }

--- a/lib/subscribers/langgraph/graph-stream.js
+++ b/lib/subscribers/langgraph/graph-stream.js
@@ -21,10 +21,6 @@ class LangGraphStreamSubscriber extends AiMonitoringSubscriber {
     this.events = ['asyncEnd']
   }
 
-  get streamingEnabled() {
-    return this.aiEnabled && this.agent.config.ai_monitoring.streaming.enabled
-  }
-
   handler(data, ctx) {
     // Store LangGraph AI agent name and update
     // segment name to use it.
@@ -35,10 +31,7 @@ class LangGraphStreamSubscriber extends AiMonitoringSubscriber {
 
   asyncEnd(data) {
     const { agent, logger, aiAgentName } = this
-    if (!this.aiEnabled) {
-      logger.debug('LangGraph instrumentation is disabled, not instrumenting stream.')
-      return
-    }
+
     if (!this.streamingEnabled) {
       logger.debug('LangGraph streaming instrumentation is disabled, not instrumenting stream.')
       this.agent.metrics.getOrCreateMetric(STREAMING_DISABLED).incrementCallCount()

--- a/lib/subscribers/openai/chat.js
+++ b/lib/subscribers/openai/chat.js
@@ -35,7 +35,7 @@ class OpenAIChatCompletions extends AiMonitoringChatSubscriber {
   }
 
   asyncEnd(data) {
-    if (!this.enabled) {
+    if (!this.aiEnabled) {
       this.logger.debug('`ai_monitoring.enabled` is set to false, stream will not be instrumented.')
       return
     }

--- a/test/unit/config/config-server-side.test.js
+++ b/test/unit/config/config-server-side.test.js
@@ -150,14 +150,6 @@ describe('when receiving server-side configuration', () => {
     assert.equal(config.high_security, false)
   })
 
-  test('should disable ai monitoring', (t) => {
-    const { config } = t.nr
-    config.ai_monitoring.enabled = true
-    assert.equal(config.ai_monitoring.enabled, true)
-    config.onConnect({ collect_ai: false })
-    assert.equal(config.ai_monitoring.enabled, false)
-  })
-
   test('should load named transaction apdexes', (t) => {
     const { config } = t.nr
     const apdexes = { 'WebTransaction/Custom/UrlGenerator/en/betting/Football': 7.0 }
@@ -661,6 +653,90 @@ describe('when receiving server-side configuration', () => {
       })
 
       config.onConnect({ apdex_t: 0.1 })
+    })
+  })
+
+  describe('ai_monitoring SSC scenarios', () => {
+    test('should disable ai monitoring when only collect_ai is false', (t) => {
+      const { config } = t.nr
+      config.ai_monitoring.enabled = true
+      assert.equal(config.ai_monitoring.enabled, true)
+      config.onConnect({ collect_ai: false })
+      assert.equal(config.ai_monitoring.enabled, false)
+    })
+
+    test('should not change ai monitoring when only collect_ai is true', (t) => {
+      const { config } = t.nr
+      config.ai_monitoring.enabled = false
+      config.onConnect({ collect_ai: true })
+      // collect_ai can only disable, never enable
+      assert.equal(config.ai_monitoring.enabled, false)
+    })
+
+    test('should let `ai_monitoring.enabled` take precedence and enable when collect_ai is false', (t) => {
+      const { config } = t.nr
+      config.ai_monitoring.enabled = false
+      config.onConnect({ collect_ai: false, 'ai_monitoring.enabled': true })
+      assert.equal(config.ai_monitoring.enabled, true)
+    })
+
+    test('should let `ai_monitoring.enabled` take precedence and disable when collect_ai is true', (t) => {
+      const { config } = t.nr
+      config.ai_monitoring.enabled = true
+      config.onConnect({ collect_ai: true, 'ai_monitoring.enabled': false })
+      assert.equal(config.ai_monitoring.enabled, false)
+    })
+
+    test('should stay disabled when both collect_ai and ai_monitoring.enabled are false', (t) => {
+      const { config } = t.nr
+      config.ai_monitoring.enabled = true
+      config.onConnect({ collect_ai: false, 'ai_monitoring.enabled': false })
+      assert.equal(config.ai_monitoring.enabled, false)
+    })
+
+    test('should enable ai monitoring when only ai_monitoring.enabled is sent', (t) => {
+      const { config } = t.nr
+      config.ai_monitoring.enabled = false
+      config.onConnect({ 'ai_monitoring.enabled': true })
+      assert.equal(config.ai_monitoring.enabled, true)
+    })
+
+    test('should not enable ai monitoring via server side config when high security mode is on', (t) => {
+      const config = new Config({ high_security: true, ai_monitoring: { enabled: true } })
+      // HSM forces ai_monitoring off at construction
+      assert.equal(config.ai_monitoring.enabled, false)
+      config.onConnect({ high_security: true, collect_ai: false, 'ai_monitoring.enabled': true })
+      assert.equal(config.ai_monitoring.enabled, false)
+    })
+
+    test('should change values via server side config for ai_monitoring', (t) => {
+      t.plan(6)
+      const { config } = t.nr
+      config.ai_monitoring = {
+        enabled: false,
+        streaming: {
+          enabled: true
+        },
+        record_content: {
+          enabled: true
+        }
+      }
+      config.on('ai_monitoring.enabled', (value) => {
+        t.assert.equal(value, true)
+      })
+
+      config.on('ai_monitoring.streaming.enabled', (value) => {
+        t.assert.equal(value, false)
+      })
+
+      config.on('ai_monitoring.record_content.enabled', (value) => {
+        t.assert.equal(value, false)
+      })
+
+      config.onConnect({ 'ai_monitoring.enabled': true, 'ai_monitoring.record_content.enabled': false, 'ai_monitoring.streaming.enabled': false })
+      t.assert.equal(config.ai_monitoring.enabled, true)
+      t.assert.equal(config.ai_monitoring.streaming.enabled, false)
+      t.assert.equal(config.ai_monitoring.record_content.enabled, false)
     })
   })
 

--- a/test/unit/config/config-server-side.test.js
+++ b/test/unit/config/config-server-side.test.js
@@ -676,28 +676,28 @@ describe('when receiving server-side configuration', () => {
     test('should let `ai_monitoring.enabled` take precedence and enable when collect_ai is false', (t) => {
       const { config } = t.nr
       config.ai_monitoring.enabled = false
-      config.onConnect({ collect_ai: false, 'ai_monitoring.enabled': true })
+      config.onConnect({ collect_ai: false, agent_config: { 'ai_monitoring.enabled': true } })
       assert.equal(config.ai_monitoring.enabled, true)
     })
 
     test('should let `ai_monitoring.enabled` take precedence and disable when collect_ai is true', (t) => {
       const { config } = t.nr
       config.ai_monitoring.enabled = true
-      config.onConnect({ collect_ai: true, 'ai_monitoring.enabled': false })
+      config.onConnect({ collect_ai: true, agent_config: { 'ai_monitoring.enabled': false } })
       assert.equal(config.ai_monitoring.enabled, false)
     })
 
     test('should stay disabled when both collect_ai and ai_monitoring.enabled are false', (t) => {
       const { config } = t.nr
       config.ai_monitoring.enabled = true
-      config.onConnect({ collect_ai: false, 'ai_monitoring.enabled': false })
+      config.onConnect({ collect_ai: false, agent_config: { 'ai_monitoring.enabled': false } })
       assert.equal(config.ai_monitoring.enabled, false)
     })
 
     test('should enable ai monitoring when only ai_monitoring.enabled is sent', (t) => {
       const { config } = t.nr
       config.ai_monitoring.enabled = false
-      config.onConnect({ 'ai_monitoring.enabled': true })
+      config.onConnect({ agent_config: { 'ai_monitoring.enabled': true } })
       assert.equal(config.ai_monitoring.enabled, true)
     })
 
@@ -705,7 +705,7 @@ describe('when receiving server-side configuration', () => {
       const config = new Config({ high_security: true, ai_monitoring: { enabled: true } })
       // HSM forces ai_monitoring off at construction
       assert.equal(config.ai_monitoring.enabled, false)
-      config.onConnect({ high_security: true, collect_ai: false, 'ai_monitoring.enabled': true })
+      config.onConnect({ high_security: true, collect_ai: false, agent_config: { 'ai_monitoring.enabled': true } })
       assert.equal(config.ai_monitoring.enabled, false)
     })
 
@@ -733,7 +733,7 @@ describe('when receiving server-side configuration', () => {
         t.assert.equal(value, false)
       })
 
-      config.onConnect({ 'ai_monitoring.enabled': true, 'ai_monitoring.record_content.enabled': false, 'ai_monitoring.streaming.enabled': false })
+      config.onConnect({ agent_config: { 'ai_monitoring.enabled': true, 'ai_monitoring.record_content.enabled': false, 'ai_monitoring.streaming.enabled': false } })
       t.assert.equal(config.ai_monitoring.enabled, true)
       t.assert.equal(config.ai_monitoring.streaming.enabled, false)
       t.assert.equal(config.ai_monitoring.record_content.enabled, false)
@@ -748,7 +748,7 @@ describe('when receiving server-side configuration', () => {
         t.assert.equal(value, true)
       })
       config.profiling.enabled = false
-      config.onConnect({ 'profiling.enabled': true })
+      config.onConnect({ agent_config: { 'profiling.enabled': true } })
       t.assert.equal(config.profiling.enabled, true)
     })
 
@@ -759,7 +759,7 @@ describe('when receiving server-side configuration', () => {
         t.assert.equal(value, false)
       })
       config.profiling.enabled = true
-      config.onConnect({ 'profiling.enabled': false })
+      config.onConnect({ agent_config: { 'profiling.enabled': false } })
       t.assert.equal(config.profiling.enabled, false)
     })
 
@@ -770,7 +770,7 @@ describe('when receiving server-side configuration', () => {
         throw new Error('should not update dynamically')
       })
       config.profiling.enabled = false
-      config.onConnect({ 'profiling.enabled': false })
+      config.onConnect({ agent_config: { 'profiling.enabled': false } })
       t.assert.equal(config.profiling.enabled, false)
     })
 
@@ -781,7 +781,7 @@ describe('when receiving server-side configuration', () => {
         throw new Error('should not update dynamically')
       })
       config.profiling.enabled = true
-      config.onConnect({ 'profiling.enabled': true })
+      config.onConnect({ agent_config: { 'profiling.enabled': true } })
       t.assert.equal(config.profiling.enabled, true)
     })
   })

--- a/test/versioned/anthropic-sdk/chat-completions.test.js
+++ b/test/versioned/anthropic-sdk/chat-completions.test.js
@@ -12,6 +12,7 @@ const { assertPackageMetrics, assertSegments, assertSpanKind, match } = require(
 const { assertChatCompletionMessages, assertChatCompletionSummary } = require('./common')
 const AnthropicMockServer = require('./mock-server')
 const helper = require('../../lib/agent_helper')
+const { findSegment } = require('../../lib/metrics_helper')
 
 const {
   AI: { ANTHROPIC }
@@ -411,6 +412,99 @@ test('should not create llm events when streaming is enabled but ai_monitoring i
     assert.equal(activeSeg.name, 'ROOT')
     const children = tx.trace.getChildren(activeSeg.id)
     assert.notEqual(children?.[0]?.name, ANTHROPIC.COMPLETION)
+
+    tx.end()
+    end()
+  })
+})
+
+test('should create segment and llm events when ai_monitoring is disabled at instrumentation but enabled before the call', (t, end) => {
+  const { host, port } = t.nr
+  // tear down the enabled agent/module set up in `beforeEach`
+  helper.unloadAgent(t.nr.agent)
+  removeModules('@anthropic-ai/sdk')
+
+  // set up the agent instance with ai_monitoring disabled
+  const agent = helper.instrumentMockedAgent({
+    ai_monitoring: {
+      enabled: false,
+      streaming: {
+        enabled: true
+      }
+    }
+  })
+  t.nr.agent = agent
+  const Anthropic = require('@anthropic-ai/sdk')
+  const client = new Anthropic({
+    apiKey: 'fake-versioned-test-key',
+    baseURL: `http://${host}:${port}`
+  })
+  t.nr.client = client
+
+  // enable ai_monitoring before making the call
+  agent.config.ai_monitoring.enabled = true
+  helper.runInTransaction(agent, async (tx) => {
+    await client.messages.create({
+      model: 'claude-sonnet-4-20250514',
+      max_tokens: 100,
+      messages: [{ role: 'user', content: 'You are a mathematician.' }]
+    })
+
+    const events = agent.customEventAggregator.events.toArray()
+    assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+    assert.ok(findSegment(tx.trace, tx.trace.root, ANTHROPIC.COMPLETION))
+
+    tx.end()
+    end()
+  })
+})
+
+test('should create segment and llm events in stream when ai_monitoring is disabled at instrumentation but enabled before the call', (t, end) => {
+  const { host, port } = t.nr
+  // tear down the enabled agent/module set up in `beforeEach`
+  helper.unloadAgent(t.nr.agent)
+  removeModules('@anthropic-ai/sdk')
+
+  // set up the agent instance with ai_monitoring disabled
+  const agent = helper.instrumentMockedAgent({
+    ai_monitoring: {
+      enabled: false,
+      streaming: {
+        enabled: true
+      }
+    }
+  })
+  t.nr.agent = agent
+  const Anthropic = require('@anthropic-ai/sdk')
+  const client = new Anthropic({
+    apiKey: 'fake-versioned-test-key',
+    baseURL: `http://${host}:${port}`
+  })
+  t.nr.client = client
+
+  // enable ai_monitoring before making the call
+  agent.config.ai_monitoring.enabled = true
+  helper.runInTransaction(agent, async (tx) => {
+    const content = 'Streamed response'
+    const stream = await client.messages.create({
+      model: 'claude-sonnet-4-20250514',
+      max_tokens: 100,
+      temperature: 0.5,
+      stream: true,
+      messages: [{ role: 'user', content }]
+    })
+
+    let res = ''
+    for await (const event of stream) {
+      if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
+        res += event.delta.text
+      }
+    }
+    assert.ok(res)
+
+    const events = agent.customEventAggregator.events.toArray()
+    assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+    assert.ok(findSegment(tx.trace, tx.trace.root, ANTHROPIC.COMPLETION))
 
     tx.end()
     end()

--- a/test/versioned/aws-sdk-v3/bedrock-chat-completions.test.js
+++ b/test/versioned/aws-sdk-v3/bedrock-chat-completions.test.js
@@ -782,6 +782,107 @@ test('Chat completions', async (t) => {
     })
   })
 
+  await t.test('should create segment and llm events when ai_monitoring is disabled at instrumentation but enabled before the call', async (t) => {
+    // tear down the enabled agent/module set up in `beforeEach`
+    t.nr.server.destroy()
+    helper.unloadAgent(t.nr.agent)
+    Object.keys(require.cache).forEach((key) => {
+      if (key.includes('@aws-sdk') || key.includes('@smithy')) {
+        delete require.cache[key]
+      }
+    })
+
+    // set up the agent instance with ai_monitoring disabled
+    const agent = helper.instrumentMockedAgent({
+      ai_monitoring: {
+        enabled: false
+      }
+    })
+    t.nr.agent = agent
+    const bedrock = require('@aws-sdk/client-bedrock-runtime')
+    const { server, baseUrl } = await createAiResponseServer()
+    t.nr.server = server
+    const client = new bedrock.BedrockRuntimeClient({
+      region: 'us-east-1',
+      credentials: FAKE_CREDENTIALS,
+      endpoint: baseUrl,
+      maxAttempts: 1
+    })
+
+    const modelId = 'amazon.titan-text-express-v1'
+    const prompt = 'text amazon ultimate question'
+    const input = requests.amazon(prompt, modelId)
+    const command = new bedrock.InvokeModelCommand(input)
+
+    // enable ai_monitoring before making the first `.send()` call
+    agent.config.ai_monitoring.enabled = true
+    await helper.runInTransaction(agent, async (tx) => {
+      await client.send(command)
+      const events = agent.customEventAggregator.events.toArray()
+      assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+      assertSegments(
+        tx.trace,
+        tx.trace.root,
+        ['Llm/completion/Bedrock/InvokeModelCommand'],
+        { exact: false }
+      )
+      tx.end()
+    })
+  })
+
+  await t.test('should create segment and llm events in stream when ai_monitoring is disabled at instrumentation but enabled before the call', async (t) => {
+    // tear down the enabled agent/module set up in `beforeEach`
+    t.nr.server.destroy()
+    helper.unloadAgent(t.nr.agent)
+    Object.keys(require.cache).forEach((key) => {
+      if (key.includes('@aws-sdk') || key.includes('@smithy')) {
+        delete require.cache[key]
+      }
+    })
+
+    // set up the agent instance with ai_monitoring disabled
+    const agent = helper.instrumentMockedAgent({
+      ai_monitoring: {
+        enabled: false
+      }
+    })
+    t.nr.agent = agent
+    const bedrock = require('@aws-sdk/client-bedrock-runtime')
+    const { server, baseUrl } = await createAiResponseServer()
+    t.nr.server = server
+    const client = new bedrock.BedrockRuntimeClient({
+      region: 'us-east-1',
+      credentials: FAKE_CREDENTIALS,
+      endpoint: baseUrl,
+      maxAttempts: 1
+    })
+
+    const modelId = 'amazon.titan-text-express-v1'
+    const prompt = 'text amazon ultimate question streamed'
+    const input = requests.amazon(prompt, modelId)
+    const command = new bedrock.InvokeModelWithResponseStreamCommand(input)
+
+    // enable ai_monitoring before making the first `.send()` call
+    agent.config.ai_monitoring.enabled = true
+    await helper.runInTransaction(agent, async (tx) => {
+      const response = await client.send(command)
+      for await (const event of response.body) {
+        // no-op iteration over the stream in order to exercise the instrumentation
+        consumeStreamChunk(event)
+      }
+
+      const events = agent.customEventAggregator.events.toArray()
+      assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+      assertSegments(
+        tx.trace,
+        tx.trace.root,
+        ['Llm/completion/Bedrock/InvokeModelWithResponseStreamCommand'],
+        { exact: false }
+      )
+      tx.end()
+    })
+  })
+
   await t.test('should utilize tokenCountCallback when set', async (t) => {
     const { agent, bedrock, client } = t.nr
     const plan = tspl(t, { plan: 13 })

--- a/test/versioned/aws-sdk-v3/bedrock-converse-api.test.js
+++ b/test/versioned/aws-sdk-v3/bedrock-converse-api.test.js
@@ -17,6 +17,7 @@ const helper = require('../../lib/agent_helper')
 const { FAKE_CREDENTIALS, getAiResponseServer } = require('../../lib/aws-server-stubs')
 const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
 const { assertPackageMetrics, assertSegments, match } = require('../../lib/custom-assertions')
+const { findSegment } = require('../../lib/metrics_helper')
 const promiseResolvers = require('../../lib/promise-resolvers')
 const responseConstants = require('../../lib/aws-server-stubs/ai-server/responses/constants')
 const createAiResponseServer = getAiResponseServer(__dirname)
@@ -440,6 +441,142 @@ test('Converse API', { skip: semver.lt(bedrockVersion, '3.587.0') }, async (t) =
         'should increment streaming disabled metric'
       )
 
+      tx.end()
+    })
+  })
+
+  await t.test('should not create segment or llm events when ai_monitoring.enabled is false', async (t) => {
+    const { agent, bedrock, client, expectedExternalPath } = t.nr
+    agent.config.ai_monitoring.enabled = false
+    const prompt = 'text converse ultimate question'
+    const input = {
+      modelId,
+      messages: [
+        { role: 'user', content: [{ text: prompt }] }
+      ],
+    }
+    const command = new bedrock.ConverseCommand(input)
+
+    await helper.runInTransaction(agent, async (tx) => {
+      await client.send(command)
+      const events = agent.customEventAggregator.events.toArray()
+      assert.equal(events.length, 0, 'should not create llm events when ai_monitoring is disabled')
+      assert.ok(
+        !findSegment(tx.trace, tx.trace.root, 'Llm/completion/Bedrock/ConverseCommand'),
+        'should not create Llm completion segment when ai_monitoring is disabled'
+      )
+      // the external call should still happen, just without the Llm wrapper segment
+      assert.ok(findSegment(tx.trace, tx.trace.root, expectedExternalPath(modelId)))
+      tx.end()
+    })
+  })
+
+  await t.test('should create segment and llm events when ai_monitoring is disabled at instrumentation but enabled before the call', async (t) => {
+    // tear down the enabled agent/module set up in `beforeEach`
+    t.nr.server.destroy()
+    helper.unloadAgent(t.nr.agent)
+    Object.keys(require.cache).forEach((key) => {
+      if (key.includes('@aws-sdk') || key.includes('@smithy')) {
+        delete require.cache[key]
+      }
+    })
+
+    // set up the agent instance with ai_monitoring disabled
+    const agent = helper.instrumentMockedAgent({
+      ai_monitoring: {
+        enabled: false
+      }
+    })
+    t.nr.agent = agent
+    const bedrock = require('@aws-sdk/client-bedrock-runtime')
+    const { server, baseUrl } = await createAiResponseServer()
+    t.nr.server = server
+    const client = new bedrock.BedrockRuntimeClient({
+      region: 'us-east-1',
+      credentials: FAKE_CREDENTIALS,
+      endpoint: baseUrl,
+      maxAttempts: 1
+    })
+
+    const prompt = 'text converse ultimate question'
+    const input = {
+      modelId,
+      messages: [
+        { role: 'user', content: [{ text: prompt }] }
+      ],
+    }
+    const command = new bedrock.ConverseCommand(input)
+
+    // enable ai_monitoring before making the first `.send()` call
+    agent.config.ai_monitoring.enabled = true
+    await helper.runInTransaction(agent, async (tx) => {
+      await client.send(command)
+      const events = agent.customEventAggregator.events.toArray()
+      assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+      assert.ok(
+        findSegment(tx.trace, tx.trace.root, 'Llm/completion/Bedrock/ConverseCommand'),
+        'should create Llm completion segment when ai_monitoring is enabled before the call'
+      )
+      tx.end()
+    })
+  })
+
+  await t.test('should create segment and llm events in stream when ai_monitoring is disabled at instrumentation but enabled before the call', async (t) => {
+    // tear down the enabled agent/module set up in `beforeEach`
+    t.nr.server.destroy()
+    helper.unloadAgent(t.nr.agent)
+    Object.keys(require.cache).forEach((key) => {
+      if (key.includes('@aws-sdk') || key.includes('@smithy')) {
+        delete require.cache[key]
+      }
+    })
+
+    // set up the agent instance with ai_monitoring disabled
+    const agent = helper.instrumentMockedAgent({
+      ai_monitoring: {
+        enabled: false
+      }
+    })
+    t.nr.agent = agent
+    const bedrock = require('@aws-sdk/client-bedrock-runtime')
+    const { server, baseUrl } = await createAiResponseServer()
+    t.nr.server = server
+    const client = new bedrock.BedrockRuntimeClient({
+      region: 'us-east-1',
+      credentials: FAKE_CREDENTIALS,
+      endpoint: baseUrl,
+      maxAttempts: 1
+    })
+
+    const prompt = 'text converse ultimate question streamed'
+    const input = {
+      modelId,
+      messages: [
+        { role: 'user', content: [{ text: prompt }] }
+      ],
+      inferenceConfig: {
+        maxTokens: 100,
+        temperature: 0.5
+      },
+    }
+    const command = new bedrock.ConverseStreamCommand(input)
+
+    // enable ai_monitoring before making the first `.send()` call
+    agent.config.ai_monitoring.enabled = true
+    await helper.runInTransaction(agent, async (tx) => {
+      const response = await client.send(command)
+      assert.ok(response)
+      for await (const event of response.stream) {
+        // no-op iteration over the stream in order to exercise the instrumentation
+        consumeStreamChunk(event)
+      }
+
+      const events = agent.customEventAggregator.events.toArray()
+      assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+      assert.ok(
+        findSegment(tx.trace, tx.trace.root, 'Llm/completion/Bedrock/ConverseStreamCommand'),
+        'should create Llm completion segment when ai_monitoring is enabled before the call'
+      )
       tx.end()
     })
   })

--- a/test/versioned/aws-sdk-v3/bedrock-embeddings.test.js
+++ b/test/versioned/aws-sdk-v3/bedrock-embeddings.test.js
@@ -7,6 +7,7 @@
 const assert = require('node:assert')
 const test = require('node:test')
 const helper = require('../../lib/agent_helper')
+const { findSegment } = require('../../lib/metrics_helper')
 const { assertSegments, match } = require('../../lib/custom-assertions')
 const { FAKE_CREDENTIALS, getAiResponseServer } = require('../../lib/aws-server-stubs')
 const { DESTINATIONS } = require('../../../lib/config/attribute-filter')
@@ -253,6 +254,73 @@ test('Embeddings', async (t) => {
         const msg = events[0][1]
         assert.equal(msg['llm.foo'], 'bar')
 
+        tx.end()
+      })
+    })
+
+    await t.test(`${modelId}: should not create segment or llm events when ai_monitoring.enabled is false`, async (t) => {
+      const { agent, bedrock, client, expectedExternalPath } = t.nr
+      agent.config.ai_monitoring.enabled = false
+      const prompt = `embed text ${resKey} success`
+      const input = requests[resKey](prompt, modelId)
+      const command = new bedrock.InvokeModelCommand(input)
+
+      await helper.runInTransaction(agent, async (tx) => {
+        await client.send(command)
+        const events = agent.customEventAggregator.events.toArray()
+        assert.equal(events.length, 0, 'should not create llm events when ai_monitoring is disabled')
+        assert.ok(
+          !findSegment(tx.trace, tx.trace.root, 'Llm/embedding/Bedrock/InvokeModelCommand'),
+          'should not create Llm embedding segment when ai_monitoring is disabled'
+        )
+        // the external call should still happen, just without the Llm wrapper segment
+        assert.ok(findSegment(tx.trace, tx.trace.root, expectedExternalPath(modelId)))
+        tx.end()
+      })
+    })
+
+    await t.test(`${modelId}: should create segment and LlmEmbedding event when ai_monitoring is disabled at instrumentation but enabled before the call`, async (t) => {
+      // tear down the enabled agent/module set up in `beforeEach`
+      t.nr.server.destroy()
+      helper.unloadAgent(t.nr.agent)
+      Object.keys(require.cache).forEach((key) => {
+        if (key.includes('@aws-sdk') || key.includes('@smithy')) {
+          delete require.cache[key]
+        }
+      })
+
+      // set up the agent instance with ai_monitoring disabled
+      const agent = helper.instrumentMockedAgent({
+        ai_monitoring: {
+          enabled: false
+        }
+      })
+      t.nr.agent = agent
+      const bedrock = require('@aws-sdk/client-bedrock-runtime')
+      const { server, baseUrl } = await createAiResponseServer()
+      t.nr.server = server
+      const client = new bedrock.BedrockRuntimeClient({
+        region: 'us-east-1',
+        credentials: FAKE_CREDENTIALS,
+        endpoint: baseUrl
+      })
+
+      const prompt = `embed text ${resKey} success`
+      const input = requests[resKey](prompt, modelId)
+      const command = new bedrock.InvokeModelCommand(input)
+
+      // enable ai_monitoring before making the first `.send()` call
+      agent.config.ai_monitoring.enabled = true
+      await helper.runInTransaction(agent, async (tx) => {
+        await client.send(command)
+        const events = agent.customEventAggregator.events.toArray()
+        assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+        const embedding = events.filter(([{ type }]) => type === 'LlmEmbedding')[0]
+        assert.equal(embedding[0].type, 'LlmEmbedding')
+        assert.ok(
+          findSegment(tx.trace, tx.trace.root, 'Llm/embedding/Bedrock/InvokeModelCommand'),
+          'should create Llm embedding segment when ai_monitoring is enabled before the call'
+        )
         tx.end()
       })
     })

--- a/test/versioned/google-adk/agent-run-async.test.js
+++ b/test/versioned/google-adk/agent-run-async.test.js
@@ -294,3 +294,46 @@ test('should not create segment or events when ai_monitoring.enabled is false', 
     tx.end()
   })
 })
+
+test('should create segment and events when ai_monitoring is disabled at instrumentation but enabled before the call', async (t) => {
+  t.plan(2)
+  const assert = t.assert
+
+  // tear down the enabled agent/module set up in `beforeEach`
+  helper.unloadAgent(t.nr.agent)
+  removeModules(['@google/adk'])
+
+  // set up the agent instance with ai_monitoring disabled
+  const agent = helper.instrumentMockedAgent({
+    ai_monitoring: {
+      enabled: false,
+      streaming: {
+        enabled: true
+      }
+    }
+  })
+  t.nr.agent = agent
+  const { BaseAgent } = require('@google/adk')
+
+  const testAgent = createTestAgent(BaseAgent, {
+    name: 'enabled_before_agent',
+    events: [{ id: 'evt-1', author: 'enabled_before_agent', content: { parts: [{ text: 'hello' }] } }]
+  })
+
+  // enable ai_monitoring before making the call
+  agent.config.ai_monitoring.enabled = true
+
+  await helper.runInTransaction(agent, async (tx) => {
+    await consumeGenerator(testAgent.runAsync({}))
+
+    const segments = tx.trace.getChildren(tx.trace.root.id)
+    const adkSegments = segments.filter((s) => s.name.includes('Llm/agent/GoogleADK'))
+    assert.ok(adkSegments.length > 0, 'should create GoogleADK segments')
+
+    const events = agent.customEventAggregator.events.toArray()
+    const agentEvents = events.filter((e) => e[0].type === 'LlmAgent')
+    assert.ok(agentEvents.length > 0, 'should create LlmAgent events when ai_monitoring is enabled before the call')
+
+    tx.end()
+  })
+})

--- a/test/versioned/google-adk/tool-run-async.test.js
+++ b/test/versioned/google-adk/tool-run-async.test.js
@@ -311,3 +311,47 @@ test('should record LLM custom attributes on tool events', async (t) => {
     tx.end()
   })
 })
+
+test('should create events when ai_monitoring is disabled at instrumentation but enabled before the call', async (t) => {
+  t.plan(2)
+  const assert = t.assert
+
+  // tear down the enabled agent/module set up in `beforeEach`
+  helper.unloadAgent(t.nr.agent)
+  removeModules(['@google/adk'])
+
+  // set up the agent instance with ai_monitoring disabled
+  const agent = helper.instrumentMockedAgent({
+    ai_monitoring: {
+      enabled: false
+    }
+  })
+  t.nr.agent = agent
+  const { FunctionTool } = require('@google/adk')
+
+  const tool = new FunctionTool({
+    name: 'enabled_before_tool',
+    description: 'A tool enabled before the call',
+    execute: async () => 'done'
+  })
+
+  // enable ai_monitoring before making the call
+  agent.config.ai_monitoring.enabled = true
+
+  await helper.runInTransaction(agent, async (tx) => {
+    await tool.runAsync({
+      args: {},
+      toolContext: { actions: {}, state: { toRecord: () => { return {} } } }
+    })
+
+    const segments = tx.trace.getChildren(tx.trace.root.id)
+    const adkSegments = segments.filter((s) => s.name.includes('Llm/tool/GoogleADK'))
+    assert.ok(adkSegments.length > 0, 'should create GoogleADK tool segments')
+
+    const events = agent.customEventAggregator.events.toArray()
+    const toolEvents = events.filter((e) => e[0].type === 'LlmTool')
+    assert.ok(toolEvents.length > 0, 'should create LlmTool events when ai_monitoring is enabled before the call')
+
+    tx.end()
+  })
+})

--- a/test/versioned/google-genai/chat-completions.test.js
+++ b/test/versioned/google-genai/chat-completions.test.js
@@ -12,6 +12,7 @@ const { assertPackageMetrics, assertSegments, assertSpanKind, match } = require(
 const { assertChatCompletionMessages, assertChatCompletionSummary } = require('./common')
 const GoogleGenAIMockServer = require('./mock-server')
 const helper = require('../../lib/agent_helper')
+const { findSegment } = require('../../lib/metrics_helper')
 
 const {
   AI: { GEMINI }
@@ -463,6 +464,105 @@ test('should not create llm events when streaming is enabled but ai_monitoring i
     assert.equal(activeSeg.name, 'ROOT')
     const children = tx.trace.getChildren(activeSeg.id)
     assert.notEqual(children?.[0]?.name, GEMINI.COMPLETION)
+
+    tx.end()
+    end()
+  })
+})
+
+test('should create segment and llm events when ai_monitoring is disabled at instrumentation but enabled before the call', (t, end) => {
+  const { host, port } = t.nr
+  // tear down the enabled agent/module set up in `beforeEach`
+  helper.unloadAgent(t.nr.agent)
+  removeModules('@google/genai')
+
+  // set up the agent instance with ai_monitoring disabled
+  const agent = helper.instrumentMockedAgent({
+    ai_monitoring: {
+      enabled: false,
+      streaming: {
+        enabled: true
+      }
+    }
+  })
+  t.nr.agent = agent
+  const { GoogleGenAI } = require('@google/genai')
+  const client = new GoogleGenAI({
+    apiKey: 'fake-versioned-test-key',
+    vertexai: false,
+    httpOptions: {
+      baseUrl: `http://${host}:${port}/`,
+    },
+    httpMethod: 'GET'
+  })
+  t.nr.client = client
+
+  // enable ai_monitoring before making the call
+  agent.config.ai_monitoring.enabled = true
+  helper.runInTransaction(agent, async (tx) => {
+    await client.models.generateContent({
+      model: 'gemini-2.0-flash',
+      contents: 'You are a mathematician.'
+    })
+
+    const events = agent.customEventAggregator.events.toArray()
+    assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+    assert.ok(findSegment(tx.trace, tx.trace.root, GEMINI.COMPLETION))
+
+    tx.end()
+    end()
+  })
+})
+
+test('should create segment and llm events in stream when ai_monitoring is disabled at instrumentation but enabled before the call', (t, end) => {
+  const { host, port } = t.nr
+  // tear down the enabled agent/module set up in `beforeEach`
+  helper.unloadAgent(t.nr.agent)
+  removeModules('@google/genai')
+
+  // set up the agent instance with ai_monitoring disabled
+  const agent = helper.instrumentMockedAgent({
+    ai_monitoring: {
+      enabled: false,
+      streaming: {
+        enabled: true
+      }
+    }
+  })
+  t.nr.agent = agent
+  const { GoogleGenAI } = require('@google/genai')
+  const client = new GoogleGenAI({
+    apiKey: 'fake-versioned-test-key',
+    vertexai: false,
+    httpOptions: {
+      baseUrl: `http://${host}:${port}/`,
+    },
+    httpMethod: 'GET'
+  })
+  t.nr.client = client
+
+  // enable ai_monitoring before making the call
+  agent.config.ai_monitoring.enabled = true
+  helper.runInTransaction(agent, async (tx) => {
+    const content = 'Streamed response'
+    const stream = await client.models.generateContentStream({
+      config: {
+        maxOutputTokens: 100,
+        temperature: 0.5
+      },
+      model: 'gemini-2.0-flash',
+      contents: content
+    })
+
+    let res = ''
+    for await (const chunk of stream) {
+      res += chunk.text
+    }
+    assert.ok(res)
+
+    const events = agent.customEventAggregator.events.toArray()
+    assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+    assert.ok(findSegment(tx.trace, tx.trace.root, GEMINI.COMPLETION))
 
     tx.end()
     end()

--- a/test/versioned/google-genai/embeddings.test.js
+++ b/test/versioned/google-genai/embeddings.test.js
@@ -11,6 +11,7 @@ const { removeModules } = require('../../lib/cache-buster')
 const { assertSegments, assertSpanKind, match } = require('../../lib/custom-assertions')
 const GoogleGenAIMockServer = require('./mock-server')
 const helper = require('../../lib/agent_helper')
+const { findSegment } = require('../../lib/metrics_helper')
 
 const {
   AI: { GEMINI }
@@ -195,6 +196,52 @@ test('should not create llm events when ai_monitoring is disabled', (t, end) => 
     assert.equal(activeSeg.name, 'ROOT')
     const children = tx.trace.getChildren(activeSeg.id)
     assert.notEqual(children?.[0]?.name, GEMINI.EMBEDDING)
+
+    tx.end()
+    end()
+  })
+})
+
+test('should create segment and llm events when ai_monitoring is disabled at instrumentation but enabled before the call', (t, end) => {
+  const { host, port } = t.nr
+  // tear down the enabled agent/module set up in `beforeEach`
+  helper.unloadAgent(t.nr.agent)
+  removeModules('@google/genai')
+
+  // set up the agent instance with ai_monitoring disabled
+  const agent = helper.instrumentMockedAgent({
+    ai_monitoring: {
+      enabled: false,
+      streaming: {
+        enabled: true
+      }
+    }
+  })
+  t.nr.agent = agent
+  const { GoogleGenAI } = require('@google/genai')
+  const client = new GoogleGenAI({
+    apiKey: 'fake-versioned-test-key',
+    vertexai: false,
+    httpOptions: {
+      baseUrl: `http://${host}:${port}/`,
+    },
+    httpMethod: 'GET'
+  })
+  t.nr.client = client
+
+  // enable ai_monitoring before making the call
+  agent.config.ai_monitoring.enabled = true
+  helper.runInTransaction(agent, async (tx) => {
+    await client.models.embedContent({
+      contents: 'This is an embedding test.',
+      model: 'text-embedding-004'
+    })
+
+    const events = agent.customEventAggregator.events.toArray()
+    assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+    const embedding = events.find((e) => e[0].type === 'LlmEmbedding')
+    assert.ok(embedding, 'should create an LlmEmbedding event')
+    assert.ok(findSegment(tx.trace, tx.trace.root, GEMINI.EMBEDDING))
 
     tx.end()
     end()

--- a/test/versioned/langchain-openai/runnables-streaming.test.js
+++ b/test/versioned/langchain-openai/runnables-streaming.test.js
@@ -10,6 +10,7 @@ const assert = require('node:assert')
 
 const { removeModules } = require('../../lib/cache-buster')
 const { match } = require('../../lib/custom-assertions')
+const { findSegment } = require('../../lib/metrics_helper')
 const {
   runStreamingEnabledTests,
   runStreamingDisabledTest,
@@ -32,6 +33,8 @@ async function beforeEach({ enabled, ctx }) {
   ctx.nr = {}
   const { host, port, server } = await createOpenAIMockServer()
   ctx.nr.server = server
+  ctx.nr.host = host
+  ctx.nr.port = port
   ctx.nr.agent = helper.instrumentMockedAgent(config)
   ctx.nr.agent.config.ai_monitoring.streaming.enabled = enabled
 
@@ -117,4 +120,68 @@ test('ai_monitoring disabled', async (t) => {
     inputData: { topic: 'Streamed' },
     expectedContent: () => mockResponses.get('Streamed response').streamData
   })(t)
+})
+
+test('should create segment and llm events in stream when ai_monitoring is disabled at instrumentation but enabled before the call', async (t) => {
+  // set up an enabled agent + mock server so we can reuse the still-open server
+  await beforeEach({ enabled: true, ctx: t })
+  t.after((ctx) => afterEach(ctx))
+
+  const { host, port } = t.nr
+  // tear down the enabled agent/module set up above
+  helper.unloadAgent(t.nr.agent)
+  removeModules(['@langchain/core', 'openai'])
+
+  // set up the agent instance with ai_monitoring disabled but streaming enabled
+  const agent = helper.instrumentMockedAgent({
+    ai_monitoring: {
+      enabled: false,
+      streaming: {
+        enabled: true
+      }
+    }
+  })
+  t.nr.agent = agent
+
+  const { ChatPromptTemplate } = require('@langchain/core/prompts')
+  const { StringOutputParser } = require('@langchain/core/output_parsers')
+  const { ChatOpenAI } = require('@langchain/openai')
+  const prompt = ChatPromptTemplate.fromMessages([['assistant', '{topic} response']])
+  const model = new ChatOpenAI({
+    streaming: true,
+    apiKey: 'fake-key',
+    maxRetries: 0,
+    configuration: {
+      baseURL: `http://${host}:${port}`
+    }
+  })
+  const outputParser = new StringOutputParser()
+
+  // enable ai_monitoring before making the call
+  agent.config.ai_monitoring.enabled = true
+  await new Promise((resolve) => {
+    helper.runInTransaction(agent, async (tx) => {
+      const chain = prompt.pipe(model).pipe(outputParser)
+      const stream = await chain.stream({ topic: 'Streamed' })
+      let content = ''
+      for await (const chunk of stream) {
+        content += chunk
+      }
+      assert.ok(content.length > 0, 'should receive streamed content')
+
+      const events = agent.customEventAggregator.events.toArray()
+      assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+
+      const langchainEvents = events.filter((event) => {
+        const [, chainEvent] = event
+        return chainEvent.vendor === 'langchain'
+      })
+      assert.ok(langchainEvents.length > 0, 'should create langchain events when ai_monitoring is enabled before the call')
+
+      assert.ok(findSegment(tx.trace, tx.trace.root, 'Llm/chain/LangChain/stream'), 'should create the stream segment')
+
+      tx.end()
+      resolve()
+    })
+  })
 })

--- a/test/versioned/langchain-openai/runnables.test.js
+++ b/test/versioned/langchain-openai/runnables.test.js
@@ -9,6 +9,7 @@ const test = require('node:test')
 const assert = require('node:assert')
 
 const { removeModules } = require('../../lib/cache-buster')
+const { findSegment } = require('../../lib/metrics_helper')
 const { runRunnablesTests } = require('../langchain/runnables')
 const createOpenAIMockServer = require('../openai/mock-server')
 const helper = require('../../lib/agent_helper')
@@ -23,6 +24,8 @@ test.beforeEach(async (ctx) => {
   ctx.nr = {}
   const { host, port, server } = await createOpenAIMockServer()
   ctx.nr.server = server
+  ctx.nr.host = host
+  ctx.nr.port = port
   ctx.nr.agent = helper.instrumentMockedAgent(config)
 
   const { ChatPromptTemplate } = require('@langchain/core/prompts')
@@ -62,4 +65,50 @@ runRunnablesTests({
       assert.equal(str, '[object LlmErrorMessage]')
     }
   }
+})
+
+test('should create segment and llm events when ai_monitoring is disabled at instrumentation but enabled before the call', (t, end) => {
+  const { host, port } = t.nr
+  // tear down the enabled agent/module set up in `beforeEach`
+  helper.unloadAgent(t.nr.agent)
+  removeModules(['@langchain/core', 'openai'])
+
+  // set up the agent instance with ai_monitoring disabled
+  const agent = helper.instrumentMockedAgent({ ai_monitoring: { enabled: false } })
+  t.nr.agent = agent
+
+  const { ChatPromptTemplate } = require('@langchain/core/prompts')
+  const { StringOutputParser } = require('@langchain/core/output_parsers')
+  const { ChatOpenAI } = require('@langchain/openai')
+  const prompt = ChatPromptTemplate.fromMessages([['assistant', 'You are a {topic}.']])
+  const model = new ChatOpenAI({
+    apiKey: 'fake-key',
+    maxRetries: 0,
+    configuration: {
+      baseURL: `http://${host}:${port}`
+    }
+  })
+  const outputParser = new StringOutputParser()
+
+  // enable ai_monitoring before making the call
+  agent.config.ai_monitoring.enabled = true
+  helper.runInTransaction(agent, async (tx) => {
+    const chain = prompt.pipe(model).pipe(outputParser)
+    const result = await chain.invoke({ topic: 'scientist' })
+    assert.ok(result)
+
+    const events = agent.customEventAggregator.events.toArray()
+    assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+
+    const langchainEvents = events.filter((event) => {
+      const [, chainEvent] = event
+      return chainEvent.vendor === 'langchain'
+    })
+    assert.ok(langchainEvents.length > 0, 'should create langchain events when ai_monitoring is enabled before the call')
+
+    assert.ok(findSegment(tx.trace, tx.trace.root, 'Llm/chain/LangChain/invoke'), 'should create the invoke segment')
+
+    tx.end()
+    end()
+  })
 })

--- a/test/versioned/langchain-openai/vectorstore.test.js
+++ b/test/versioned/langchain-openai/vectorstore.test.js
@@ -9,6 +9,7 @@ const test = require('node:test')
 const assert = require('node:assert')
 
 const { removeModules } = require('../../lib/cache-buster')
+const { findSegment } = require('../../lib/metrics_helper')
 const { runVectorstoreTests } = require('../langchain/vectorstore')
 const { Document } = require('@langchain/core/documents')
 const createOpenAIMockServer = require('../openai/mock-server')
@@ -24,6 +25,8 @@ test.beforeEach(async (ctx) => {
   ctx.nr = {}
   const { host, port, server } = await createOpenAIMockServer()
   ctx.nr.server = server
+  ctx.nr.host = host
+  ctx.nr.port = port
   ctx.nr.agent = helper.instrumentMockedAgent(config)
 
   const { VectorStore } = require('@langchain/core/vectorstores')
@@ -65,4 +68,57 @@ runVectorstoreTests({
       assert.equal(str, '[object LlmErrorMessage]')
     }
   }
+})
+
+test('should create segment and llm events when ai_monitoring is disabled at instrumentation but enabled before the call', async (t) => {
+  const { host, port } = t.nr
+  // tear down the enabled agent/module set up in `beforeEach`
+  helper.unloadAgent(t.nr.agent)
+  removeModules(['@langchain/core', 'openai'])
+
+  // set up the agent instance with ai_monitoring disabled
+  const agent = helper.instrumentMockedAgent({ ai_monitoring: { enabled: false } })
+  t.nr.agent = agent
+
+  const { VectorStore } = require('@langchain/core/vectorstores')
+  const CustomVectorStore = require('../langchain/custom-vector-store')(VectorStore)
+  const { OpenAIEmbeddings } = require('@langchain/openai')
+  const embedding = new OpenAIEmbeddings({
+    apiKey: 'fake-key',
+    configuration: {
+      baseURL: `http://${host}:${port}`
+    }
+  })
+  const docs = [
+    new Document({
+      metadata: { id: '2' },
+      pageContent: 'This is an embedding test.'
+    })
+  ]
+  const vs = new CustomVectorStore(embedding)
+  await vs.addDocuments(docs)
+  t.nr.vs = vs
+
+  // enable ai_monitoring before making the call
+  agent.config.ai_monitoring.enabled = true
+  await new Promise((resolve) => {
+    helper.runInTransaction(agent, async (tx) => {
+      const result = await vs.similaritySearch('This is an embedding test.', 1)
+      assert.ok(result)
+
+      const events = agent.customEventAggregator.events.toArray()
+      assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+
+      const langchainEvents = events.filter((event) => {
+        const [, chainEvent] = event
+        return chainEvent.vendor === 'langchain'
+      })
+      assert.ok(langchainEvents.length > 0, 'should create langchain events when ai_monitoring is enabled before the call')
+
+      assert.ok(findSegment(tx.trace, tx.trace.root, 'Llm/vectorstore/LangChain/similaritySearch'), 'should create the similaritySearch segment')
+
+      tx.end()
+      resolve()
+    })
+  })
 })

--- a/test/versioned/langchain/tools.test.js
+++ b/test/versioned/langchain/tools.test.js
@@ -228,6 +228,37 @@ test('should not create segment when ai_monitoring is disabled', (t, end) => {
   })
 })
 
+test('should create segment and llm events when ai_monitoring is disabled at instrumentation but enabled before the call', (t, end) => {
+  const { input } = t.nr
+  // tear down the enabled agent/module set up in `beforeEach`
+  helper.unloadAgent(t.nr.agent)
+  removeModules(['@langchain/core'])
+  removeMatchedModules(/custom-tool\.js$/)
+
+  // set up the agent instance with ai_monitoring disabled
+  const agent = helper.instrumentMockedAgent({ ai_monitoring: { enabled: false } })
+  t.nr.agent = agent
+  const TestTool = require('./custom-tool')
+  const tool = new TestTool({ baseUrl })
+  t.nr.tool = tool
+
+  // enable ai_monitoring before making the call
+  agent.config.ai_monitoring.enabled = true
+  helper.runInTransaction(agent, async (tx) => {
+    await tool.call(input)
+
+    const events = agent.customEventAggregator.events.toArray()
+    assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+
+    assertSegments(tx.trace, tx.trace.root, ['Llm/tool/LangChain/node-agent-test-tool'], {
+      exact: false
+    })
+
+    tx.end()
+    end()
+  })
+})
+
 test('should properly merge metadata from instance and params', (t, end) => {
   const { agent, tool, input } = t.nr
   helper.runInTransaction(agent, async (tx) => {

--- a/test/versioned/langgraph/graph-invoke.test.js
+++ b/test/versioned/langgraph/graph-invoke.test.js
@@ -155,3 +155,65 @@ test('should not create segment or events when ai_monitoring.enabled is false', 
     tx.end()
   })
 })
+
+test('should create segment and events when ai_monitoring is disabled at instrumentation but enabled before the call', async (t) => {
+  // reuse the still-open mock server from `beforeEach`
+  const { address: host, port } = t.nr.server.address()
+
+  // tear down the enabled agent/modules set up in `beforeEach`
+  helper.unloadAgent(t.nr.agent)
+  removeModules(['@langchain/langgraph', '@langchain/core', '@langchain/openai'])
+
+  // set up the agent instance with ai_monitoring disabled
+  const agent = helper.instrumentMockedAgent({
+    ai_monitoring: {
+      enabled: false,
+      streaming: {
+        enabled: true
+      }
+    }
+  })
+  t.nr.agent = agent
+
+  const { createReactAgent } = require('@langchain/langgraph/prebuilt')
+  const { ChatOpenAI } = require('@langchain/openai')
+
+  const mockLLM = new ChatOpenAI({
+    modelName: 'gpt-4',
+    temperature: 0,
+    apiKey: 'fake-key',
+    maxRetries: 0,
+    configuration: {
+      baseURL: `http://${host}:${port}`
+    }
+  })
+
+  const langgraphAgent = createReactAgent({
+    llm: mockLLM,
+    tools: [],
+    name: 'LangGraphReactAgent'
+  })
+  t.nr.langgraphAgent = langgraphAgent
+
+  // enable ai_monitoring before making the call
+  agent.config.ai_monitoring.enabled = true
+
+  await helper.runInTransaction(agent, async (tx) => {
+    const result = await langgraphAgent.invoke(
+      { messages: [{ role: 'user', content: 'You are a scientist.' }] }
+    )
+    assert.ok(result?.messages?.[1]?.content)
+
+    // Should create LangGraph segment
+    const segments = tx.trace.getChildren(tx.trace.root.id)
+    const langgraphSegments = segments.filter((s) => s.name.includes('Llm/agent/LangGraph'))
+    assert.ok(langgraphSegments.length > 0, 'should create LangGraph segments')
+
+    // Should create LlmAgent events
+    const events = agent.customEventAggregator.events.toArray()
+    const agentEvents = events.filter((e) => e[0].type === 'LlmAgent')
+    assert.ok(agentEvents.length > 0, 'should create LlmAgent events when ai_monitoring is enabled before the call')
+
+    tx.end()
+  })
+})

--- a/test/versioned/langgraph/graph-stream.test.js
+++ b/test/versioned/langgraph/graph-stream.test.js
@@ -485,3 +485,67 @@ test('should not create events when ai_monitoring.streaming.enabled is false', a
     tx.end()
   })
 })
+
+test('should create segment and events when ai_monitoring is disabled at instrumentation but enabled before the call', async (t) => {
+  // reuse the still-open mock server from `beforeEach`
+  const { address: host, port } = t.nr.server.address()
+
+  // tear down the enabled agent/modules set up in `beforeEach`
+  helper.unloadAgent(t.nr.agent)
+  removeModules(['@langchain/langgraph', '@langchain/core', '@langchain/openai'])
+
+  // set up the agent instance with ai_monitoring disabled (keep streaming enabled)
+  const agent = helper.instrumentMockedAgent({
+    ai_monitoring: {
+      enabled: false,
+      streaming: {
+        enabled: true
+      }
+    }
+  })
+  t.nr.agent = agent
+
+  const { createReactAgent } = require('@langchain/langgraph/prebuilt')
+  const { ChatOpenAI } = require('@langchain/openai')
+
+  const mockLLM = new ChatOpenAI({
+    modelName: 'gpt-4',
+    temperature: 0,
+    apiKey: 'fake-key',
+    maxRetries: 0,
+    configuration: {
+      baseURL: `http://${host}:${port}`
+    }
+  })
+
+  const langgraphAgent = createReactAgent({
+    llm: mockLLM,
+    tools: [],
+    name: 'LangGraphReactAgent'
+  })
+  t.nr.langgraphAgent = langgraphAgent
+
+  // enable ai_monitoring before making the call
+  agent.config.ai_monitoring.enabled = true
+
+  await helper.runInTransaction(agent, async (tx) => {
+    const stream = await langgraphAgent.stream(
+      { messages: [{ role: 'user', content: 'You are a scientist.' }] }
+    )
+    for await (const chunk of stream) {
+      consumeChunk(chunk)
+    }
+
+    // Should create LangGraph segment
+    const segments = tx.trace.getChildren(tx.trace.root.id)
+    const langgraphSegments = segments.filter((s) => s.name.includes('Llm/agent/LangGraph'))
+    assert.ok(langgraphSegments.length > 0, 'should create LangGraph segments')
+
+    // Should create LlmAgent events
+    const events = agent.customEventAggregator.events.toArray()
+    const agentEvents = events.filter((e) => e[0].type === 'LlmAgent')
+    assert.ok(agentEvents.length > 0, 'should create LlmAgent events when ai_monitoring is enabled before the call')
+
+    tx.end()
+  })
+})

--- a/test/versioned/openai/chat-completions-res-api.test.js
+++ b/test/versioned/openai/chat-completions-res-api.test.js
@@ -566,4 +566,91 @@ test('responses.create', { skip: semver.lte(pkgVersion, '4.87.0') }, async (t) =
       end()
     })
   })
+
+  await t.test('should create segment and llm events when ai_monitoring is disabled at instrumentation but enabled before the call', (t, end) => {
+    const { host, port } = t.nr
+    // tear down the enabled agent/module set up in `beforeEach`
+    helper.unloadAgent(t.nr.agent)
+    removeModules('openai')
+
+    // set up the agent instance with ai_monitoring disabled
+    const agent = helper.instrumentMockedAgent({
+      ai_monitoring: {
+        enabled: false
+      },
+      streaming: {
+        enabled: true
+      }
+    })
+    t.nr.agent = agent
+    const OpenAI = require('openai')
+    const client = new OpenAI({
+      apiKey: 'fake-versioned-test-key',
+      baseURL: `http://${host}:${port}`
+    })
+    t.nr.client = client
+
+    // enable ai_monitoring before making the call
+    agent.config.ai_monitoring.enabled = true
+    helper.runInTransaction(agent, async (tx) => {
+      await client.responses.create({
+        input: [{ role: 'user', content: 'You are a mathematician.' }]
+      })
+
+      const events = agent.customEventAggregator.events.toArray()
+      assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+      assert.ok(findSegment(tx.trace, tx.trace.root, OPENAI.COMPLETION))
+
+      tx.end()
+      end()
+    })
+  })
+
+  await t.test('should create segment and llm events in stream when ai_monitoring is disabled at instrumentation but enabled before the call', (t, end) => {
+    const { host, port } = t.nr
+    // tear down the enabled agent/module set up in `beforeEach`
+    helper.unloadAgent(t.nr.agent)
+    removeModules('openai')
+
+    // set up the agent instance with ai_monitoring disabled
+    const agent = helper.instrumentMockedAgent({
+      ai_monitoring: {
+        enabled: false
+      },
+      streaming: {
+        enabled: true
+      }
+    })
+    t.nr.agent = agent
+    const OpenAI = require('openai')
+    const client = new OpenAI({
+      apiKey: 'fake-versioned-test-key',
+      baseURL: `http://${host}:${port}`
+    })
+    t.nr.client = client
+
+    // enable ai_monitoring before making the call
+    agent.config.ai_monitoring.enabled = true
+    helper.runInTransaction(agent, async (tx) => {
+      const content = 'Streamed response'
+      const stream = await client.responses.create({
+        stream: true,
+        input: content,
+        model: 'gpt-4'
+      })
+
+      let chunk = {}
+      for await (chunk of stream) {
+        continue
+      }
+      assert.ok(chunk.response?.output?.[0]?.content?.[0]?.text)
+
+      const events = agent.customEventAggregator.events.toArray()
+      assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+      assert.ok(findSegment(tx.trace, tx.trace.root, OPENAI.COMPLETION))
+
+      tx.end()
+      end()
+    })
+  })
 })

--- a/test/versioned/openai/chat-completions.test.js
+++ b/test/versioned/openai/chat-completions.test.js
@@ -523,6 +523,53 @@ test('chat.completions.create', async (t) => {
         end()
       })
     })
+
+    await t.test('should create segment and llm events in stream when ai_monitoring is disabled at instrumentation but enabled before the call', (t, end) => {
+      const { host, port } = t.nr
+      // tear down the enabled agent/module set up in `beforeEach`
+      helper.unloadAgent(t.nr.agent)
+      removeModules('openai')
+
+      // set up the agent instance with ai_monitoring disabled
+      const agent = helper.instrumentMockedAgent({
+        ai_monitoring: {
+          enabled: false,
+          streaming: {
+            enabled: true
+          }
+        }
+      })
+      t.nr.agent = agent
+      const OpenAI = require('openai')
+      const client = new OpenAI({
+        apiKey: 'fake-versioned-test-key',
+        baseURL: `http://${host}:${port}`
+      })
+      t.nr.client = client
+
+      // enable ai_monitoring before making the call
+      agent.config.ai_monitoring.enabled = true
+      helper.runInTransaction(agent, async (tx) => {
+        const content = 'Streamed response'
+        const stream = await client.chat.completions.create({
+          stream: true,
+          messages: [{ role: 'user', content }]
+        })
+
+        let res = ''
+        for await (const chunk of stream) {
+          res += chunk.choices[0]?.delta?.content
+        }
+        assert.ok(res)
+
+        const events = agent.customEventAggregator.events.toArray()
+        assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+        assert.ok(findSegment(tx.trace, tx.trace.root, OPENAI.COMPLETION))
+
+        tx.end()
+        end()
+      })
+    })
   } else {
     await t.test('should not instrument streams when openai < 4.12.2', (t, end) => {
       const { client, agent, host, port } = t.nr
@@ -578,6 +625,45 @@ test('chat.completions.create', async (t) => {
       assert.equal(events.length, 0, 'should not create llm events when ai_monitoring is disabled')
 
       assert.ok(!findSegment(tx.trace, tx.trace.root, OPENAI.COMPLETION))
+
+      tx.end()
+      end()
+    })
+  })
+
+  await t.test('should create segment and llm events when ai_monitoring is disabled at instrumentation but enabled before the call', (t, end) => {
+    const { host, port } = t.nr
+    // tear down the enabled agent/module set up in `beforeEach`
+    helper.unloadAgent(t.nr.agent)
+    removeModules('openai')
+
+    // set up the agent instance with ai_monitoring disabled
+    const agent = helper.instrumentMockedAgent({
+      ai_monitoring: {
+        enabled: false,
+        streaming: {
+          enabled: true
+        }
+      }
+    })
+    t.nr.agent = agent
+    const OpenAI = require('openai')
+    const client = new OpenAI({
+      apiKey: 'fake-versioned-test-key',
+      baseURL: `http://${host}:${port}`
+    })
+    t.nr.client = client
+
+    // enable ai_monitoring before making the call
+    agent.config.ai_monitoring.enabled = true
+    helper.runInTransaction(agent, async (tx) => {
+      await client.chat.completions.create({
+        messages: [{ role: 'user', content: 'You are a mathematician.' }]
+      })
+
+      const events = agent.customEventAggregator.events.toArray()
+      assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+      assert.ok(findSegment(tx.trace, tx.trace.root, OPENAI.COMPLETION))
 
       tx.end()
       end()

--- a/test/versioned/openai/embeddings.test.js
+++ b/test/versioned/openai/embeddings.test.js
@@ -206,3 +206,45 @@ test('should not create segment or llm events when ai_monitoring.enabled is fals
     end()
   })
 })
+
+test('should create segment and llm events when ai_monitoring is disabled at instrumentation but enabled before the call', (t, end) => {
+  const { host, port } = t.nr
+  // tear down the enabled agent/module set up in `beforeEach`
+  helper.unloadAgent(t.nr.agent)
+  removeModules('openai')
+
+  // set up the agent instance with ai_monitoring disabled
+  const agent = helper.instrumentMockedAgent({
+    ai_monitoring: {
+      enabled: false
+    },
+    streaming: {
+      enabled: true
+    }
+  })
+  t.nr.agent = agent
+  const OpenAI = require('openai')
+  const client = new OpenAI({
+    apiKey: 'fake-versioned-test-key',
+    baseURL: `http://${host}:${port}`
+  })
+  t.nr.client = client
+
+  // enable ai_monitoring before making the call
+  agent.config.ai_monitoring.enabled = true
+  helper.runInTransaction(agent, async (tx) => {
+    await client.embeddings.create({
+      input: 'This is an embedding test.',
+      model: 'text-embedding-ada-002'
+    })
+
+    const events = agent.customEventAggregator.events.toArray()
+    assert.ok(events.length > 0, 'should create llm events when ai_monitoring is enabled before the call')
+    const [embedding] = events
+    assert.equal(embedding[0].type, 'LlmEmbedding')
+    assert.ok(findSegment(tx.trace, tx.trace.root, OPENAI.EMBEDDING))
+
+    tx.end()
+    end()
+  })
+})


### PR DESCRIPTION
## Description

This PR adds support for ai_monitoring configuration via SSC.  The one caveat worth noting is that `ai_monitoring.enabled` takes precedence over `collect_ai` if the value of `ai_monitoring.enabled` is dff than the compiled config.  Per spec:

> The [connect response](https://source.datanerd.us/agents/agent-specs/blob/main/Connect-LEGACY.md#connect-reply-fields) will include a flag collect_ai that returns a boolean value indicating whether AIM was disabled. This value mirrors what the agent has set locally. Additional ai_monitoring.enabled, ai_monitoring.streaming.enabled, and ai_monitoring.record_content.enabled settings are included in the connect response as well. If ai_monitoring.enabled is present in the connect response, this value MUST take precedence to override the ai_monitoring.enabled value and fallback on using the value from collect_ai. For example, if collect_ai is False, and ai_monitoring.enabled locally is True, the agent would ultimately disable AI Monitoring. If both collect_ai is False and ai_monitoring.enabled is True in the connect response, ai_monitoring.enabled would ultimately enable AI Monitoring. If HSM is enabled, the appropriate AI monitoing settings SHOULD be set appropriately in the connect response. As a safeguard however, agents SHOULD also enforce HSM mode on AI settings they recieve from the connect response.

To support this I had to re-tool all the ai monitoring subscribers to all register regardless of if `ai_monitoring.enabled` was true at startup.  I added tests to verify this works and I also split out that check into `this.aiEnabled` and included in the `this.streamingEnabled` check.

**Note**: I verified all scenarios of toggle ai_monitoring config on/off in UI. 


## Related Issues
Closes #4077 