### PR TITLE
ci: Added a workflow to scan repos for code and security scanning alerts

### DIFF
--- a/.github/workflows/security-alerts-slack.yml
+++ b/.github/workflows/security-alerts-slack.yml
@@ -1,0 +1,30 @@
+name: Security Alert Notifications
+
+on:
+  schedule:
+    - cron: '0 14 * * 1-5'  # 9am EST (UTC-5) weekdays
+  workflow_dispatch:
+
+permissions:
+  security-events: read
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          check-latest: true
+      - name: Install Dependencies
+        run: npm install 
+      - name: Check for secret or code scanning alerts
+        run: node ./bin/scan-github-security-alerts.js --repos $NR_REPOS 
+        env:
+          GITHUB_TOKEN: ${{ secrets.NODE_AGENT_GH_TOKEN }}
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+          SLACK_CHANNEL: ${{ vars.SLACK_CHANNEL }}
+          SLACK_SECRET: ${{ secrets.SLACK_SECRET }}
+          NR_REPOS: ${{ vars.NR_REPOS}}

--- a/bin/scan-github-security-alerts.js
+++ b/bin/scan-github-security-alerts.js
@@ -24,6 +24,27 @@ program.requiredOption(
 )
 program.option('--dry-run', 'Execute the logic but do not send slack message')
 
