### PR TITLE
ci: Refactored obtaining both agent version and nuget filename into one job

### DIFF
--- a/.github/workflows/azure-site-extension.yml
+++ b/.github/workflows/azure-site-extension.yml
@@ -45,40 +45,39 @@ jobs:
           check-latest: true
           architecture: ${{ matrix.arch }}
 
-      - name: Get agent version from package.json
-        id: get_version
-        run: jq -r '"version=\(.version)"' ./package.json >> $env:GITHUB_OUTPUT
-
-      - name: Set package filename
+      - name: Get workflow metadata
+        id: workflow_meta
         run: |
-          echo "PACKAGE_FILENAME=NewRelic.Azure.WebSites.Extension.NodeAgent.${{steps.get_version.outputs.version}}" | Out-File -FilePath $env:GITHUB_ENV -Append
+          $version = jq -r '.version' ./package.json
+          echo "agent_version=$version" >> $env:GITHUB_OUTPUT
+          echo "pkg_filename=NewRelic.Azure.WebSites.Extension.NodeAgent.$version" >> $env:GITHUB_OUTPUT
 
-      - name: Verify environment vars # because we can't access GH env vars until the next step
+      - name: Verify outputs # because we can't access step outputs until the next step
         run: |
-          echo "Agent version: ${{ steps.get_version.outputs.version }}"
-          echo "Package filename: ${{ env.PACKAGE_FILENAME }}"
+          echo "Agent version: ${{ steps.workflow_meta.outputs.agent_version }}"
+          echo "Package filename: ${{ steps.workflow_meta.outputs.pkg_filename }}"
 
       - name: Install agent
         working-directory: cloud-tooling/azure-site-extension/Content
         run: |
-          npm i --prefix . newrelic@${{ steps.get_version.outputs.version }}
+          npm i --prefix . newrelic@${{ steps.workflow_meta.outputs.agent_version }}
           echo "Agent installed"
 
       - name: Configure package files
         working-directory: cloud-tooling/azure-site-extension
         run: |
-          (Get-Content ${{ env.SPEC_FILE_TEMPLATE }}).Replace('{VERSION}', "${{ steps.get_version.outputs.version }}") | Set-Content ${{ env.PACKAGE_FILENAME }}.nuspec
+          (Get-Content ${{ env.SPEC_FILE_TEMPLATE }}).Replace('{VERSION}', "${{ steps.workflow_meta.outputs.agent_version }}") | Set-Content ${{ steps.workflow_meta.outputs.pkg_filename }}.nuspec
 
       - name: Create bundle
         working-directory: cloud-tooling/azure-site-extension
-        run: nuget pack "${{ env.PACKAGE_FILENAME }}.nuspec"
+        run: nuget pack "${{ steps.workflow_meta.outputs.pkg_filename }}.nuspec"
 
       # This step is for us to check what's going to be published
       - name: Archive package for verification
         uses: actions/upload-artifact@v7
         with:
-          name: azure-site-extension-test-${{ env.PACKAGE_FILENAME }}
-          path: cloud-tooling/azure-site-extension/${{ env.PACKAGE_FILENAME }}.nupkg
+          name: azure-site-extension-test-${{ steps.workflow_meta.outputs.pkg_filename }}
+          path: cloud-tooling/azure-site-extension/${{ steps.workflow_meta.outputs.pkg_filename }}.nupkg
 
       # Get a short-lived NuGet API key via OIDC authorization.
       - name: NuGet login (OIDC → temp API key)
@@ -90,4 +89,4 @@ jobs:
       - name: Publish site extension
         working-directory: cloud-tooling/azure-site-extension
         run: |
-          dotnet nuget push "${{ env.PACKAGE_FILENAME }}.nupkg" --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source ${{ vars.NUGET_SOURCE }}
+          dotnet nuget push "${{ steps.workflow_meta.outputs.pkg_filename }}.nupkg" --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source ${{ vars.NUGET_SOURCE }}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
There were a few changes to azure site extensions and some could've been avoided if the workflow was more consistent on storing context.
This PR updates the azure site extension workflow to have one job to obtain both agent version and the nuget file name and stores them in `GITHUB_OUTPUT`.
