### PR TITLE
fix: Handled `$0` as a replacment in a metric normalization rule to return the matched string in its entirety

### DIFF
--- a/lib/metrics/normalizer/rule.js
+++ b/lib/metrics/normalizer/rule.js
@@ -126,6 +126,12 @@ NormalizerRule.prototype.apply = function apply(input) {
       this.pattern.lastIndex = 0
       if (segment && this.pattern.test(segment)) {
         this.matched = true
+        // js doesn't have a concept of `$0` which is no-op
+        // instead of mapping to `$&` which is its equivalent
+        // just return the segment untouched
+        if (this.replacement === '$0') {
+          return segment
+        }
         return segment.replace(this.pattern, this.replacement)
       }
       return segment

--- a/test/unit/metric/normalizer-rule.test.js
+++ b/test/unit/metric/normalizer-rule.test.js
@@ -284,4 +284,33 @@ test('NormalizerRule', async function (t) {
       assert.equal(re.global, true)
     })
   })
+
+  await t.test('should return entire string if `replacement` is not present', () => {
+    const rule = new Rule({
+      each_segment: false,
+      eval_order: -1,
+      ignore: false,
+      match_expression: '^MyMetric/.*$',
+      replace_all: false,
+      terminate_chain: true
+    })
+    const metric = 'MyMetric/Is/A/Sample/Name'
+    const result = rule.apply(metric)
+    assert.equal(result, metric)
+  })
+
+  await t.test('should return entire string if replacement is `$0`', () => {
+    const rule = new Rule({
+      each_segment: false,
+      eval_order: -1,
+      ignore: false,
+      match_expression: '^MyMetric/.*$',
+      replace_all: false,
+      replacement: '$0',
+      terminate_chain: true
+    })
+    const metric = 'MyMetric/Is/A/Sample/Name'
+    const result = rule.apply(metric)
+    assert.equal(result, metric)
+  })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

See #4149 for more information

## Related Issues
Closes #4149
