### PR TITLE
refactor: Include all `.mjs` equivalents in `openai` instrumentation to properly function when using ESM

### DIFF
--- a/lib/subscribers/openai/config.js
+++ b/lib/subscribers/openai/config.js
@@ -21,7 +21,25 @@ module.exports = {
         },
         {
           channelName: 'nr_completionsCreate',
+          module: { name: 'openai', versionRange: '>=4.0.0', filePath: 'resources/chat/completions.mjs' },
+          functionQuery: {
+            className: 'Completions',
+            methodName: 'create',
+            kind: 'Async'
+          }
+        },
+        {
+          channelName: 'nr_completionsCreate',
           module: { name: 'openai', versionRange: '>=4.0.0', filePath: 'resources/chat/completions/completions.js' },
+          functionQuery: {
+            className: 'Completions',
+            methodName: 'create',
+            kind: 'Async'
+          }
+        },
+        {
+          channelName: 'nr_completionsCreate',
+          module: { name: 'openai', versionRange: '>=4.0.0', filePath: 'resources/chat/completions/completions.mjs' },
           functionQuery: {
             className: 'Completions',
             methodName: 'create',
@@ -41,6 +59,15 @@ module.exports = {
             methodName: 'create',
             kind: 'Async'
           }
+        },
+        {
+          channelName: 'nr_responses',
+          module: { name: 'openai', versionRange: '>=4.87.0', filePath: 'resources/responses/responses.mjs' },
+          functionQuery: {
+            className: 'Responses',
+            methodName: 'create',
+            kind: 'Async'
+          }
         }
       ]
     },
@@ -49,7 +76,7 @@ module.exports = {
       instrumentations: [
         {
           channelName: 'nr_makeRequest',
-          module: { name: 'openai', versionRange: '>=4.0.0', filePath: 'core.js' },
+          module: { name: 'openai', versionRange: '>=4.0.0 <5.0.0', filePath: 'core.js' },
           functionQuery: {
             className: 'APIClient',
             methodName: 'makeRequest',
@@ -58,7 +85,25 @@ module.exports = {
         },
         {
           channelName: 'nr_makeRequest',
-          module: { name: 'openai', versionRange: '>=4.0.0', filePath: 'client.js' },
+          module: { name: 'openai', versionRange: '>=4.0.0 <5.0.0', filePath: 'core.mjs' },
+          functionQuery: {
+            className: 'APIClient',
+            methodName: 'makeRequest',
+            kind: 'Async'
+          }
+        },
+        {
+          channelName: 'nr_makeRequest',
+          module: { name: 'openai', versionRange: '>=5.0.0', filePath: 'client.js' },
+          functionQuery: {
+            className: 'OpenAI',
+            methodName: 'makeRequest',
+            kind: 'Async'
+          }
+        },
+        {
+          channelName: 'nr_makeRequest',
+          module: { name: 'openai', versionRange: '>=5.0.0', filePath: 'client.mjs' },
           functionQuery: {
             className: 'OpenAI',
             methodName: 'makeRequest',
@@ -80,7 +125,23 @@ module.exports = {
         },
         {
           channelName: 'nr_parseResponse',
+          module: { name: 'openai', versionRange: '>=4.87.0 <5.0.0', filePath: 'core.mjs' },
+          functionQuery: {
+            functionName: 'defaultParseResponse',
+            kind: 'Async'
+          }
+        },
+        {
+          channelName: 'nr_parseResponse',
           module: { name: 'openai', versionRange: '>=5.0.0', filePath: 'internal/parse.js' },
+          functionQuery: {
+            functionName: 'defaultParseResponse',
+            kind: 'Async'
+          }
+        },
+        {
+          channelName: 'nr_parseResponse',
+          module: { name: 'openai', versionRange: '>=5.0.0', filePath: 'internal/parse.mjs' },
           functionQuery: {
             functionName: 'defaultParseResponse',
             kind: 'Async'
@@ -94,6 +155,15 @@ module.exports = {
         {
           channelName: 'nr_embeddingsCreate',
           module: { name: 'openai', versionRange: '>=4.0.0', filePath: 'resources/embeddings.js' },
+          functionQuery: {
+            className: 'Embeddings',
+            methodName: 'create',
+            kind: 'Async'
+          }
+        },
+        {
+          channelName: 'nr_embeddingsCreate',
+          module: { name: 'openai', versionRange: '>=4.0.0', filePath: 'resources/embeddings.mjs' },
           functionQuery: {
             className: 'Embeddings',
             methodName: 'create',


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

When looking into #4228, I noticed we aren't wrapping the `.mjs` files for openai.  This would lead to a loss of instrumentation when using ESM. This PR updates the openai config to wrap both `.js` and `.mjs`. I also fixed the version ranges for `core.js/mjs` as it only exists in <5.0.0.
