### PR TITLE
fix: avoid rewrapping cached OpenTelemetry meters

### DIFF
--- a/lib/otel/metrics/index.js
+++ b/lib/otel/metrics/index.js
@@ -78,12 +78,17 @@ class SetupMetrics extends SetupSignal {
     this.#metricReader = reader
 
     const getMeter = provider.getMeter
+    const wrappedMeters = new WeakSet()
     provider.getMeter = function nrGetMeter(...args) {
       agent.metrics
         .getOrCreateMetric('Supportability/Metrics/Nodejs/OpenTelemetryBridge/getMeter')
         .incrementCallCount()
 
       const meter = getMeter.apply(provider, args)
+      if (wrappedMeters.has(meter)) {
+        return meter
+      }
+
       const proto = Object.getPrototypeOf(meter)
       const methods = Object.getOwnPropertyNames(proto).filter((name) => name.startsWith('create'))
       const originals = {}
@@ -104,6 +109,7 @@ class SetupMetrics extends SetupSignal {
           return originals[method].apply(meter, args)
         }
       }
+      wrappedMeters.add(meter)
 
       return meter
     }

--- a/test/unit/lib/otel/metrics/index.test.js
+++ b/test/unit/lib/otel/metrics/index.test.js
@@ -38,6 +38,7 @@ test.beforeEach((ctx) => {
   ctx.nr = {}
   const guid = 'guid-123456'
   const licenseKey = 'license-123456'
+  const metricCalls = new Map()
 
   const agent = {
     get [Symbol.toStringTag]() { return 'Agent' },
@@ -74,16 +75,19 @@ test.beforeEach((ctx) => {
           'Supportability/Metrics/Nodejs/OpenTelemetryBridge/meter/createCounter'
         ]
         ctx.assert.ok(validMetrics.includes(name), `Unexpected metric: ${name}`)
-        return this
-      },
-      incrementCallCount() {
-        ctx.assert.ok(true)
+        return {
+          incrementCallCount() {
+            ctx.assert.ok(true)
+            metricCalls.set(name, (metricCalls.get(name) ?? 0) + 1)
+          }
+        }
       }
     }
   }
   Object.setPrototypeOf(agent, EventEmitter.prototype)
 
   ctx.nr.agent = agent
+  ctx.nr.metricCalls = metricCalls
 })
 
 test.afterEach(() => {
@@ -176,6 +180,34 @@ test('serverless mode does not wait for the started event', (t) => {
     'should log that metrics are finalized eagerly in serverless mode'
   )
   t.assert.ok(bootstrapped, 'should emit otelMetricsBootstrapped from the constructor')
+})
+
+test('wraps methods on a cached meter only once', (t) => {
+  const { agent, metricCalls } = t.nr
+  agent.serverlessMode = true
+
+  const signal = new SetupMetrics({ agent, logger: captureLogger() })
+  t.assert.ok(signal)
+
+  const provider = otelApi.metrics.getMeterProvider()
+  const meter = provider.getMeter('cached-meter')
+  const createCounter = meter.createCounter
+
+  for (let i = 0; i < 5; i++) {
+    const cachedMeter = provider.getMeter('cached-meter')
+    t.assert.equal(cachedMeter, meter)
+    t.assert.equal(cachedMeter.createCounter, createCounter)
+  }
+
+  meter.createCounter('test-counter')
+  t.assert.equal(
+    metricCalls.get('Supportability/Metrics/Nodejs/OpenTelemetryBridge/getMeter'),
+    6
+  )
+  t.assert.equal(
+    metricCalls.get('Supportability/Metrics/Nodejs/OpenTelemetryBridge/meter/createCounter'),
+    1
+  )
 })
 
 test('flushToString collects, exports, and returns the base64 OTLP payload', async (t) => {


### PR DESCRIPTION
## Description

`MeterProvider.getMeter()` can return the same cached Meter for repeated lookups. The bridge wrapped its `create*` methods again each time, retaining nested wrappers and counting one instrument creation more than once.

Track wrapped Meters weakly so repeated lookups keep the original wrappers while `getMeter` supportability counting still records every call.

## How to Test

- `npm run lint`
- `node --test test/unit/lib/otel/metrics/*.test.js`
- focused metrics test on Node 22, 24, and 26

## Related Issues

Fixes #4213