### PR TITLE
fix: Improved Apollo server resolver instrumentation performance

### DIFF
--- a/lib/subscribers/apollo-server/resolve.js
+++ b/lib/subscribers/apollo-server/resolve.js
@@ -57,7 +57,12 @@ module.exports = class ApolloResolveSubscriber extends BaseSubscriber {
     }
 
     if (fieldMetrics) {
-      this.maybeCaptureFieldMetrics({ transaction, info, args: flattenedArgs || {} })
+      this.captureFieldMetrics({
+        transaction,
+        fieldName: info.fieldName,
+        fieldType: info.parentType.toString(),
+        args: flattenedArgs || {}
+      })
     }
 
     if (skipSegment) {
@@ -147,26 +152,6 @@ module.exports = class ApolloResolveSubscriber extends BaseSubscriber {
           }
         }
       }
-    }
-  }
-
-  /**
-   * Captures both field and args of resolvers as metrics.
-   *
-   * This is intended to be used to determine if a field within a graphql schema is still being requested.
-   *
-   * @param {object} params to function
-   * @param {object} params.info info key from resolver context
-   * @param {object} params.transaction active transaction
-   * @param {object} params.args args key from resolver context
-   *
-   */
-  maybeCaptureFieldMetrics({ info, transaction, args }) {
-    const { config } = this
-    if (config.apollo_server.field_metrics) {
-      const fieldName = info.fieldName
-      const fieldType = info.parentType.toString()
-      this.captureFieldMetrics({ transaction, args, fieldName, fieldType })
     }
   }
 

