### PR TITLE
chore: Set `ignoreApdex` warning log to `trace`-level

### DIFF
--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -713,7 +713,7 @@ Transaction.prototype.measure = function measure(name, scope, duration, exclusiv
  */
 Transaction.prototype._setApdex = function _setApdex(name, duration, keyApdexInMillis) {
   if (this.ignoreApdex) {
-    logger.warn('Ignoring the collection of apdex stats for %s as ignoreApdex is true', this.name)
+    logger.trace('Ignoring the collection of apdex stats for %s as ignoreApdex is true', this.name)
     return
   }
 


### PR DESCRIPTION
## Description

When users set `ignoreApdex: true`, they get a warning log that Apdex is disabled for every transaction. This is unhelpful because they already know that and the warnings can pollute our logs. This PR changes it only appear when trace-level logs are enabled.

## How to Test

There were no tests asserting this warning log was present.

```
npm run unit
```

## Related Issues

Closes #4187