### PR TITLE
perf: skip gRPC/http2 instrumentation when parent segment is opaque

### DIFF
--- a/lib/instrumentation/core/http2.js
+++ b/lib/instrumentation/core/http2.js
@@ -49,6 +49,11 @@ function initialize(agent, http2, moduleName, shim) {
       }
       const activeSegment = agent.tracer.getSegment()
 
+      if (activeSegment?.opaque) {
+        logger.trace('Not recording http2 external, parent segment is opaque')
+        return fn.apply(this, args)
+      }
+
       const [headers] = args
       args[0] = addDTHeaders({
         transaction: txn,

--- a/lib/subscribers/grpcjs/client.js
+++ b/lib/subscribers/grpcjs/client.js
@@ -36,6 +36,10 @@ module.exports = class GrpcClientSubscriber extends Subscriber {
       ctx
     })
 
+    if (newCtx === ctx) {
+      return ctx
+    }
+
     // Acquire the original parameters to the handler, create patched
     // versions of them, and update the parameters list with the patched
     // instances.

--- a/test/unit/instrumentation/http2/http2.test.js
+++ b/test/unit/instrumentation/http2/http2.test.js
@@ -566,6 +566,45 @@ test('http2 outbound request', async (t) => {
       const attributes = segment.getAttributes()
       assert.ok(!attributes['request.parameters.a'])
       assert.ok(!attributes['request.parameters.b'])
+
+      const children = t.nr.transaction.trace.getChildren(t.nr.parentSegment.id)
+      assert.equal(children.length, 0, 'should not create a child segment under an opaque parent')
+      end()
+    }
+  })
+
+  await t.test('should not inject DT headers when parent segment is opaque', (t, end) => {
+    const { agent, http2, protocol, host, port } = t.nr
+    agent.config.distributed_tracing.enabled = true
+    agent.config.trusted_account_key = 190
+    agent.config.account_id = 190
+    agent.config.primary_application_id = '389103'
+    helper.runInTransaction(agent, function (transaction) {
+      t.nr.transaction = transaction
+      const parentSegment = agent.tracer.createSegment({
+        name: 'ParentSegment',
+        parent: transaction.trace.root,
+        transaction
+      })
+      parentSegment.opaque = true
+      agent.tracer.setSegment({ transaction, segment: parentSegment })
+      makeRequest(
+        http2,
+        {
+          protocol,
+          host,
+          port,
+          path: '/',
+          method: 'GET'
+        },
+        finish
+      )
+    })
+
+    function finish(err, responseHeaders) {
+      assert.ok(!err)
+      assert.ok(!responseHeaders.traceparent, 'should not inject traceparent header when parent segment is opaque')
+      assert.ok(!responseHeaders.newrelic, 'should not inject newrelic header when parent segment is opaque')
       end()
     }
   })

