### PR TITLE
ci: Added a poll npm workflow to ensure new package version exists before executing any dependent workflows

### DIFF
--- a/.github/workflows/azure-site-extension.yml
+++ b/.github/workflows/azure-site-extension.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: ["Create Release"]
+    workflows: ["Poll NPM for Release Availability"]
     types:
       - completed
 
@@ -45,42 +45,11 @@ jobs:
           check-latest: true
           architecture: ${{ matrix.arch }}
 
-      - name: Get local agent version 
+      - name: Get agent version from package.json
+        id: get_version
         run: |
-          $env:local_agent_version = node -p "require('./package.json').version"
-          echo "AGENT_VERSION=$env:local_agent_version" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Find agent version at npm 
-        run: |
-          $env:npm_agent_version = npm view newrelic version 
-          echo "NPM_AGENT_VERSION=$env:npm_agent_version" | Out-File -FilePath $env:GITHUB_ENV -Append
-          
-      - name: Check NPM availability
-        if: ${{ env.NPM_AGENT_VERSION != env.AGENT_VERSION }}
-        run: |
-          $count = 0
-          $seconds = 30
-          while($count -lt 10) {
-            $seconds = ($seconds * $count)
-            echo "Sleeping $seconds ($count)"
-            Start-Sleep -s $seconds
-            $npmversion = npm view newrelic version
-            echo "Checking npm version ($count): $npmversion"
-            $test = [Version]$npmversion -match [Version]${{ env.AGENT_VERSION }}
-            if ([Version]$npmversion -match [Version]${{ env.AGENT_VERSION }}) {
-              break;
-            }
-            $count++
-          }
-          $env:npm_agent_version = npm view newrelic version 
-          echo "Done with delayed check. Published version: $env:npm_agent_version Local version: ${{env.AGENT_VERSION}}"
-          echo "NPM_AGENT_VERSION=$env:npm_agent_version" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Has the new agent been published?
-        if: ${{ env.NPM_AGENT_VERSION != env.AGENT_VERSION }}
-        run: |
-          echo "Published agent version (${{env.NPM_AGENT_VERSION }}) is behind local agent version (${{env.AGENT_VERSION}}); exiting."
-          exit 1;
+          $version = node -p "require('./package.json').version"
+          echo "version=$version" >> $env:GITHUB_OUTPUT
 
       - name: Set package filename
         run: |
@@ -88,19 +57,19 @@ jobs:
 
       - name: Verify environment vars # because we can't access GH env vars until the next step
         run: |
-          echo "Agent version: ${{ env.AGENT_VERSION }}"
+          echo "Agent version: ${{ steps.get_version.outputs.version }}"
           echo "Package filename: ${{ env.PACKAGE_FILENAME }}"
 
       - name: Install agent
         working-directory: cloud-tooling/azure-site-extension/Content
         run: |
-          npm i --prefix . newrelic@${{ env.AGENT_VERSION }}
+          npm i --prefix . newrelic@${{ steps.get_version.outputs.version }}
           echo "Agent installed"
 
       - name: Configure package files
         working-directory: cloud-tooling/azure-site-extension
         run: |
-          (Get-Content ${{ env.SPEC_FILE_TEMPLATE }}).Replace('{VERSION}', "${{ env.AGENT_VERSION }}") | Set-Content ${{ env.PACKAGE_FILENAME }}.nuspec
+          (Get-Content ${{ env.SPEC_FILE_TEMPLATE }}).Replace('{VERSION}', "${{ steps.get_version.outputs.version }}") | Set-Content ${{ env.PACKAGE_FILENAME }}.nuspec
 
       - name: Create bundle
         working-directory: cloud-tooling/azure-site-extension

--- a/.github/workflows/poll-npm-availability.yml
+++ b/.github/workflows/poll-npm-availability.yml
@@ -1,0 +1,51 @@
+name: Poll NPM for Release Availability
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Create Release"]
+    types:
+      - completed
+
+jobs:
+  poll-npm:
+    runs-on: ubuntu-latest
+    if:
+      (github.event.workflow_run && github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'workflow_dispatch')
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Get agent version from package.json
+        id: get_version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Poll npm registry until version is available
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          MAX_ATTEMPTS="${{ vars.NPM_POLL_MAX_ATTEMPTS || 20 }}"
+          INTERVAL=30
+
+          echo "Polling npm for newrelic@${VERSION}..."
+
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            NPM_VERSION=$(npm view "newrelic@${VERSION}" --prefer-online version 2>/dev/null || echo "")
+            echo "Attempt ${i}/${MAX_ATTEMPTS}: registry returned '${NPM_VERSION}'"
+
+            if [ "${NPM_VERSION}" = "${VERSION}" ]; then
+              echo "newrelic@${VERSION} is available on npm."
+              exit 0
+            fi
+
+            if [ "$i" -lt "$MAX_ATTEMPTS" ]; then
+              echo "Not yet available, sleeping ${INTERVAL}s..."
+              sleep $INTERVAL
+            fi
+          done
+
+          echo "ERROR: newrelic@${VERSION} did not appear on npm after $((MAX_ATTEMPTS * INTERVAL))s."
+          exit 1

--- a/.github/workflows/release-lambda-init-containers.yml
+++ b/.github/workflows/release-lambda-init-containers.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: ["Create Release"]
+    workflows: ["Poll NPM for Release Availability"]
     types:
       - completed
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

This PR introduces a polling workflow after create release. This is necessary for the azure site extension and lambda and init container workflows because they run `npm i newrelic@<new-version>`. This new workflow verifies the new version of `newrelic` exists before exiting. It will poll every 30 s for n attempts. The default is so but in our repo action variables i set it to 30. So this will wait 15 minutes, for now, before failing.  I can't seem to get a straight answer on time to publish now but have a question out if `npm view newrelic@<version>` is the right mechanism to ensure the new version exists on registry.

As a sanity I modified the script locally to change the version to a legit one after 3 checks:

```sh
VERSION="14.5.0"
MAX_ATTEMPTS="20"
INTERVAL=30

echo "Polling npm for newrelic@${VERSION}..."

for i in $(seq 1 $MAX_ATTEMPTS); do
  NPM_VERSION=$(npm view "newrelic@${VERSION}" --prefer-online version 2>/dev/null || echo "")
  echo "Attempt ${i}/${MAX_ATTEMPTS}: registry returned '${NPM_VERSION}'"
  if [ "$i" = "2" ]; then
    VERSION="14.3.4"
  fi

  if [ "${NPM_VERSION}" = "${VERSION}" ]; then
    echo "newrelic@${VERSION} is available on npm."
    exit 0
  fi

  if [ "$i" -lt "$MAX_ATTEMPTS" ]; then
    echo "Not yet available, sleeping ${INTERVAL}s..."
    sleep $INTERVAL
  fi
done

echo "ERROR: newrelic@${VERSION} did not appear on npm after $((MAX_ATTEMPTS * INTERVAL))s."
exit 1
```



and the output was:

```
Polling npm for newrelic@14.5.0...
Attempt 1/20: registry returned ''
Not yet available, sleeping 30s...
Attempt 2/20: registry returned ''
Not yet available, sleeping 30s...
Attempt 3/20: registry returned ''
newrelic@14.3.4 is available on npm.
```

## Related Issues
Closes #4180
