### PR TITLE
test: Applied sampling to `pg-native` tests to reduce the matrix under test

### DIFF
--- a/test/versioned/pg/package.json
+++ b/test/versioned/pg/package.json
@@ -21,8 +21,14 @@
         "node": ">=22 <24"
       },
       "dependencies": {
-        "pg": ">=8.2.0",
-        "pg-native": ">=3.0.0 <3.4.0 || >=3.4.5"
+        "pg": {
+          "versions": ">=8.2.0",
+          "samples": 1 
+        },
+        "pg-native": {
+          "versions": ">=3.0.0 <3.4.0 || >=3.4.5",
+          "samples": 2 
+        }
       },
       "files": [
         "force-native.test.js",
@@ -34,8 +40,14 @@
         "node": ">=24"
       },
       "dependencies": {
-        "pg": ">=8.16.0",
-        "pg-native": ">=3.5.0"
+        "pg": {
+          "versions": ">=8.16.0",
+          "samples": 1
+        },
+        "pg-native": {
+          "versions": ">=3.5.0",
+          "samples": 2
+        }
       },
       "files": [
         "force-native.test.js",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We have been working on speeding up versioned tests. We are now sharding the suites. The last run shows the following:

```
┌──────────┬──────────────────────┐
│ Duration │         Job          │
├──────────┼──────────────────────┤
│ 21m 34s  │ versioned (22.x, 9)  │
├──────────┼──────────────────────┤
│ 8m 16s   │ versioned (24.x, 9)  │
├──────────┼──────────────────────┤
│ 8m 01s   │ versioned (26.x, 9)  │
├──────────┼──────────────────────┤
│ 7m 35s   │ versioned (22.x, 1)  │
├──────────┼──────────────────────┤
│ 7m 30s   │ versioned (22.x, 7)  │
├──────────┼──────────────────────┤
│ 6m 35s   │ versioned (24.x, 7)  │
├──────────┼──────────────────────┤
│ 6m 35s   │ versioned (24.x, 1)  │
├──────────┼──────────────────────┤
│ 6m 10s   │ versioned (26.x, 7)  │
├──────────┼──────────────────────┤
│ 6m 10s   │ versioned (26.x, 1)  │
├──────────┼──────────────────────┤
│ 5m 03s   │ versioned (22.x, 4)  │
├──────────┼──────────────────────┤
│ 4m 58s   │ versioned (22.x, 6)  │
├──────────┼──────────────────────┤
│ 4m 50s   │ versioned (22.x, 5)  │
├──────────┼──────────────────────┤
│ 4m 47s   │ versioned (24.x, 4)  │
├──────────┼──────────────────────┤
│ 4m 43s   │ versioned (22.x, 8)  │
├──────────┼──────────────────────┤
│ 4m 36s   │ versioned (24.x, 5)  │
├──────────┼──────────────────────┤
│ 4m 31s   │ versioned (24.x, 8)  │
├──────────┼──────────────────────┤
│ 4m 30s   │ versioned (26.x, 4)  │
├──────────┼──────────────────────┤
│ 4m 28s   │ versioned (24.x, 6)  │
├──────────┼──────────────────────┤
│ 4m 01s   │ versioned (26.x, 6)  │
├──────────┼──────────────────────┤
│ 3m 57s   │ versioned (26.x, 8)  │
├──────────┼──────────────────────┤
│ 3m 47s   │ versioned (26.x, 5)  │
├──────────┼──────────────────────┤
│ 3m 35s   │ versioned (22.x, 0)  │
├──────────┼──────────────────────┤
│ 3m 23s   │ integration (22.x)   │
├──────────┼──────────────────────┤
│ 3m 19s   │ versioned (24.x, 0)  │
├──────────┼──────────────────────┤
│ 3m 18s   │ versioned (22.x, 2)  │
├──────────┼──────────────────────┤
│ 3m 05s   │ versioned (26.x, 0)  │
├──────────┼──────────────────────┤
│ 3m 04s   │ versioned (24.x, 2)  │
├──────────┼──────────────────────┤
│ 3m 00s   │ versioned (26.x, 2)  │
├──────────┼──────────────────────┤
│ 2m 56s   │ versioned (22.x, 3)  │
├──────────┼──────────────────────┤
│ 2m 50s   │ versioned (24.x, 10) │
├──────────┼──────────────────────┤
│ 2m 43s   │ versioned (24.x, 3)  │
├──────────┼──────────────────────┤
│ 2m 43s   │ versioned (26.x, 10) │
├──────────┼──────────────────────┤
│ 2m 28s   │ versioned (22.x, 10) │
├──────────┼──────────────────────┤
│ 2m 25s   │ versioned (26.x, 3)  │
├──────────┼──────────────────────┤
│ 2m 24s   │ unit (26.x)          │
├──────────┼──────────────────────┤
│ 2m 17s   │ unit (24.x)          │
├──────────┼──────────────────────┤
│ 1m 56s   │ integration (24.x)   │
├──────────┼──────────────────────┤
│ 1m 54s   │ integration (26.x)   │
├──────────┼──────────────────────┤
│ 1m 46s   │ unit (22.x)          │
├──────────┼──────────────────────┤
│ 1m 32s   │ versioned (22.x, 11) │
├──────────┼──────────────────────┤
│ 1m 27s   │ lint (lts/*)         │
├──────────┼──────────────────────┤
│ 1m 00s   │ versioned (24.x, 11) │
├──────────┼──────────────────────┤
│ 0m 51s   │ versioned (26.x, 11) │
├──────────┼──────────────────────┤
│ 0m 43s   │ ci (lts/*)           │
├──────────┼──────────────────────┤
│ 0m 27s   │ codecov (22.x)       │
├──────────┼──────────────────────┤
│ 0m 25s   │ codecov (26.x)       │
├──────────┼──────────────────────┤
│ 0m 16s   │ codecov (24.x)       │
├──────────┼──────────────────────┤
│ 0m 11s   │ should_run           │
├──────────┼──────────────────────┤
│ 0m 05s   │ versioned-setup      │
├──────────┼──────────────────────┤
│ 0m 03s   │ all-clear            │
└──────────┴──────────────────────┘
```

The clear long tail is node 22 and suite 9 which includes pg, amongst others. Running that suite locally on node 22 it takes 19 minutes. After this change it takes 1-2 mins. Without sampling `pg` we were essentially running against 90 diff combinations of pg and pg-native.  Since most of the instrumentation is in pg, the idea is we pin `pg` and just run 2 samples of `pg-native` to verify the native instrumentation works