--- a/test/versioned/grpc/client-opaque-parent.test.js
+++ b/test/versioned/grpc/client-opaque-parent.test.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert')
+
+const { removeModules } = require('../../lib/cache-buster')
+const helper = require('../../lib/agent_helper')
+
+const {
+  assertMetricsNotExisting,
+  makeUnaryRequest,
+  createServer,
+  getClient
+} = require('./util.cjs')
+
+// When the active segment is opaque (e.g. a nested client call under a parent
+// gRPC External segment), GrpcClientSubscriber.handler() should detect that
+// createSegment() produced no new segment and skip the metadata clone, args
+// mutation, and DT header injection entirely. The tests show:
+//
+//  1. No External segment should be recorded for the nested call.
+//  2. No DT headers should be injected into the outbound metadata.
+
+test.beforeEach(async (ctx) => {
+  ctx.nr = {}
+  ctx.nr.agent = helper.instrumentMockedAgent()
+  ctx.nr.grpc = require('@grpc/grpc-js')
+
+  const { port, proto, server } = await createServer(ctx.nr.grpc, ctx.nr.agent)
+  ctx.nr.port = port
+  ctx.nr.proto = proto
+  ctx.nr.server = server
+  ctx.nr.client = getClient(ctx.nr.grpc, proto, port)
+})
+
+test.afterEach((ctx) => {
+  helper.unloadAgent(ctx.nr.agent)
+  ctx.nr.server.forceShutdown()
+  ctx.nr.client.close()
+  removeModules(['@grpc/grpc-js'])
+})
+
+test('should not create an External segment when the parent segment is opaque', (t, end) => {
+  const { agent, client, port } = t.nr
+
+  helper.runInTransaction(agent, 'web', async (tx) => {
+    tx.name = 'opaqueParentTransaction'
+
+    // Mark the current (base) segment opaque to simulate being inside another
+    // instrumented call whose segment blocks child creation (e.g. a parent
+    // gRPC External segment, which the subscriber marks opaque=true).
+    const ctx = agent.tracer.getContext()
+    ctx.segment.opaque = true
+
+    await makeUnaryRequest({
+      client,
+      fnName: 'sayHello',
+      payload: { name: 'opaque-no-segment' }
+    })
+
+    agent.on('transactionFinished', (transaction) => {
+      if (transaction.name === 'opaqueParentTransaction') {
+        assertMetricsNotExisting({ agent, port })
+        end()
+      }
+    })
+
+    tx.end()
+  })
+})
+
+test('should not inject distributed trace headers when the parent segment is opaque', (t, end) => {
+  const { agent, client, server } = t.nr
+
+  helper.runInTransaction(agent, 'web', async (tx) => {
+    const payload = { name: 'opaque-no-dt-headers' }
+
+    const ctx = agent.tracer.getContext()
+    ctx.segment.opaque = true
+
+    await makeUnaryRequest({
+      client,
+      fnName: 'sayHello',
+      payload
+    })
+
+    const dtMeta = server.metadataMap.get(payload.name)
+    assert.equal(
+      dtMeta.has('traceparent'),
+      false,
+      'should not inject traceparent into metadata when parent segment is opaque'
+    )
+    assert.equal(
+      dtMeta.has('newrelic'),
+      false,
+      'should not inject newrelic header into metadata when parent segment is opaque'
+    )
+
+    tx.end()
+    end()
+  })
+})

--- a/test/versioned/grpc/package.json
+++ b/test/versioned/grpc/package.json
@@ -12,6 +12,7 @@
         "@grpc/grpc-js": ">=1.4.0"
       },
       "files": [
+        "client-opaque-parent.test.js",
         "client-unary.test.js",
         "client-streaming.test.js",
         "client-server-streaming.test.js",


### PR DESCRIPTION
This PR solves a performance edge case in the grpc-js instrumentation. This is the only remaining case similar to #4210 that the bot found.

-----

## Summary

- When the active segment is opaque, `GrpcClientSubscriber.handler()` now returns early after `createSegment()` instead of proceeding to clone metadata, mutate call arguments, and inject distributed trace headers — work that was always discarded since no segment would be recorded.
- The same guard is applied to the http2 shim's `wrappedRequest`, which also injected DT headers unconditionally when inside a transaction regardless of the parent segment's opaque state (gRPC uses HTTP/2 underneath, so both paths fired).

## Background

PR #4210 introduced the pattern of skipping instrumentation context work when a segment would not be created (Apollo resolver scalars). This PR applies the same pattern to two other cases identified during a review of `lib/subscribers/`.

## Test plan

- [ ] New versioned test `test/versioned/grpc/client-opaque-parent.test.js` — two cases: no External segment created, no DT headers injected when parent segment is opaque
- [ ] Extended `test/unit/instrumentation/http2/http2.test.js` — added child-segment count assertion to existing opaque test; added new test asserting DT headers are not injected when parent segment is opaque
- [ ] Existing `test/versioned/grpc/client-unary.test.js` — all 10 tests pass, confirming no regression in the normal (non-opaque) path

🤖 Generated with [Claude Code](https://claude.com/claude-code)