### PR TITLE
docs: Fix jsdoc parse errors and OOM in docs script

### DIFF
--- a/lib/llm-events/aws-bedrock/bedrock-response.js
+++ b/lib/llm-events/aws-bedrock/bedrock-response.js
@@ -100,7 +100,7 @@ class BedrockResponse {
   /**
    * The prompt responses returned by the model.
    *
-   * @returns {string[]|*[]} Should be an array of string responses to the
+   * @returns {string[]|Array<*>} Should be an array of string responses to the
    * prompt.
    */
   get completions() {

--- a/lib/transaction/tracer/index.js
+++ b/lib/transaction/tracer/index.js
@@ -318,7 +318,7 @@ function _maybeBindPromise({ result, full, segment }) {
  * will be started and ended automatically.
  * @param {object} params.thisArg Entity to use as the `this` binding when
  * invoking the original function.
- * @param {*[]} params.args Array of arguments to provide to the function.
+ * @param {Array<*>} params.args Array of arguments to provide to the function.
  *
  * @returns {*} Whatever the instrumented function returns.
  */

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "addhook:precommit": "git config --local core.hooksPath .githooks",
     "bench": "node ./bin/run-bench.js",
     "docker-env": "./bin/docker-env-vars.sh",
-    "docs": "rm -rf ./out && jsdoc -c ./jsdoc-conf.jsonc --private -r .",
+    "docs": "rm -rf ./out && jsdoc -c ./jsdoc-conf.jsonc --private",
     "integration": "npm run sub-install && BORP_CONF_FILE=.borp.int.yaml time c8 -o ./coverage/integration borp --timeout 600000 --reporter ./test/lib/test-reporter.mjs",
     "integration:esm": "NODE_OPTIONS='--loader=./esm-loader.mjs' BORP_CONF_FILE=.borp.int-esm.yaml time c8 -o ./coverage/integration-esm borp --reporter ./test/lib/test-reporter.mjs",
     "prepare-test": "npm run docker-env",


### PR DESCRIPTION
I was doing some work where I wanted to verify what would get generated with `npm run docs` and I discovered that script was failing with errors. This PR fixes the errors.

-----

## Summary

`npm run docs` was failing with both JSDoc type-parse errors and a fatal out-of-memory crash. This fixes both.

### Changes

- **Invalid JSDoc type expressions** — jsdoc's type parser cannot parse `*[]`. Replaced with `Array<*>` in:
  - `lib/llm-events/aws-bedrock/bedrock-response.js`
  - `lib/transaction/tracer/index.js`
- **OOM crash** — removed `-r .` from the `docs` npm script. That flag forced jsdoc to recurse the entire repo (`node_modules`, generated `out/`, `test/`), overriding the scoped `include` list in `jsdoc-conf.jsonc` and exhausting the heap. The config already sets `recurse: true` with an explicit include list, so the flag was redundant and harmful.

## Testing

`npm run docs` now completes with no parse errors, no crash, and generates the documented API surface (66 files in `out/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)