### PR TITLE
test: Updated `runnables-streaming.js` to consume the stream on the tracking metrics tests to avoid test time outs

### DIFF
--- a/test/versioned/langchain/runnables-streaming.js
+++ b/test/versioned/langchain/runnables-streaming.js
@@ -52,14 +52,19 @@ function runStreamingEnabledTests(config) {
     await t.test('should log tracking metrics', function(t, end) {
       t.plan(5)
       const { agent, langchainCoreVersion, prompt, model } = t.nr
-      helper.runInTransaction(agent, async () => {
-        await prompt.pipe(model).stream(inputData)
+      helper.runInTransaction(agent, async (tx) => {
+        const chain = prompt.pipe(model)
+        const stream = await chain.stream(inputData)
+        for await (const chunk of stream) {
+          consumeStreamChunk(chunk)
+        }
         assertPackageMetrics({
           agent,
           pkg: '@langchain/core',
           version: langchainCoreVersion,
           subscriberType: true
         }, { assert: t.assert })
+        tx.end()
         end()
       })
     })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

I was updating tracing-hooks in #3167 and noticed the langchain-aws tests were hanging. It was because the `should log tracking metrics` wasn't consuming the stream it was creating and at times creating a stream that was never destroyed until the timeout elapsed. This PR fixes that test to do a no-op on the stream to avoid the timeouts.

