### PR TITLE
revert: Correctly parse `subquery` collection names in SQL; assert previously-skipped cross agent test cases

### DIFF
--- a/lib/db/query-parsers/sql.js
+++ b/lib/db/query-parsers/sql.js
@@ -23,10 +23,6 @@ const OPERATIONS = [
   new StatementMatcher('delete', /^[^\S]*?delete[^\S]+?from[^\S]+([^\s\n\r,(;]+)/gim)
 ]
 const COMMENT_PATTERN = /\/\\*.*?\\*\//g
-// Matches a SELECT whose FROM clause is itself a subquery, e.g.
-// `SELECT * FROM (SELECT * FROM foobar)`. The outer statement matchers can't
-// name a real table for these, so they're reported as the literal '(subquery)'.
-const SUBQUERY_PATTERN = /^\s*select\b[\s\S]*?\bfrom[\s\n\r]*\(\s*select\b/i
 /* eslint-enable no-useless-escape, sonarjs/super-linear-regex, sonarjs/duplicates-in-character-class */
 
 // This must be called synchronously after the initial db call for backtraces to
@@ -55,15 +51,6 @@ module.exports = function parseSql(sql) {
   }
 
   sql = sql.replace(COMMENT_PATTERN, '').trim()
-
-  if (SUBQUERY_PATTERN.test(sql)) {
-    return {
-      operation: 'select',
-      database: null,
-      collection: '(subquery)',
-      query: sql
-    }
-  }
 
   let parsedStatement
 

--- a/test/benchmark/db/query-parsers/sql.bench.js
+++ b/test/benchmark/db/query-parsers/sql.bench.js
@@ -31,14 +31,6 @@ const tests = [
     fn: selectStatement
   },
   {
-    name: 'plain-select-statement',
-    fn: plainSelectStatement
-  },
-  {
-    name: 'subquery-select-statement',
-    fn: subquerySelectStatement
-  },
-  {
     name: 'update-statement',
     fn: updateStatement
   },
@@ -75,14 +67,6 @@ function selectStatement() {
   parseSql(
     "with foobar (col1) as cte select * from foo as a join on cte using (col1) where a.bar = 'baz'"
   )
-}
-
-function plainSelectStatement() {
-  parseSql("select * from foo as a join bar as b on a.id = b.id where a.baz = 'qux'")
-}
-
-function subquerySelectStatement() {
-  parseSql('select * from (select * from foobar)')
 }
 
 function updateStatement() {

--- a/test/unit/db/query-parsers/sql.test.js
+++ b/test/unit/db/query-parsers/sql.test.js
@@ -150,17 +150,13 @@ test('database query parser', async (t) => {
 
         assert.equal(ps.operation, cat.operation, `should parse the operation as ${cat.operation}`)
 
-        // Instead of stripping the schema/database prefix to match the cross-agent spec,
-        // our parser intentionally keeps it on the collection name (e.g. "database.foobar")
-        // for backward compatibility with existing metric names.
-        // @see comment lib/db/statement-matcher.js:28-32
-        // Also covers the '(subquery)' cases, since ps.database is null for those.
-        const expectedCollection = ps.database ? `${ps.database}.${cat.table}` : cat.table
-        assert.equal(
-          ps.collection,
-          expectedCollection,
-          `should parse the collection as ${expectedCollection}`
-        )
+        if (cat.table === '(subquery)') {
+          t.todo('should parse subquery collections as ' + cat.table)
+        } else if (/\w+\.\w+/.test(ps.collection)) {
+          t.todo('should strip database names from collection names as ' + cat.table)
+        } else {
+          assert.equal(ps.collection, cat.table, `should parse the collection as ${cat.table}`)
+        }
       })
     }
   })


### PR DESCRIPTION
Reverts newrelic/node-newrelic#4196

Let's take a step back and verify the information in #4214.