### PR TITLE
chore: Updated `@apm-js-collab/tracing-hooks` to `0.13.0`

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -92,7 +92,7 @@ code, the source code can be found at [https://github.com/newrelic/node-newrelic
 
 ### @apm-js-collab/tracing-hooks
 
-This product includes source derived from [@apm-js-collab/tracing-hooks](https://github.com/apm-js-collab/tracing-hooks) ([v0.9.1](https://github.com/apm-js-collab/tracing-hooks/tree/v0.9.1)), distributed under the [Apache-2.0 License](https://github.com/apm-js-collab/tracing-hooks/blob/v0.9.1/LICENSE):
+This product includes source derived from [@apm-js-collab/tracing-hooks](https://github.com/apm-js-collab/tracing-hooks) ([v0.13.0](https://github.com/apm-js-collab/tracing-hooks/tree/v0.13.0)), distributed under the [Apache-2.0 License](https://github.com/apm-js-collab/tracing-hooks/blob/v0.13.0/LICENSE):
 
 ```
 
@@ -2945,7 +2945,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ### import-in-the-middle
 
-This product includes source derived from [import-in-the-middle](https://github.com/nodejs/import-in-the-middle) ([v3.2.0](https://github.com/nodejs/import-in-the-middle/tree/v3.2.0)), distributed under the [Apache-2.0 License](https://github.com/nodejs/import-in-the-middle/blob/v3.2.0/LICENSE):
+This product includes source derived from [import-in-the-middle](https://github.com/nodejs/import-in-the-middle) ([v3.3.0](https://github.com/nodejs/import-in-the-middle/tree/v3.3.0)), distributed under the [Apache-2.0 License](https://github.com/nodejs/import-in-the-middle/blob/v3.3.0/LICENSE):
 
 ```
                                  Apache License

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "#test/assert": "./test/lib/custom-assertions/index.js"
   },
   "dependencies": {
-    "@apm-js-collab/tracing-hooks": "^0.9.1",
+    "@apm-js-collab/tracing-hooks": "^0.13.0",
     "@grpc/grpc-js": "^1.13.2",
     "@grpc/proto-loader": "^0.8.1",
     "@newrelic/security-agent": "^3.0.0",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Mon Jul 06 2026 10:50:42 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Wed Jul 22 2026 16:17:29 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-newrelic",
   "includeOptDeps": true,
@@ -56,15 +56,15 @@
   },
   "includeDev": true,
   "dependencies": {
-    "@apm-js-collab/tracing-hooks@0.9.1": {
+    "@apm-js-collab/tracing-hooks@0.13.0": {
       "name": "@apm-js-collab/tracing-hooks",
-      "version": "0.9.1",
-      "range": "^0.9.1",
+      "version": "0.13.0",
+      "range": "^0.13.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/apm-js-collab/tracing-hooks",
-      "versionedRepoUrl": "https://github.com/apm-js-collab/tracing-hooks/tree/v0.9.1",
+      "versionedRepoUrl": "https://github.com/apm-js-collab/tracing-hooks/tree/v0.13.0",
       "licenseFile": "node_modules/@apm-js-collab/tracing-hooks/LICENSE",
-      "licenseUrl": "https://github.com/apm-js-collab/tracing-hooks/blob/v0.9.1/LICENSE",
+      "licenseUrl": "https://github.com/apm-js-collab/tracing-hooks/blob/v0.13.0/LICENSE",
       "licenseTextSource": "file"
     },
     "@grpc/grpc-js@1.14.4": {
@@ -263,15 +263,15 @@
       "email": "nathan@tootallnate.net",
       "url": "http://n8.io/"
     },
-    "import-in-the-middle@3.2.0": {
+    "import-in-the-middle@3.3.0": {
       "name": "import-in-the-middle",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "range": "^3.0.1",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/nodejs/import-in-the-middle",
-      "versionedRepoUrl": "https://github.com/nodejs/import-in-the-middle/tree/v3.2.0",
+      "versionedRepoUrl": "https://github.com/nodejs/import-in-the-middle/tree/v3.3.0",
       "licenseFile": "node_modules/import-in-the-middle/LICENSE",
-      "licenseUrl": "https://github.com/nodejs/import-in-the-middle/blob/v3.2.0/LICENSE",
+      "licenseUrl": "https://github.com/nodejs/import-in-the-middle/blob/v3.3.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Bryan English",
       "email": "bryan.english@datadoghq.com"


### PR DESCRIPTION
## Description

There has been quite a few releases of `@apm-js-collab/tracing-hooks`. This Pr updates it to the latest. Locally I have a failure in `@langchain/aws` but it exists on main. I'll open a follow up PR to address that
