### PR TITLE
chore: Changed smoke-test schedule with our bot user

### DIFF
--- a/.github/workflows/smoke-test-workflow.yml
+++ b/.github/workflows/smoke-test-workflow.yml
@@ -13,7 +13,7 @@ on:
     # Run once a day at 9AM PDT (16 UTC) on week days (1-5).
     # Last commit on default branch.
     # https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule
-    - cron:  '0 16 * * 1-5'
+    - cron:  '0 15 * * 1-5'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/smoke-test-workflow.yml
+++ b/.github/workflows/smoke-test-workflow.yml
@@ -10,7 +10,7 @@ on:
   # Run on pushes to any branch. Not triggered for forked repo PRs.
   push:
   schedule:
-    # Run once a day at 9AM PDT (16 UTC) on week days (1-5).
+    # Run once a day at 8AM PDT (15 UTC) on week days (1-5).
     # Last commit on default branch.
     # https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule
     - cron:  '0 15 * * 1-5'


### PR DESCRIPTION
The current cron for smoke test is tied to @michaelgoin and we want it to be invoked on behalf of our bot user