+// These options are simply for testing
+// It is worth noting at the time of testing this (07/31/2026)
+// it is not returning resolved secret scanning, only code scanning alerts
+program.option(
+  '--per-page [number]',
+  'Customize how many results come back on the call to Github',
+  '100'
+)
+program.option(
+  '--alert-state [string]',
+  'State of alerts',
+  'open',
+  (value) => {
+    const allowed = ['open', 'resolved']
+    if (!allowed.includes(value)) {
+      throw new Error(`--alert-state must be one of ${allowed.join(', ')}`)
+    }
+    return value
+  }
+)
+
 /**
  * Fetches all open secret scanning and code scanning alerts for each repo
  * and posts them to Slack.
@@ -34,7 +55,7 @@ program.option('--dry-run', 'Execute the logic but do not send slack message')
  * SLACK_TOKEN - token from bot
  * SLACK_SECRET - signing secret from bot
  *
- * `node ./bin/scan-github-security-alerts.js --repos <comma-delimited repo list>`
+ * `node ./bin/scan-github-security-alerts.js --repos <comma-delimited repo list> --per-page [100] --alert-state [open] [--dry-run]`
  */
 async function scanSecurityAlerts() {
   try {
@@ -54,8 +75,8 @@ async function scanSecurityAlerts() {
       console.log(`\nScanning ${ORG}/${repo}...`)
 
       await Promise.all([
-        scanSecretAlerts({ app, octokit, repo, isDryRun: opts.dryRun }),
-        scanCodeAlerts({ app, octokit, repo, isDryRun: opts.dryRun })
+        scanSecretAlerts({ app, octokit, repo, opts }),
+        scanCodeAlerts({ app, octokit, repo, opts })
       ])
     }
   } catch (err) {
@@ -71,8 +92,9 @@ function stopOnError(err) {
   process.exit(1)
 }
 
-async function scanSecretAlerts({ app, octokit, repo, isDryRun }) {
-  const secretAlerts = await fetchSecretScanningAlerts(octokit, repo)
+async function scanSecretAlerts({ app, octokit, repo, opts }) {
+  const { dryRun: isDryRun } = opts
+  const secretAlerts = await fetchSecretScanningAlerts(octokit, repo, opts)
   console.log(`${secretAlerts.length} secret scanning alert(s)`)
 
   for (const alert of secretAlerts) {
@@ -80,21 +102,22 @@ async function scanSecretAlerts({ app, octokit, repo, isDryRun }) {
     if (isDryRun) {
       console.log(`[DRY RUN] Secret alert #${alert.number}:`, JSON.stringify(blocks, null, 2))
     } else {
-      await app.client.chat.postMessage({ channel, blocks })
+      await app.client.chat.postMessage({ channel, text: `Secret scanning alert #${alert.number} in ${ORG}/${repo}`, blocks })
       console.log(`Posted secret alert #${alert.number} to ${channel}`)
     }
   }
 }
 
-async function scanCodeAlerts({ app, octokit, repo, isDryRun }) {
-  const codeAlerts = await fetchCodeScanningAlerts(octokit, repo)
+async function scanCodeAlerts({ app, octokit, repo, opts }) {
+  const { dryRun: isDryRun } = opts
+  const codeAlerts = await fetchCodeScanningAlerts(octokit, repo, opts)
   console.log(`${codeAlerts.length} code scanning alert(s)`)
   for (const alert of codeAlerts) {
     const blocks = buildCodeAlertBlocks(repo, alert)
     if (isDryRun) {
       console.log(`[DRY RUN] Code alert #${alert.number}:`, JSON.stringify(blocks, null, 2))
     } else {
-      await app.client.chat.postMessage({ channel, blocks })
+      await app.client.chat.postMessage({ channel, text: `Code scanning alert #${alert.number} in ${ORG}/${repo}`, blocks })
       console.log(`Posted code alert #${alert.number} to ${channel}`)
     }
   }
@@ -110,13 +133,16 @@ function areEnvVarsSet(dryRun) {
   return missingEnvVars.length === 0
 }
 
-async function fetchSecretScanningAlerts(octokit, repo) {
+async function fetchSecretScanningAlerts(octokit, repo, opts) {
+  const { perPage, alertState } = opts
   try {
+    // we haven't implemented paging, so this will return up to 100 max.
+    // If we have more than that, we've done something wrong
     const { data } = await octokit.request('GET /repos/{owner}/{repo}/secret-scanning/alerts', {
       owner: ORG,
       repo,
-      state: 'open',
-      per_page: 100
+      state: alertState,
+      per_page: perPage
     })
     return data
   } catch (err) {
@@ -128,13 +154,16 @@ async function fetchSecretScanningAlerts(octokit, repo) {
   }
 }
 
-async function fetchCodeScanningAlerts(octokit, repo) {
+async function fetchCodeScanningAlerts(octokit, repo, opts) {
+  const { perPage, alertState } = opts
   try {
+    // we haven't implemented paging, so this will return up to 100 max.
+    // If we have more than that, we've done something wrong
     const { data } = await octokit.request('GET /repos/{owner}/{repo}/code-scanning/alerts', {
       owner: ORG,
       repo,
-      state: 'open',
-      per_page: 100
+      state: alertState,
+      per_page: perPage
     })
     return data
   } catch (err) {

--- a/bin/scan-github-security-alerts.js
+++ b/bin/scan-github-security-alerts.js
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { Octokit } = require('@octokit/rest')
+const { App } = require('@slack/bolt')
+const { Command } = require('commander')
+
+const ORG = 'newrelic'
+const requiredEnvVars = ['GITHUB_TOKEN', 'SLACK_CHANNEL', 'SLACK_TOKEN', 'SLACK_SECRET']
+const channel = process.env.SLACK_CHANNEL
+const token = process.env.SLACK_TOKEN
+const signingSecret = process.env.SLACK_SECRET
+let missingEnvVars = []
+
+const program = new Command()
+program.requiredOption(
+  '--repos <repos>',
+  'Comma-delimited list of repos in the newrelic org to scan for open security alerts'
+)
+program.option('--dry-run', 'Execute the logic but do not send slack message')
+
+/**
+ * Fetches all open secret scanning and code scanning alerts for each repo
+ * and posts them to Slack.
+ *
+ * To use this script you must set the following env vars:
+ * GITHUB_TOKEN - api token to talk to Github API
+ * SLACK_CHANNEL - slack channel to post alerts to
+ * SLACK_TOKEN - token from bot
+ * SLACK_SECRET - signing secret from bot
+ *
+ * `node ./bin/scan-github-security-alerts.js --repos <comma-delimited repo list>`
+ */
+async function scanSecurityAlerts() {
+  try {
+    program.parse()
+    const opts = program.opts()
+
+    if (!areEnvVarsSet(opts.dryRun)) {
+      console.log(`${missingEnvVars.join(', ')} are not set.`)
+      stopOnError()
+    }
+
+    const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN })
+    const app = opts.dryRun ? null : new App({ token, signingSecret })
+    const repos = opts.repos?.split(',') ?? []
+
+    for (const repo of repos) {
+      console.log(`\nScanning ${ORG}/${repo}...`)
+
+      await Promise.all([
+        scanSecretAlerts({ app, octokit, repo, isDryRun: opts.dryRun }),
+        scanCodeAlerts({ app, octokit, repo, isDryRun: opts.dryRun })
+      ])
+    }
+  } catch (err) {
+    stopOnError(err)
+  }
+}
+
+function stopOnError(err) {
+  if (err) {
+    console.error(err)
+  }
+  console.log('Halting execution with exit code: 1')
+  process.exit(1)
+}
+
+async function scanSecretAlerts({ app, octokit, repo, isDryRun }) {
+  const secretAlerts = await fetchSecretScanningAlerts(octokit, repo)
+  console.log(`${secretAlerts.length} secret scanning alert(s)`)
+
+  for (const alert of secretAlerts) {
+    const blocks = buildSecretAlertBlocks(repo, alert)
+    if (isDryRun) {
+      console.log(`[DRY RUN] Secret alert #${alert.number}:`, JSON.stringify(blocks, null, 2))
+    } else {
+      await app.client.chat.postMessage({ channel, blocks })
+      console.log(`Posted secret alert #${alert.number} to ${channel}`)
+    }
+  }
+}
+
+async function scanCodeAlerts({ app, octokit, repo, isDryRun }) {
+  const codeAlerts = await fetchCodeScanningAlerts(octokit, repo)
+  console.log(`${codeAlerts.length} code scanning alert(s)`)
+  for (const alert of codeAlerts) {
+    const blocks = buildCodeAlertBlocks(repo, alert)
+    if (isDryRun) {
+      console.log(`[DRY RUN] Code alert #${alert.number}:`, JSON.stringify(blocks, null, 2))
+    } else {
+      await app.client.chat.postMessage({ channel, blocks })
+      console.log(`Posted code alert #${alert.number} to ${channel}`)
+    }
+  }
+}
+
+function areEnvVarsSet(dryRun) {
+  if (dryRun) {
+    return Object.prototype.hasOwnProperty.call(process.env, 'GITHUB_TOKEN')
+  }
+  missingEnvVars = requiredEnvVars.filter(
+    (envVar) => !Object.prototype.hasOwnProperty.call(process.env, envVar)
+  )
+  return missingEnvVars.length === 0
+}
+
+async function fetchSecretScanningAlerts(octokit, repo) {
+  try {
+    const { data } = await octokit.request('GET /repos/{owner}/{repo}/secret-scanning/alerts', {
+      owner: ORG,
+      repo,
+      state: 'open',
+      per_page: 100
+    })
+    return data
+  } catch (err) {
+    if (err.status === 404) {
+      console.log(`  Secret scanning not enabled for ${repo}, skipping.`)
+      return []
+    }
+    throw err
+  }
+}
+
+async function fetchCodeScanningAlerts(octokit, repo) {
+  try {
+    const { data } = await octokit.request('GET /repos/{owner}/{repo}/code-scanning/alerts', {
+      owner: ORG,
+      repo,
+      state: 'open',
+      per_page: 100
+    })
+    return data
+  } catch (err) {
+    if (err.status === 404) {
+      console.log(`  Code scanning not enabled for ${repo}, skipping.`)
+      return []
+    }
+    throw err
+  }
+}
+
+function buildSecretAlertBlocks(repo, alert) {
+  const repoUrl = `https://github.com/${ORG}/${repo}`
+  return [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: 'Secret Scanning Alert' }
+    },
+    {
+      type: 'section',
+      fields: [
+        { type: 'mrkdwn', text: `*Repository:*\n<${repoUrl}|${ORG}/${repo}>` },
+        { type: 'mrkdwn', text: `*Details:*\n*Type:* ${alert.secret_type_display_name ?? alert.secret_type}` }
+      ]
+    },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: `Alert #${alert.number}` },
+          url: alert.html_url,
+          style: 'primary'
+        }
+      ]
+    }
+  ]
+}
+
+function buildCodeAlertBlocks(repo, alert) {
+  const repoUrl = `https://github.com/${ORG}/${repo}`
+  const severity = (alert.rule.severity ?? 'unknown').toUpperCase()
+  return [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: 'Code Scanning Alert' }
+    },
+    {
+      type: 'section',
+      fields: [
+        { type: 'mrkdwn', text: `*Repository:*\n<${repoUrl}|${ORG}/${repo}>` },
+        {
+          type: 'mrkdwn',
+          text: `*Details:*\n*Rule:* ${alert.rule.description ?? alert.rule.id}\n*Severity:* ${severity}\n*Tool:* ${alert.tool.name}`
+        }
+      ]
+    },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: `Alert #${alert.number}` },
+          url: alert.html_url,
+          style: 'primary'
+        }
+      ]
+    }
+  ]
+}
+
+if (require.main === module) {
+  scanSecurityAlerts()
+} else {
+  module.exports = {
+    areEnvVarsSet,
+    buildSecretAlertBlocks,
+    buildCodeAlertBlocks,
+    fetchSecretScanningAlerts,
+    fetchCodeScanningAlerts,
+    scanCodeAlerts,
+    scanSecretAlerts
+  }
+}

