### PR TITLE
feat: Added `otlp_resource_attributes` to all outgoing opentelemetry metrics calls

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -141,6 +141,10 @@ function Config(config) {
 
   this.browser_monitoring.loader = 'rum'
   this.browser_monitoring.loader_version = ''
+  // default to empty object, this will get populated
+  // from `onConnect` if hybrid agent is enabled
+  // along with hybrid agent's metrics feature
+  this.otlp_resource_attributes = {}
 
   // Settings to play nice with DLPs (see NODE-1044).
   this.simple_compression = false // Disables subcomponent compression
@@ -619,6 +623,10 @@ Config.prototype._fromServer = function _fromServer(params, key) {
         'profiling.enabled',
         'enabled'
       )
+      break
+
+    case 'otlp_resource_attributes':
+      this.otlp_resource_attributes = params.otlp_resource_attributes ?? {}
       break
 
     // These settings are not allowed from the server.

--- a/lib/otel/metrics/index.js
+++ b/lib/otel/metrics/index.js
@@ -115,8 +115,7 @@ class SetupMetrics extends SetupSignal {
           { agent, logger }
         )
 
-        const resourceAttrs = config.otlp_resource_attributes
-        const resource = resourceFromAttributes(resourceAttrs)
+        const resource = resourceFromAttributes({ 'entity.guid': config.entity_guid, ...config.otlp_resource_attributes })
         // Assigning the resource after having received the `entity.guid` from
         // the server is a key detail of this implementation. Unfortunately,
         // we don't have real public access to the object that retains the

--- a/lib/otel/metrics/index.js
+++ b/lib/otel/metrics/index.js
@@ -115,7 +115,8 @@ class SetupMetrics extends SetupSignal {
           { agent, logger }
         )
 
-        const resource = resourceFromAttributes({ 'entity.guid': config.entity_guid })
+        const resourceAttrs = config.otlp_resource_attributes
+        const resource = resourceFromAttributes(resourceAttrs)
         // Assigning the resource after having received the `entity.guid` from
         // the server is a key detail of this implementation. Unfortunately,
         // we don't have real public access to the object that retains the

--- a/test/integration/otel/metrics-proxy.test.js
+++ b/test/integration/otel/metrics-proxy.test.js
@@ -38,8 +38,14 @@ async function buildServers(secure = false) {
   agentConfig.proxy = proxyServer.proxyUrl
 
   const agent = helper.instrumentMockedAgent(agentConfig)
-  agent.config.entity_guid = 'guid-123456'
-  agent.config.license_key = 'license-123456'
+  const guid = 'guid-123456'
+  const licenseKey = 'license-123456'
+  agent.config.entity_guid = guid
+  agent.config.license_key = licenseKey
+  agent.config.otlp_resource_attributes = {
+    'entity.guid': guid,
+    licenseKey
+  }
   const dataTracker = {}
   const {
     server: otelServer,

--- a/test/integration/otel/metrics-proxy.test.js
+++ b/test/integration/otel/metrics-proxy.test.js
@@ -43,7 +43,6 @@ async function buildServers(secure = false) {
   agent.config.entity_guid = guid
   agent.config.license_key = licenseKey
   agent.config.otlp_resource_attributes = {
-    'entity.guid': guid,
     licenseKey
   }
   const dataTracker = {}
@@ -70,7 +69,7 @@ test.afterEach(() => {
 })
 
 test('sends metrics through HTTP proxy', { timeout: 5_000 }, async (t) => {
-  t.plan(24)
+  t.plan(26)
 
   const { agent, dataTracker, otelServer, proxyServer } = await buildServers()
   t.after(async () => {
@@ -121,6 +120,8 @@ test('sends metrics through HTTP proxy', { timeout: 5_000 }, async (t) => {
   let resource = payload.resourceMetrics[0].resource
   t.assert.equal(resource.attributes[0].key, 'entity.guid')
   t.assert.deepEqual(resource.attributes[0].value, { stringValue: 'guid-123456' })
+  t.assert.equal(resource.attributes[1].key, 'licenseKey')
+  t.assert.deepEqual(resource.attributes[1].value, { stringValue: 'license-123456' })
 
   const found = payload.resourceMetrics[0].scopeMetrics[0].metrics
   t.assert.equal(Array.isArray(found), true)

--- a/test/integration/otel/metrics.test.js
+++ b/test/integration/otel/metrics.test.js
@@ -23,8 +23,14 @@ test.beforeEach(async (ctx) => {
       }
     }
   })
-  ctx.nr.agent.config.entity_guid = 'guid-123456'
-  ctx.nr.agent.config.license_key = 'license-123456'
+  const guid = 'guid-123456'
+  const licenseKey = 'license-123456'
+  ctx.nr.agent.config.entity_guid = guid
+  ctx.nr.agent.config.license_key = licenseKey
+  ctx.nr.agent.config.otlp_resource_attributes = {
+    'entity.guid': guid,
+    licenseKey
+  }
 
   ctx.nr.data = {}
   const otelServer = await createOtelMetricsServer(ctx.nr.data)

--- a/test/integration/otel/metrics.test.js
+++ b/test/integration/otel/metrics.test.js
@@ -28,7 +28,6 @@ test.beforeEach(async (ctx) => {
   ctx.nr.agent.config.entity_guid = guid
   ctx.nr.agent.config.license_key = licenseKey
   ctx.nr.agent.config.otlp_resource_attributes = {
-    'entity.guid': guid,
     licenseKey
   }
 
@@ -76,6 +75,8 @@ test('sends metrics', { timeout: 5_000 }, async (t) => {
   let resource = payload.resourceMetrics[0].resource
   assert.equal(resource.attributes[0].key, 'entity.guid')
   assert.deepEqual(resource.attributes[0].value, { stringValue: 'guid-123456' })
+  assert.equal(resource.attributes[1].key, 'licenseKey')
+  assert.deepEqual(resource.attributes[1].value, { stringValue: 'license-123456' })
 
   const found = payload.resourceMetrics[0].scopeMetrics[0].metrics
   assert.equal(Array.isArray(found), true)

--- a/test/unit/config/config-server-side.test.js
+++ b/test/unit/config/config-server-side.test.js
@@ -785,4 +785,40 @@ describe('when receiving server-side configuration', () => {
       t.assert.equal(config.profiling.enabled, true)
     })
   })
+
+  describe('Hybrid Agent OTLP Resource Attributes', () => {
+    test('should assign `otlp_resource_attributes` from server side config', (t) => {
+      const { config } = t.nr
+      const payload = {
+        licenseKey: 'fake-key',
+        'tags.account': 'Test Account',
+        instanceName: 'host nodejs:test-app',
+        'tags.accountId': '1',
+        appName: 'test-app',
+        host: 'host',
+        'entity.guid': 'guid',
+        'host.displayName': 'host',
+        'agent.version': '1.1.1',
+        realAgentId: '11111111',
+        'tags.trustedAccountId': '1'
+      }
+      config.otlp_resource_attributes = {}
+      config.onConnect({ otlp_resource_attributes: payload })
+      assert.deepEqual(config.otlp_resource_attributes, payload)
+    })
+
+    test('should set to empty object if `otlp_resource_attributes` is null', (t) => {
+      const { config } = t.nr
+      config.otlp_resource_attributes = {}
+      config.onConnect({ otlp_resource_attributes: null })
+      assert.deepEqual(config.otlp_resource_attributes, {})
+    })
+
+    test('should set to empty object if `otlp_resource_attributes` is undefined', (t) => {
+      const { config } = t.nr
+      config.otlp_resource_attributes = {}
+      config.onConnect({ otlp_resource_attributes: undefined })
+      assert.deepEqual(config.otlp_resource_attributes, {})
+    })
+  })
 })

--- a/test/unit/config/config.test.js
+++ b/test/unit/config/config.test.js
@@ -32,11 +32,11 @@ test('when loading invalid configuration file', async (t) => {
   })
 
   await t.test('should continue agent startup with config.newrelic_home property removed', () => {
-    const Cornfig = require('../../../lib/config')
+    const LocalConfig = require('../../../lib/config')
     let configuration
 
     assert.doesNotThrow(function envTest() {
-      configuration = Cornfig.initialize()
+      configuration = LocalConfig.initialize()
     })
 
     assert.ok(!configuration.newrelic_home)
@@ -619,4 +619,9 @@ test('redacted_license_key', async (t) => {
     const config = new Config({ license_key: '' })
     assert.equal(config.redacted_license_key, '', 'should return empty string for empty license')
   })
+})
+
+test('otlp_resource_attributes', () => {
+  const config = Config.initialize()
+  assert.deepEqual(config.otlp_resource_attributes, {})
 })

--- a/test/unit/lib/otel/metrics/index.test.js
+++ b/test/unit/lib/otel/metrics/index.test.js
@@ -12,12 +12,21 @@ const SetupMetrics = require('#agentlib/otel/metrics/index.js')
 
 test.beforeEach((ctx) => {
   ctx.nr = {}
+  const guid = 'guid-123456'
+  const licenseKey = 'license-123456'
 
   const agent = {
     get [Symbol.toStringTag]() { return 'Agent' },
     config: {
-      entity_guid: 'guid-123456',
-      license_key: 'license-123456',
+      otlp_resource_attributes: {
+        'entity.guid': guid,
+        licenseKey,
+        appName: 'test-app',
+        'tags.accountId': '1',
+        'tags.account': 'Test Account'
+      },
+      entity_guid: guid,
+      license_key: licenseKey,
       host: 'example.com',
       port: 443,
       opentelemetry: {
@@ -64,7 +73,13 @@ test('configures global provider after agent start', async (t) => {
 
   await once(agent, 'otelMetricsBootstrapped')
   const provider = require('@opentelemetry/api').metrics.getMeterProvider()
-  t.assert.deepEqual(provider._sharedState.resource.attributes, { 'entity.guid': 'guid-123456' })
+  t.assert.deepEqual(provider._sharedState.resource.attributes, {
+    'entity.guid': 'guid-123456',
+    'tags.accountId': '1',
+    'tags.account': 'Test Account',
+    appName: 'test-app',
+    licenseKey: 'license-123456'
+  })
 })
 
 test('logs warning and uses defaults when export_interval <= export_timeout', async (t) => {

--- a/test/unit/lib/otel/metrics/index.test.js
+++ b/test/unit/lib/otel/metrics/index.test.js
@@ -19,7 +19,6 @@ test.beforeEach((ctx) => {
     get [Symbol.toStringTag]() { return 'Agent' },
     config: {
       otlp_resource_attributes: {
-        'entity.guid': guid,
         licenseKey,
         appName: 'test-app',
         'tags.accountId': '1',


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This PR adds logic to assign `config.otlp_resource_attributes` from connect response. All the attributes in this object should be posted to otel metrics calls.  

**Note**: `entity.guid` comes in from `otlp_resource_attributes` so we do not have to merge that with the incoming `otlp_resource_attributes`.

## How to Test

```sh
npm run unit
```

## Related Issues
Closes #4103
