### PR TITLE
fix: Ensuring addAttribute only increases the count for new Attributes

### DIFF
--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -118,7 +118,8 @@ class Attributes {
    * @param {boolean} [truncateExempt] - Flag marking value exempt from truncation
    */
   addAttribute(destinations, key, value, truncateExempt = false) {
-    if (this.attributeCount + 1 > this.limit) {
+    const isNewAttribute = !this.has(key)
+    if (isNewAttribute && this.attributeCount + 1 > this.limit) {
       return logger.debug(
         `Maximum number of custom attributes have been added.
         Dropping attribute ${key} with ${value} type.`
@@ -142,7 +143,9 @@ class Attributes {
     // Only set the attribute if at least one destination passed
     const validDestinations = this.filter(destinations, key)
     if (validDestinations) {
-      this.attributeCount = this.attributeCount + 1
+      if (isNewAttribute) {
+        this.attributeCount = this.attributeCount + 1
+      }
       this._set(validDestinations, key, value, truncateExempt)
     }
   }

--- a/test/unit/attributes.test.js
+++ b/test/unit/attributes.test.js
@@ -102,6 +102,23 @@ test('#addAttributes', async (t) => {
 
     assert.equal(Object.keys(res).length, 1)
     assert.equal(res.Roboto, 99)
+    assert.equal(inst.attributeCount, 1)
+  })
+
+  await t.test('allows overwriting attributes when at limit', () => {
+    const inst = new Attributes({ scope: TRANSACTION_SCOPE, limit: 1 })
+    inst.addAttribute(0x01, 'Roboto', 1)
+    inst.addAttribute(0x01, 'Roboto', 99)
+    inst.addAttribute(0x01, 'Roboto', 123)
+    inst.addAttribute(0x01, 'OpenSans', 456)
+
+    const res = inst.get(0x01)
+    const hasAttribute = Object.hasOwnProperty.bind(res)
+
+    assert.equal(Object.keys(res).length, 1)
+    assert.equal(res.Roboto, 123)
+    assert.equal(hasAttribute('OpenSans'), false)
+    assert.equal(inst.attributeCount, 1)
   })
 })
 


### PR DESCRIPTION
## Description

This fixes an issue in the new relic agent where `addAttribute`  always assumed the attribute wasn't present when called and increased the attribute count. This led to reaching the attribute limit faster then expected/

## How to Test

Tested with unit tests and with a running application to ensure addAttribute now checks for updates