### PR TITLE
fix: Avoid unconditional @opentelemetry/core require on agent startup

### DIFF
--- a/lib/otel/fake-span.js
+++ b/lib/otel/fake-span.js
@@ -5,28 +5,13 @@
 
 'use strict'
 
-const TimedEvent = require('../spans/timed-event')
-const { EXCEPTION_MESSAGE, EXCEPTION_STACKTRACE, EXCEPTION_TYPE } = require('./traces/constants')
-
-/**
- * Checks whether a value looks like a point in time (a `Date`, an epoch
- * number, or an OTEL hrtime `[seconds, nanoseconds]` tuple) rather than a
- * set of event attributes.
- *
- * @param {*} value The value to check.
- *
- * @returns {boolean} True if the value should be treated as a time.
- */
-function isTimeInput(value) {
-  return (
-    typeof value === 'number' ||
-    value instanceof Date ||
-    (Array.isArray(value) &&
-      value.length === 2 &&
-      typeof value[0] === 'number' &&
-      typeof value[1] === 'number')
-  )
-}
+const isTimeInput = require('./is-time-input.js')
+const TimedEvent = require('../spans/timed-event.js')
+const {
+  EXCEPTION_MESSAGE,
+  EXCEPTION_STACKTRACE,
+  EXCEPTION_TYPE
+} = require('./traces/constants.js')
 
 /**
  * In order to be able to return the appropriate span context

--- a/lib/otel/is-otel-hr-time.js
+++ b/lib/otel/is-otel-hr-time.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Determines if the input is an Open Telemetry `HrTime` tuple, i.e. a
+ * `[seconds, nanoseconds]` pair. This is a copy of upstream's implementation
+ * in the `@opentelemetry/core` package. We use a local copy so that we
+ * do not have to depend directly on that package for the function. Doing so
+ * makes it complicated to properly lazy load the package for the AWS Lambda
+ * "slim" layer.
+ *
+ * @see https://github.com/open-telemetry/opentelemetry-js/blob/99dde77/packages/opentelemetry-core/src/common/time.ts#L142-L149
+ *
+ * @param {*} value The value to check.
+ *
+ * @returns {boolean} True when the value is an `HrTime` tuple.
+ */
+module.exports = function isOtelHrTime(value) {
+  return (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    typeof value[0] === 'number' &&
+    typeof value[1] === 'number'
+  )
+}

--- a/lib/otel/is-otel-hr-time.js
+++ b/lib/otel/is-otel-hr-time.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+'use strict'
+
 /**
  * Determines if the input is an Open Telemetry `HrTime` tuple, i.e. a
  * `[seconds, nanoseconds]` pair. This is a copy of upstream's implementation

--- a/lib/otel/is-time-input.js
+++ b/lib/otel/is-time-input.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const isOtelHrTime = require('./is-otel-hr-time.js')
+
+/**
+ * Checks whether a value looks like a point in time (a `Date`, an epoch
+ * number, or an OTEL hrtime `[seconds, nanoseconds]` tuple) rather than a
+ * set of event attributes.
+ *
+ * @param {*} value The value to check.
+ *
+ * @returns {boolean} True if the value should be treated as a time.
+ */
+module.exports = function isTimeInput(value) {
+  return (
+    typeof value === 'number' ||
+    value instanceof Date ||
+    isOtelHrTime(value)
+  )
+}

--- a/lib/otel/normalize-timestamp.js
+++ b/lib/otel/normalize-timestamp.js
@@ -7,9 +7,7 @@
 
 module.exports = normalizeTimestamp
 