--- a/lib/subscribers/apollo-server/resolve.js
+++ b/lib/subscribers/apollo-server/resolve.js
@@ -37,15 +37,36 @@ module.exports = class ApolloResolveSubscriber extends BaseSubscriber {
     const operationSegment = ctx?.segment
     const transaction = ctx.transaction
     const [, resolverArgs, , info] = args
-    const pathArray = this.flattenToArray(info.path)
-    const formattedPath = pathArray.reverse().join('.')
-    const flattenedArgs = this.flattenArgs({ obj: resolverArgs })
 
-    this.maybeCaptureFieldMetrics({ transaction, info, args: flattenedArgs })
+    // Do the cheap short-circuit check first. When scalar capture is disabled
+    // (the default), a non-top-level scalar field creates no segment, so we can
+    // skip flattening the field path and the resolver args entirely -- work
+    // that the discarded path used to do on every scalar field.
+    const skipSegment =
+      !this.config.apollo_server.scalars && !this.isTopLevelField(info) && this.isScalar(info)
 
-    if (!this.config.apollo_server.scalars && !this.isTopLevelField(info) && this.isScalar(info)) {
+    // The flattened args are only consumed by field metrics capture and by the
+    // resolver-segment attributes. Only compute them when something will use
+    // them: field_metrics is enabled, or we are keeping the segment and there
+    // are args to attach. Arg-less fields (the common case) skip this.
+    const fieldMetrics = this.config.apollo_server.field_metrics
+    const hasArgs = resolverArgs != null && typeof resolverArgs === 'object'
+    let flattenedArgs = null
+    if (hasArgs && (fieldMetrics || !skipSegment)) {
+      flattenedArgs = this.flattenArgs({ obj: resolverArgs })
+    }
+
+    if (fieldMetrics) {
+      this.maybeCaptureFieldMetrics({ transaction, info, args: flattenedArgs || {} })
+    }
+
+    if (skipSegment) {
       return this.agent.tracer.runInContext({ handler: origResolve, context: ctx, thisArg, args })
     }
+
+    // Only build the segment name now that we know a segment will be created.
+    const pathArray = this.flattenToArray(info.path)
+    const formattedPath = pathArray.reverse().join('.')
 
     const newCtx = this.createSegment({
       recorder: resolverRecorder,
@@ -115,12 +136,15 @@ module.exports = class ApolloResolveSubscriber extends BaseSubscriber {
       // Like our http and framework instrumentation, we add
       // the attributes on the operation segment. We also add
       // the attributes to resolver segments as they help
-      // inform performance impacts.
-      for (const segment of [operationSegment, resolverSegment]) {
-        for (const [key, value] of Object.entries(flattenedArgs)) {
-          // Require adding to attribute 'include' configuration
-          // so as not to accidentally send sensitive info to New Relic.
-          segment.attributes.addAttribute(DESTINATIONS.NONE, `${FIELD_ARGS_ATTR}.${key}`, value)
+      // inform performance impacts. `flattenedArgs` is null when the field has
+      // no resolver arguments, in which case there is nothing to attach.
+      if (flattenedArgs) {
+        for (const segment of [operationSegment, resolverSegment]) {
+          for (const [key, value] of Object.entries(flattenedArgs)) {
+            // Require adding to attribute 'include' configuration
+            // so as not to accidentally send sensitive info to New Relic.
+            segment.attributes.addAttribute(DESTINATIONS.NONE, `${FIELD_ARGS_ATTR}.${key}`, value)
+          }
         }
       }
     }

--- a/test/benchmark/lib/subscribers/apollo-server/fixtures.js
+++ b/test/benchmark/lib/subscribers/apollo-server/fixtures.js
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/*
+ * Fixtures for the apollo-server resolve subscriber benchmark.
+ *
+ * The resolve subscriber's hot path (`wrapResolve` and its helpers) only reads
+ * a small, duck-typed slice of a GraphQL resolver `info` object:
+ *
+ *   - info.path       a `{ key, prev }` linked list (built by graphql-js)
+ *   - info.fieldName  the field's name
+ *   - info.returnType a type instance; the code inspects `constructor.name`
+ *                     (=== 'GraphQLScalarType' / 'GraphQLNonNull'), `.ofType`,
+ *                     and `.toString()`
+ *   - info.parentType a type instance; the code reads `.name` and `.toString()`
+ *
+ * Rather than pull in the (peer-only) `graphql` package, we build minimal
+ * fakes whose `constructor.name` matches what `isScalarType` /
+ * `isNonNullScalarType` check for. This keeps the benchmark a true unit-level
+ * microbenchmark of the subscriber code, with no @apollo/server or graphql
+ * runtime in the measured path.
+ */
+
+// A constructor whose `.name` is exactly the GraphQL class name the subscriber
+// string-compares against.
+function makeType(className, toStringValue, extra = {}) {
+  function T() {}
+  Object.defineProperty(T, 'name', { value: className })
+  T.prototype.toString = () => toStringValue
+  const instance = new T()
+  return Object.assign(instance, extra)
+}
+
+const scalarString = () => makeType('GraphQLScalarType', 'String')
+const objectPost = () => makeType('GraphQLObjectType', '[Post!]!', { name: 'Post' })
+const objectUser = () => makeType('GraphQLObjectType', 'User', { name: 'User' })
+const objectComment = () => makeType('GraphQLObjectType', 'Comment', { name: 'Comment' })
+
+// NonNull(String) — exercises the isNonNullScalarType unwrap branch.
+const nonNullScalar = () => makeType('GraphQLNonNull', 'String!', { ofType: scalarString() })
+
+/**
+ * Build a graphql-js style path linked list from a top-down array of keys.
+ * ['users', 0, 'posts', 1, 'comments', 2, 'body'] => nested { key, prev } with
+ * the deepest field (`body`) as the head, matching what graphql passes in.
+ *
+ * @param {Array<string|number>} keys ordered from root to leaf
+ * @returns {object} the leaf-most path node
+ */
+function buildPath(keys) {
+  let node
+  for (const key of keys) {
+    node = { key, prev: node }
+  }
+  return node
+}
+
+// A realistically deep path: users[0].posts[1].comments[2].<field>
+const DEEP_PATH_KEYS = ['users', 0, 'posts', 1, 'comments', 2]
+
+/**
+ * A scalar leaf field with no arguments — the dominant case in real schemas
+ * (id, name, title, body, ...). Under the default config this field creates NO
+ * segment, so all the per-call pre-work the subscriber does before the scalar
+ * short-circuit is pure overhead.
+ *
+ * @returns {object} a resolver `info` fake for a scalar leaf field
+ */
+function scalarFieldInfo() {
+  return {
+    fieldName: 'body',
+    path: buildPath([...DEEP_PATH_KEYS, 'body']),
+    returnType: scalarString(),
+    parentType: objectComment()
+  }
+}
+
+/**
+ * A scalar leaf field that DOES carry resolver arguments. Still short-circuits
+ * (no segment) under the default config, but has args present so we can measure
+ * the cost of arg handling on the discarded path.
+ *
+ * @returns {object} a resolver `info` fake for a NonNull scalar leaf field
+ */
+function scalarFieldWithArgsInfo() {
+  return {
+    fieldName: 'body',
+    path: buildPath([...DEEP_PATH_KEYS, 'body']),
+    returnType: nonNullScalar(),
+    parentType: objectComment()
+  }
+}
+
+/**
+ * A non-top-level object field (User.posts). This one DOES get a resolver
+ * segment created plus attribute capture — the "kept" path.
+ *
+ * @returns {object} a resolver `info` fake for a non-top-level object field
+ */
+function objectFieldInfo() {
+  return {
+    fieldName: 'posts',
+    path: buildPath(['users', 0, 'posts']),
+    returnType: objectPost(),
+    parentType: objectUser()
+  }
+}
+
+// Representative resolver-argument shapes.
+const NO_ARGS = Object.freeze({})
+const SIMPLE_ARGS = Object.freeze({ limit: 10, offset: 0 })
+const NESTED_ARGS = Object.freeze({
+  filter: { status: 'PUBLISHED', author: { id: '42' } },
+  page: { first: 10 }
+})
+
+/**
+ * Assemble the positional `args` array that Apollo passes to a field resolver
+ * and that the subscriber destructures as `[, resolverArgs, , info]`.
+ *
+ * @param {object} resolverArgs the resolver arguments object
+ * @param {object} info the resolver info object
+ * @returns {Array} [source, args, context, info]
+ */
+function resolverArgs(resolverArgs, info) {
+  return [{ __source: true }, resolverArgs, { __context: true }, info]
+}
+
+// A trivial original resolver to stand in for the user's resolver.
+const origResolve = () => 'value'
+
+module.exports = {
+  buildPath,
+  scalarFieldInfo,
+  scalarFieldWithArgsInfo,
+  objectFieldInfo,
+  NO_ARGS,
+  SIMPLE_ARGS,
+  NESTED_ARGS,
+  resolverArgs,
+  origResolve
+}

--- a/test/benchmark/lib/subscribers/apollo-server/resolve.bench.js
+++ b/test/benchmark/lib/subscribers/apollo-server/resolve.bench.js
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/*
+ * Benchmark for the apollo-server resolve subscriber hot path.
+ *
+ * `wrapResolve` runs once per resolved GraphQL field, so its per-call cost is
+ * multiplied by every field in every query. This suite isolates that cost by
+ * field-type case, plus the individual helpers it calls, so the effect of
+ * future optimizations to `wrapResolve` can be measured directly.
+ *
+ * The most important cases are the SCALAR ones: under the default config
+ * (`apollo_server.scalars = false`), a scalar field creates no segment, yet the
+ * current `wrapResolve` still flattens the field path and the resolver args
+ * before it reaches the scalar short-circuit — work that is then discarded.
+ * Scalar leaf fields dominate real responses, so this is the hot case to watch.
+ */
+
+const benchmark = require('#testlib/benchmark.js')
+const logger = require('#agentlib/logger.js')
+const ApolloResolveSubscriber = require('#agentlib/subscribers/apollo-server/resolve.js')
+const fixtures = require('./fixtures.js')
+
+// Default config: scalars off, field_metrics off. This is the shipped default
+// and the config the optimization targets.
+const suite = benchmark.createBenchmark({
+  name: 'apollo-server resolve subscriber',
+  runs: 100_000,
+  agent: {
+    config: {
+      apollo_server: {
+        scalars: false,
+        field_metrics: false
+      }
+    }
+  }
+})
+
+// Build the subscriber once per test via `before`; construction (which sets up
+// a diagnostics channel) is not what we're measuring. `before` runs after the
+// agent is instrumented, so `agent` is available.
+function makeSubscriber(agent) {
+  const subLogger = logger.child({ component: 'apollo-resolve-bench' })
+  return new ApolloResolveSubscriber({ agent, logger: subLogger })
+}
+
+const tests = [
+  // ---- Full wrapResolve, by field-type case (run in a transaction so the
+  //      tracer context, segment creation and attribute capture are real) ----
+  {
+    name: 'wrapResolve/scalar-no-args',
+    runInTransaction: true,
+    before: (agent) => {
+      return {
+        sub: makeSubscriber(agent),
+        args: fixtures.resolverArgs(fixtures.NO_ARGS, fixtures.scalarFieldInfo())
+      }
+    },
+    fn: wrapResolve
+  },
+  {
+    name: 'wrapResolve/scalar-with-args',
+    runInTransaction: true,
+    before: (agent) => {
+      return {
+        sub: makeSubscriber(agent),
+        args: fixtures.resolverArgs(fixtures.NESTED_ARGS, fixtures.scalarFieldWithArgsInfo())
+      }
+    },
+    fn: wrapResolve
+  },
+  {
+    name: 'wrapResolve/object-no-args',
+    runInTransaction: true,
+    before: (agent) => {
+      return {
+        sub: makeSubscriber(agent),
+        args: fixtures.resolverArgs(fixtures.NO_ARGS, fixtures.objectFieldInfo())
+      }
+    },
+    fn: wrapResolve
+  },
+  {
+    name: 'wrapResolve/object-with-args',
+    runInTransaction: true,
+    before: (agent) => {
+      return {
+        sub: makeSubscriber(agent),
+        args: fixtures.resolverArgs(fixtures.SIMPLE_ARGS, fixtures.objectFieldInfo())
+      }
+    },
+    fn: wrapResolve
+  },
+
+  // ---- Individual helpers, isolated (no transaction needed) ----
+  {
+    name: 'flattenToArray (deep path)',
+    before: (agent) => { return { sub: makeSubscriber(agent), path: fixtures.scalarFieldInfo().path } },
+    fn: (agent, { sub, path }) => {
+      sub.flattenToArray(path)
+    }
+  },
+  {
+    name: 'flattenArgs (nested)',
+    before: (agent) => { return { sub: makeSubscriber(agent) } },
+    fn: (agent, { sub }) => {
+      sub.flattenArgs({ obj: fixtures.NESTED_ARGS })
+    }
+  },
+  {
+    name: 'isScalar (scalar type)',
+    before: (agent) => { return { sub: makeSubscriber(agent), info: fixtures.scalarFieldInfo() } },
+    fn: (agent, { sub, info }) => {
+      sub.isScalar(info)
+    }
+  },
+  {
+    name: 'isScalar (object type)',
+    before: (agent) => { return { sub: makeSubscriber(agent), info: fixtures.objectFieldInfo() } },
+    fn: (agent, { sub, info }) => {
+      sub.isScalar(info)
+    }
+  }
+]
+
+for (const test of tests) {
+  suite.add(test)
+}
+
+suite.run()
+
+/**
+ * Drives the subscriber's per-field entry point. `thisArg` is the resolver's
+ * `this` (unused by the subscriber's own logic); the original resolver is a
+ * trivial stub so the measurement reflects subscriber overhead, not user code.
+ *
+ * @param {object} agent the mocked agent (unused; context comes from the tracer)
+ * @param {object} ctx the per-run context produced by `before`
+ * @param {object} ctx.sub the resolve subscriber under test
+ * @param {Array} ctx.args positional resolver args `[source, args, context, info]`
+ */
+function wrapResolve(agent, { sub, args }) {
+  sub.wrapResolve(fixtures.origResolve, {}, args)
+}


### PR DESCRIPTION
We have a customer reporting that they have seen a significant performance impact upon moving from our external Apollo server plugin instrumentation approach to our current subscriber approach. This PR attempts to improve the situation by reducing the scenarios under which expensive work is performed.

-----

## Description

`wrapResolve` in the `@apollo/server` resolve subscriber runs once per resolved GraphQL field, so its per-call cost is multiplied across every field of every query.

Previously it flattened the field path (`flattenToArray` + `reverse().join('.')`) and the resolver args (`flattenArgs`) on **every** call, *before* the check that short-circuits scalar fields. Under the default config (`apollo_server.scalars = false`), a non-top-level scalar field creates no segment — so all of that work was computed and immediately discarded. Scalar leaf fields (`id`, `name`, `title`, ...) dominate real responses (~11:1 vs object fields in a typical nested query), so this was wasted work on the hot path for the majority of resolver invocations.

This PR reorders `wrapResolve` to:
1. Run the cheap scalar / top-level check **first**.
2. Build the segment name (`formattedPath`) only when a segment will actually be created.
3. Flatten resolver args only when they are consumed — i.e. `field_metrics` is enabled, or a segment is kept and the field has args. Arg-less and skipped fields no longer pay for it. `maybeAddAttributes` now guards against a null `flattenedArgs`.

Behavior is unchanged — the resolver segment tree, field attributes, field metrics, and error handling are all identical.

## How to Test

**Behavior (unchanged):** the `apollo-server` versioned suite passes in full against the change — 115/115 across `segments`, `attributes`, `metrics`, `errors`, `transaction-naming`, and `query-obfuscation`. The `attributes` and `metrics` tests specifically exercise the arg-flattening path that was made lazy.

**Performance:** this PR also adds a microbenchmark for the resolve subscriber hot path at `test/benchmark/lib/subscribers/apollo-server/`, covering each field-type case plus the individual helpers. Run with:

```
node ./bin/run-bench.js lib/subscribers/apollo-server
```

Before → after (mean per call, stable across runs):

| case | before | after | change |
|------|-------:|------:|-------:|
| `wrapResolve/scalar-no-args`   | 0.00171ms | 0.00132ms | **−23%** |
| `wrapResolve/scalar-with-args` | 0.00242ms | 0.00171ms | **−29%** |
| `wrapResolve/object-no-args`   | 0.00446ms | ~0.00428ms | −6% |
| `wrapResolve/object-with-args` | 0.00524ms | ~0.00515ms | ~same |

The scalar (no-segment) cases get materially faster; the object (segment-creating) path is unchanged, as expected — its cost is real segment creation.

## Related Issues

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)