### PR TITLE
chore: Attached serverless mode config to agent instance

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -186,7 +186,13 @@ function Agent(config) {
   this.environment = require('./environment')
   this.version = config.version
 
-  if (config.serverless_mode.enabled) {
+  Object.defineProperty(this, 'serverlessMode', {
+    get () {
+      return this.config.serverless_mode.enabled === true
+    }
+  })
+
+  if (this.serverlessMode === true) {
     this.collector = new ServerlessCollector(this)
   } else {
     this.collector = new CollectorAPI(this)
@@ -280,7 +286,7 @@ function Agent(config) {
     {
       periodMs: DEFAULT_HARVEST_INTERVAL_MS,
       config,
-      isAsync: !config.serverless_mode.enabled,
+      isAsync: this.serverlessMode === false,
       method: 'transaction_sample_data',
       enabled: (config) => config.transaction_tracer.enabled && config.collect_traces
     },
@@ -295,7 +301,7 @@ function Agent(config) {
       config,
       periodMs: DEFAULT_HARVEST_INTERVAL_MS,
       method: 'sql_trace_data',
-      isAsync: !config.serverless_mode.enabled,
+      isAsync: this.serverlessMode === false,
       enabled: (config) => config.slow_sql.enabled
     },
     this.collector,
@@ -309,8 +315,8 @@ function Agent(config) {
       duration: config.profiling.duration,
       periodMs: DEFAULT_HARVEST_INTERVAL_MS,
       method: 'pprof_data',
-      isAsync: !config.serverless_mode.enabled,
-      enabled: (config) => config.profiling.enabled && config.serverless_mode.enabled === false
+      isAsync: this.serverlessMode === false,
+      enabled: (config) => config.profiling.enabled && this.serverlessMode === false
     },
     this
   )

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -302,6 +302,7 @@ function Agent(config) {
       periodMs: DEFAULT_HARVEST_INTERVAL_MS,
       method: 'sql_trace_data',
       isAsync: this.serverlessMode === false,
+      serverlessMode: this.serverlessMode,
       enabled: (config) => config.slow_sql.enabled
     },
     this.collector,

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -382,7 +382,7 @@ Agent.prototype.start = function start(callback) {
 
   systemMetricsSampler.start(agent)
 
-  if (this.config.serverless_mode.enabled) {
+  if (this.serverlessMode === true) {
     return this._serverlessModeStart(callback)
   }
 

--- a/lib/db/query-trace-aggregator.js
+++ b/lib/db/query-trace-aggregator.js
@@ -5,13 +5,13 @@
 
 'use strict'
 
-const logger = require('../logger').child({ component: 'query_tracer' })
+const defaultLogger = require('../logger').child({ component: 'query_tracer' })
 const Aggregator = require('../aggregators/base-aggregator')
 const SlowQuery = require('./slow-query')
 const QuerySample = require('./query-sample')
 
 class QueryTraceAggregator extends Aggregator {
-  constructor(opts, collector, harvester) {
+  constructor(opts, collector, harvester, { logger = defaultLogger } = {}) {
     opts = opts || {}
     opts.method = opts.method || 'sql_trace_data'
     if (!opts.config) {
@@ -22,7 +22,10 @@ class QueryTraceAggregator extends Aggregator {
     const config = opts.config
     this.samples = new Map()
 
+    this.serverlessMode = opts.serverlessMode
     this.config = config
+
+    this.logger = logger
   }
 
   removeShortest() {
@@ -58,16 +61,16 @@ class QueryTraceAggregator extends Aggregator {
     switch (ttConfig.record_sql) {
       case 'raw':
         slowQuery = new SlowQuery({ segment, transaction, type, query, trace })
-        logger.trace('recording raw sql')
+        this.logger.trace('recording raw sql')
         segment.addAttribute('sql', slowQuery.query, true)
         break
       case 'obfuscated':
         slowQuery = new SlowQuery({ transaction, segment, type, query, trace })
-        logger.trace('recording obfuscated sql')
+        this.logger.trace('recording obfuscated sql')
         segment.addAttribute('sql_obfuscated', slowQuery.obfuscated, true)
         break
       default:
-        logger.trace(
+        this.logger.trace(
           'not recording sql statement, transaction_tracer.record_sql was set to %s',
           ttConfig.record_sql
         )
@@ -95,7 +98,8 @@ class QueryTraceAggregator extends Aggregator {
 
     // Do not remove the shortest sample when in serverless mode, since
     // sampling is disabled.
-    if (this.config.serverless_mode.enabled) {
+    if (this.serverlessMode === true) {
+      this.logger.trace('Keeping shortest sample due to serverless mode being on.')
       return
     }
 
@@ -106,7 +110,7 @@ class QueryTraceAggregator extends Aggregator {
 
   _toPayload(cb) {
     if (this.samples.size === 0) {
-      logger.debug('No query traces to send.')
+      this.logger.debug('No query traces to send.')
       return cb(null, null)
     }
 
@@ -120,7 +124,7 @@ class QueryTraceAggregator extends Aggregator {
       return [this.runId, this.prepareJSONSync()]
     }
 
-    logger.debug('No query traces to send.')
+    this.logger.debug('No query traces to send.')
   }
 
   _getMergeData() {

--- a/lib/instrumentation/core/globals.js
+++ b/lib/instrumentation/core/globals.js
@@ -22,7 +22,7 @@ function initialize(agent, nodule, name, shim) {
       // domain.
       // In serverless mode this will be handled by its own _fatalException wrapper
       if (
-        !shim.agent.config.serverless_mode.enabled &&
+        shim.agent.serverlessMode === false &&
         !process.domain &&
         !exceptionCallbackRegistered
       ) {

--- a/lib/samplers/index.js
+++ b/lib/samplers/index.js
@@ -242,7 +242,7 @@ class Samplers {
     const config = agent.config
     this.adaptiveSampler = new AdaptiveSampler({
       agent,
-      serverless: config.serverless_mode.enabled,
+      serverless: agent.serverlessMode,
       period: config.sampling_target_period_in_seconds * 1000,
       target: config.sampling_target
     })
@@ -294,7 +294,7 @@ class Samplers {
     if (samplerDefinition?.adaptive?.sampling_target) {
       return new AdaptiveSampler({
         agent,
-        serverless: config.serverless_mode.enabled,
+        serverless: agent.serverlessMode,
         period: config.sampling_target_period_in_seconds * 1000,
         target: samplerDefinition.adaptive.sampling_target
       })

--- a/test/unit/agent/agent.test.js
+++ b/test/unit/agent/agent.test.js
@@ -177,6 +177,12 @@ test('when loaded with defaults', async (t) => {
     const { agent } = t.nr
     assert.throws(() => agent.setState('bogus'), /Invalid state bogus/)
   })
+
+  await t.test('defines serverlessMode getter', (t) => {
+    const { agent } = t.nr
+    assert.equal(typeof agent.serverlessMode, 'boolean')
+    assert.equal(agent.serverlessMode, false)
+  })
 })
 
 test('should load naming rules when configured', () => {

--- a/test/unit/db/query-trace-aggregator.test.js
+++ b/test/unit/db/query-trace-aggregator.test.js
@@ -1038,6 +1038,37 @@ test('Query Trace Aggregator', async (t) => {
       assert.ok(queries.samples.has('droptableusers'))
       end()
     })
+
+    await t.test('should not limit to max_samples when in serverless mode', (t, end) => {
+      const opts = {
+        config: new Config({
+          slow_sql: { enabled: true, max_samples: 2 },
+          transaction_tracer: { record_sql: 'obfuscated', explain_threshold: 500 }
+        }),
+        method: 'sql_trace_data',
+        serverlessMode: true
+      }
+      const harvester = { add: sinon.stub() }
+      const logger = { trace: sinon.stub() }
+      const queries = new QueryTraceAggregator(opts, {}, harvester, { logger })
+      const removeShortest = sinon.spy(queries, 'removeShortest')
+
+      addQuery(queries, 600, null)
+      addQuery(queries, 550, null, 'create table users')
+      addQuery(queries, 650, null, 'drop table users')
+
+      assert.ok('size' in queries.samples)
+      assert.equal(queries.samples.size, 3)
+      assert.ok(queries.samples.has('select*fromfoowherea=?'))
+      assert.ok(queries.samples.has('createtableusers'))
+      assert.ok(queries.samples.has('droptableusers'))
+      assert.ok(
+        logger.trace.calledWith('Keeping shortest sample due to serverless mode being on.'),
+        'should log that the shortest sample is kept'
+      )
+      assert.equal(removeShortest.callCount, 0, 'should not invoke removeShortest')
+      end()
+    })
   })
 
   await t.test('merging query tracers', async (t) => {


### PR DESCRIPTION
While conducting research for #4126 I determined that we are referencing `config.serverless_mode.enabled` in all of the places that we need to branch on that setting. I think it makes sense for the agent instance to indicate if it is operating in serverless mode or not. So this PR updates the agent to expose the information directly, and then updates all of the usage locations to reference the agent instead of the parsed config.