### PR TITLE
chore: Translate OTel exception into timed event

### DIFF
--- a/lib/otel/fake-span.js
+++ b/lib/otel/fake-span.js
@@ -5,6 +5,9 @@
 
 'use strict'
 
+const TimedEvent = require('../spans/timed-event')
+const { EXCEPTION_MESSAGE, EXCEPTION_STACKTRACE, EXCEPTION_TYPE } = require('./traces/constants')
+
 /**
  * In order to be able to return the appropriate span context
  * within otel bridge. We have to create fake spans for new relic
@@ -71,11 +74,31 @@ module.exports = class FakeSpan {
     return this
   }
 
-  addEvent(name, _attrsOrTime, _time) {
-    this.#segment.logger.warn(
-      'addEvent is not implemented. Not adding event: %s.',
-      name
-    )
+  /**
+   * Adds a new timed event to the backing segment.
+   *
+   * This replicates what the original actually does.
+   * See:
+   * https://github.com/open-telemetry/opentelemetry-js/blob/9b05f66/packages/sdk-trace/src/Span.ts#L389-L410.
+   *
+   * @param {string} name The name of the event.
+   * @param {object} [attributesOrStartTime] The attributes to associate with
+   * the event.
+   * @param {number[]|number|Date} [timeStamp] The start time of the event.
+   *
+   * @returns {FakeSpan}
+   */
+  addEvent(name, attributesOrStartTime, timeStamp) {
+    const timedEvent = new TimedEvent({
+      event: {
+        name,
+        attributes: attributesOrStartTime ?? {},
+        time: timeStamp
+      },
+      spanContext: this.spanContext()
+    })
+    this.#segment.addTimedEvent(timedEvent)
+
     return this
   }
 
@@ -135,10 +158,39 @@ module.exports = class FakeSpan {
     return true
   }
 
+  /**
+   * Records an exception as a timed event on the backing segment.
+   *
+   * This replicates what the original actually does.
+   * See:
+   * https://github.com/open-telemetry/opentelemetry-js/blob/9b05f66/packages/sdk-trace/src/Span.ts#L427-L451.
+   *
+   * @param {string|Error} exception The exception to record.
+   * @param {number[]|number|Date} [time] The time the exception occurred.
+   */
   recordException(exception, time) {
-    // This replicates what the original actually does.
-    // See:
-    // https://github.com/open-telemetry/opentelemetry-js/blob/9b05f66/packages/sdk-trace/src/Span.ts#L427-L451.
-    this.addEvent(exception, null, time)
+    const attributes = {}
+
+    if (typeof exception === 'string') {
+      attributes[EXCEPTION_MESSAGE] = exception
+    } else if (exception) {
+      if (exception.code) {
+        attributes[EXCEPTION_TYPE] = exception.code.toString()
+      } else if (exception.name) {
+        attributes[EXCEPTION_TYPE] = exception.name
+      }
+      if (exception.message) {
+        attributes[EXCEPTION_MESSAGE] = exception.message
+      }
+      if (exception.stack) {
+        attributes[EXCEPTION_STACKTRACE] = exception.stack
+      }
+    }
+
+    if (attributes[EXCEPTION_TYPE] || attributes[EXCEPTION_MESSAGE]) {
+      this.addEvent('exception', attributes, time)
+    } else {
+      this.#segment.logger.warn('Failed to record exception: %s.', exception)
+    }
   }
 }

