### PR TITLE
test: Add benchmarks for lib/attributes.js methods

### DIFF
--- a/test/benchmark/lib/attributes.bench.js
+++ b/test/benchmark/lib/attributes.bench.js
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const benchmark = require('#testlib/benchmark.js')
+const { Attributes } = require('#agentlib/attributes.js')
+const AttributeFilter = require('#agentlib/config/attribute-filter.js')
+
+const DESTINATIONS = AttributeFilter.DESTINATIONS
+const TRANSACTION_SCOPE = Attributes.SCOPE_TRANSACTION
+
+// The `Attributes` constructor reads the agent config via `Config.getInstance()`,
+// so an agent must be loaded before instances can be created.
+const suite = benchmark.createBenchmark({
+  name: 'Attributes',
+  runs: 200_000,
+  agent: {
+    config: {
+      attributes: {
+        enabled: true,
+        include: ['request.headers.include-wild*'],
+        exclude: ['request.headers.exclude-wild*']
+      }
+    }
+  }
+})
+
+const tests = [
+  {
+    name: 'constructor',
+    fn: construct
+  },
+  {
+    name: 'isValidLength',
+    before: freshInstance,
+    fn: isValidLength
+  },
+  {
+    name: '_set',
+    before: freshInstance,
+    fn: set
+  },
+  {
+    name: 'get',
+    before: populatedInstance,
+    fn: get
+  },
+  {
+    name: 'has',
+    before: populatedInstance,
+    fn: has
+  },
+  {
+    name: 'reset',
+    before: populatedInstance,
+    fn: reset
+  },
+  {
+    name: 'addAttribute',
+    before: freshInstance,
+    fn: addAttribute
+  },
+  {
+    name: 'addAttributes',
+    before: freshInstance,
+    fn: addAttributes
+  },
+  {
+    name: 'hasValidDestination',
+    before: freshInstance,
+    fn: hasValidDestination
+  }
+]
+
+for (const test of tests) {
+  suite.add(test)
+}
+suite.run()
+
+function freshInstance() {
+  return { inst: new Attributes({ scope: TRANSACTION_SCOPE }) }
+}
+
+function populatedInstance() {
+  const inst = new Attributes({ scope: TRANSACTION_SCOPE })
+  inst.addAttribute(DESTINATIONS.TRANS_SCOPE, 'one', '1')
+  inst.addAttribute(DESTINATIONS.TRANS_SCOPE, 'two', '2')
+  return { inst }
+}
+
+function construct() {
+  // eslint-disable-next-line no-new
+  new Attributes({ scope: TRANSACTION_SCOPE })
+}
+
+function isValidLength(agent, { inst }) {
+  inst.isValidLength('some.attribute.name')
+}
+
+function set(agent, { inst }) {
+  inst._set(DESTINATIONS.TRANS_SCOPE, 'test', 'success', false)
+}
+
+function get(agent, { inst }) {
+  inst.get(DESTINATIONS.TRANS_SCOPE)
+}
+
+function has(agent, { inst }) {
+  inst.has('one')
+}
+
+function reset(agent, { inst }) {
+  inst.reset()
+}
+
+function addAttribute(agent, { inst }) {
+  inst.addAttribute(DESTINATIONS.TRANS_SCOPE, 'test', 'success')
+}
+
+function addAttributes(agent, { inst }) {
+  inst.addAttributes(DESTINATIONS.TRANS_SCOPE, { one: '1', two: '2', three: '3' })
+}
+
+function hasValidDestination(agent, { inst }) {
+  inst.hasValidDestination(DESTINATIONS.TRANS_SCOPE, 'test')
+}

--- a/test/lib/benchmark.js
+++ b/test/lib/benchmark.js
@@ -51,7 +51,9 @@ class Benchmark {
    *   the anonymous for loop in `events`).
    * @param {Function} [opts.teardown] Executed after the tests run, typically to clean up resources or listeners.
    *   This could return a promise or function invocation. See `closeServer` in `http` for an example.
-   * @param {Function} [opts.before] Executed before each test run. This could return a value--for example, see
+   * @param {Function} [opts.before] Executed before each test run. May be synchronous or an async
+   *   function; if it returns a value (or resolves to one), that value is passed to the test `fn` as
+   *   a context object so per-run setup can be excluded from the measured work. For example, see
    *   the `shim/shared.js` function `getTest`, which is returned by the `before` properties in `shim/wrapped.bench.js`
    *   tests, after some pre-test configuration. In other cases, such as `shim/merged.bench.js`, `before` is used to fill
    *   queues shared by the tests, and there is no returned value--it's used only to produce side effects.
@@ -136,13 +138,15 @@ class Benchmark {
      * @param {Function} [executeCb] If the test is run in a transaction, `executeCb` is defined,
      *   and will run after any user-defined `after` function. If `executeCb` is defined, the result of
      *   that is the `after` function's return value.
+     * @param {*} [context] Value returned by the test's `before` function, passed to the test
+     *   function so that per-run setup is excluded from the measured work.
      * @returns {Function} an invocation of the `after` function
      */
-    const execute = async (test, next, executeCb) => {
+    const execute = async (test, next, executeCb, context) => {
       const prevCpu = process.cpuUsage()
       const testFn = test.fn
 
-      await testFn(agent)
+      await testFn(agent, context)
       return after(test, next, executeCb, prevCpu)
     }
 
@@ -160,8 +164,12 @@ class Benchmark {
         global.gc()
       }
 
+      // The `before` function may be synchronous or an async function. Its
+      // return value (if any) is passed to the test function as a context
+      // object so that per-run setup is excluded from the measured work.
+      let context
       if (typeof test.before === 'function') {
-        test.before(agent)
+        context = await test.before(agent)
       }
 
       if (agent && test.runInTransaction) {
@@ -170,13 +178,13 @@ class Benchmark {
             txn.end()
             return execCallback(txn)
           }
-          return execute(test, next, afterExecute)
+          return execute(test, next, afterExecute, context)
         }
 
         return helper.runInTransaction(agent, inTransaction)
       }
 
-      return execute(test, next)
+      return execute(test, next, undefined, context)
     }
 
     /**


### PR DESCRIPTION
## Description

Adds benchmark coverage for every method in `lib/attributes.js` and extends the benchmark suite to support setup that is excluded from the measured work.

### `test/benchmark/lib/attributes.bench.js`
Benchmarks each `Attributes` method following the pattern in `test/benchmark/db/query-parsers/sql.bench.js` (flat `tests` array of `{ name, fn }`, a loop calling `suite.add`, then `suite.run()`):

- `constructor`, `isValidLength`, `_set`, `get`, `has`, `reset`, `addAttribute`, `addAttributes`, `hasValidDestination`

Because the `Attributes` constructor reads config via `Config.getInstance()`, the suite loads an agent through the framework's `agent: { config }` option. Per-run setup (creating / pre-populating instances) is done in `before` so it is not part of the timed function.

### `test/lib/benchmark.js`
The `before` function's return value is now captured and awaited, so `before` may be synchronous or an `async function`. The returned value is passed to the test `fn` as a context object (second argument), for both the transaction and non-transaction paths. This is backward-compatible — no existing benchmark `fn` reads a second positional argument, and `before`'s return value was previously discarded.

## Testing
- `node test/benchmark/lib/attributes.bench.js` emits stats for all nine methods.
- `npm run lint` passes (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)