--- a/bin/test/scan-github-security-alerts.test.js
+++ b/bin/test/scan-github-security-alerts.test.js
@@ -25,7 +25,8 @@ function beforeEach(ctx) {
     '@octokit/rest': MockOctokitRest,
     '@slack/bolt': MockSlackBolt
   })
-  ctx.nr = { script, sandox, octokit, slackApp }
+  const opts = { dryRun: false, alertState: 'open', perPage: '100' }
+  ctx.nr = { script, sandox, octokit, slackApp, opts }
 }
 
 function afterEach(ctx) {
@@ -110,7 +111,7 @@ test('scan-github-security-alerts', async (t) => {
         { number: 3, html_url: 'https://github.com/newrelic/node-newrelic/security/secret-scanning/3', secret_type: 'github_personal_access_token', secret_type_display_name: 'GitHub Personal Access Token' }
       ]
       octokit.request.resolves({ data: alerts })
-      const result = await script.fetchSecretScanningAlerts(octokit, 'node-newrelic')
+      const result = await script.fetchSecretScanningAlerts(octokit, 'node-newrelic', { alertState: 'open', perPage: '100' })
 
       assert.deepEqual(result, alerts)
       assert.equal(octokit.request.firstCall.args[0], 'GET /repos/{owner}/{repo}/secret-scanning/alerts')
@@ -122,7 +123,7 @@ test('scan-github-security-alerts', async (t) => {
       const { script, octokit } = t.nr
       octokit.request.rejects(Object.assign(new Error('Not Found'), { status: 404 }))
 
-      const result = await script.fetchSecretScanningAlerts(octokit, 'node-newrelic')
+      const result = await script.fetchSecretScanningAlerts(octokit, 'node-newrelic', { alertState: 'open', perPage: '100' })
 
       assert.deepEqual(result, [])
     })
@@ -132,7 +133,7 @@ test('scan-github-security-alerts', async (t) => {
       octokit.request.rejects(Object.assign(new Error('Server Error'), { status: 500 }))
 
       await assert.rejects(
-        () => script.fetchSecretScanningAlerts(octokit, 'node-newrelic'),
+        () => script.fetchSecretScanningAlerts(octokit, 'node-newrelic', { alertState: 'open', perPage: '100' }),
         /Server Error/
       )
     })
@@ -154,7 +155,7 @@ test('scan-github-security-alerts', async (t) => {
       ]
       octokit.request.resolves({ data: alerts })
 
-      const result = await script.fetchCodeScanningAlerts(octokit, 'node-newrelic')
+      const result = await script.fetchCodeScanningAlerts(octokit, 'node-newrelic', { alertState: 'open', perPage: '100' })
 
       assert.deepEqual(result, alerts)
       assert.equal(octokit.request.firstCall.args[0], 'GET /repos/{owner}/{repo}/code-scanning/alerts')
@@ -166,7 +167,7 @@ test('scan-github-security-alerts', async (t) => {
       const { script, octokit } = t.nr
       octokit.request.rejects(Object.assign(new Error('Not Found'), { status: 404 }))
 
-      const result = await script.fetchCodeScanningAlerts(octokit, 'node-newrelic')
+      const result = await script.fetchCodeScanningAlerts(octokit, 'node-newrelic', { alertState: 'open', perPage: '100' })
 
       assert.deepEqual(result, [])
     })
@@ -176,7 +177,7 @@ test('scan-github-security-alerts', async (t) => {
       octokit.request.rejects(Object.assign(new Error('Forbidden'), { status: 403 }))
 
       await assert.rejects(
-        () => script.fetchCodeScanningAlerts(octokit, 'node-newrelic'),
+        () => script.fetchCodeScanningAlerts(octokit, 'node-newrelic', { alertState: 'open', perPage: '100' }),
         /Forbidden/
       )
     })
@@ -340,14 +341,14 @@ test('scan-github-security-alerts', async (t) => {
     t.afterEach(afterEach)
 
     await t.test('should post to Slack for each open alert', async (t) => {
-      const { script, octokit, slackApp } = t.nr
+      const { script, octokit, slackApp, opts } = t.nr
       const alerts = [
         { number: 3, html_url: 'https://github.com/newrelic/node-newrelic/security/secret-scanning/3', secret_type: 'github_personal_access_token', secret_type_display_name: 'GitHub Personal Access Token' },
         { number: 4, html_url: 'https://github.com/newrelic/node-newrelic/security/secret-scanning/4', secret_type: 'npm_access_token', secret_type_display_name: 'npm Access Token' }
       ]
       octokit.request.resolves({ data: alerts })
 
-      await script.scanSecretAlerts({ app: slackApp, octokit, repo: 'node-newrelic', isDryRun: false })
+      await script.scanSecretAlerts({ app: slackApp, octokit, repo: 'node-newrelic', opts })
 
       assert.equal(slackApp.client.chat.postMessage.callCount, 2)
       const firstCall = slackApp.client.chat.postMessage.firstCall.args[0]
@@ -355,21 +356,22 @@ test('scan-github-security-alerts', async (t) => {
     })
 
     await t.test('should not post to Slack when dry-run is true', async (t) => {
-      const { script, octokit, slackApp } = t.nr
+      const { script, octokit, slackApp, opts } = t.nr
       octokit.request.resolves({ data: [
         { number: 3, html_url: 'https://example.com/3', secret_type: 'github_personal_access_token', secret_type_display_name: 'GitHub Personal Access Token' }
       ] })
 
-      await script.scanSecretAlerts({ app: slackApp, octokit, repo: 'node-newrelic', isDryRun: true })
+      const newOpts = { ...opts, dryRun: true }
+      await script.scanSecretAlerts({ app: slackApp, octokit, repo: 'node-newrelic', opts: newOpts })
 
       assert.equal(slackApp.client.chat.postMessage.callCount, 0)
     })
 
     await t.test('should not post to Slack when there are no open alerts', async (t) => {
-      const { script, octokit, slackApp } = t.nr
+      const { script, octokit, slackApp, opts } = t.nr
       octokit.request.resolves({ data: [] })
 
-      await script.scanSecretAlerts({ app: slackApp, octokit, repo: 'node-newrelic', isDryRun: false })
+      await script.scanSecretAlerts({ app: slackApp, octokit, repo: 'node-newrelic', opts })
 
       assert.equal(slackApp.client.chat.postMessage.callCount, 0)
     })
@@ -380,7 +382,7 @@ test('scan-github-security-alerts', async (t) => {
     t.afterEach(afterEach)
 
     await t.test('should post to Slack for each open alert', async (t) => {
-      const { script, octokit, slackApp } = t.nr
+      const { script, octokit, slackApp, opts } = t.nr
       const alerts = [
         {
           number: 75,
@@ -397,7 +399,7 @@ test('scan-github-security-alerts', async (t) => {
       ]
       octokit.request.resolves({ data: alerts })
 
-      await script.scanCodeAlerts({ app: slackApp, octokit, repo: 'node-newrelic', isDryRun: false })
+      await script.scanCodeAlerts({ app: slackApp, octokit, repo: 'node-newrelic', opts })
 
       assert.equal(slackApp.client.chat.postMessage.callCount, 2)
       const firstCall = slackApp.client.chat.postMessage.firstCall.args[0]
@@ -405,7 +407,7 @@ test('scan-github-security-alerts', async (t) => {
     })
 
     await t.test('should not post to Slack when dry-run is true', async (t) => {
-      const { script, octokit, slackApp } = t.nr
+      const { script, octokit, slackApp, opts } = t.nr
       octokit.request.resolves({ data: [
         {
           number: 75,
@@ -415,16 +417,17 @@ test('scan-github-security-alerts', async (t) => {
         }
       ] })
 
-      await script.scanCodeAlerts({ app: slackApp, octokit, repo: 'node-newrelic', isDryRun: true })
+      const newOpts = { ...opts, dryRun: true }
+      await script.scanCodeAlerts({ app: slackApp, octokit, repo: 'node-newrelic', opts: newOpts })
 
       assert.equal(slackApp.client.chat.postMessage.callCount, 0)
     })
 
     await t.test('should not post to Slack when there are no open alerts', async (t) => {
-      const { script, octokit, slackApp } = t.nr
+      const { script, octokit, slackApp, opts } = t.nr
       octokit.request.resolves({ data: [] })
 
-      await script.scanCodeAlerts({ app: slackApp, octokit, repo: 'node-newrelic', isDryRun: false })
+      await script.scanCodeAlerts({ app: slackApp, octokit, repo: 'node-newrelic', opts })
 
       assert.equal(slackApp.client.chat.postMessage.callCount, 0)
     })

--- a/bin/test/scan-github-security-alerts.test.js
+++ b/bin/test/scan-github-security-alerts.test.js
@@ -1,0 +1,432 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+const { removeModules } = require('#testlib/cache-buster.js')
+
+const SCRIPT_PATH = '../scan-github-security-alerts'
+
+function beforeEach(ctx) {
+  const sandox = sinon.createSandbox()
+  console.log = sandox.stub()
+  console.error = sandox.stub()
+  const octokit = { request: sandox.stub() }
+  const MockOctokitRest = { Octokit: sandox.stub().returns(octokit) }
+  const slackApp = { client: { chat: { postMessage: sandox.stub() } } }
+  const MockSlackBolt = { App: sandox.stub().returns(slackApp) }
+  const script = proxyquire(SCRIPT_PATH, {
+    '@octokit/rest': MockOctokitRest,
+    '@slack/bolt': MockSlackBolt
+  })
+  ctx.nr = { script, sandox, octokit, slackApp }
+}
+
+function afterEach(ctx) {
+  removeModules(['commander'])
+  ctx.nr.sandox.restore()
+}
+
+test('scan-github-security-alerts', async (t) => {
+  await t.test('areEnvVarsSet', async (t) => {
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    await t.test('should return true when all required env vars are set', (t) => {
+      const { script } = t.nr
+      const saved = {
+        GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+        SLACK_CHANNEL: process.env.SLACK_CHANNEL,
+        SLACK_TOKEN: process.env.SLACK_TOKEN,
+        SLACK_SECRET: process.env.SLACK_SECRET
+      }
+      process.env.GITHUB_TOKEN = 'token'
+      process.env.SLACK_CHANNEL = 'slack-channel'
+      process.env.SLACK_TOKEN = 'slack-token'
+      process.env.SLACK_SECRET = 'secret'
+
+      t.after(() => {
+        for (const [k, v] of Object.entries(saved)) {
+          if (v !== undefined) process.env[k] = v
+          else delete process.env[k]
+        }
+      })
+
+      assert.equal(script.areEnvVarsSet(false), true)
+    })
+
+    await t.test('should return true for dry-run when only GITHUB_TOKEN is set', (t) => {
+      const { script } = t.nr
+      const saved = process.env.GITHUB_TOKEN
+      process.env.GITHUB_TOKEN = 'token'
+      delete process.env.SLACK_CHANNEL
+      delete process.env.SLACK_TOKEN
+      delete process.env.SLACK_SECRET
+
+      t.after(() => {
+        if (saved !== undefined) process.env.GITHUB_TOKEN = saved
+        else delete process.env.GITHUB_TOKEN
+      })
+
+      assert.equal(script.areEnvVarsSet(true), true)
+    })
+
+    await t.test('should return false when required env vars are missing', (t) => {
+      const { script } = t.nr
+      const saved = {
+        GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+        SLACK_CHANNEL: process.env.SLACK_CHANNEL,
+        SLACK_TOKEN: process.env.SLACK_TOKEN,
+        SLACK_SECRET: process.env.SLACK_SECRET
+      }
+      delete process.env.GITHUB_TOKEN
+      delete process.env.SLACK_CHANNEL
+      delete process.env.SLACK_TOKEN
+      delete process.env.SLACK_SECRET
+
+      t.after(() => {
+        for (const [k, v] of Object.entries(saved)) {
+          if (v !== undefined) process.env[k] = v
+        }
+      })
+
+      assert.equal(script.areEnvVarsSet(false), false)
+    })
+  })
+
+  await t.test('fetchSecretScanningAlerts', async (t) => {
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    await t.test('should return alert data on success', async (t) => {
+      const { script, octokit } = t.nr
+      const alerts = [
+        { number: 3, html_url: 'https://github.com/newrelic/node-newrelic/security/secret-scanning/3', secret_type: 'github_personal_access_token', secret_type_display_name: 'GitHub Personal Access Token' }
+      ]
+      octokit.request.resolves({ data: alerts })
+      const result = await script.fetchSecretScanningAlerts(octokit, 'node-newrelic')
+
+      assert.deepEqual(result, alerts)
+      assert.equal(octokit.request.firstCall.args[0], 'GET /repos/{owner}/{repo}/secret-scanning/alerts')
+      assert.equal(octokit.request.firstCall.args[1].repo, 'node-newrelic')
+      assert.equal(octokit.request.firstCall.args[1].state, 'open')
+    })
+
+    await t.test('should return empty array when secret scanning is not enabled (404)', async (t) => {
+      const { script, octokit } = t.nr
+      octokit.request.rejects(Object.assign(new Error('Not Found'), { status: 404 }))
+
+      const result = await script.fetchSecretScanningAlerts(octokit, 'node-newrelic')
+
+      assert.deepEqual(result, [])
+    })
+
+    await t.test('should rethrow non-404 errors', async (t) => {
+      const { script, octokit } = t.nr
+      octokit.request.rejects(Object.assign(new Error('Server Error'), { status: 500 }))
+
+      await assert.rejects(
+        () => script.fetchSecretScanningAlerts(octokit, 'node-newrelic'),
+        /Server Error/
+      )
+    })
+  })
+
+  await t.test('fetchCodeScanningAlerts', async (t) => {
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    await t.test('should return alert data on success', async (t) => {
+      const { script, octokit } = t.nr
+      const alerts = [
+        {
+          number: 75,
+          html_url: 'https://github.com/newrelic/node-newrelic/security/code-scanning/75',
+          rule: { id: 'js/incomplete-url-scheme-check', description: 'Incomplete URL scheme check', severity: 'high' },
+          tool: { name: 'CodeQL' }
+        }
+      ]
+      octokit.request.resolves({ data: alerts })
+
+      const result = await script.fetchCodeScanningAlerts(octokit, 'node-newrelic')
+
+      assert.deepEqual(result, alerts)
+      assert.equal(octokit.request.firstCall.args[0], 'GET /repos/{owner}/{repo}/code-scanning/alerts')
+      assert.equal(octokit.request.firstCall.args[1].repo, 'node-newrelic')
+      assert.equal(octokit.request.firstCall.args[1].state, 'open')
+    })
+
+    await t.test('should return empty array when code scanning is not enabled (404)', async (t) => {
+      const { script, octokit } = t.nr
+      octokit.request.rejects(Object.assign(new Error('Not Found'), { status: 404 }))
+
+      const result = await script.fetchCodeScanningAlerts(octokit, 'node-newrelic')
+
+      assert.deepEqual(result, [])
+    })
+
+    await t.test('should rethrow non-404 errors', async (t) => {
+      const { script, octokit } = t.nr
+      octokit.request.rejects(Object.assign(new Error('Forbidden'), { status: 403 }))
+
+      await assert.rejects(
+        () => script.fetchCodeScanningAlerts(octokit, 'node-newrelic'),
+        /Forbidden/
+      )
+    })
+  })
+
+  await t.test('buildSecretAlertBlocks', async (t) => {
+    t.beforeEach((ctx) => {
+      beforeEach(ctx)
+      const alert = {
+        number: 3,
+        html_url: 'https://github.com/newrelic/node-newrelic/security/secret-scanning/3',
+        secret_type: 'github_personal_access_token',
+        secret_type_display_name: 'GitHub Personal Access Token'
+      }
+      ctx.nr.alert = alert
+    })
+
+    t.afterEach(afterEach)
+
+    await t.test('should set the header to "Secret Scanning Alert"', (t) => {
+      const { script, alert } = t.nr
+      const blocks = script.buildSecretAlertBlocks('node-newrelic', alert)
+      const header = blocks.find((b) => b.type === 'header')
+
+      assert.equal(header.text.text, 'Secret Scanning Alert')
+    })
+
+    await t.test('should include a linked repository field', (t) => {
+      const { script, alert } = t.nr
+      const blocks = script.buildSecretAlertBlocks('node-newrelic', alert)
+      const section = blocks.find((b) => b.type === 'section')
+      const repoField = section.fields.find((f) => f.text.includes('Repository'))
+
+      assert.ok(repoField.text.includes('https://github.com/newrelic/node-newrelic'))
+      assert.ok(repoField.text.includes('newrelic/node-newrelic'))
+    })
+
+    await t.test('should include the secret type display name in the details field', (t) => {
+      const { script, alert } = t.nr
+      const blocks = script.buildSecretAlertBlocks('node-newrelic', alert)
+      const section = blocks.find((b) => b.type === 'section')
+      const detailField = section.fields.find((f) => f.text.includes('Details'))
+
+      assert.ok(detailField.text.includes('GitHub Personal Access Token'))
+    })
+
+    await t.test('should fall back to secret_type when secret_type_display_name is absent', (t) => {
+      const { script } = t.nr
+      const alert = {
+        number: 3,
+        html_url: 'https://github.com/newrelic/node-newrelic/security/secret-scanning/3',
+        secret_type: 'github_personal_access_token',
+        secret_type_display_name: null
+      }
+      const blocks = script.buildSecretAlertBlocks('node-newrelic', alert)
+      const section = blocks.find((b) => b.type === 'section')
+      const detailField = section.fields.find((f) => f.text.includes('Details'))
+
+      assert.ok(detailField.text.includes('github_personal_access_token'))
+    })
+
+    await t.test('should include a button linking to the alert', (t) => {
+      const { script, alert } = t.nr
+      const blocks = script.buildSecretAlertBlocks('node-newrelic', alert)
+      const actions = blocks.find((b) => b.type === 'actions')
+      const button = actions.elements[0]
+
+      assert.equal(button.type, 'button')
+      assert.equal(button.text.text, 'Alert #3')
+      assert.equal(button.url, alert.html_url)
+    })
+  })
+
+  await t.test('buildCodeAlertBlocks', async (t) => {
+    t.beforeEach((ctx) => {
+      beforeEach(ctx)
+      const alert = {
+        number: 75,
+        html_url: 'https://github.com/newrelic/node-newrelic/security/code-scanning/75',
+        rule: { id: 'js/incomplete-url-scheme-check', description: 'Incomplete URL scheme check', severity: 'high' },
+        tool: { name: 'CodeQL' }
+      }
+      ctx.nr.alert = alert
+    })
+
+    t.afterEach(afterEach)
+
+    await t.test('should set the header to "Code Scanning Alert"', (t) => {
+      const { script, alert } = t.nr
+      const blocks = script.buildCodeAlertBlocks('node-newrelic', alert)
+      const header = blocks.find((b) => b.type === 'header')
+
+      assert.equal(header.text.text, 'Code Scanning Alert')
+    })
+
+    await t.test('should include a linked repository field', (t) => {
+      const { script, alert } = t.nr
+      const blocks = script.buildCodeAlertBlocks('node-newrelic', alert)
+      const section = blocks.find((b) => b.type === 'section')
+      const repoField = section.fields.find((f) => f.text.includes('Repository'))
+
+      assert.ok(repoField.text.includes('https://github.com/newrelic/node-newrelic'))
+      assert.ok(repoField.text.includes('newrelic/node-newrelic'))
+    })
+
+    await t.test('should include rule description, uppercased severity, and tool name in the details field', (t) => {
+      const { script, alert } = t.nr
+      const blocks = script.buildCodeAlertBlocks('node-newrelic', alert)
+      const section = blocks.find((b) => b.type === 'section')
+      const detailField = section.fields.find((f) => f.text.includes('Details'))
+
+      assert.ok(detailField.text.includes('Incomplete URL scheme check'))
+      assert.ok(detailField.text.includes('HIGH'))
+      assert.ok(detailField.text.includes('CodeQL'))
+    })
+
+    await t.test('should fall back to rule.id when rule.description is absent', (t) => {
+      const { script } = t.nr
+      const alert = {
+        number: 75,
+        html_url: 'https://github.com/newrelic/node-newrelic/security/code-scanning/75',
+        rule: { id: 'js/incomplete-url-scheme-check', description: null, severity: 'high' },
+        tool: { name: 'CodeQL' }
+      }
+      const blocks = script.buildCodeAlertBlocks('node-newrelic', alert)
+      const section = blocks.find((b) => b.type === 'section')
+      const detailField = section.fields.find((f) => f.text.includes('Details'))
+
+      assert.ok(detailField.text.includes('js/incomplete-url-scheme-check'))
+    })
+
+    await t.test('should fall back to "UNKNOWN" when rule.severity is absent', (t) => {
+      const { script } = t.nr
+      const alert = {
+        number: 75,
+        html_url: 'https://github.com/newrelic/node-newrelic/security/code-scanning/75',
+        rule: { id: 'js/some-rule', description: 'Some rule', severity: null },
+        tool: { name: 'CodeQL' }
+      }
+      const blocks = script.buildCodeAlertBlocks('node-newrelic', alert)
+      const section = blocks.find((b) => b.type === 'section')
+      const detailField = section.fields.find((f) => f.text.includes('Details'))
+
+      assert.ok(detailField.text.includes('UNKNOWN'))
+    })
+
+    await t.test('should include a button linking to the alert', (t) => {
+      const { script, alert } = t.nr
+      const blocks = script.buildCodeAlertBlocks('node-newrelic', alert)
+      const actions = blocks.find((b) => b.type === 'actions')
+      const button = actions.elements[0]
+
+      assert.equal(button.type, 'button')
+      assert.equal(button.text.text, 'Alert #75')
+      assert.equal(button.url, alert.html_url)
+    })
+  })
+
+  await t.test('scanSecretAlerts', async (t) => {
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    await t.test('should post to Slack for each open alert', async (t) => {
+      const { script, octokit, slackApp } = t.nr
+      const alerts = [
+        { number: 3, html_url: 'https://github.com/newrelic/node-newrelic/security/secret-scanning/3', secret_type: 'github_personal_access_token', secret_type_display_name: 'GitHub Personal Access Token' },
+        { number: 4, html_url: 'https://github.com/newrelic/node-newrelic/security/secret-scanning/4', secret_type: 'npm_access_token', secret_type_display_name: 'npm Access Token' }
+      ]
+      octokit.request.resolves({ data: alerts })
+
+      await script.scanSecretAlerts({ app: slackApp, octokit, repo: 'node-newrelic', isDryRun: false })
+
+      assert.equal(slackApp.client.chat.postMessage.callCount, 2)
+      const firstCall = slackApp.client.chat.postMessage.firstCall.args[0]
+      assert.ok(firstCall.blocks.some((b) => b.type === 'header' && b.text.text === 'Secret Scanning Alert'))
+    })
+
+    await t.test('should not post to Slack when dry-run is true', async (t) => {
+      const { script, octokit, slackApp } = t.nr
+      octokit.request.resolves({ data: [
+        { number: 3, html_url: 'https://example.com/3', secret_type: 'github_personal_access_token', secret_type_display_name: 'GitHub Personal Access Token' }
+      ] })
+
+      await script.scanSecretAlerts({ app: slackApp, octokit, repo: 'node-newrelic', isDryRun: true })
+
+      assert.equal(slackApp.client.chat.postMessage.callCount, 0)
+    })
+
+    await t.test('should not post to Slack when there are no open alerts', async (t) => {
+      const { script, octokit, slackApp } = t.nr
+      octokit.request.resolves({ data: [] })
+
+      await script.scanSecretAlerts({ app: slackApp, octokit, repo: 'node-newrelic', isDryRun: false })
+
+      assert.equal(slackApp.client.chat.postMessage.callCount, 0)
+    })
+  })
+
+  await t.test('scanCodeAlerts', async (t) => {
+    t.beforeEach(beforeEach)
+    t.afterEach(afterEach)
+
+    await t.test('should post to Slack for each open alert', async (t) => {
+      const { script, octokit, slackApp } = t.nr
+      const alerts = [
+        {
+          number: 75,
+          html_url: 'https://github.com/newrelic/node-newrelic/security/code-scanning/75',
+          rule: { id: 'js/incomplete-url-scheme-check', description: 'Incomplete URL scheme check', severity: 'high' },
+          tool: { name: 'CodeQL' }
+        },
+        {
+          number: 76,
+          html_url: 'https://github.com/newrelic/node-newrelic/security/code-scanning/76',
+          rule: { id: 'js/prototype-pollution', description: 'Prototype pollution', severity: 'critical' },
+          tool: { name: 'CodeQL' }
+        }
+      ]
+      octokit.request.resolves({ data: alerts })
+
+      await script.scanCodeAlerts({ app: slackApp, octokit, repo: 'node-newrelic', isDryRun: false })
+
+      assert.equal(slackApp.client.chat.postMessage.callCount, 2)
+      const firstCall = slackApp.client.chat.postMessage.firstCall.args[0]
+      assert.ok(firstCall.blocks.some((b) => b.type === 'header' && b.text.text === 'Code Scanning Alert'))
+    })
+
+    await t.test('should not post to Slack when dry-run is true', async (t) => {
+      const { script, octokit, slackApp } = t.nr
+      octokit.request.resolves({ data: [
+        {
+          number: 75,
+          html_url: 'https://example.com/75',
+          rule: { id: 'js/some-rule', description: 'Some rule', severity: 'high' },
+          tool: { name: 'CodeQL' }
+        }
+      ] })
+
+      await script.scanCodeAlerts({ app: slackApp, octokit, repo: 'node-newrelic', isDryRun: true })
+
+      assert.equal(slackApp.client.chat.postMessage.callCount, 0)
+    })
+
+    await t.test('should not post to Slack when there are no open alerts', async (t) => {
+      const { script, octokit, slackApp } = t.nr
+      octokit.request.resolves({ data: [] })
+
+      await script.scanCodeAlerts({ app: slackApp, octokit, repo: 'node-newrelic', isDryRun: false })
+
+      assert.equal(slackApp.client.chat.postMessage.callCount, 0)
+    })
+  })
+})


### PR DESCRIPTION
## Description
We find out that we have code and secret scanning alerts long after they exist. This PR adds a workflow that runs every weekday at 9 EST and checks all repos we own for any security alerts and posts them to our slack channel.  I had to opt for a cron because github actions doesn't expose these as events to trigger a workflow on and would require a webhook which is too much work for us. These don't happen frequently so running daily is good enough to solve our issue. I was able to test the script but it is not returning any resolved secret scanning alerts. If we ever get a secret scanning alert we can always re-adjust. At least code scanning is working on both open/resolved with our bot agent token