### PR TITLE
fix: Updated `openai` instrumentation to cache the results of `responses.parse` chain on openai custom promises

### DIFF
--- a/lib/subscribers/openai/api-promise.js
+++ b/lib/subscribers/openai/api-promise.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const Subscriber = require('../base')
+
+/**
+ * Instruments APIPromise._thenUnwrap to prevent double response body consumption.
+ *
+ * When NR's end handler for nr_responses calls wrapPromise(), it calls
+ * apiPromise.then() which triggers APIPromise.parse(), setting parsedPromise
+ * (a chain: responsePromise → defaultParseResponse → response.json()).
+ *
+ * responses.parse() then calls _thenUnwrap() on that same APIPromise to create
+ * a second APIPromise whose parseResponse closure calls the original's parseResponse
+ * field directly, bypassing the parsedPromise cache. Both chains subscribe to the
+ * same responsePromise and both call response.json(), causing "Body is unusable".
+ */
+class OpenAIApiPromiseSubscriber extends Subscriber {
+  constructor({ agent, logger, channelName = 'nr_thenUnwrap' }) {
+    super({ agent, logger, packageName: 'openai', channelName })
+    this.events = ['end']
+    this.requireActiveTx = false
+  }
+
+  /**
+   * Not all calls to _thenUnwrap have to be instrumented. This check verifies
+   * if the properties exist that need wrapping on all openai versions
+   * @param {object} data from tracing channel
+   * @returns {boolean} if the _thenUnwrap should be instrumented
+   */
+  skipWrapping(data) {
+    return data?.self?.parsedPromise === undefined || data.result === undefined
+  }
+
+  /**
+   * parse() uses a closure that reads parseResponse via a live property lookup at call time, so caching it works.
+   * @param {object} data from tracing channel
+   */
+  cacheWrappedPromise(data) {
+    const original = data.self
+    const originalParseResponse = original.parseResponse
+    let cachedResult = null
+    original.parseResponse = function wrappedParseResponse(client, props) {
+      if (!cachedResult) {
+        cachedResult = originalParseResponse(client, props)
+      }
+      return cachedResult
+    }
+  }
+
+  end(data) {
+    if (this.skipWrapping(data)) {
+      return
+    }
+
+    this.cacheWrappedPromise(data)
+  }
+}
+
+module.exports = OpenAIApiPromiseSubscriber

