### PR TITLE
fix: Updated `getBrowserTimingHeader` to handle when a transaction may not be finalized and still return the browser agent string without transaction intrinsics

### DIFF
--- a/api.js
+++ b/api.js
@@ -725,6 +725,10 @@ function validateBrowserMonitoring(config, transaction, allowTransactionlessInje
     return { isValidConfig: false, failureIdx: 1 }
   }
 
+  if (transaction && transaction.isIgnored()) {
+    return { isValidConfig: false, failureIdx: 1 }
+  }
+
   return { isValidConfig: true }
 }
 
@@ -754,11 +758,11 @@ API.prototype.getBrowserTimingHeader = function getBrowserTimingHeader(options =
   )
   metric.incrementCallCount()
 
-  const trans = this.agent.getTransaction()
+  const transaction = this.agent.getTransaction()
 
   const { isValidConfig, failureIdx, quietMode } = validateBrowserMonitoring(
     this.agent.config,
-    trans,
+    transaction,
     options.allowTransactionlessInjection
   )
 
@@ -774,61 +778,12 @@ API.prototype.getBrowserTimingHeader = function getBrowserTimingHeader(options =
     beacon: config.browser_monitoring.beacon,
     errorBeacon: config.browser_monitoring.error_beacon,
     licenseKey: config.browser_monitoring.browser_key,
-    applicationID: config.application_id,
-
-    // we don't use these parameters yet
-    agentToken: null
+    applicationID: config.application_id
   }
 
