### PR TITLE
fix: Resolved mongodb host details at operation time to support `mongodb+srv://` clients

### DIFF
--- a/lib/subscribers/mongodb/bulk.js
+++ b/lib/subscribers/mongodb/bulk.js
@@ -41,13 +41,6 @@ module.exports = class BulkSubscriber extends Wrapper {
     const { self: bulkOperation, arguments: args } = data
     const [collection] = args
     const collectionName = collection.collectionName
-    const details = getHostDetails(collection)
-    this.parameters = {
-      host: details.host,
-      port_path_or_id: details.port_path_or_id,
-      database_name: details.database_name,
-      product: this.system
-    }
 
     for (const method of CURSOR_METHODS) {
       if (typeof bulkOperation[method] !== 'function') {
@@ -58,6 +51,17 @@ module.exports = class BulkSubscriber extends Wrapper {
         getSegmentName: () => {
           const operation = bulkOperation.isOrdered ? 'orderedBulk' : 'unorderedBulk'
           return `${DB_METRIC_CONSTANTS.STATEMENT}/${this.system}/${collectionName}/${operation}/batch`
+        },
+        // Resolve host details when the operation runs, not when the bulk
+        // operation is constructed. See `WrapperSubscriber#wrapDatabaseMethod`.
+        getParameters: () => {
+          const details = getHostDetails(collection)
+          return {
+            host: details.host,
+            port_path_or_id: details.port_path_or_id,
+            database_name: details.database_name,
+            product: this.system
+          }
         },
         getRecorderContext: () => {
           return {

--- a/lib/subscribers/mongodb/collection.js
+++ b/lib/subscribers/mongodb/collection.js
@@ -78,13 +78,6 @@ module.exports = class CollectionSubscriber extends Wrapper {
   end(data, ctx) {
     const { self: dbClient, arguments: args } = data
     const [dbInstance, collectionName] = args
-    const details = getHostDetails(dbInstance)
-    this.parameters = {
-      host: details.host,
-      port_path_or_id: details.port_path_or_id,
-      database_name: details.database_name,
-      product: this.system
-    }
 
     for (const method of CURSOR_METHODS) {
       if (typeof dbClient[method] !== 'function') {
@@ -93,6 +86,18 @@ module.exports = class CollectionSubscriber extends Wrapper {
 
       this.wrapDatabaseMethod(dbClient, method, {
         getSegmentName: (method) => `${DB_METRIC_CONSTANTS.STATEMENT}/${this.system}/${collectionName}/${method}`,
+        // Resolve host details when the operation runs, not when the
+        // `Collection` handle is constructed. See
+        // `WrapperSubscriber#wrapDatabaseMethod`.
+        getParameters: () => {
+          const details = getHostDetails(dbInstance)
+          return {
+            host: details.host,
+            port_path_or_id: details.port_path_or_id,
+            database_name: details.database_name,
+            product: this.system
+          }
+        },
         getRecorderContext: (method) => {
           return {
             operation: method,

--- a/lib/subscribers/mongodb/cursor.js
+++ b/lib/subscribers/mongodb/cursor.js
@@ -46,13 +46,6 @@ module.exports = class CursorSubscriber extends Wrapper {
     const { self: dbClient, arguments: args } = data
     const [mongoClient, dbNamespace] = args
     const { collection } = dbNamespace
-    const details = getHostDetails(mongoClient)
-    this.parameters = {
-      host: details.host,
-      port_path_or_id: details.port_path_or_id,
-      database_name: dbNamespace.db,
-      product: this.system
-    }
 
     for (const method of CURSOR_METHODS) {
       if (typeof dbClient[method] !== 'function') {
@@ -61,6 +54,17 @@ module.exports = class CursorSubscriber extends Wrapper {
 
       this.wrapDatabaseMethod(dbClient, method, {
         getSegmentName: (method) => `${DB_METRIC_CONSTANTS.STATEMENT}/${this.system}/${collection}/${method}`,
+        // Resolve host details when the operation runs, not when the cursor is
+        // constructed. See `WrapperSubscriber#wrapDatabaseMethod`.
+        getParameters: () => {
+          const details = getHostDetails(mongoClient)
+          return {
+            host: details.host,
+            port_path_or_id: details.port_path_or_id,
+            database_name: dbNamespace.db,
+            product: this.system
+          }
+        },
         getRecorderContext: (method) => {
           return {
             operation: method,

--- a/lib/subscribers/mongodb/db.js
+++ b/lib/subscribers/mongodb/db.js
@@ -67,13 +67,6 @@ module.exports = class DbClassSubscriber extends Wrapper {
   end(data, ctx) {
     const { self: dbClient, arguments: args } = data
     const [dbInstance, dbName] = args
-    const details = getHostDetails(dbInstance)
-    this.parameters = {
-      host: details.host,
-      port_path_or_id: details.port_path_or_id,
-      database_name: dbName,
-      product: this.system
-    }
 
     for (const method of DB_METHODS) {
       if (typeof dbClient[method] !== 'function') {
@@ -82,6 +75,17 @@ module.exports = class DbClassSubscriber extends Wrapper {
 
       this.wrapDatabaseMethod(dbClient, method, {
         getSegmentName: (method) => `${DB_METRIC_CONSTANTS.OPERATION}/${this.system}/${method}`,
+        // Resolve host details when the operation runs, not when the `Db`
+        // handle is constructed. See `WrapperSubscriber#wrapDatabaseMethod`.
+        getParameters: () => {
+          const details = getHostDetails(dbInstance)
+          return {
+            host: details.host,
+            port_path_or_id: details.port_path_or_id,
+            database_name: dbName,
+            product: this.system
+          }
+        },
         getRecorderContext: (method) => {
           return {
             operation: method,

--- a/lib/subscribers/mongodb/utils/get-host-details.js
+++ b/lib/subscribers/mongodb/utils/get-host-details.js
@@ -44,33 +44,33 @@ module.exports = function getHostDetails(mongoObject) {
   let port
 
   if (mongoObject.constructor.name === 'MongoClient') {
-    host = mongoObject.options.hosts[0].host
-    port = mongoObject.options.hosts[0].port
+    host = mongoObject.options.hosts[0]?.host
+    port = mongoObject.options.hosts[0]?.port
   } else if (mongoObject?.databaseName && mongoObject?.client) {
     // Direct `Db` instance.
     databaseName = mongoObject.databaseName
-    host = mongoObject.client.options.hosts[0].host
-    port = mongoObject.client.options.hosts[0].port
+    host = mongoObject.client.options.hosts[0]?.host
+    port = mongoObject.client.options.hosts[0]?.port
   } else if (mongoObject.dbName && mongoObject.s?.db?.s?.client?.options) {
     // Likely an instance of `Collection`.
     databaseName = mongoObject.dbName
-    host = mongoObject.s.db.s.client.options.hosts[0].host
-    port = mongoObject.s.db.s.client.options.hosts[0].port
+    host = mongoObject.s.db.s.client.options.hosts[0]?.host
+    port = mongoObject.s.db.s.client.options.hosts[0]?.port
   } else if (mongoObject.databaseName && mongoObject.s?.client?.options) {
     // Some `mongodb@4` object.
     databaseName = mongoObject.databaseName
-    host = mongoObject.s.client.options.hosts[0].host
-    port = mongoObject.s.client.options.hosts[0].port
+    host = mongoObject.s.client.options.hosts[0]?.host
+    port = mongoObject.s.client.options.hosts[0]?.port
   } else if (mongoObject?.s?.db && mongoObject.s.db.client) {
     // mongodb@5 bulk operation
     databaseName = mongoObject.s.db.databaseName
-    host = mongoObject.s.db.client.options.hosts[0].host
-    port = mongoObject.s.db.client.options.hosts[0].port
+    host = mongoObject.s.db.client.options.hosts[0]?.host
+    port = mongoObject.s.db.client.options.hosts[0]?.port
   } else if (mongoObject.constructor.name === 'Topology') {
     // A "topology" object (from ancient times). Remove this when we drop
     // support for v4.
-    host = mongoObject.s.options.hosts[0].host
-    port = mongoObject.s.options.hosts[0].port
+    host = mongoObject.s.options.hosts[0]?.host
+    port = mongoObject.s.options.hosts[0]?.port
   }
 
   if (LOCALHOST_ALIASES.includes(host) === true) {

--- a/lib/subscribers/mongodb/wrapper.js
+++ b/lib/subscribers/mongodb/wrapper.js
@@ -60,6 +60,15 @@ module.exports = class WrapperSubscriber extends DbSubscriber {
    * transaction and passed in to the `addAttributes` method. This function
    * is used to get a copy of the attributes object to provide to the
    * base method.
+   * @param {Function} [callbacks.getParameters] Returns the `parameters`
+   * object (`host`, `port_path_or_id`, `database_name`, `product`) to assign
+   * to the subscriber prior to creating the segment. When provided, it is
+   * invoked each time the wrapped method runs so that connection details are
+   * resolved at operation time rather than when the `Db`/`Collection` handle
+   * was constructed. This matters for `mongodb+srv://` clients, whose host
+   * list is empty until `connect()` resolves the DNS SRV record after
+   * construction. When omitted, the subscriber's existing `parameters` are
+   * used unchanged.
    */
   wrapDatabaseMethod(instance, methodName, callbacks) {
     const self = this
@@ -67,7 +76,8 @@ module.exports = class WrapperSubscriber extends DbSubscriber {
     const {
       getSegmentName,
       getRecorderContext,
-      getSegmentAttributes = () => { return {} }
+      getSegmentAttributes = () => { return {} },
+      getParameters = null
     } = callbacks
 
     instance[methodName] = function nrWrappedMethod(...args) {
@@ -81,6 +91,10 @@ module.exports = class WrapperSubscriber extends DbSubscriber {
       }
 
       self.logger.debug('Recording function %s', methodName)
+
+      if (typeof getParameters === 'function') {
+        self.parameters = getParameters()
+      }
 
       ctx = self.createSegment({
         name: getSegmentName(methodName),

--- a/test/versioned/mongodb/package.json
+++ b/test/versioned/mongodb/package.json
@@ -26,7 +26,8 @@
         "collection-misc.test.js",
         "collection-update.test.js",
         "cursor.test.js",
-        "db.test.js"
+        "db.test.js",
+        "srv-connect.test.js"
       ]
     }
   ],

--- a/test/versioned/mongodb/srv-connect.test.js
+++ b/test/versioned/mongodb/srv-connect.test.js
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert')
+const dns = require('node:dns')
+const { setImmediate } = require('node:timers/promises')
+
+const params = require('../../lib/params')
+const { removeModules } = require('../../lib/cache-buster')
+const helper = require('../../lib/agent_helper')
+const common = require('./common')
+
+// Reproduces https://github.com/newrelic/node-newrelic/issues/4154
+//
+// When a `MongoClient` is created from a `mongodb+srv://` connection string,
+// the driver leaves `options.hosts` as an empty array until DNS SRV resolution
+// completes during `client.connect()`. The mongodb subscribers fire on `Db`
+// and `Collection` construction (before connect), so `getHostDetails` reading
+// `options.hosts[0].host` throws a `TypeError`. Because the throw happens
+// inside a `diagnostics_channel` publish, it can surface on a later tick as an
+// uncaught exception rather than propagating to the `client.db()` /
+// `db.collection()` caller.
+//
+// To assert this synchronously each test installs an `uncaughtException`
+// listener, performs the construction, then flushes the tick queue with a
+// single `await setImmediate()` before asserting no error was captured. This
+// is deterministic — it does not rely on the test runner observing a throw
+// after the test has already ended.
+//
+// The `mongodb+srv://` scheme requires DNS SRV resolution, so — following the
+// pattern in `test/integration/core/dns.test.js` — we patch `dns` to resolve
+// the fake SRV hostname to the local Docker MongoDB container. This lets the
+// tests exercise the real connect path (not just construction) against a live
+// server.
+
+// The SRV target name must share the parent domain of `SRV_HOST` or the driver
+// rejects it (see `matchesParentDomain` in the mongodb driver).
+const SRV_HOST = 'cluster0.example.mongodb.net'
+const SRV_TARGET = `localhost.example.${SRV_HOST.split('.').slice(-2).join('.')}`
+// `mongodb+srv://` forces TLS on by default; the local container is plaintext.
+const SRV_URI = `mongodb+srv://${SRV_HOST}/${common.DB_NAME}?tls=false`
+
+test.beforeEach((ctx) => {
+  ctx.nr = {}
+  ctx.nr.agent = helper.instrumentMockedAgent()
+  ctx.nr.mongodb = require('mongodb')
+
+  // Patch DNS so the SRV lookup resolves to the local Docker container.
+  ctx.nr.dns = {
+    resolve: dns.promises.resolve,
+    resolveSrv: dns.promises.resolveSrv,
+    resolveTxt: dns.promises.resolveTxt,
+    lookup: dns.lookup
+  }
+
+  // The SRV lookup resolves to the local Docker container.
+  const srvRecords = [
+    { name: SRV_TARGET, port: Number(params.mongodb_port), weight: 0, priority: 0 }
+  ]
+  const noTxtRecord = () => {
+    const error = new Error('no TXT record')
+    error.code = 'ENODATA'
+    throw error
+  }
+
+  // Different driver versions resolve SRV/TXT differently: mongodb@4–6 call the
+  // dedicated `dns.promises.resolveSrv` / `resolveTxt`, while mongodb@7+ calls
+  // `dns.promises.resolve(address, rrtype)`. Patch all of them.
+  dns.promises.resolveSrv = async () => srvRecords
+  dns.promises.resolveTxt = noTxtRecord
+  dns.promises.resolve = async (address, rrtype) => {
+    if (rrtype === 'SRV') {
+      return srvRecords
+    }
+    if (rrtype === 'TXT') {
+      return noTxtRecord()
+    }
+    return ctx.nr.dns.resolve(address, rrtype)
+  }
+  dns.lookup = (hostname, options, callback) => {
+    if (typeof options === 'function') {
+      callback = options
+      options = {}
+    }
+    // Redirect the fake SRV target to the real Mongo host.
+    const target = hostname === SRV_TARGET ? params.mongodb_host : hostname
+    return ctx.nr.dns.lookup(target, options, callback)
+  }
+
+  // Capture the deferred subscriber error synchronously.
+  ctx.nr.uncaught = []
+  ctx.nr.onUncaught = (err) => ctx.nr.uncaught.push(err)
+  process.on('uncaughtException', ctx.nr.onUncaught)
+})
+
+test.afterEach(async (ctx) => {
+  process.removeListener('uncaughtException', ctx.nr.onUncaught)
+  dns.promises.resolve = ctx.nr.dns.resolve
+  dns.promises.resolveSrv = ctx.nr.dns.resolveSrv
+  dns.promises.resolveTxt = ctx.nr.dns.resolveTxt
+  dns.lookup = ctx.nr.dns.lookup
+
+  if (ctx.nr.client) {
+    await ctx.nr.client.close(true)
+  }
+  helper.unloadAgent(ctx.nr.agent)
+  removeModules(['mongodb'])
+})
+
+test('client.db() before connect should not throw', async (t) => {
+  const { mongodb, uncaught } = t.nr
+  const client = new mongodb.MongoClient(SRV_URI)
+  t.nr.client = client
+
+  // `options.hosts` is `[]` here because SRV resolution only happens during
+  // `connect()`.
+  assert.deepEqual(client.options.hosts, [], 'hosts should be empty before connect')
+
+  const db = client.db()
+  assert.ok(db, 'should return a db handle')
+
+  // Flush the tick queue so any deferred subscriber error is captured.
+  await setImmediate()
+  assert.deepEqual(uncaught, [], 'creating a Db handle from an SRV client should not throw')
+})
+
+test('db.collection() before connect should not throw', async (t) => {
+  const { mongodb, uncaught } = t.nr
+  const client = new mongodb.MongoClient(SRV_URI)
+  t.nr.client = client
+  const db = client.db()
+
+  // `client.db()` also fires the buggy publish; drop anything it captured so we
+  // only assert against `db.collection()`.
+  await setImmediate()
+  uncaught.length = 0
+
+  const collection = db.collection('users')
+  assert.ok(collection, 'should return a collection handle')
+
+  // Flush the tick queue so any deferred subscriber error is captured.
+  await setImmediate()
+  assert.deepEqual(uncaught, [], 'creating a Collection handle from an SRV client should not throw')
+})
+
+test('operations over an SRV connection are instrumented', async (t) => {
+  const { agent, mongodb, uncaught } = t.nr
+  const client = new mongodb.MongoClient(SRV_URI)
+  t.nr.client = client
+
+  // Create handles before connect — the crashing code path from the issue.
+  const db = client.db()
+  const collection = db.collection(common.COLLECTIONS.collection1)
+
+  await client.connect()
+  assert.deepEqual(
+    client.options.hosts.map((h) => h.host),
+    [SRV_TARGET],
+    'hosts should be populated from SRV resolution after connect'
+  )
+
+  await helper.runInTransaction(agent, async (transaction) => {
+    transaction.name = common.TRANSACTION_NAME
+    await collection.findOne({ i: 0 })
+
+    const children = transaction.trace.getChildren(transaction.trace.root.id)
+    const mongoSegment = children.find((c) => common.MONGO_SEGMENT_RE.test(c.name))
+    assert.ok(mongoSegment, 'should create a MongoDB segment')
+
+    // Host details are resolved at operation time, so even though the handles
+    // were created before `hosts` was populated, the segment should carry the
+    // server name that SRV resolution produced during `connect()`.
+    const attributes = mongoSegment.getAttributes()
+    assert.equal(attributes.product, 'MongoDB', 'should have product attribute')
+    assert.equal(attributes.database_name, common.DB_NAME, 'should have database name attribute')
+    assert.equal(attributes.host, SRV_TARGET, 'should attribute the SRV-resolved server name')
+    assert.equal(
+      attributes.port_path_or_id,
+      common.getPort(),
+      'should attribute the SRV-resolved port'
+    )
+
+    transaction.end()
+  })
+
+  await setImmediate()
+  assert.deepEqual(uncaught, [], 'instrumented SRV operations should not throw')
+})
+
+test('an operation issued before SRV resolution degrades gracefully', async (t) => {
+  const { agent, mongodb } = t.nr
+
+  // Force SRV resolution to fail so the client never populates `hosts`. This
+  // guarantees the instrumented operation runs while `options.hosts` is empty,
+  // exercising the `getHostDetails` guard directly. Without the guard this
+  // path throws a `TypeError` from the subscriber; with it, instrumentation
+  // records the segment with host/port omitted and lets the driver's own
+  // connection error surface.
+  const srvError = () => {
+    const error = new Error('SRV resolution failed')
+    error.code = 'ENOTFOUND'
+    throw error
+  }
+  dns.promises.resolveSrv = srvError
+  dns.promises.resolve = async (address, rrtype) => {
+    if (rrtype === 'SRV' || rrtype === 'TXT') {
+      return srvError()
+    }
+    return t.nr.dns.resolve(address, rrtype)
+  }
+
+  const client = new mongodb.MongoClient(SRV_URI)
+  t.nr.client = client
+  const collection = client.db().collection(common.COLLECTIONS.collection1)
+  assert.deepEqual(client.options.hosts, [], 'hosts should be empty before connect')
+
+  await helper.runInTransaction(agent, async (transaction) => {
+    transaction.name = common.TRANSACTION_NAME
+    // `serverSelectionTimeoutMS` only matters as a fail-fast guard: SRV
+    // resolution fails first (above), so we never reach server selection. But
+    // if the SRV stub ever regresses and resolution succeeds, this keeps the
+    // test from hanging on the driver's 30s default before rejecting.
+    await assert.rejects(
+      collection.findOne({ i: 0 }, { serverSelectionTimeoutMS: 100 }),
+      (err) => {
+        // Must be a driver resolution error, not a `TypeError` leaking from the
+        // subscriber's host-details lookup.
+        assert.notEqual(err.name, 'TypeError', 'instrumentation should not throw a TypeError')
+        assert.equal(err.code, 'ENOTFOUND')
+        assert.equal(err.message, 'SRV resolution failed')
+        return true
+      }
+    )
+
+    const children = transaction.trace.getChildren(transaction.trace.root.id)
+    const mongoSegment = children.find((c) => common.MONGO_SEGMENT_RE.test(c.name))
+    assert.ok(mongoSegment, 'should still create a MongoDB segment')
+
+    const attributes = mongoSegment.getAttributes()
+    assert.equal(attributes.product, 'MongoDB', 'should have product attribute')
+    assert.equal(attributes.host, undefined, 'should omit host when hosts is empty')
+    assert.equal(
+      attributes.port_path_or_id,
+      undefined,
+      'should omit port when hosts is empty'
+    )
+
+    transaction.end()
+  })
+})


### PR DESCRIPTION
## Description

Fixes #4154.

The v14 `diagnostics_channel`-based mongodb subscribers crash the application when a `Db` or `Collection` handle is created on a `MongoClient` configured with a `mongodb+srv://` connection string before `client.connect()` has resolved.

For SRV URIs the driver leaves `options.hosts` as `[]` at parse time and only populates it after DNS SRV resolution completes during `connect()`. The subscribers fire on `Db`/`Collection` **construction**, so `getHostDetails` read `options.hosts[0].host` against an empty array and threw:

```
TypeError: Cannot read properties of undefined (reading 'host')
    at getHostDetails (lib/subscribers/mongodb/utils/get-host-details.js:47:41)
    at DbClassSubscriber.end (lib/subscribers/mongodb/db.js:70:21)
    at Channel.publish (node:diagnostics_channel:156:9)
    ...
    at new Db (mongodb/lib/db.js:80:34)
    at MongoClient.db (mongodb/src/mongo_client.ts:846:16)
```

Because the throw happens inside a `diagnostics_channel` publish, it surfaces as an **uncaught exception** and crashes the process a tick after `client.db()` / `db.collection()` return normally.

## Changes

- **`get-host-details.js`** — Guarded every `hosts[0]` access with optional chaining so it degrades gracefully (host/port omitted) instead of throwing when `options.hosts` is empty, matching the issue's expected behavior.
- **`wrapper.js` + `db.js` / `collection.js` / `bulk.js` / `cursor.js`** — Resolve host details **at operation time** via a new `getParameters` callback in `wrapDatabaseMethod`, rather than caching them once at handle construction. By the time an operation runs, `connect()` has populated `hosts`, so segments once again carry the resolved server name and port for SRV clients (not just avoiding the crash).

## Testing

Added `test/versioned/mongodb/srv-connect.test.js`. Following the DNS-patching pattern in `test/integration/core/dns.test.js`, the SRV hostname resolves to the local Docker MongoDB container, so the tests exercise the real connect path against a live server:

1. `client.db()` before connect does not throw.
2. `db.collection()` before connect does not throw.
3. Operations over an SRV connection are instrumented **and the segment carries the SRV-resolved server name/port**.
4. An operation issued before SRV resolution degrades gracefully — the `getHostDetails` guard is exercised directly (segment recorded with host/port omitted, driver's own error surfaces, no `TypeError`).

Verified each test fails against the unpatched code and passes with the fix, and the full mongodb versioned suite passes across all four driver versions (4.17.2, 5.9.2, 6.21.0, 7.5.0). `npm run lint` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)