### PR TITLE
fix: Correctly parse `subquery` collection names in SQL; assert previously-skipped cross agent test cases

### DIFF
--- a/lib/db/query-parsers/sql.js
+++ b/lib/db/query-parsers/sql.js
@@ -23,6 +23,10 @@ const OPERATIONS = [
   new StatementMatcher('delete', /^[^\S]*?delete[^\S]+?from[^\S]+([^\s\n\r,(;]+)/gim)
 ]
 const COMMENT_PATTERN = /\/\\*.*?\\*\//g
+// Matches a SELECT whose FROM clause is itself a subquery, e.g.
+// `SELECT * FROM (SELECT * FROM foobar)`. The outer statement matchers can't
+// name a real table for these, so they're reported as the literal '(subquery)'.
+const SUBQUERY_PATTERN = /^\s*select\b[\s\S]*?\bfrom[\s\n\r]*\(\s*select\b/i
 /* eslint-enable no-useless-escape, sonarjs/super-linear-regex, sonarjs/duplicates-in-character-class */
 
 // This must be called synchronously after the initial db call for backtraces to
@@ -51,6 +55,15 @@ module.exports = function parseSql(sql) {
   }
 
   sql = sql.replace(COMMENT_PATTERN, '').trim()
+
+  if (SUBQUERY_PATTERN.test(sql)) {
+    return {
+      operation: 'select',
+      database: null,
+      collection: '(subquery)',
+      query: sql
+    }
+  }
 
   let parsedStatement
 

--- a/test/benchmark/db/query-parsers/sql.bench.js
+++ b/test/benchmark/db/query-parsers/sql.bench.js
@@ -31,6 +31,14 @@ const tests = [
     fn: selectStatement
   },
   {
+    name: 'plain-select-statement',
+    fn: plainSelectStatement
+  },
+  {
+    name: 'subquery-select-statement',
+    fn: subquerySelectStatement
+  },
+  {
     name: 'update-statement',
     fn: updateStatement
   },
@@ -67,6 +75,14 @@ function selectStatement() {
   parseSql(
     "with foobar (col1) as cte select * from foo as a join on cte using (col1) where a.bar = 'baz'"
   )
+}
+
+function plainSelectStatement() {
+  parseSql("select * from foo as a join bar as b on a.id = b.id where a.baz = 'qux'")
+}
+
+function subquerySelectStatement() {
+  parseSql('select * from (select * from foobar)')
 }
 
 function updateStatement() {

--- a/test/unit/db/query-parsers/sql.test.js
+++ b/test/unit/db/query-parsers/sql.test.js
@@ -150,13 +150,17 @@ test('database query parser', async (t) => {
 
         assert.equal(ps.operation, cat.operation, `should parse the operation as ${cat.operation}`)
 
-        if (cat.table === '(subquery)') {
-          t.todo('should parse subquery collections as ' + cat.table)
-        } else if (/\w+\.\w+/.test(ps.collection)) {
-          t.todo('should strip database names from collection names as ' + cat.table)
-        } else {
-          assert.equal(ps.collection, cat.table, `should parse the collection as ${cat.table}`)
-        }
+        // Instead of stripping the schema/database prefix to match the cross-agent spec,
+        // our parser intentionally keeps it on the collection name (e.g. "database.foobar")
+        // for backward compatibility with existing metric names.
+        // @see comment lib/db/statement-matcher.js:28-32
+        // Also covers the '(subquery)' cases, since ps.database is null for those.
+        const expectedCollection = ps.database ? `${ps.database}.${cat.table}` : cat.table
+        assert.equal(
+          ps.collection,
+          expectedCollection,
+          `should parse the collection as ${expectedCollection}`
+        )
       })
     }
   })


### PR DESCRIPTION
## Description

This PR solves the issue described in #2521. In `test/unit/db/query-parsers/sql.test.js`, we had a couple of `t.todo`s that skipped asserting certain behavior in the CAT subtests: `("subquery")` and `db.table` specifically. 

Before this PR, the parser returned a unhelpful collection name (i.e. `("SELECT")`) for `FROM`-subqueries instead of a real table. Added detection in `lib/db/query-parsers/sql.js` so it now returns `"(subquery)"` per the [cross-agent tests](https://source.datanerd.us/agents/cross_agent_tests/blob/2e25086365918708a9cb4a1dd47d3d30941dd961/sql_parsing.json#L21-L22), matching what other language agents already do.

However, for `db.table`, we cannot strip the schema/database prefix (e.g. `"database"` in `"database.foobar"`) because that would conflict with existing metric names. So, I changed the `todo` to assert the behavior we currently produce.

## How to Test

```
npm run unit
```

## Related Issues

Closes #2521