### PR TITLE
feat: Add internal OTEL API to agent

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -349,6 +349,16 @@ Object.defineProperty(Agent.prototype, Symbol.toStringTag, {
   value: 'Agent'
 })
 
+const kOtel = Symbol('otel.api')
+Object.defineProperty(Agent.prototype, 'otel', {
+  get() {
+    return this[kOtel]
+  },
+  set(val) {
+    this[kOtel] = val
+  }
+})
+
 /**
  * The agent is meant to only exist once per application, but the singleton is
  * managed by index.js. An agent will be created even if the agent's disabled by

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -169,7 +169,10 @@ const DEFAULT_HARVEST_INTERVAL_MS = 60000
  * available. Don't try to recover here, because without configuration the
  * agent can't be brought up to a useful state.
  *
- * @param {Config} config Agent configuration object
+ * @param {AgentConfig} config Agent configuration object
+ *
+ * @class
+ * @alias Agent
  */
 function Agent(config) {
   EventEmitter.call(this)
@@ -345,17 +348,24 @@ function Agent(config) {
 }
 util.inherits(Agent, EventEmitter)
 
-Object.defineProperty(Agent.prototype, Symbol.toStringTag, {
-  value: 'Agent'
-})
-
 const kOtel = Symbol('otel.api')
-Object.defineProperty(Agent.prototype, 'otel', {
-  get() {
-    return this[kOtel]
+Object.defineProperties(Agent.prototype, /** @lends Agent */ {
+  [Symbol.toStringTag]: {
+    value: 'Agent'
   },
-  set(val) {
-    this[kOtel] = val
+
+  /**
+   * Internal Open Telemetry API. Attached via `lib/otel/setup.js`.
+   *
+   * @private
+   */
+  otel: {
+    get() {
+      return this[kOtel]
+    },
+    set(val) {
+      this[kOtel] = val
+    }
   }
 })
 

--- a/lib/otel/setup.js
+++ b/lib/otel/setup.js
@@ -37,10 +37,21 @@ function setupOtel(agent, logger = defaultLogger) {
   opentelemetry.context.setGlobalContextManager(new ContextManager(agent))
   opentelemetry.propagation.setGlobalPropagator(new TracePropagator(agent))
 
+  // The internal OTEL API. Each field is the corresponding signal wrapper
+  // instance, or `undefined` when that signal is disabled. This is an internal
+  // only API attached to the agent so that features can interact with the OTEL
+  // objects, e.g. `agent.otel.metrics.flushMetrics()`.
+  const api = {
+    logs: undefined,
+    metrics: undefined,
+    traces: undefined
+  }
+
   if (agent.config.opentelemetry.traces.enabled === true) {
     const SetupTraces = require('./traces/index.js')
     const signal = new SetupTraces({ agent })
     signals.push(signal)
+    api.traces = signal
   } else {
     logger.debug('`opentelemetry.traces` is not enabled, skipping')
     agent.metrics
@@ -52,6 +63,7 @@ function setupOtel(agent, logger = defaultLogger) {
     const SetupMetrics = require('./metrics/index.js')
     const signal = new SetupMetrics({ agent })
     signals.push(signal)
+    api.metrics = signal
   } else {
     logger.debug('`opentelemetry.metrics` is not enabled, skipping')
     agent.metrics
@@ -63,9 +75,12 @@ function setupOtel(agent, logger = defaultLogger) {
     const SetupLogs = require('./logs/index.js')
     const signal = new SetupLogs({ agent })
     signals.push(signal)
+    api.logs = signal
   } else {
     logger.debug('`opentelemetry.logs` is not enabled, skipping')
   }
+
+  agent.otel = api
 
   agent.metrics
     .getOrCreateMetric('Supportability/Nodejs/OpenTelemetryBridge/Setup')

--- a/lib/otel/setup.js
+++ b/lib/otel/setup.js
@@ -13,6 +13,14 @@ const defaultLogger = require('../logger').child({ component: 'opentelemetry-bri
 
 const signals = []
 
+/**
+ * Bootstraps the Open Telemetry tracing signals. The provided agent instance
+ * will have its `.otel` property updated with an API object if any signals
+ * are enabled.
+ *
+ * @param {Agent} agent The current agent instance.
+ * @param {AgentLogger} logger Agent logger instance.
+ */
 function setupOtel(agent, logger = defaultLogger) {
   if (agent.config.opentelemetry.enabled !== true) {
     logger.warn(
@@ -37,15 +45,12 @@ function setupOtel(agent, logger = defaultLogger) {
   opentelemetry.context.setGlobalContextManager(new ContextManager(agent))
   opentelemetry.propagation.setGlobalPropagator(new TracePropagator(agent))
 
-  // The internal OTEL API. Each field is the corresponding signal wrapper
-  // instance, or `undefined` when that signal is disabled. This is an internal
-  // only API attached to the agent so that features can interact with the OTEL
-  // objects, e.g. `agent.otel.metrics.flushMetrics()`.
   const api = {
     logs: undefined,
     metrics: undefined,
     traces: undefined
   }
+  agent.otel = api
 
   if (agent.config.opentelemetry.traces.enabled === true) {
     const SetupTraces = require('./traces/index.js')
@@ -79,8 +84,6 @@ function setupOtel(agent, logger = defaultLogger) {
   } else {
     logger.debug('`opentelemetry.logs` is not enabled, skipping')
   }
-
-  agent.otel = api
 
   agent.metrics
     .getOrCreateMetric('Supportability/Nodejs/OpenTelemetryBridge/Setup')

--- a/test/unit/agent/agent.test.js
+++ b/test/unit/agent/agent.test.js
@@ -183,6 +183,14 @@ test('when loaded with defaults', async (t) => {
     assert.equal(typeof agent.serverlessMode, 'boolean')
     assert.equal(agent.serverlessMode, false)
   })
+
+  await t.test('defines otel getter/setter', (t) => {
+    const { agent } = t.nr
+    assert.equal(agent.otel, undefined)
+    const api = { logs: {}, metrics: {}, traces: {} }
+    agent.otel = api
+    assert.equal(agent.otel, api)
+  })
 })
 
 test('should load naming rules when configured', () => {

--- a/test/unit/lib/otel/setup.test.js
+++ b/test/unit/lib/otel/setup.test.js
@@ -98,6 +98,42 @@ test('should log message if metrics is not enabled', async (t) => {
   assert.equal(loggerMock.debug.args[0][0], '`opentelemetry.metrics` is not enabled, skipping')
 })
 
+test('should attach otel api with all signals when enabled', (t) => {
+  const { agent, loggerMock } = t.nr
+  agent.config.opentelemetry.enabled = true
+  agent.config.opentelemetry.traces.enabled = true
+  agent.config.opentelemetry.metrics.enabled = true
+  agent.config.opentelemetry.logs.enabled = true
+  setupOtel(agent, loggerMock)
+
+  assert.ok(agent.otel)
+  assert.ok(agent.otel.traces)
+  assert.ok(agent.otel.metrics)
+  assert.ok(agent.otel.logs)
+})
+
+test('should leave disabled signals undefined on otel api', (t) => {
+  const { agent, loggerMock } = t.nr
+  agent.config.opentelemetry.enabled = true
+  agent.config.opentelemetry.traces.enabled = true
+  agent.config.opentelemetry.metrics.enabled = false
+  agent.config.opentelemetry.logs.enabled = false
+  setupOtel(agent, loggerMock)
+
+  assert.ok(agent.otel)
+  assert.ok(agent.otel.traces)
+  assert.equal(agent.otel.metrics, undefined)
+  assert.equal(agent.otel.logs, undefined)
+})
+
+test('should not attach otel api when opentelemetry is disabled', (t) => {
+  const { agent, loggerMock } = t.nr
+  agent.config.opentelemetry.enabled = false
+  setupOtel(agent, loggerMock)
+
+  assert.equal(agent.otel, undefined)
+})
+
 test('should bootstrap metrics', async (t) => {
   const { agent, loggerMock } = t.nr
   agent.config.opentelemetry.enabled = true


### PR DESCRIPTION
Closes #4143

## Summary

Adds an internal `agent.otel` API so that features built on top of the OTEL bridge can interact with the OTEL signal objects.

- `lib/agent.js`: adds an `otel` getter/setter to `Agent.prototype`, backed by a private symbol.
- `lib/otel/setup.js`: `setupOtel` now builds an API object of the shape `{ logs, metrics, traces }`, where each field is the corresponding signal wrapper instance (`SetupLogs` / `SetupMetrics` / `SetupTraces`), and assigns it to `agent.otel`. Signals that are disabled stay `undefined`. When OTEL is disabled entirely, `agent.otel` is never set.

Because signals may be individually disabled (or OTEL disabled entirely), the API may be partially or fully undefined. Consumers use optional chaining, e.g. `agent.otel?.metrics?.flushMetrics()`. As discussed in the issue, no stub API is provided since this is an internal-only API and a stub would require maintaining parity with the real implementations.

## Testing

- Added unit tests in `test/unit/lib/otel/setup.test.js` covering all-enabled, partially-enabled, and OTEL-disabled cases.
- Added a unit test in `test/unit/agent/agent.test.js` for the `otel` getter/setter.
- `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)