### PR TITLE
ci: Normalized how we retrieve agent version from package.json

### DIFF
--- a/.github/workflows/agent-metadata.yml
+++ b/.github/workflows/agent-metadata.yml
@@ -48,8 +48,7 @@ jobs:
             echo "agent-type=${{ inputs.agent-type }}" >> $GITHUB_OUTPUT
             echo "use-cache=${{ inputs.use-cache }}" >> $GITHUB_OUTPUT
           else
-            VERSION=$(node -p "require('./package.json').version")
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            jq -r '"version=\(.version)"' ./package.json >> $GITHUB_OUTPUT
             echo "agent-type=NRNodeAgent" >> $GITHUB_OUTPUT
             echo "use-cache=true" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/azure-site-extension.yml
+++ b/.github/workflows/azure-site-extension.yml
@@ -47,9 +47,7 @@ jobs:
 
       - name: Get agent version from package.json
         id: get_version
-        run: |
-          $version = node -p "require('./package.json').version"
-          echo "version=$version" >> $env:GITHUB_OUTPUT
+        run: jq -r '"version=\(.version)"' ./package.json >> $env:$GITHUB_OUTPUT
 
       - name: Set package filename
         run: |

--- a/.github/workflows/poll-npm-availability.yml
+++ b/.github/workflows/poll-npm-availability.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Get agent version from package.json
         id: get_version
-        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+        run: jq -r '"version=\(.version)"' ./package.json >> $GITHUB_OUTPUT
 
       - name: Poll npm registry until version is available
         run: |

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -44,8 +44,6 @@ jobs:
       - run: |
           git config user.name ${GITHUB_ACTOR}
           git config user.email gh-actions-${GITHUB_ACTOR}@github.com
-      - id: get_tag
-        run: echo "latest_tag=$(cat package.json | jq .version)" >> $GITHUB_OUTPUT
       - run: npm run publish-docs
 
   docs:
@@ -67,9 +65,9 @@ jobs:
           git config user.name ${GITHUB_ACTOR}
           git config user.email gh-actions-${GITHUB_ACTOR}@github.com
       - id: get_tag
-        run: echo "latest_tag=$(cat package.json | jq .version)" >> $GITHUB_OUTPUT
+        run: jq -r '"version=\(.version)"' ./package.json >> $GITHUB_OUTPUT
       - name: Create Docs Website PR
-        run: node ./bin/create-docs-pr.js --tag v${{ steps.get_tag.outputs.latest_tag }}
+        run: node ./bin/create-docs-pr.js --tag v${{ steps.get_tag.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.NODE_AGENT_GH_TOKEN }}
           GITHUB_USER: ${{ vars.NODE_AGENT_CI_USER_NAME }}

--- a/.github/workflows/release-lambda-init-containers.yml
+++ b/.github/workflows/release-lambda-init-containers.yml
@@ -22,12 +22,12 @@ jobs:
         with:
           fetch-depth: 2
       - id: get_tag
-        run: echo "latest_tag=$(cat package.json | jq .version)" >> $GITHUB_OUTPUT
+        run: jq -r '"version=\(.version)"' ./package.json >> $GITHUB_OUTPUT
       - name: Create release tags for Lambda and K8s Init Containers
         run: |
-          RELEASE_TITLE="New Relic Node Agent v${{ steps.get_tag.outputs.latest_tag }}.0"
-          RELEASE_TAG="v${{ steps.get_tag.outputs.latest_tag }}.0_nodejs"
-          RELEASE_NOTES="Automated release for [Node Agent v${{ steps.get_tag.outputs.latest_tag }}](https://github.com/newrelic/node-newrelic/releases/tag/v${{ steps.get_tag.outputs.latest_tag }})"
+          RELEASE_TITLE="New Relic Node Agent v${{ steps.get_tag.outputs.version }}.0"
+          RELEASE_TAG="v${{ steps.get_tag.outputs.version }}.0_nodejs"
+          RELEASE_NOTES="Automated release for [Node Agent v${{ steps.get_tag.outputs.version }}](https://github.com/newrelic/node-newrelic/releases/tag/v${{ steps.get_tag.outputs.version }})"
           gh auth login --with-token <<< $GH_RELEASE_TOKEN
           echo "newrelic/newrelic-lambda-layers - Releasing \"${RELEASE_TITLE}\" with tag ${RELEASE_TAG}"
           gh release create "${RELEASE_TAG}" --title="${RELEASE_TITLE}" --repo=newrelic/newrelic-lambda-layers --notes="${RELEASE_NOTES}"

--- a/bin/publish-docs.sh
+++ b/bin/publish-docs.sh
@@ -4,7 +4,7 @@ set -ex
 # Copyright 2020 New Relic Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-PACKAGE_VERSION=$(node -e 'console.log(require("./package").version)')
+PACKAGE_VERSION=$(jq -r '.version' ./package.json)
 
 git fetch origin gh-pages
 git checkout gh-pages


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

In #4182 it was suggested to streamline how we get package version of agent. I noticed we had a few ways to do so.
This PR normalizes how we retrieve agent version via `jq -r '.version' ./package.json`