-const {
-  isTimeInputHrTime
-} = require('@opentelemetry/core')
+const isOtelHrTime = require('./is-otel-hr-time.js')
 
 /**
  * Returns a normalized epoch in milliseconds based upon the value provided
@@ -41,7 +39,7 @@ function normalizeTimestamp(input) {
     return input
   }
 
-  if (isTimeInputHrTime(input) === true) {
+  if (isOtelHrTime(input) === true) {
     return hrtimeToMilliseconds(input)
   }
 

--- a/test/unit/lib/otel/normalize-timestamp-no-otel-require.test.js
+++ b/test/unit/lib/otel/normalize-timestamp-no-otel-require.test.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert')
+const { execFileSync } = require('node:child_process')
+const path = require('node:path')
+
+const ROOT = path.join(__dirname, '..', '..', '..', '..')
+
+/**
+ * Regression test for https://github.com/newrelic/node-newrelic/issues/4162
+ *
+ * `lib/otel/normalize-timestamp.js` is reachable from the always-on agent
+ * startup path:
+ *
+ *   lib/transaction/tracer/index.js
+ *     -> lib/context-manager/async-local-context-manager.js
+ *       -> lib/otel/context.js
+ *         -> lib/otel/fake-span.js
+ *           -> lib/spans/timed-event.js
+ *             -> lib/otel/normalize-timestamp.js
+ *
+ * It must not `require('@opentelemetry/core')` (or any `@opentelemetry/*`
+ * package) at module load time, otherwise the "slim" Lambda layer/image --
+ * which ships without any `@opentelemetry/*` packages -- crashes at startup
+ * with `Cannot find module '@opentelemetry/core'`.
+ *
+ * These tests run in a child process so the assertion sees a pristine module
+ * cache, and so a broken require actually throws MODULE_NOT_FOUND rather than
+ * silently resolving against this test suite's own dependencies.
+ */
+
+function runChild(script) {
+  return execFileSync(process.execPath, ['-e', script], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  }).trim()
+}
+
+test('requiring normalize-timestamp does not load @opentelemetry/core', () => {
+  const output = runChild(`
+    require('./lib/otel/normalize-timestamp.js')
+    const loaded = Object.keys(require.cache).some((k) => k.includes('@opentelemetry'))
+    process.stdout.write(loaded ? 'loaded' : 'clean')
+  `)
+  assert.equal(output, 'clean')
+})
+
+test('the always-on tracer require chain does not load @opentelemetry/core', () => {
+  const output = runChild(`
+    require('./lib/transaction/tracer/index.js')
+    const loaded = Object.keys(require.cache).filter((k) => k.includes('@opentelemetry'))
+    process.stdout.write(loaded.length === 0 ? 'clean' : loaded.join(','))
+  `)
+  assert.equal(output, 'clean')
+})
+
+test('normalize-timestamp works when @opentelemetry/* cannot be resolved', () => {
+  // Simulate the slim build by making every `@opentelemetry/*` resolution fail,
+  // then exercise the code path that used to depend on `isTimeInputHrTime`.
+  const output = runChild(`
+    const Module = require('module')
+    const origResolve = Module._resolveFilename
+    Module._resolveFilename = function (request, ...rest) {
+      if (request.startsWith('@opentelemetry/')) {
+        const err = new Error("Cannot find module '" + request + "'")
+        err.code = 'MODULE_NOT_FOUND'
+        throw err
+      }
+      return origResolve.call(this, request, ...rest)
+    }
+
+    const normalizeTimestamp = require('./lib/otel/normalize-timestamp.js')
+    // [seconds, nanoseconds] hrtime tuple -> milliseconds since epoch.
+    const found = normalizeTimestamp([1764938931, 327000000])
+    process.stdout.write(new Date(found).toISOString())
+  `)
+  assert.equal(output, '2025-12-05T12:48:51.327Z')
+})


### PR DESCRIPTION
## Description

Fixes #4162.

Since v14.3.2 (#4151), the agent crashes at startup with `Cannot find module '@opentelemetry/core'` on the **slim** Node.js Lambda layer/image, which ships without any `@opentelemetry/*` packages.

### Root cause

#4151 wired `lib/spans/timed-event.js` into the **always-on** agent startup require chain:

```
lib/transaction/tracer/index.js
  → lib/context-manager/async-local-context-manager.js
    → lib/otel/context.js
      → lib/otel/fake-span.js
        → lib/spans/timed-event.js
          → lib/otel/normalize-timestamp.js
            → require('@opentelemetry/core')   ← unconditional
```

`lib/otel/normalize-timestamp.js` did a top-level `require('@opentelemetry/core')` (for `isTimeInputHrTime`), so simply requiring the agent now loaded that package on **every** startup — not just when the OTel bridge is enabled. The slim build strips `@opentelemetry/*`, so it crashed unconditionally.

### Fix

Replace the single used export (`isTimeInputHrTime`) with a local copy of the upstream implementation in `lib/otel/is-otel-hr-time.js`, shared by `lib/otel/is-time-input.js` and `lib/otel/normalize-timestamp.js`. Nothing on the always-on path now requires an `@opentelemetry/*` package. The OTel-bridge paths (traces/logs/metrics via `lib/otel/setup.js`) are unchanged — they still use `@opentelemetry/core` and only run when the bridge is enabled and the package is present.

### Tests

Adds `test/unit/lib/otel/normalize-timestamp-no-otel-require.test.js`, which runs in child processes (for a pristine module cache) and asserts:

1. Requiring `normalize-timestamp.js` does not load `@opentelemetry/core`.
2. The always-on tracer require chain does not load any `@opentelemetry/*` package.
3. `normalize-timestamp.js` produces correct output even when every `@opentelemetry/*` resolution throws `MODULE_NOT_FOUND` (slim-build simulation).

Verified the test fails without the fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)