-  const hasActiveTransaction = trans !== null
-
-  if (hasActiveTransaction) {
-    // bail gracefully outside an ignored transaction
-    if (trans.isIgnored()) {
-      return _gracefail(1)
-    }
-
-    /* If we're in an unnamed transaction, add a friendly warning this is to
-     * avoid people going crazy, trying to figure out why browser monitoring is
-     * not working when they're missing a transaction name.
-     */
-    const name = trans.getFullName()
-    if (!name) {
-      return _gracefail(3)
-    }
-
-    const time = trans.timer.getDurationInMillis()
-    rumHash.applicationTime = time
-
-    /*
-     * Only the first 13 chars of the license should be used for hashing with
-     * the transaction name.
-     */
-    const key = config.license_key.substring(0, 13)
-    rumHash.transactionName = hashes.obfuscateNameUsingKey(name, key)
-
-    rumHash.queueTime = trans.queueTime
-    rumHash.ttGuid = trans.id
-
-    const attrs = Object.create(null)
-
-    const customAttrs = trans.trace.custom.get(ATTR_DEST.BROWSER_EVENT)
-    if (!properties.isEmpty(customAttrs)) {
-      attrs.u = customAttrs
-    }
-
-    const agentAttrs = trans.trace.attributes.get(ATTR_DEST.BROWSER_EVENT)
-    if (!properties.isEmpty(agentAttrs)) {
-      attrs.a = agentAttrs
-    }
-
-    if (!properties.isEmpty(attrs)) {
-      rumHash.atts = hashes.obfuscateNameUsingKey(JSON.stringify(attrs), key)
-    }
-  } else {
-    logger.debug(
-      'No transaction detected when generating RUM header, continuing without transaction info'
-    )
+  // attempt to include transaction specific intrinsics
+  if (!options.allowTransactionlessInjection) {
+    generateTransactionIntrinsics({ config, rumHash, transaction })
   }
 
   // if debugging, do pretty format of JSON
@@ -845,6 +800,58 @@ API.prototype.getBrowserTimingHeader = function getBrowserTimingHeader(options =
   logger.trace('generating RUM header', out)
 
   return out
+}
+
+/**
+ * This attempts to add any intrinsics to the `NREUM.info` portion of the browser
+ * agent string.  The only required fields are: agent, beacon, errorBeacon, licenseKey,
+ * or applicationID
+ *
+ * @param {object} params to function
+ * @param {object} params.config agent configuration
+ * @param {object} params.rumHash the object that is serialized into the response as the browser agent string
+ * @param {Transaction} params.transaction active transaction
+ */
+function generateTransactionIntrinsics({ config, rumHash, transaction }) {
+  // We could get here if `options.allowTransactionlessInjection` is true
+  if (transaction === null) {
+    logger.debug('No transaction detected when generating RUM header, continuing without transaction info')
+    return
+  }
+
+  const key = config.license_key.substring(0, 13)
+  const name = transaction.getFullName()
+  // This could be falsey depending on how it is being called
+  // In traditional server side rendering frameworks that this would be called
+  // in, the transaction name should be populated but in full stack frameworks
+  // where the client loads server side components, the transaction name may
+  // not be finalized until after the browser agent is injected
+  if (name) {
+    /*
+     * Only the first 13 chars of the license should be used for hashing with
+     * the transaction name.
+     */
+    rumHash.transactionName = hashes.obfuscateNameUsingKey(name, key)
+  }
+
+  const time = transaction.timer.getDurationInMillis()
+  rumHash.applicationTime = time
+  rumHash.queueTime = transaction.queueTime
+  const attrs = Object.create(null)
+
+  const customAttrs = transaction.trace.custom.get(ATTR_DEST.BROWSER_EVENT)
+  if (!properties.isEmpty(customAttrs)) {
+    attrs.u = customAttrs
+  }
+
+  const agentAttrs = transaction.trace.attributes.get(ATTR_DEST.BROWSER_EVENT)
+  if (!properties.isEmpty(agentAttrs)) {
+    attrs.a = agentAttrs
+  }
+
+  if (!properties.isEmpty(attrs)) {
+    rumHash.atts = hashes.obfuscateNameUsingKey(JSON.stringify(attrs), key)
+  }
 }
 
 /**

--- a/test/unit/rum.test.js
+++ b/test/unit/rum.test.js
@@ -73,10 +73,14 @@ test('the RUM API', async function (t) {
     assert.equal(api.getBrowserTimingHeader(), '<!-- NREUM: (2) -->')
   })
 
-  await t.test('should issue a warning if transaction has no name', function (t, end) {
+  await t.test('should generate header if transaction name is missing', function (t, end) {
     const { agent, api } = t.nr
     helper.runInTransaction(agent, function () {
-      assert.equal(api.getBrowserTimingHeader(), '<!-- NREUM: (3) -->')
+      const timingHeader = api.getBrowserTimingHeader()
+      timingHeader.startsWith(
+        '<script type=\'text/javascript\'>window.NREUM||(NREUM={});NREUM.info = {"licenseKey":1234,"applicationID":12345,'
+      )
+      assert.ok(timingHeader.endsWith('}; function() {}</script>'))
       end()
     })
   })
@@ -171,6 +175,8 @@ test('the RUM API', async function (t) {
         )
       )
       assert.ok(timingHeader.endsWith('}; function() {}</script>'))
+      assert.ok(timingHeader.includes('"transactionName":"OwwBMRwSC1MKBg1JBwJGLQocHgRMAh8cRD0eAExP"'))
+      assert.ok(timingHeader.includes('"atts":"F0sCR1QIR1IOFAxFGxhHFhcHUV8CRA0cTAQDSx4Y"'))
       end()
     })
   })
@@ -182,10 +188,33 @@ test('the RUM API', async function (t) {
       const timingHeader = api.getBrowserTimingHeader({ allowTransactionlessInjection: true })
       assert.ok(
         timingHeader.startsWith(
-          '<script type=\'text/javascript\'>window.NREUM||(NREUM={});NREUM.info = {"licenseKey":1234,"applicationID":12345,'
+          '<script type=\'text/javascript\'>window.NREUM||(NREUM={});NREUM.info = {"licenseKey":1234,"applicationID":12345'
         )
       )
       assert.ok(timingHeader.endsWith('}; function() {}</script>'))
+      assert.ok(!timingHeader.includes('applicationTime'))
+      assert.ok(!timingHeader.includes('queueTime'))
+      assert.ok(!timingHeader.includes('transactionName'))
+    }
+  )
+
+  await t.test(
+    'should get the browser agent script when allowTransactionlessInjection is true but not include any transaction related intrinsics',
+    function (t, end) {
+      const { api, agent } = t.nr
+      helper.runInTransaction(agent, function (tx) {
+        const timingHeader = api.getBrowserTimingHeader({ allowTransactionlessInjection: true })
+        assert.ok(
+          timingHeader.startsWith(
+            '<script type=\'text/javascript\'>window.NREUM||(NREUM={});NREUM.info = {"licenseKey":1234,"applicationID":12345'
+          )
+        )
+        assert.ok(timingHeader.endsWith('}; function() {}</script>'))
+        assert.ok(!timingHeader.includes('applicationTime'))
+        assert.ok(!timingHeader.includes('queueTime'))
+        assert.ok(!timingHeader.includes('transactionName'))
+        end()
+      })
     }
   )
 

--- a/test/versioned/express/render.test.js
+++ b/test/versioned/express/render.test.js
@@ -192,7 +192,7 @@ test('agent instrumentation of Express', async function (t) {
   })
 
   await t.test('should generate rum headers', { timeout: 1000 }, async function (t) {
-    const plan = tsplan(t, { plan: 5 })
+    const plan = tsplan(t, { plan: 6 })
     const { app, agent, port } = t.nr
     const api = new API(agent)
 
@@ -207,6 +207,9 @@ test('agent instrumentation of Express', async function (t) {
     app.get(TEST_PATH, function (req, res) {
       const rum = api.getBrowserTimingHeader()
       plan.equal(rum.substring(0, 7), '<script')
+      // assert the `NREUM.info` exists and is correct
+      // not all are asserted because they are timer based
+      plan.ok(rum.includes('window.NREUM||(NREUM={});NREUM.info = {"licenseKey":"12345","applicationID":"12345","transactionName":"OwwBMRwSCywKBg0FBg1KKwsVLQ4WCgYaTCIrJ0pwHwAKGA=="'))
       res.render('index', { title: 'yo dawg', rum })
     })
 

--- a/test/versioned/hapi/render.test.js
+++ b/test/versioned/hapi/render.test.js
@@ -155,6 +155,10 @@ test('should generate rum headers', { timeout: 1000 }, (t, end) => {
     handler: function (req, h) {
       const rum = api.getBrowserTimingHeader()
       assert.equal(rum.substring(0, 7), '<script')
+      // assert the `NREUM.info` exists and is correct
+      // not all are asserted because they are timer based
+      assert.ok(rum.includes('window.NREUM||(NREUM={});NREUM.info = {"licenseKey":"12345","applicationID":"12345","transactionName":"OwwBMRwSC1MKBg1JBwJGKwQeGkpnLjFWDxwJGhc="'))
+
       return h.view('index', { title: 'yo dawg', rum })
     }
   })


### PR DESCRIPTION
## Description

This PR fixes behavior when using `newrelic.getBrowserTimingHeader` in a non-traditional server-side html rendering situation.  In full stack frameworks like Next.js, customers want to inject the browser agent and use our api to do so with `newrelic.getBrowserTimingHeader`. The issue is before this PR it required to have an active, finalized transaction.  We did add an option `allowTransactionlessHeader` but it didn't do enough. It simply just checked if there was an active transaction, which was true.  However due to loading over of the script tag in the next.js layout and the completion of the server side Next.js code, it was always returning `<!-- NREUM: (3) -->`, which meant it lacked a transaction name.  Web transactions aren't finalized until the server handlers are done which in this case wasn't true.  In fact in our legacy Next.js instrumentation, this didn't work correctly. It just encoded `WebTransaction/NormalizedUri/*` as the transaction name.

After speaking with folks on the browser agent, the idea of sending `transactionName` in the intrinsics for the browser agent isn't applicable.  The intention of this property is that it would be associated with all browser events. But since Next.js is just building a layout to be used in client and may have interactions from server it'd be Client -> Server. In the legacy server side rendering of javascript it's different it's Server -> Client. I also found we were passing in attributes that have been deprecated since 2014: ttGuid and agentToken, so I removed those.

So the fix is really to not make any of the transaction intrinsics required and just return what we can or in the case of when `allowTransactionlessHeader`, it doesn't even inject any transaction intrinsics into the browser agent.  This doesn't affect the experience and will still load the browser agent and properly capture things like DT between Next.js client and server interactions. You can see that from this trace:

<img width="1236" height="1298" alt="screenshot 2026-08-06 at 5 11 04 PM" src="https://github.com/user-attachments/assets/a290d1d4-9779-407a-a737-c1370425ea76" />


Lastly, I plan to amend our spec and call out that transaction intrinsics aren't required. The only required keys on the browser agent string are: `agent, beacon, errorBeacon, licenseKey, and applicationID`.

## Related Issues
Closes #4205 