--- a/lib/otel/fake-span.js
+++ b/lib/otel/fake-span.js
@@ -9,6 +9,26 @@ const TimedEvent = require('../spans/timed-event')
 const { EXCEPTION_MESSAGE, EXCEPTION_STACKTRACE, EXCEPTION_TYPE } = require('./traces/constants')
 
 /**
+ * Checks whether a value looks like a point in time (a `Date`, an epoch
+ * number, or an OTEL hrtime `[seconds, nanoseconds]` tuple) rather than a
+ * set of event attributes.
+ *
+ * @param {*} value The value to check.
+ *
+ * @returns {boolean} True if the value should be treated as a time.
+ */
+function isTimeInput(value) {
+  return (
+    typeof value === 'number' ||
+    value instanceof Date ||
+    (Array.isArray(value) &&
+      value.length === 2 &&
+      typeof value[0] === 'number' &&
+      typeof value[1] === 'number')
+  )
+}
+
+/**
  * In order to be able to return the appropriate span context
  * within otel bridge. We have to create fake spans for new relic
  * segments.  The only thing needed is a method for `spanContext`
@@ -79,16 +99,24 @@ module.exports = class FakeSpan {
    *
    * This replicates what the original actually does.
    * See:
-   * https://github.com/open-telemetry/opentelemetry-js/blob/9b05f66/packages/sdk-trace/src/Span.ts#L389-L410.
+   * https://github.com/open-telemetry/opentelemetry-js/blob/9b05f668ee7ab884a44b04b504e0baaff6c6d2b2/packages/sdk-trace/src/Span.ts#L201-L263
    *
    * @param {string} name The name of the event.
-   * @param {object} [attributesOrStartTime] The attributes to associate with
-   * the event.
+   * @param {object|number[]|number|Date} [attributesOrStartTime] Either the
+   * attributes to associate with the event, or the start time of the event
+   * when no attributes are being provided.
    * @param {number[]|number|Date} [timeStamp] The start time of the event.
    *
    * @returns {FakeSpan}
    */
   addEvent(name, attributesOrStartTime, timeStamp) {
+    if (isTimeInput(attributesOrStartTime)) {
+      if (!isTimeInput(timeStamp)) {
+        timeStamp = attributesOrStartTime
+      }
+      attributesOrStartTime = undefined
+    }
+
     const timedEvent = new TimedEvent({
       event: {
         name,

--- a/lib/otel/normalize-timestamp.js
+++ b/lib/otel/normalize-timestamp.js
@@ -45,7 +45,7 @@ function normalizeTimestamp(input) {
     return hrtimeToMilliseconds(input)
   }
 
-  if (input != null && Object.getPrototypeOf(input) === Date.prototype) {
+  if (input && Object.getPrototypeOf(input) === Date.prototype) {
     return input.getTime()
   }
 

--- a/lib/otel/normalize-timestamp.js
+++ b/lib/otel/normalize-timestamp.js
@@ -45,7 +45,7 @@ function normalizeTimestamp(input) {
     return hrtimeToMilliseconds(input)
   }
 
-  if (Object.getPrototypeOf(input) === Date.prototype) {
+  if (input != null && Object.getPrototypeOf(input) === Date.prototype) {
     return input.getTime()
   }
 

--- a/test/unit/lib/otel/fake-span.test.js
+++ b/test/unit/lib/otel/fake-span.test.js
@@ -67,13 +67,7 @@ test('should add attributes to the segment', () => {
   assert.equal(instance, span)
 })
 
-test('addEvent should log warning', () => {
-  const logs = []
-  const logger = {
-    warn(msg, name) {
-      logs.push([msg, name])
-    }
-  }
+test('addEvent should add a timed event to the segment', () => {
   const segment = new TraceSegment({
     id: 'id',
     config: { attributes: {} },
@@ -81,16 +75,38 @@ test('addEvent should log warning', () => {
     parentId: 1,
     collect: true
   })
-  segment.logger = logger
   const tx = { traceId: 'traceId' }
   const span = new FakeSpan(segment, tx)
 
-  const instance = span.addEvent('foo')
+  const instance = span.addEvent('foo', { bar: 'baz' })
   assert.equal(instance, span)
-  assert.deepEqual(logs, [[
-    'addEvent is not implemented. Not adding event: %s.',
-    'foo'
-  ]])
+  assert.equal(segment.timedEvents.length, 1)
+
+  const [intrinsics, userAttrs, agentAttrs] = segment.timedEvents[0].toJSON()
+  assert.equal(intrinsics.name, 'foo')
+  assert.equal(intrinsics.type, 'SpanEvent')
+  assert.equal(intrinsics['span.id'], 'id')
+  assert.equal(intrinsics['trace.id'], 'traceId')
+  assert.equal(typeof intrinsics.timestamp, 'number')
+  assert.deepEqual(userAttrs, {})
+  assert.deepEqual(agentAttrs, { bar: 'baz' })
+})
+
+test('addEvent should add a timed event with no attributes given', () => {
+  const segment = new TraceSegment({
+    id: 'id',
+    config: { attributes: {} },
+    name: 'test-segment',
+    parentId: 1,
+    collect: true
+  })
+  const tx = { traceId: 'traceId' }
+  const span = new FakeSpan(segment, tx)
+
+  span.addEvent('foo')
+  assert.equal(segment.timedEvents.length, 1)
+  const [, , agentAttrs] = segment.timedEvents[0].toJSON()
+  assert.deepEqual(agentAttrs, {})
 })
 
 test('should add links to spans', () => {
@@ -216,7 +232,49 @@ test('recording returns true', () => {
   assert.deepEqual(span.isRecording(), true)
 })
 
-test('recordException should log warning', () => {
+test('recordException should add a timed event from a string exception', () => {
+  const segment = new TraceSegment({
+    id: 'id',
+    config: { attributes: {} },
+    name: 'test-segment',
+    parentId: 1,
+    collect: true
+  })
+  const tx = { traceId: 'traceId' }
+  const span = new FakeSpan(segment, tx)
+
+  const instance = span.recordException('a message')
+  assert.equal(instance, undefined)
+  assert.equal(segment.timedEvents.length, 1)
+
+  const [intrinsics, , agentAttrs] = segment.timedEvents[0].toJSON()
+  assert.equal(intrinsics.name, 'exception')
+  assert.deepEqual(agentAttrs, { 'exception.message': 'a message' })
+})
+
+test('recordException should add a timed event from an Error exception', () => {
+  const segment = new TraceSegment({
+    id: 'id',
+    config: { attributes: {} },
+    name: 'test-segment',
+    parentId: 1,
+    collect: true
+  })
+  const tx = { traceId: 'traceId' }
+  const span = new FakeSpan(segment, tx)
+  const error = new Error('boom')
+
+  span.recordException(error)
+  assert.equal(segment.timedEvents.length, 1)
+
+  const [, , agentAttrs] = segment.timedEvents[0].toJSON()
+  assert.equal(agentAttrs['exception.type'], 'Error')
+  assert.equal(agentAttrs['exception.message'], 'boom')
+  assert.equal(typeof agentAttrs['exception.stacktrace'], 'string')
+  assert.ok(error.stack.startsWith(agentAttrs['exception.stacktrace']))
+})
+
+test('recordException should log a warning when the exception has no usable information', () => {
   const logs = []
   const logger = {
     warn(msg, name) {
@@ -234,10 +292,10 @@ test('recordException should log warning', () => {
   const tx = { traceId: 'traceId' }
   const span = new FakeSpan(segment, tx)
 
-  const instance = span.recordException('foo', 'whatever')
-  assert.equal(instance, undefined)
+  span.recordException({})
+  assert.equal(segment.timedEvents.length, 0)
   assert.deepEqual(logs, [[
-    'addEvent is not implemented. Not adding event: %s.',
-    'foo'
+    'Failed to record exception: %s.',
+    {}
   ]])
 })

--- a/test/unit/lib/otel/fake-span.test.js
+++ b/test/unit/lib/otel/fake-span.test.js
@@ -109,6 +109,27 @@ test('addEvent should add a timed event with no attributes given', () => {
   assert.deepEqual(agentAttrs, {})
 })
 
+test('addEvent handles (string, number) passed in', () => {
+  const segment = new TraceSegment({
+    id: 'id',
+    config: { attributes: {} },
+    name: 'test-segment',
+    parentId: 1,
+    collect: true
+  })
+  const tx = { traceId: 'traceId' }
+  const span = new FakeSpan(segment, tx)
+
+  const someTime = 1784564100000
+  span.addEvent('my-exception', someTime)
+  assert.equal(segment.timedEvents.length, 1)
+
+  const [intrinsics, , agentAttrs] = segment.timedEvents[0].toJSON()
+  assert.equal(intrinsics.name, 'my-exception')
+  assert.notEqual(intrinsics.timestamp, someTime, `${someTime} is not treated as a timestamp`)
+  assert.deepEqual(agentAttrs, {})
+})
+
 test('should add links to spans', () => {
   const segment = new TraceSegment({
     id: 'id',

--- a/test/unit/lib/otel/fake-span.test.js
+++ b/test/unit/lib/otel/fake-span.test.js
@@ -126,7 +126,7 @@ test('addEvent handles (string, number) passed in', () => {
 
   const [intrinsics, , agentAttrs] = segment.timedEvents[0].toJSON()
   assert.equal(intrinsics.name, 'my-exception')
-  assert.notEqual(intrinsics.timestamp, someTime, `${someTime} is not treated as a timestamp`)
+  assert.equal(intrinsics.timestamp, someTime, `${someTime} is treated as a timestamp`)
   assert.deepEqual(agentAttrs, {})
 })
 

--- a/test/unit/lib/otel/fake-span.test.js
+++ b/test/unit/lib/otel/fake-span.test.js
@@ -274,6 +274,27 @@ test('recordException should add a timed event from an Error exception', () => {
   assert.ok(error.stack.startsWith(agentAttrs['exception.stacktrace']))
 })
 
+test('recordException should prefer exception.code over exception.name for the exception type', () => {
+  const segment = new TraceSegment({
+    id: 'id',
+    config: { attributes: {} },
+    name: 'test-segment',
+    parentId: 1,
+    collect: true
+  })
+  const tx = { traceId: 'traceId' }
+  const span = new FakeSpan(segment, tx)
+  const error = new Error('file not found')
+  error.code = 'ENOENT'
+
+  span.recordException(error)
+  assert.equal(segment.timedEvents.length, 1)
+
+  const [, , agentAttrs] = segment.timedEvents[0].toJSON()
+  assert.equal(agentAttrs['exception.type'], 'ENOENT')
+  assert.equal(agentAttrs['exception.message'], 'file not found')
+})
+
 test('recordException should log a warning when the exception has no usable information', () => {
   const logs = []
   const logger = {


### PR DESCRIPTION

## Description

This PR implements the `addEvent` and `recordException` methods into the `FakeSpan` (`lib/otel/fake-span.js`), which were previously just stubs. 

- `addEvent(name,attributes,time)` now builds a `TimedEvent` from the given parameters and pushes to the actual `TraceSegment` via `segment.addTimedEvent()`.
- `recordException(exception,time)` extracts the exception attibutes from a string or `Error`, mirroring [what OTel does](https://github.com/open-telemetry/opentelemetry-js/blob/9b05f66/packages/sdk-trace/src/Span.ts#L427-L451) and records it as an `'exception'` event via `FakeSpan.addEvent`.

## How to Test
```
node --test test/unit/lib/otel/fake-span.test.js
```
## Related Issues

Closes #4138