### PR TITLE
chore: Remove dead `otlp_endpoint` config option

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -50,13 +50,6 @@ defaultConfig.definition = () => {
      */
     host: '',
     /**
-     * Endpoint to send OpenTelemetry spans to.
-     *
-     * This should be automatically deduced from your region and other
-     * settings, but if desired, you can override it.
-     */
-    otlp_endpoint: '',
-    /**
      * The port on which the collector proxy will be listening.
      *
      * You shouldn't need to change this.

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1469,13 +1469,6 @@ Config.prototype._canonicalize = function _canonicalize() {
       this.host = 'collector.newrelic.com'
     }
   }
-  if (this.otlp_endpoint === '') {
-    if (region) {
-      this.otlp_endpoint = `otlp.${region}.nr-data.net`
-    } else {
-      this.otlp_endpoint = 'otlp.nr-data.net'
-    }
-  }
 
   if (this.license_key) {
     this.license_key = this.license_key.trim()

--- a/test/unit/config/config-env.test.js
+++ b/test/unit/config/config-env.test.js
@@ -113,35 +113,6 @@ test('when overriding configuration values via environment variables', async (t)
     })
   })
 
-  await t.test('should default OTel host if nothing to parse in the license key', (t, end) => {
-    idempotentEnv({ NEW_RELIC_LICENSE_KEY: 'hambulance' }, (tc) => {
-      assert.ok(tc.otlp_endpoint)
-      assert.equal(tc.otlp_endpoint, 'otlp.nr-data.net')
-      end()
-    })
-  })
-
-  await t.test('should parse the region off the license key for OTel', (t, end) => {
-    idempotentEnv({ NEW_RELIC_LICENSE_KEY: 'eu01xxhambulance' }, (tc) => {
-      assert.ok(tc.otlp_endpoint)
-      assert.equal(tc.otlp_endpoint, 'otlp.eu01.nr-data.net')
-      end()
-    })
-  })
-
-  await t.test(
-    'should take an explicit OTel endpoint over the license key parsed host',
-    (t, end) => {
-      idempotentEnv({ NEW_RELIC_LICENSE_KEY: 'eu01xxhambulance' }, function () {
-        idempotentEnv({ NEW_RELIC_OTLP_ENDPOINT: 'localhost' }, (tc) => {
-          assert.ok(tc.otlp_endpoint)
-          assert.equal(tc.otlp_endpoint, 'localhost')
-          end()
-        })
-      })
-    }
-  )
-
   await t.test('should pick up on feature flags set via environment variables', (t, end) => {
     const ffNamePrefix = 'NEW_RELIC_FEATURE_FLAG_'
     const awaitFeatureFlag = ffNamePrefix + 'AWAIT_SUPPORT'


### PR DESCRIPTION
Closes #4141