### PR TITLE
refactor: Removed dead `wrapNoSegment` code from `zlib` instrumentation

### DIFF
--- a/lib/instrumentation/core/zlib.js
+++ b/lib/instrumentation/core/zlib.js
@@ -15,32 +15,7 @@ const methods = ['deflate', 'deflateRaw', 'gzip', 'gunzip', 'inflate', 'inflateR
 function initialize(agent, zlib, moduleName, shim) {
   shim.record(zlib, methods, recordZLib)
 
-  if (zlib.Deflate && zlib.Deflate.prototype) {
-    const proto = Object.getPrototypeOf(zlib.Deflate.prototype)
-    if (proto._transform) {
-      // streams2
-      shim.wrap(proto, '_transform', wrapNoSegment)
-    } else if (proto.write && proto.flush && proto.end) {
-      // plain ol' streams
-      shim.wrap(proto, ['write', 'flush', 'end'], wrapNoSegment)
-    }
-  }
-
   function recordZLib(shim, fn, name) {
     return new RecorderSpec({ name: `zlib.${name}`, callback: shim.LAST, recorder })
-  }
-}
-
-function wrapNoSegment(shim, fn) {
-  return function wrappedZLibNoSegment(...args) {
-    if (!shim.getActiveSegment()) {
-      return fn.apply(this, args)
-    }
-
-    const cbIndex = args.length - 1
-
-    shim.bindSegment(args, cbIndex)
-
-    return fn.apply(this, args)
   }
 }

--- a/test/integration/core/zlib.test.js
+++ b/test/integration/core/zlib.test.js
@@ -164,6 +164,78 @@ test('createInflateRaw', function (t, end) {
   })
 })
 
+test('recorded method still ends segment and binds callback on error', function (t, end) {
+  const { agent } = t.nr
+  helper.runInTransaction(agent, function (transaction) {
+    // gunzip on non-gzip data errors.
+    zlib.gunzip(Buffer.from('not gzip data'), function (err) {
+      assert.ok(err, 'should error on invalid input')
+      assert.equal(agent.getTransaction(), transaction, 'callback should run in transaction')
+
+      const { trace } = transaction
+      const traceChildren = trace.getChildren(trace.root.id)
+      assert.equal(traceChildren.length, 1, 'should have a single child')
+      const child = traceChildren[0]
+      assert.equal(child.name, 'zlib.gunzip', 'child segment should have correct name')
+      assert.ok(child.timer.touched, 'child should have started and ended')
+      end()
+    })
+  })
+})
+
+test('stream preserves transaction context in its own event handlers', function (t, end) {
+  const { agent } = t.nr
+  helper.runInTransaction(agent, function (transaction) {
+    const stream = zlib.createGzip()
+
+    // The zlib stream classes do not create their own segments, but the active
+    // transaction must still propagate across the stream's internal async
+    // callbacks. Assert the transaction survives into the stream's own async
+    // event handlers.
+    stream.on('data', function () {
+      assert.equal(
+        agent.getTransaction(),
+        transaction,
+        'transaction should be active in data handler'
+      )
+    })
+
+    stream.on('end', function () {
+      assert.equal(
+        agent.getTransaction(),
+        transaction,
+        'transaction should be active in end handler'
+      )
+      end()
+    })
+
+    stream.on('error', function (err) {
+      assert.ok(!err, 'should not error')
+      end()
+    })
+
+    stream.end(CONTENT)
+    stream.resume()
+  })
+})
+
+test('stream works outside of a transaction', function (t, end) {
+  const { agent } = t.nr
+  // No runInTransaction wrapper -- zlib streams must work normally when there
+  // is no active transaction.
+  assert.equal(agent.getTransaction(), null, 'precondition: no active transaction')
+
+  const concatStream = concat(function (result) {
+    assert.equal(result.toString('base64'), GZIP_CONTENT, 'should have correct result')
+    assert.equal(agent.getTransaction(), null, 'should still have no transaction')
+    end()
+  })
+
+  const stream = zlib.createGzip()
+  stream.pipe(concatStream)
+  stream.end(CONTENT)
+})
+
 function testStream({ agent, end, method, src, out }) {
   helper.runInTransaction(agent, function (transaction) {
     const concatStream = concat(check)


### PR DESCRIPTION
## Summary

Removes dead code from the `zlib` core-module instrumentation: the `wrapNoSegment` function and the `zlib.Deflate` prototype-wrapping block.

That code manually rebound zlib stream callbacks (`_transform`, or legacy `write`/`flush`/`end`) to the active segment. It was necessary in the continuation-local-storage (CLS) era, when callbacks crossing zlib's internal C++ boundary lost transaction context. The agent now uses only `AsyncLocalContextManager`, which propagates context across the native boundary automatically, so the manual rebind is redundant.

The live `shim.record(...)` path that produces the `zlib.*` segments/metrics is unchanged.

## Verification

Confirmed empirically that toggling the callback binding on/off produces **byte-identical** behavior across Node **22, 24, and 26** (the full supported `engines: >=22` range), for:

- transaction context in stream `data` / `end` / `flush` / `setImmediate` handlers
- segment parenting of children created inside stream callbacks
- an adversarial promise-based `gzip` → `gunzip` `stream/promises.pipeline`

The legacy `write`/`flush`/`end` branch was also dead, since modern zlib streams always expose `_transform`.

## Tests

Adds three integration tests as regression guards:

- **error path** — a recorded method ends its segment and binds the callback even when the operation errors
- **stream context propagation** — the transaction survives into a zlib stream's own async event handlers
- **stream outside a transaction** — zlib streams work normally with no active transaction

All 17 tests in `test/integration/core/zlib.test.js` pass on Node 22/24/26. `eslint` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
