### PR TITLE
chore: Add `collect_cpu_time` feature flag

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1284,7 +1284,7 @@ defaultConfig.definition = () => {
           formatter: boolean,
           default: false
         },
-      }
+      },
     },
 
     /**

--- a/lib/feature_flags.js
+++ b/lib/feature_flags.js
@@ -13,7 +13,10 @@ exports.prerelease = {
   reverse_naming_rules: false,
   unresolved_promise_cleanup: true,
   kafkajs_instrumentation: false,
-  undici_error_tracking: true
+  undici_error_tracking: true,
+  // When enabled, the CPU profiler additionally records measured on-CPU (`cpu`)
+  // time per sample alongside wall time. cpu <= wall by definition.
+  collect_cpu_time: false
 }
 
 // flags that are no longer used for released features

--- a/test/unit/feature_flag.test.js
+++ b/test/unit/feature_flag.test.js
@@ -42,7 +42,8 @@ const used = [
   'aws_bedrock_instrumentation',
   'langchain_instrumentation',
   'kafkajs_instrumentation',
-  'undici_error_tracking'
+  'undici_error_tracking',
+  'collect_cpu_time'
 ]
 
 test.beforeEach((ctx) => {


### PR DESCRIPTION
## Description

This PR adds the `collect_cpu_time` feature flag. The intent of this feature flag is to configure the `collectCpuTime` property in pprof in our `CpuProfiler`. We do not know if including `cpu` in the `sample_type` object will have backend complications, so we will default it to `false`.

## How to Test

```
node --test test/unit/feature_flag.test.js
```

## Related Issues

Closes #4144 