### PR TITLE
chore: Fixed typos in 14.3.1 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,7 +35,7 @@
 
 #### Bug fixes
 
-* Handled `$0` as a replacment in a metric normalization rule to return the matched string in its entirety ([#4150](https://github.com/newrelic/node-newrelic/pull/4150)) ([b57fcc8](https://github.com/newrelic/node-newrelic/commit/b57fcc87d741122e87285f73b1c68f566ec9f1db))
+* Handled `$0` as a replacement in a metric normalization rule to return the matched string in its entirety ([#4150](https://github.com/newrelic/node-newrelic/pull/4150)) ([b57fcc8](https://github.com/newrelic/node-newrelic/commit/b57fcc87d741122e87285f73b1c68f566ec9f1db))
 
 #### Documentation
 
@@ -45,11 +45,11 @@
 #### Miscellaneous chores
 
 * Attached serverless mode config to agent instance ([#4140](https://github.com/newrelic/node-newrelic/pull/4140)) ([7a3592f](https://github.com/newrelic/node-newrelic/commit/7a3592f58354a824cf7d148173cb38e64bd8beed))
-* Remove dead `otlp_endpoint` config option ([#4142](https://github.com/newrelic/node-newrelic/pull/4142)) ([05b072f](https://github.com/newrelic/node-newrelic/commit/05b072f8b5c7b4ec18b36c0aa4267a86f5966b9c))
+* Removed dead `otlp_endpoint` config option ([#4142](https://github.com/newrelic/node-newrelic/pull/4142)) ([05b072f](https://github.com/newrelic/node-newrelic/commit/05b072f8b5c7b4ec18b36c0aa4267a86f5966b9c))
 
 #### Continuous integration
 
-* Revert CI schedules to previous schedules ([#4139](https://github.com/newrelic/node-newrelic/pull/4139)) ([b6f8708](https://github.com/newrelic/node-newrelic/commit/b6f8708530574d600371cc639a26ab655322e47f))
+* Reverted CI schedules to previous schedules ([#4139](https://github.com/newrelic/node-newrelic/pull/4139)) ([b6f8708](https://github.com/newrelic/node-newrelic/commit/b6f8708530574d600371cc639a26ab655322e47f))
 
 ### v14.3.0 (2026-07-14)
 

--- a/changelog.json
+++ b/changelog.json
@@ -29,7 +29,7 @@
       "changes": {
         "security": [],
         "bugfixes": [
-          "Handled `$0` as a replacment in a metric normalization rule to return the matched string in its entirety"
+          "Handled `$0` as a replacement in a metric normalization rule to return the matched string in its entirety"
         ],
         "features": []
       }


### PR DESCRIPTION
The docs team reached out to us that our 14.3.1 release had a few typos. It has been resolved in the docs website, but this PR fixes it in our agent.