### PR TITLE
ci: Revert CI schedules to previous schedules

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -7,8 +7,8 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    # Runs on Mondays at 7 AM PST (14 UTC)
-    - cron: '0 14 * * 1'
+    # Runs on Mondays at 8 AM PST (15 UTC)
+    - cron: '0 15 * * 1'
 
 jobs:
   checking-pending-prs:

--- a/.github/workflows/smoke-test-workflow.yml
+++ b/.github/workflows/smoke-test-workflow.yml
@@ -10,10 +10,10 @@ on:
   # Run on pushes to any branch. Not triggered for forked repo PRs.
   push:
   schedule:
-    # Run once a day at 8AM PDT (15 UTC) on week days (1-5).
+    # Run once a day at 9AM PDT (16 UTC) on mon-fri 
     # Last commit on default branch.
     # https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule
-    - cron:  '0 15 * * 1-5'
+    - cron:  '0 16 * * 1-5'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/versioned-security-agent.yml
+++ b/.github/workflows/versioned-security-agent.yml
@@ -23,7 +23,8 @@ on:
         description: Version of security agent to test
         required: false
   schedule:
-    - cron:  '0 8 * * 1-5'
+    # Run once a day at 2AM PDT (9 UTC) on mon-fri 
+    - cron:  '0 9 * * 1-5'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
My attempt at changing schedules with bot user to attribute all cron workflows to bot didn't work because I merged the PRs via UI. I'm opening this PR but the bot user will merge via CLI, or UI but logged in as bot