--- a/lib/subscribers/openai/config.js
+++ b/lib/subscribers/openai/config.js
@@ -68,6 +68,34 @@ module.exports = {
       ]
     },
     {
+      path: './openai/legacy-api-promise.js',
+      instrumentations: [
+        {
+          channelName: 'nr_legacyThenUnwrap',
+          module: { name: 'openai', versionRange: '>=4.87.0 <5.0.0', filePath: 'core.js' },
+          functionQuery: {
+            className: 'APIPromise',
+            methodName: '_thenUnwrap',
+            kind: 'Sync'
+          }
+        },
+      ]
+    },
+    {
+      path: './openai/api-promise.js',
+      instrumentations: [
+        {
+          channelName: 'nr_thenUnwrap',
+          module: { name: 'openai', versionRange: '>=5.0.0', filePath: 'core/api-promise.js' },
+          functionQuery: {
+            className: 'APIPromise',
+            methodName: '_thenUnwrap',
+            kind: 'Sync'
+          }
+        }
+      ]
+    },
+    {
       path: './openai/embeddings.js',
       instrumentations: [
         {

--- a/lib/subscribers/openai/legacy-api-promise.js
+++ b/lib/subscribers/openai/legacy-api-promise.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const OpenAIApiPromiseSubscriber = require('./api-promise')
+
+/**
+ * Overrides the behavior of wrapping `_thenUnwrap` for openai < 5
+ */
+class OpenAILegacyApiPromiseSubscriber extends OpenAIApiPromiseSubscriber {
+  constructor({ agent, logger }) {
+    super({ agent, logger, channelName: 'nr_legacyThenUnwrap' })
+  }
+
+  /**
+   * In openai <5 parse() captures parseResponse by reference at setup time.
+   * Wrap `parsedPromise` and cache the first resolved parsedResponse to avoid
+   * it getting called multiple times
+   *
+   * @param {object} data from tracing channel
+   */
+  cacheWrappedPromise(data) {
+    const original = data.self
+    const newPromise = data.result
+
+    const cached = original.parsedPromise
+    newPromise.parsedPromise = cached.then(async function wrappedParsedPromise(baseData) {
+      const props = await original.responsePromise
+      const savedParseResponse = original.parseResponse
+      // assign to original parseResponse but it is an async function
+      // however baseData was already resolved so this just injects it
+      // into the call path of _thenUnwrap
+      original.parseResponse = () => Promise.resolve(baseData)
+      try {
+        return await newPromise.parseResponse(props)
+      } finally {
+        original.parseResponse = savedParseResponse
+      }
+    })
+  }
+}
+
+module.exports = OpenAILegacyApiPromiseSubscriber

--- a/test/versioned/openai/chat-completions-res-api.test.js
+++ b/test/versioned/openai/chat-completions-res-api.test.js
@@ -26,7 +26,7 @@ const TRACKING_METRIC = `Supportability/Nodejs/ML/OpenAI/${pkgVersion}`
 const responses = require('./mock-responses-api-responses')
 const { assertChatCompletionMessages, assertChatCompletionSummary } = require('./common-responses-api')
 
-test('responses.create', { skip: semver.lte(pkgVersion, '4.87.0') }, async (t) => {
+test('responses.create', { skip: semver.lt(pkgVersion, '4.87.0') }, async (t) => {
   t.beforeEach(async (ctx) => {
     ctx.nr = {}
     const { host, port, server } = await createOpenAIMockServer(responses)
@@ -54,21 +54,15 @@ test('responses.create', { skip: semver.lte(pkgVersion, '4.87.0') }, async (t) =
     removeModules('openai')
   })
 
-  // Note: I cannot figure out how to get the mock server to do the right thing,
-  // but this was failing with a different issue before
   await t.test('should not crash when you call `responses.parse`', async (t) => {
     const plan = tspl(t, { plan: 1 })
     const { client, agent } = t.nr
     await helper.runInTransaction(agent, async (tx) => {
-      try {
-        await client.responses.parse({
-          input: [{ role: 'user', content: 'You are a mathematician.' }]
-        })
-      } catch (err) {
-        plan.match(err.message, /Body is unusable|body used already for/)
-      } finally {
-        tx.end()
-      }
+      const result = await client.responses.parse({
+        input: [{ role: 'user', content: 'You are a mathematician.' }]
+      })
+      plan.equal(result.output_text, '1 plus 2 is 3.')
+      tx.end()
     })
 
     await plan.completed

--- a/test/versioned/openai/chat-completions.test.js
+++ b/test/versioned/openai/chat-completions.test.js
@@ -54,21 +54,15 @@ test('chat.completions.create', async (t) => {
     removeModules('openai')
   })
 
-  // Note: I cannot figure out how to get the mock server to do the right thing,
-  // but this was failing with a different issue before
   await t.test('should not crash when you call `completions.parse`', { skip: semver.lt(pkgVersion, '5.0.0') }, async (t) => {
     const plan = tspl(t, { plan: 1 })
     const { client, agent } = t.nr
     await helper.runInTransaction(agent, async (tx) => {
-      try {
-        await client.chat.completions.parse({
-          messages: [{ role: 'user', content: 'You are a mathematician.' }]
-        })
-      } catch (err) {
-        plan.match(err.message, /.*Body is unusable.*/)
-      } finally {
-        tx.end()
-      }
+      const result = await client.chat.completions.parse({
+        messages: [{ role: 'user', content: 'You are a mathematician.' }]
+      })
+      plan.equal(result.choices[0].message.content, '1 plus 2 is 3.')
+      tx.end()
     })
 
     await plan.completed

--- a/test/versioned/openai/mock-responses-api-responses.js
+++ b/test/versioned/openai/mock-responses-api-responses.js
@@ -58,7 +58,9 @@ responses.set('You are a mathematician.', {
   body: {
     output: [
       {
+        type: 'message',
         content: [{
+          type: 'output_text',
           text: '1 plus 2 is 3.',
         }],
         role: 'assistant',


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

When our agent instruments `Responses.create`/ `Completions.create`, it side-chains onto the returned `APIPromise` by calling `.then()`. This triggers `APIPromise.parse()`, which creates an internal parsedPromise chain that reads the response body via `response.json()`. When the caller then invokes `responses.parse()`/`completions.parse()`, that method calls `_thenUnwrap()` on the same APIPromise to create a second promise — and that second promise also independently calls `response.json()` on the already-consumed body, producing `TypeError: Body is unusable: Body has already been read.`

This PR adds instrumentation for `APIPromise._thenUnwrap()` that intercepts the moment a second promise is chained off an already-in-flight parse, and prevents it from re-reading the response body by caching the result.  openai custom promises are mess, fun fun fun. Turns out our tests were asserting this actual bug due to a misunderstanding of how `respones.parse`/`completions.parse` works.  I also fixed the tests to assert that when calling those methods you actually get the responses expected and not an error.

## How to Test

```sh
npm run versioned openai
```

## Related Issues
Closes #4171
