### PR TITLE
refactor: Split `BedrockResponse` and `BedrockCommand` into `Converse` and `InvokeModel` variants

### DIFF
--- a/lib/llm-events/aws-bedrock/converse-command.js
+++ b/lib/llm-events/aws-bedrock/converse-command.js
@@ -8,15 +8,12 @@
 const { stringifyConverseChunkedMessage } = require('./stringify-message')
 
 /**
- * Parses an AWS Bedrock Converse/ConverseStream command instance into a
- * re-usable entity.
+ * Parses an AWS Bedrock `ConverseCommand`/`ConverseStreamCommand`
+ * instance into a re-usable entity.
  */
 class ConverseCommand {
   #input
   #modelId
-  /**
-   * The `messages` field on the input.
-   */
   #messages
 
   /**
@@ -25,7 +22,7 @@ class ConverseCommand {
    */
   constructor(input) {
     this.#input = input
-    this.#modelId = this.#input.modelId?.toLowerCase() ?? ''
+    this.#modelId = input.modelId?.toLowerCase() ?? ''
     this.#messages = input.messages
   }
 

--- a/lib/llm-events/aws-bedrock/converse-command.js
+++ b/lib/llm-events/aws-bedrock/converse-command.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { stringifyConverseChunkedMessage } = require('./stringify-message')
+
+/**
+ * Parses an AWS Bedrock Converse/ConverseStream command instance into a
+ * re-usable entity.
+ */
+class ConverseCommand {
+  #input
+  #modelId
+  /**
+   * The `messages` field on the input.
+   */
+  #messages
+
+  /**
+   * @param {object} input The `input` property from a `ConverseCommand`
+   * or `ConverseStreamCommand` instance.
+   */
+  constructor(input) {
+    this.#input = input
+    this.#modelId = this.#input.modelId?.toLowerCase() ?? ''
+    this.#messages = input.messages
+  }
+
+  /**
+   * @returns {boolean} Always `true`, this command is from the Converse API.
+   */
+  get isConverse() {
+    return true
+  }
+
+  /**
+   * The maximum number of tokens allowed as defined by the user.
+   *
+   * @returns {number|undefined}
+   */
+  get maxTokens() {
+    return this.#input?.inferenceConfig?.maxTokens
+  }
+
+  /**
+   * The model identifier for the command.
+   *
+   * @see https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids-arns.html
+   *
+   * @returns {string}
+   */
+  get modelId() {
+    return this.#modelId
+  }
+
+  /**
+   * @returns {string} One of `embedding` or `completion`.
+   */
+  get modelType() {
+    return this.#modelId.toLowerCase().includes('embed') ? 'embedding' : 'completion'
+  }
+
+  /**
+   * The question posed to the LLM.
+   *
+   * @returns {object[]}
+   */
+  get prompt() {
+    const result = []
+    for (const message of this.#messages) {
+      // The `message.content` field is an array of ContentBlock objects.
+      // For text messages, the structure is: content: [{ text: '...' }]
+      if (Array.isArray(message?.content) === true) {
+        result.push({
+          role: message.role,
+          content: stringifyConverseChunkedMessage(message.content)
+        })
+      }
+    }
+    return result
+  }
+
+  /**
+   * @returns {number|undefined}
+   */
+  get temperature() {
+    return this.#input?.inferenceConfig?.temperature
+  }
+}
+
+module.exports = ConverseCommand

--- a/lib/llm-events/aws-bedrock/converse-command.js
+++ b/lib/llm-events/aws-bedrock/converse-command.js
@@ -6,14 +6,14 @@
 'use strict'
 
 const { stringifyConverseChunkedMessage } = require('./stringify-message')
+const ModelCommand = require('./model-command')
 
 /**
  * Parses an AWS Bedrock `ConverseCommand`/`ConverseStreamCommand`
  * instance into a re-usable entity.
  */
-class ConverseCommand {
+class ConverseCommand extends ModelCommand {
   #input
-  #modelId
   #messages
 
   /**
@@ -21,16 +21,9 @@ class ConverseCommand {
    * or `ConverseStreamCommand` instance.
    */
   constructor(input) {
+    super(input)
     this.#input = input
-    this.#modelId = input.modelId?.toLowerCase() ?? ''
     this.#messages = input.messages
-  }
-
-  /**
-   * @returns {boolean} Always `true`, this command is from the Converse API.
-   */
-  get isConverse() {
-    return true
   }
 
   /**
@@ -40,24 +33,6 @@ class ConverseCommand {
    */
   get maxTokens() {
     return this.#input?.inferenceConfig?.maxTokens
-  }
-
-  /**
-   * The model identifier for the command.
-   *
-   * @see https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids-arns.html
-   *
-   * @returns {string}
-   */
-  get modelId() {
-    return this.#modelId
-  }
-
-  /**
-   * @returns {string} One of `embedding` or `completion`.
-   */
-  get modelType() {
-    return this.#modelId.toLowerCase().includes('embed') ? 'embedding' : 'completion'
   }
 
   /**

--- a/lib/llm-events/aws-bedrock/converse-response.js
+++ b/lib/llm-events/aws-bedrock/converse-response.js
@@ -18,8 +18,8 @@ const { stringifyConverseChunkedMessage } = require('./stringify-message')
  */
 
 /**
- * Represents a response from the Bedrock Converse/ConverseStream API. This
- * object provides an abstraction that normalizes responses into a known
+ * Represents a response from the Bedrock Converse API. This object
+ * provides an abstraction that normalizes responses into a known
  * interface and simplifies accessing desired fields.
  */
 class ConverseResponse {
@@ -38,7 +38,7 @@ class ConverseResponse {
     this.#innerResponse = isError ? response.$response : response.response
     this.isError = isError
 
-    if (this.isError) {
+    if (isError) {
       return
     }
 

--- a/lib/llm-events/aws-bedrock/converse-response.js
+++ b/lib/llm-events/aws-bedrock/converse-response.js
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { stringifyConverseChunkedMessage } = require('./stringify-message')
+
+/**
+ * @typedef {object} AwsBedrockMiddlewareResponse
+ * @property {object} response Has a `body` property that is an IncomingMessage,
+ * a `headers` property that are the response headers, a `reason` property that
+ * indicates the status code reason, and a `statusCode` property.
+ * @property {object} output Has a `$metadata` property that includes the
+ * `requestId`, and a `body` property that is a Uint8Array representation
+ * of the response payload.
+ */
+
+/**
+ * Represents a response from the Bedrock Converse/ConverseStream API. This
+ * object provides an abstraction that normalizes responses into a known
+ * interface and simplifies accessing desired fields.
+ */
+class ConverseResponse {
+  #originalResponse
+  #innerResponse
+  #innerOutput
+  #output
+
+  /**
+   * @param {object} params params object
+   * @param {AwsBedrockMiddlewareResponse} params.response AWS Bedrock middleware response
+   * @param {boolean} params.isError is there an error
+   */
+  constructor({ response, isError = false }) {
+    this.#originalResponse = response
+    this.#innerResponse = isError ? response.$response : response.response
+    this.isError = isError
+
+    if (this.isError) {
+      return
+    }
+
+    this.#innerOutput = response.output.output
+    this.#output = this.#innerOutput.message
+  }
+
+  /**
+   * @returns {boolean} Always `true`, this response is from the Converse API.
+   */
+  get isConverse() {
+    return true
+  }
+
+  /**
+   * @returns {number} The number of tokens in the prompt.
+   */
+  get inputTokenCount() {
+    return parseInt(this.#originalResponse?.output?.usage?.inputTokens || 0, 10)
+  }
+
+  /**
+   * @returns {number} The number of tokens in the completion.
+   */
+  get outputTokenCount() {
+    return parseInt(this.#originalResponse?.output?.usage?.outputTokens || 0, 10)
+  }
+
+  /**
+   * @returns {number} The total number of tokens used by the request and response.
+   */
+  get totalTokenCount() {
+    return parseInt(this.#originalResponse?.output?.usage?.totalTokens || 0, 10)
+  }
+
+  /**
+   * The prompt responses returned by the model.
+   *
+   * @returns {string[]} Should be an array of string responses to the prompt.
+   */
+  get completions() {
+    const content = this.#output?.content
+    if (!content) return []
+    return [typeof content === 'string' ? content : stringifyConverseChunkedMessage(content)]
+  }
+
+  /**
+   * The reason the model has given for finishing the response.
+   *
+   * @returns {string|undefined}
+   */
+  get finishReason() {
+    if (this.isError) {
+      return undefined
+    }
+    return this.#originalResponse.output.stopReason
+  }
+
+  /**
+   * HTTP headers provided in the API response.
+   *
+   * @returns {object} Typical key-value set of HTTP headers.
+   */
+  get headers() {
+    return this.#innerResponse.headers
+  }
+
+  /**
+   * Retrieve the response identifier. For the Converse API, the requestId
+   * serves as the id.
+   *
+   * @returns {string|undefined}
+   */
+  get id() {
+    return this.requestId
+  }
+
+  /**
+   * UUID assigned to the initial request as returned by the API.
+   *
+   * @returns {string}
+   */
+  get requestId() {
+    return this.headers?.['x-amzn-requestid']
+  }
+
+  /**
+   * The HTTP status code of the response.
+   *
+   * @returns {number}
+   */
+  get statusCode() {
+    return this.#innerResponse.statusCode
+  }
+}
+
+module.exports = ConverseResponse

--- a/lib/llm-events/aws-bedrock/converse-response.js
+++ b/lib/llm-events/aws-bedrock/converse-response.js
@@ -6,6 +6,7 @@
 'use strict'
 
 const { stringifyConverseChunkedMessage } = require('./stringify-message')
+const ModelResponse = require('./model-response')
 
 /**
  * @typedef {object} AwsBedrockMiddlewareResponse
@@ -22,9 +23,8 @@ const { stringifyConverseChunkedMessage } = require('./stringify-message')
  * provides an abstraction that normalizes responses into a known
  * interface and simplifies accessing desired fields.
  */
-class ConverseResponse {
+class ConverseResponse extends ModelResponse {
   #originalResponse
-  #innerResponse
   #innerOutput
   #output
 
@@ -34,11 +34,10 @@ class ConverseResponse {
    * @param {boolean} params.isError is there an error
    */
   constructor({ response, isError = false }) {
+    super({ response, isError })
     this.#originalResponse = response
-    this.#innerResponse = isError ? response.$response : response.response
-    this.isError = isError
 
-    if (isError) {
+    if (this.isError) {
       return
     }
 
@@ -91,15 +90,6 @@ class ConverseResponse {
   }
 
   /**
-   * HTTP headers provided in the API response.
-   *
-   * @returns {object} Typical key-value set of HTTP headers.
-   */
-  get headers() {
-    return this.#innerResponse.headers
-  }
-
-  /**
    * Retrieve the response identifier. For the Converse API, the requestId
    * serves as the id.
    *
@@ -107,24 +97,6 @@ class ConverseResponse {
    */
   get id() {
     return this.requestId
-  }
-
-  /**
-   * UUID assigned to the initial request as returned by the API.
-   *
-   * @returns {string}
-   */
-  get requestId() {
-    return this.headers?.['x-amzn-requestid']
-  }
-
-  /**
-   * The HTTP status code of the response.
-   *
-   * @returns {number}
-   */
-  get statusCode() {
-    return this.#innerResponse.statusCode
   }
 }
 

--- a/lib/llm-events/aws-bedrock/converse-response.js
+++ b/lib/llm-events/aws-bedrock/converse-response.js
@@ -47,13 +47,6 @@ class ConverseResponse {
   }
 
   /**
-   * @returns {boolean} Always `true`, this response is from the Converse API.
-   */
-  get isConverse() {
-    return true
-  }
-
-  /**
    * @returns {number} The number of tokens in the prompt.
    */
   get inputTokenCount() {

--- a/lib/llm-events/aws-bedrock/index.js
+++ b/lib/llm-events/aws-bedrock/index.js
@@ -9,6 +9,8 @@ module.exports = {
   LlmEmbedding: require('./embedding'),
   LlmErrorMessage: require('./error-message'),
   // Helper classes to create the Llm events
-  BedrockCommand: require('./bedrock-command'),
-  BedrockResponse: require('./bedrock-response'),
+  InvokeModelCommand: require('./invoke-model-command'),
+  ConverseCommand: require('./converse-command'),
+  InvokeModelResponse: require('./invoke-model-response'),
+  ConverseResponse: require('./converse-response'),
 }

--- a/lib/llm-events/aws-bedrock/invoke-model-command.js
+++ b/lib/llm-events/aws-bedrock/invoke-model-command.js
@@ -8,12 +8,13 @@
 const { stringifyClaudeChunkedMessage } = require('./stringify-message')
 
 /**
- * Parses an AWS Bedrock InvokeModel/InvokeModelWithResponseStream command
+ * Parses an AWS Bedrock `InvokeModel`/`InvokeModelWithResponseStream` command
  * instance into a re-usable entity.
  */
 class InvokeModelCommand {
   #input
   #modelId
+  /** The parsed input body. */
   #body
 
   /**
@@ -68,7 +69,7 @@ class InvokeModelCommand {
    * @returns {string} One of `embedding` or `completion`.
    */
   get modelType() {
-    // TODO: this.#input.body.inputText enough to determine if embedding?
+    /// This logic is common to both command types
     return this.#modelId.toLowerCase().includes('embed') ? 'embedding' : 'completion'
   }
 

--- a/lib/llm-events/aws-bedrock/invoke-model-command.js
+++ b/lib/llm-events/aws-bedrock/invoke-model-command.js
@@ -6,15 +6,14 @@
 'use strict'
 
 const { stringifyClaudeChunkedMessage } = require('./stringify-message')
+const ModelCommand = require('./model-command')
 
 /**
  * Parses an AWS Bedrock `InvokeModel`/`InvokeModelWithResponseStream` command
  * instance into a re-usable entity.
  */
-class InvokeModelCommand {
+class InvokeModelCommand extends ModelCommand {
   #input
-  #modelId
-  /** The parsed input body. */
   #body
 
   /**
@@ -22,16 +21,9 @@ class InvokeModelCommand {
    * or `InvokeModelWithResponseStreamCommand` instance.
    */
   constructor(input) {
+    super(input)
     this.#input = input
-    this.#modelId = this.#input.modelId?.toLowerCase() ?? ''
     this.#body = JSON.parse(this.#input.body)
-  }
-
-  /**
-   * @returns {boolean} Always `false`, this command is not from the Converse API.
-   */
-  get isConverse() {
-    return false
   }
 
   /**
@@ -52,25 +44,6 @@ class InvokeModelCommand {
     if (this.isTitan() === true) {
       return this.#body.textGenerationConfig?.maxTokenCount
     }
-  }
-
-  /**
-   * The model identifier for the command.
-   *
-   * @see https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids-arns.html
-   *
-   * @returns {string}
-   */
-  get modelId() {
-    return this.#modelId
-  }
-
-  /**
-   * @returns {string} One of `embedding` or `completion`.
-   */
-  get modelType() {
-    /// This logic is common to both command types
-    return this.#modelId.toLowerCase().includes('embed') ? 'embedding' : 'completion'
   }
 
   /**
@@ -119,33 +92,33 @@ class InvokeModelCommand {
     }
   }
 
-  // Helper methods that depend on modelId (common to both types)
+  // Helper methods to determine which LLM vendor was used based on modelId
   isClaude() {
-    return this.#modelId.split('.').slice(-2).join('.').startsWith('anthropic.claude-v')
+    return this.modelId.split('.').slice(-2).join('.').startsWith('anthropic.claude-v')
   }
 
   isClaude3() {
-    return this.#modelId.split('.').slice(-2).join('.').startsWith('anthropic.claude-3')
+    return this.modelId.split('.').slice(-2).join('.').startsWith('anthropic.claude-3')
   }
 
   isCohere() {
-    return this.#modelId.startsWith('cohere.') && this.isCohereEmbed() === false
+    return this.modelId.startsWith('cohere.') && this.isCohereEmbed() === false
   }
 
   isCohereEmbed() {
-    return this.#modelId.startsWith('cohere.embed')
+    return this.modelId.startsWith('cohere.embed')
   }
 
   isLlama() {
-    return this.#modelId.startsWith('meta.llama')
+    return this.modelId.startsWith('meta.llama')
   }
 
   isTitan() {
-    return this.#modelId.startsWith('amazon.titan') && this.isTitanEmbed() === false
+    return this.modelId.startsWith('amazon.titan') && this.isTitanEmbed() === false
   }
 
   isTitanEmbed() {
-    return this.#modelId.startsWith('amazon.titan-embed')
+    return this.modelId.startsWith('amazon.titan-embed')
   }
 
   isClaudeMessagesApi(body) {

--- a/lib/llm-events/aws-bedrock/invoke-model-command.js
+++ b/lib/llm-events/aws-bedrock/invoke-model-command.js
@@ -1,47 +1,36 @@
 /*
- * Copyright 2024 New Relic Corporation. All rights reserved.
+ * Copyright 2026 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict'
 
-const { stringifyClaudeChunkedMessage, stringifyConverseChunkedMessage } = require('./stringify-message')
+const { stringifyClaudeChunkedMessage } = require('./stringify-message')
 
 /**
- * Parses an AWS Bedrock command instance into a re-usable entity,
- * unifying logic for both InvokeModel and Converse commands.
+ * Parses an AWS Bedrock InvokeModel/InvokeModelWithResponseStream command
+ * instance into a re-usable entity.
  */
-class BedrockCommand {
+class InvokeModelCommand {
   #input
   #modelId
   #body
-  #messages
-  #isConverseCommand
 
   /**
-   * @param {object} input The `input` property from an InvokeModelCommand,
-   * InvokeModelWithResponseStreamCommand, ConverseCommand, or
-   * ConverseStreamCommand instance.
+   * @param {object} input The `input` property from an `InvokeModelCommand`
+   * or `InvokeModelWithResponseStreamCommand` instance.
    */
   constructor(input) {
     this.#input = input
     this.#modelId = this.#input.modelId?.toLowerCase() ?? ''
-
-    if (Object.hasOwn(input, 'body') === true) {
-      this.#body = JSON.parse(this.#input.body)
-      this.#isConverseCommand = false
-    } else if (Object.hasOwn(input, 'messages') === true) {
-      this.#messages = input.messages
-      this.#isConverseCommand = true
-    }
+    this.#body = JSON.parse(this.#input.body)
   }
 
   /**
-   *
-   * @returns {boolean} True if the command is from the Converse API.
+   * @returns {boolean} Always `false`, this command is not from the Converse API.
    */
   get isConverse() {
-    return this.#isConverseCommand
+    return false
   }
 
   /**
@@ -50,23 +39,17 @@ class BedrockCommand {
    * @returns {number|undefined}
    */
   get maxTokens() {
-    if (this.#isConverseCommand) {
-      // Logic for Converse
-      return this.#input?.inferenceConfig?.maxTokens
-    } else {
-      // Logic for InvokeModel
-      if (this.isClaude() === true) {
-        return this.#body.max_tokens_to_sample
-      }
-      if (this.isClaude3() === true || this.isCohere() === true) {
-        return this.#body.max_tokens
-      }
-      if (this.isLlama() === true) {
-        return this.#body.max_gen_length
-      }
-      if (this.isTitan() === true) {
-        return this.#body.textGenerationConfig?.maxTokenCount
-      }
+    if (this.isClaude() === true) {
+      return this.#body.max_tokens_to_sample
+    }
+    if (this.isClaude3() === true || this.isCohere() === true) {
+      return this.#body.max_tokens
+    }
+    if (this.isLlama() === true) {
+      return this.#body.max_gen_length
+    }
+    if (this.isTitan() === true) {
+      return this.#body.textGenerationConfig?.maxTokenCount
     }
   }
 
@@ -85,7 +68,7 @@ class BedrockCommand {
    * @returns {string} One of `embedding` or `completion`.
    */
   get modelType() {
-    // This logic is common to both command types
+    // TODO: this.#input.body.inputText enough to determine if embedding?
     return this.#modelId.toLowerCase().includes('embed') ? 'embedding' : 'completion'
   }
 
@@ -95,23 +78,6 @@ class BedrockCommand {
    * @returns {string|string[]|object[]}
    */
   get prompt() {
-    if (this.#isConverseCommand) {
-      // Logic for Converse
-      const result = []
-      for (const message of this.#messages) {
-        // The `message.content` field is an array of ContentBlock objects.
-        // For text messages, the structure is: content: [{ text: '...' }]
-        if (Array.isArray(message?.content) === true) {
-          result.push({
-            role: message.role,
-            content: stringifyConverseChunkedMessage(message.content)
-          })
-        }
-      }
-      return result
-    }
-
-    // Logic for InvokeModel
     if (this.isTitan() || this.isTitanEmbed()) {
       return [{ role: 'user', content: this.#body.inputText }]
     }
@@ -139,11 +105,6 @@ class BedrockCommand {
    * @returns {number|undefined}
    */
   get temperature() {
-    if (this.#isConverseCommand) {
-      // Logic for Converse
-      return this.#input?.inferenceConfig?.temperature
-    }
-    // Logic for InvokeModel
     if (this.isTitan() === true) {
       return this.#body.textGenerationConfig?.temperature
     }
@@ -223,4 +184,4 @@ function normalizeClaude3Messages(messages) {
   return result
 }
 
-module.exports = BedrockCommand
+module.exports = InvokeModelCommand

--- a/lib/llm-events/aws-bedrock/invoke-model-response.js
+++ b/lib/llm-events/aws-bedrock/invoke-model-response.js
@@ -6,6 +6,7 @@
 'use strict'
 
 const { stringifyClaudeChunkedMessage } = require('./stringify-message')
+const ModelResponse = require('./model-response')
 
 /**
  * @typedef {object} AwsBedrockMiddlewareResponse
@@ -23,9 +24,8 @@ const { stringifyClaudeChunkedMessage } = require('./stringify-message')
  * interface and simplifies accessing desired fields, accommodating the varied
  * shapes of Bedrock API responses.
  */
-class InvokeModelResponse {
+class InvokeModelResponse extends ModelResponse {
   #originalResponse
-  #innerResponse
   #innerOutput
   #parsedBody
   #command
@@ -39,10 +39,9 @@ class InvokeModelResponse {
    * @param {boolean} params.isError is there an error
    */
   constructor({ response, bedrockCommand, isError = false }) {
+    super({ response, isError })
     this.#originalResponse = response
-    this.#innerResponse = isError ? response.$response : response.response
     this.#command = bedrockCommand
-    this.isError = isError
 
     if (this.isError) {
       return
@@ -114,39 +113,12 @@ class InvokeModelResponse {
   }
 
   /**
-   * HTTP headers provided in the API response.
-   *
-   * @returns {object} Typical key-value set of HTTP headers.
-   */
-  get headers() {
-    return this.#innerResponse.headers
-  }
-
-  /**
    * Retrieve the response identifier provided by some model responses.
    *
    * @returns {string|undefined}
    */
   get id() {
     return this.#id
-  }
-
-  /**
-   * UUID assigned to the initial request as returned by the API.
-   *
-   * @returns {string}
-   */
-  get requestId() {
-    return this.headers?.['x-amzn-requestid']
-  }
-
-  /**
-   * The HTTP status code of the response.
-   *
-   * @returns {number}
-   */
-  get statusCode() {
-    return this.#innerResponse.statusCode
   }
 
   /**

--- a/lib/llm-events/aws-bedrock/invoke-model-response.js
+++ b/lib/llm-events/aws-bedrock/invoke-model-response.js
@@ -18,7 +18,7 @@ const { stringifyClaudeChunkedMessage } = require('./stringify-message')
  */
 
 /**
- * Represents a response from the Bedrock InvokeModel/InvokeModelWithResponseStream
+ * Represents a response from the Bedrock `InvokeModel`/`InvokeModelWithResponseStream`
  * API. This object provides an abstraction that normalizes responses into a known
  * interface and simplifies accessing desired fields, accommodating the varied
  * shapes of Bedrock API responses.

--- a/lib/llm-events/aws-bedrock/invoke-model-response.js
+++ b/lib/llm-events/aws-bedrock/invoke-model-response.js
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024 New Relic Corporation. All rights reserved.
+ * Copyright 2026 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict'
 
-const { stringifyClaudeChunkedMessage, stringifyConverseChunkedMessage } = require('./stringify-message')
+const { stringifyClaudeChunkedMessage } = require('./stringify-message')
 
 /**
  * @typedef {object} AwsBedrockMiddlewareResponse
@@ -18,25 +18,24 @@ const { stringifyClaudeChunkedMessage, stringifyConverseChunkedMessage } = requi
  */
 
 /**
- * Represents a response from the Bedrock API, handling both standard and Converse API responses.
- * This object provides an abstraction that normalizes responses into a known interface and
- * simplifies accessing desired fields, accommodating the varied shapes of Bedrock API responses.
+ * Represents a response from the Bedrock InvokeModel/InvokeModelWithResponseStream
+ * API. This object provides an abstraction that normalizes responses into a known
+ * interface and simplifies accessing desired fields, accommodating the varied
+ * shapes of Bedrock API responses.
  */
-class BedrockResponse {
+class InvokeModelResponse {
   #originalResponse
   #innerResponse
   #innerOutput
   #parsedBody
-  #output
   #command
   #completions = []
   #id
-  #isConverse
 
   /**
    * @param {object} params params object
    * @param {AwsBedrockMiddlewareResponse} params.response AWS Bedrock middleware response
-   * @param {BedrockCommand} params.bedrockCommand AWS Bedrock command
+   * @param {InvokeModelCommand} params.bedrockCommand AWS Bedrock command
    * @param {boolean} params.isError is there an error
    */
   constructor({ response, bedrockCommand, isError = false }) {
@@ -44,24 +43,25 @@ class BedrockResponse {
     this.#innerResponse = isError ? response.$response : response.response
     this.#command = bedrockCommand
     this.isError = isError
-    this.#isConverse = this.#command.isConverse ?? false
 
     if (this.isError) {
       return
     }
 
-    if (this.#isConverse) {
-      this.#innerOutput = response.output.output
-      this.#output = this.#innerOutput.message
-    } else {
-      this.#innerOutput = response.output
-      const json = new TextDecoder().decode(this.#innerOutput.body)
-      this.#parsedBody = JSON.parse(json)
+    this.#innerOutput = response.output
+    const json = new TextDecoder().decode(this.#innerOutput.body)
+    this.#parsedBody = JSON.parse(json)
 
-      const cmd = this.#command
-      const body = this.#parsedBody
-      this.#extractCompletionsAndId(cmd, body)
-    }
+    const cmd = this.#command
+    const body = this.#parsedBody
+    this.#extractCompletionsAndId(cmd, body)
+  }
+
+  /**
+   * @returns {boolean} Always `false`, this response is not from the Converse API.
+   */
+  get isConverse() {
+    return false
   }
 
   /**
@@ -73,27 +73,24 @@ class BedrockResponse {
     return this.#parsedBody
   }
 
+  /**
+   * @returns {number} The number of tokens in the prompt.
+   */
   get inputTokenCount() {
-    if (this.#isConverse) {
-      return parseInt(this.#originalResponse?.output?.usage?.inputTokens || 0, 10)
-    }
-
     return parseInt(this?.headers?.['x-amzn-bedrock-input-token-count'] || 0, 10)
   }
 
+  /**
+   * @returns {number} The number of tokens in the completion.
+   */
   get outputTokenCount() {
-    if (this.#isConverse) {
-      return parseInt(this.#originalResponse?.output?.usage?.outputTokens || 0, 10)
-    }
-
     return parseInt(this?.headers?.['x-amzn-bedrock-output-token-count'] || 0, 10)
   }
 
+  /**
+   * @returns {number} The total number of tokens used by the request and response.
+   */
   get totalTokenCount() {
-    if (this.#isConverse) {
-      return parseInt(this.#originalResponse?.output?.usage?.totalTokens || 0, 10)
-    }
-
     return this.inputTokenCount + this.outputTokenCount
   }
 
@@ -104,12 +101,7 @@ class BedrockResponse {
    * prompt.
    */
   get completions() {
-    if (this.#isConverse === false) {
-      return this.#completions
-    }
-    const content = this.#output?.content
-    if (!content) return []
-    return [typeof content === 'string' ? content : stringifyConverseChunkedMessage(content)]
+    return this.#completions
   }
 
   /**
@@ -120,9 +112,6 @@ class BedrockResponse {
   get finishReason() {
     if (this.isError) {
       return undefined
-    }
-    if (this.#isConverse) {
-      return this.#originalResponse.output.stopReason
     }
     const cmd = this.#command
     if (cmd.isClaude() === true || cmd.isClaude3() === true) {
@@ -155,8 +144,7 @@ class BedrockResponse {
    * @returns {string|undefined}
    */
   get id() {
-    // For Converse API, the requestId serves as the id.
-    return this.#isConverse ? this.requestId : this.#id
+    return this.#id
   }
 
   /**
@@ -179,7 +167,7 @@ class BedrockResponse {
 
   /**
    * Extracts and sets #completions and #id from the InvokeModel response body.
-   * @param {BedrockCommand} cmd AWS Bedrock Command
+   * @param {InvokeModelCommand} cmd AWS Bedrock Command
    * @param {*} body InvokeModel response body
    */
   #extractCompletionsAndId(cmd, body) {
@@ -204,4 +192,4 @@ class BedrockResponse {
   }
 }
 
-module.exports = BedrockResponse
+module.exports = InvokeModelResponse

--- a/lib/llm-events/aws-bedrock/invoke-model-response.js
+++ b/lib/llm-events/aws-bedrock/invoke-model-response.js
@@ -58,22 +58,6 @@ class InvokeModelResponse {
   }
 
   /**
-   * @returns {boolean} Always `false`, this response is not from the Converse API.
-   */
-  get isConverse() {
-    return false
-  }
-
-  /**
-   * The parsed body of the response.
-   *
-   * @returns {object|undefined}
-   */
-  get parsedBody() {
-    return this.#parsedBody
-  }
-
-  /**
    * @returns {number} The number of tokens in the prompt.
    */
   get inputTokenCount() {

--- a/lib/llm-events/aws-bedrock/model-command.js
+++ b/lib/llm-events/aws-bedrock/model-command.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/**
+ * Base class for AWS Bedrock command wrappers (`InvokeModelCommand`, `ConverseCommand`).
+ */
+class ModelCommand {
+  static MODEL_TYPE_EMBEDDING = 'embedding'
+  static MODEL_TYPE_COMPLETION = 'completion'
+
+  #modelId
+
+  /**
+   * @param {object} input The `input` property from the underlying AWS SDK command instance.
+   */
+  constructor(input) {
+    this.#modelId = input.modelId?.toLowerCase() ?? ''
+  }
+
+  /**
+   * The model identifier for the command.
+   *
+   * @see https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids-arns.html
+   *
+   * @returns {string}
+   */
+  get modelId() {
+    return this.#modelId
+  }
+
+  /**
+   * @returns {string} `ModelCommand.MODEL_TYPE_EMBEDDING` or `ModelCommand.MODEL_TYPE_COMPLETION`
+   */
+  get modelType() {
+    return this.modelId.includes('embed')
+      ? ModelCommand.MODEL_TYPE_EMBEDDING
+      : ModelCommand.MODEL_TYPE_COMPLETION
+  }
+}
+
+module.exports = ModelCommand

--- a/lib/llm-events/aws-bedrock/model-response.js
+++ b/lib/llm-events/aws-bedrock/model-response.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/**
+ * Base class for AWS Bedrock response wrappers (`InvokeModelResponse`, `ConverseResponse`).
+ */
+class ModelResponse {
+  #innerResponse
+
+  /**
+   * @param {object} params params object
+   * @param {object} params.response AWS Bedrock middleware response
+   * @param {boolean} [params.isError] is there an error
+   */
+  constructor({ response, isError = false }) {
+    this.#innerResponse = isError ? response.$response : response.response
+    this.isError = isError
+  }
+
+  /**
+   * HTTP headers provided in the API response.
+   *
+   * @returns {object} Typical key-value set of HTTP headers.
+   */
+  get headers() {
+    return this.#innerResponse.headers
+  }
+
+  /**
+   * UUID assigned to the initial request as returned by the API.
+   *
+   * @returns {string}
+   */
+  get requestId() {
+    return this.headers?.['x-amzn-requestid']
+  }
+
+  /**
+   * The HTTP status code of the response.
+   *
+   * @returns {number}
+   */
+  get statusCode() {
+    return this.#innerResponse.statusCode
+  }
+}
+
+module.exports = ModelResponse

--- a/lib/subscribers/aws-sdk/middleware/bedrock/converse-stream-handler.js
+++ b/lib/subscribers/aws-sdk/middleware/bedrock/converse-stream-handler.js
@@ -9,7 +9,7 @@
  * A stream handler processes a streamed response from the Bedrock API by
  * intercepting each stream event, passing that event unmodified up to the
  * consuming client, and then collecting the information into an "API response"
- * object that satisfies the requirements of {@link BedrockResponse}. Once the
+ * object that satisfies the requirements of {@link ConverseResponse}. Once the
  * stream has reached its end, the handler applies some finalizations to the
  * compiled response object, updates the pass through parameters with the new
  * object, and then invokes the final response handler passed in through
@@ -48,7 +48,7 @@ class ConverseStreamHandler {
   stopReason
 
   /**
-   * Represents an API response object as {@link BedrockResponse} expects.
+   * Represents an API response object as {@link ConverseResponse} expects.
    * It will be updated by the stream handler with information received
    * during processing of the stream. Upon stream completion, this object
    * will replace the `response` property of `passThroughParams`.

--- a/lib/subscribers/aws-sdk/middleware/bedrock/index.js
+++ b/lib/subscribers/aws-sdk/middleware/bedrock/index.js
@@ -7,7 +7,8 @@
 const { addLlmMeta, handleResponse, handleStream, isStreamingEnabled, setTrackingMetric, shouldSkipInstrumentation } = require('./utils')
 const { INSTRUMENTED_COMMANDS } = require('./constants')
 const {
-  BedrockCommand,
+  InvokeModelCommand,
+  ConverseCommand
 } = require('#agentlib/llm-events/aws-bedrock/index.js')
 const { AI } = require('#agentlib/metrics/names.js')
 
@@ -42,7 +43,9 @@ function bedrockMiddleware(subscriber, _clientConfig, next, context) {
     }
 
     const [{ input }] = args
-    const bedrockCommand = new BedrockCommand(input)
+    const bedrockCommand = commandName.toLowerCase().includes('converse')
+      ? new ConverseCommand(input)
+      : new InvokeModelCommand(input)
     const { modelType } = bedrockCommand
     const segmentName = `Llm/${modelType}/Bedrock/${commandName}`
 

--- a/lib/subscribers/aws-sdk/middleware/bedrock/stream-handler.js
+++ b/lib/subscribers/aws-sdk/middleware/bedrock/stream-handler.js
@@ -9,7 +9,7 @@
  * A stream handler processes a streamed response from the Bedrock API by
  * intercepting each stream event, passing that event unmodified up to the
  * consuming client, and then collecting the information into an "API response"
- * object that satisfies the requirements of {@link BedrockResponse}. Once the
+ * object that satisfies the requirements of {@link InvokeModelResponse}. Once the
  * stream has reached its end, the handler applies some finalizations to the
  * compiled response object, updates the pass through parameters with the new
  * object, and then invokes the final response handler passed in through
@@ -41,7 +41,7 @@ class StreamHandler {
   segment
 
   /**
-   * Represents an API response object as {@link BedrockResponse} expects.
+   * Represents an API response object as {@link InvokeModelResponse} expects.
    * It will be updated by the stream handler with information received
    * during processing of the stream. Upon stream completion, this object
    * will replace the `response` property of `passThroughParams`.
@@ -102,7 +102,7 @@ class StreamHandler {
     // attach a generator specific to the model that will process the stream
     // events and collect them into `this.response` such that `this.response`
     // ultimately has the shape of a non-streamed response that is expected
-    // by BedrockResponse.
+    // by InvokeModelResponse.
     //
     // Important: each of the handler function uses a `try/finally` block
     // to process the original stream. Of particular note is that there is NOT

--- a/lib/subscribers/aws-sdk/middleware/bedrock/utils.js
+++ b/lib/subscribers/aws-sdk/middleware/bedrock/utils.js
@@ -89,8 +89,8 @@ function addLlmMeta({ agent, segment, transaction }) {
  * @param {Logger} params.logger Logger instance
  * @param {TraceSegment} params.segment Current segment
  * @param {Transaction} params.transaction Current transaction
- * @param {InvokeModelCommand|ConverseCommand} params.bedrockCommand BedrockCommand object
- * @param {InvokeModelResponse|ConverseResponse} params.bedrockResponse BedrockResponse object
+ * @param {ModelCommand} params.bedrockCommand BedrockCommand object
+ * @param {ModelResponse} params.bedrockResponse BedrockResponse object
  * @param {Error} [params.err] Error object if it exists
  * @param {number} [params.timeOfFirstToken] Timestamp of first token for streaming responses
  */
@@ -173,8 +173,8 @@ function recordChatCompletionMessages({
  * @param {Logger} params.logger Logger instance
  * @param {TraceSegment} params.segment Current segment
  * @param {Transaction} params.transaction Current transaction
- * @param {InvokeModelCommand|ConverseCommand} params.bedrockCommand BedrockCommand object
- * @param {InvokeModelResponse|ConverseResponse} params.bedrockResponse BedrockResponse object
+ * @param {ModelCommand} params.bedrockCommand BedrockCommand object
+ * @param {ModelResponse} params.bedrockResponse BedrockResponse object
  * @param {Error} [params.err] Error object if it exists
  */
 function recordEmbeddingMessage({
@@ -218,13 +218,14 @@ function recordEmbeddingMessage({
 /**
  * Creates an InvokeModelResponse or ConverseResponse object from the command and response/error
  * @param {object} params Parameters to function
- * @param {InvokeModelCommand|ConverseCommand} params.bedrockCommand BedrockCommand object
+ * @param {ModelCommand} params.bedrockCommand BedrockCommand object
  * @param {object} params.response AWS Bedrock response object
  * @param {Error} [params.err] Error object if it exists
- * @returns {InvokeModelResponse|ConverseResponse} BedrockResponse object
+ * @returns {ModelResponse} BedrockResponse object
  */
 function createBedrockResponse({ bedrockCommand, response, err }) {
-  const BedrockResponse = bedrockCommand.isConverse ? ConverseResponse : InvokeModelResponse
+  const isConverse = bedrockCommand.constructor.name.toLowerCase().includes('converse')
+  const BedrockResponse = isConverse ? ConverseResponse : InvokeModelResponse
   if (err) {
     return new BedrockResponse({ bedrockCommand, response: err, isError: err !== null })
   }
@@ -245,7 +246,7 @@ function createBedrockResponse({ bedrockCommand, response, err }) {
  * @param {object} params.response AWS Bedrock reponse object
  * @param {TraceSegment} params.segment Current segment
  * @param {Transaction} params.transaction Current transaction
- * @param {InvokeModelCommand|ConverseCommand} params.bedrockCommand BedrockCommand object
+ * @param {ModelCommand} params.bedrockCommand BedrockCommand object
  * @param {string} params.modelType AWS Bedrock model type
  */
 function handleResponse({ agent, logger, err, response, segment, transaction, bedrockCommand, modelType }) {
@@ -283,7 +284,7 @@ function handleResponse({ agent, logger, err, response, segment, transaction, be
  * Handles streaming responses by wrapping the stream with appropriate handler.
  * Uses ConverseStreamHandler for Converse API streams, otherwise uses StreamHandler.
  * @param {object} passThroughParams Parameters passed through to stream handlers
- * @param {InvokeModelCommand|ConverseCommand} passThroughParams.bedrockCommand BedrockCommand object
+ * @param {ModelCommand} passThroughParams.bedrockCommand BedrockCommand object
  * @param {object} passThroughParams.response AWS Bedrock response object
  * @param {Agent} passThroughParams.agent New Relic agent instance
  * @param {Logger} passThroughParams.logger Logger instance
@@ -293,7 +294,8 @@ function handleResponse({ agent, logger, err, response, segment, transaction, be
  */
 function handleStream(passThroughParams) {
   const { bedrockCommand, response } = passThroughParams
-  if (bedrockCommand.isConverse) {
+  const isConverse = bedrockCommand.constructor.name.toLowerCase().includes('converse')
+  if (isConverse) {
     const handler = new ConverseStreamHandler({
       stream: response.output.stream,
       onComplete: handleResponse,

--- a/lib/subscribers/aws-sdk/middleware/bedrock/utils.js
+++ b/lib/subscribers/aws-sdk/middleware/bedrock/utils.js
@@ -9,7 +9,8 @@ const {
   LlmChatCompletionSummary,
   LlmEmbedding,
   LlmErrorMessage,
-  BedrockResponse
+  InvokeModelResponse,
+  ConverseResponse
 } = require('#agentlib/llm-events/aws-bedrock/index.js')
 const { DESTINATIONS } = require('#agentlib/config/attribute-filter.js')
 const StreamHandler = require('./stream-handler.js')
@@ -88,8 +89,8 @@ function addLlmMeta({ agent, segment, transaction }) {
  * @param {Logger} params.logger Logger instance
  * @param {TraceSegment} params.segment Current segment
  * @param {Transaction} params.transaction Current transaction
- * @param {BedrockCommand} params.bedrockCommand BedrockCommand object
- * @param {BedrockResponse} params.bedrockResponse BedrockResponse object
+ * @param {InvokeModelCommand|ConverseCommand} params.bedrockCommand BedrockCommand object
+ * @param {InvokeModelResponse|ConverseResponse} params.bedrockResponse BedrockResponse object
  * @param {Error} [params.err] Error object if it exists
  * @param {number} [params.timeOfFirstToken] Timestamp of first token for streaming responses
  */
@@ -172,8 +173,8 @@ function recordChatCompletionMessages({
  * @param {Logger} params.logger Logger instance
  * @param {TraceSegment} params.segment Current segment
  * @param {Transaction} params.transaction Current transaction
- * @param {BedrockCommand} params.bedrockCommand BedrockCommand object
- * @param {BedrockResponse} params.bedrockResponse BedrockResponse object
+ * @param {InvokeModelCommand|ConverseCommand} params.bedrockCommand BedrockCommand object
+ * @param {InvokeModelResponse|ConverseResponse} params.bedrockResponse BedrockResponse object
  * @param {Error} [params.err] Error object if it exists
  */
 function recordEmbeddingMessage({
@@ -215,14 +216,15 @@ function recordEmbeddingMessage({
 }
 
 /**
- * Creates a BedrockResponse object from the command and response/error
+ * Creates an InvokeModelResponse or ConverseResponse object from the command and response/error
  * @param {object} params Parameters to function
- * @param {BedrockCommand} params.bedrockCommand BedrockCommand object
+ * @param {InvokeModelCommand|ConverseCommand} params.bedrockCommand BedrockCommand object
  * @param {object} params.response AWS Bedrock response object
  * @param {Error} [params.err] Error object if it exists
- * @returns {BedrockResponse} BedrockResponse object
+ * @returns {InvokeModelResponse|ConverseResponse} BedrockResponse object
  */
 function createBedrockResponse({ bedrockCommand, response, err }) {
+  const BedrockResponse = bedrockCommand.isConverse ? ConverseResponse : InvokeModelResponse
   if (err) {
     return new BedrockResponse({ bedrockCommand, response: err, isError: err !== null })
   }
@@ -243,7 +245,7 @@ function createBedrockResponse({ bedrockCommand, response, err }) {
  * @param {object} params.response AWS Bedrock reponse object
  * @param {TraceSegment} params.segment Current segment
  * @param {Transaction} params.transaction Current transaction
- * @param {BedrockCommand} params.bedrockCommand BedrockCommand object
+ * @param {InvokeModelCommand|ConverseCommand} params.bedrockCommand BedrockCommand object
  * @param {string} params.modelType AWS Bedrock model type
  */
 function handleResponse({ agent, logger, err, response, segment, transaction, bedrockCommand, modelType }) {
@@ -281,7 +283,7 @@ function handleResponse({ agent, logger, err, response, segment, transaction, be
  * Handles streaming responses by wrapping the stream with appropriate handler.
  * Uses ConverseStreamHandler for Converse API streams, otherwise uses StreamHandler.
  * @param {object} passThroughParams Parameters passed through to stream handlers
- * @param {BedrockCommand} passThroughParams.bedrockCommand BedrockCommand object
+ * @param {InvokeModelCommand|ConverseCommand} passThroughParams.bedrockCommand BedrockCommand object
  * @param {object} passThroughParams.response AWS Bedrock response object
  * @param {Agent} passThroughParams.agent New Relic agent instance
  * @param {Logger} passThroughParams.logger Logger instance

--- a/test/unit/llm-events/aws-bedrock/converse-command.test.js
+++ b/test/unit/llm-events/aws-bedrock/converse-command.test.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert')
+const ConverseCommand = require('../../../../lib/llm-events/aws-bedrock/converse-command')
+
+test('non-conforming command is handled gracefully', (t) => {
+  const cmd = new ConverseCommand({ messages: [] })
+  assert.equal(cmd.isConverse, true)
+  assert.equal(cmd.modelId, '')
+  assert.equal(cmd.modelType, 'completion')
+  assert.deepEqual(cmd.prompt, [])
+  assert.equal(cmd.maxTokens, undefined)
+  assert.equal(cmd.temperature, undefined)
+})
+
+test('minimal converse command works', (t) => {
+  const cmd = new ConverseCommand({
+    modelId: 'anthropic.claude-3-haiku-20240307-v1:0',
+    messages: [{ role: 'user', content: [{ text: 'who are you' }] }]
+  })
+  assert.equal(cmd.modelId, 'anthropic.claude-3-haiku-20240307-v1:0')
+  assert.equal(cmd.modelType, 'completion')
+  assert.deepEqual(cmd.prompt, [{ role: 'user', content: 'who are you' }])
+  assert.equal(cmd.maxTokens, undefined)
+  assert.equal(cmd.temperature, undefined)
+})
+
+test('modelId is lowercased', (t) => {
+  const cmd = new ConverseCommand({
+    modelId: 'US.Anthropic.Claude-3-Haiku-20240307-V1:0',
+    messages: []
+  })
+  assert.equal(cmd.modelId, 'us.anthropic.claude-3-haiku-20240307-v1:0')
+})
+
+test('embedding modelId is detected', (t) => {
+  const cmd = new ConverseCommand({ modelId: 'cohere.embed-english-v3', messages: [] })
+  assert.equal(cmd.modelType, 'embedding')
+})
+
+test('complete converse command works', (t) => {
+  const cmd = new ConverseCommand({
+    modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+    messages: [
+      { role: 'user', content: [{ text: 'who are' }] },
+      { role: 'assistant', content: [{ text: 'researching' }] },
+      { role: 'user', content: [{ text: 'you' }] }
+    ],
+    inferenceConfig: {
+      maxTokens: 25,
+      temperature: 0.5
+    }
+  })
+  assert.equal(cmd.maxTokens, 25)
+  assert.equal(cmd.temperature, 0.5)
+  assert.deepEqual(cmd.prompt, [
+    { role: 'user', content: 'who are' },
+    { role: 'assistant', content: 'researching' },
+    { role: 'user', content: 'you' }
+  ])
+})
+
+test('prompt joins multi-chunk content for a single message', (t) => {
+  const cmd = new ConverseCommand({
+    messages: [{ role: 'user', content: [{ text: 'Hello' }, { text: 'world' }] }]
+  })
+  assert.deepEqual(cmd.prompt, [{ role: 'user', content: 'Hello\n\nworld' }])
+})
+
+test('prompt skips messages whose content is not chunked', (t) => {
+  const cmd = new ConverseCommand({
+    messages: [
+      { role: 'user', content: [{ text: 'who are you' }] },
+      { role: 'user', content: 'not-chunked' },
+      null,
+      { role: 'user' }
+    ]
+  })
+  assert.deepEqual(cmd.prompt, [{ role: 'user', content: 'who are you' }])
+})

--- a/test/unit/llm-events/aws-bedrock/converse-command.test.js
+++ b/test/unit/llm-events/aws-bedrock/converse-command.test.js
@@ -11,7 +11,6 @@ const ConverseCommand = require('../../../../lib/llm-events/aws-bedrock/converse
 
 test('non-conforming command is handled gracefully', (t) => {
   const cmd = new ConverseCommand({ messages: [] })
-  assert.equal(cmd.isConverse, true)
   assert.equal(cmd.modelId, '')
   assert.equal(cmd.modelType, 'completion')
   assert.deepEqual(cmd.prompt, [])

--- a/test/unit/llm-events/aws-bedrock/converse-response.test.js
+++ b/test/unit/llm-events/aws-bedrock/converse-response.test.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert')
+const ConverseResponse = require('../../../../lib/llm-events/aws-bedrock/converse-response')
+
+test.beforeEach((ctx) => {
+  ctx.nr = {}
+  ctx.nr.response = {
+    response: {
+      statusCode: 200,
+      headers: {
+        'x-amzn-requestid': 'aws-request-1',
+        'x-foo': 'foo'
+      }
+    },
+    output: {
+      output: {
+        message: { content: [{ text: 'Hello world' }] }
+      },
+      stopReason: 'done',
+      usage: {
+        inputTokens: 42,
+        outputTokens: 58,
+        totalTokens: 100
+      }
+    }
+  }
+})
+
+test('minimal converse response works', (t) => {
+  const res = new ConverseResponse(t.nr)
+  assert.deepStrictEqual(res.completions, ['Hello world'])
+  assert.equal(res.finishReason, 'done')
+  assert.deepStrictEqual(res.headers, t.nr.response.response.headers)
+  assert.equal(res.id, 'aws-request-1')
+  assert.equal(res.requestId, 'aws-request-1')
+  assert.equal(res.statusCode, 200)
+})
+
+test('malformed response is handled gracefully', (t) => {
+  t.nr.response.output.output.message = {}
+  const res = new ConverseResponse(t.nr)
+  assert.deepStrictEqual(res.completions, [])
+})
+
+test('should only set data from raw response on error', (t) => {
+  t.nr.response.$response = { ...t.nr.response.response }
+  delete t.nr.response.response
+  delete t.nr.response.output
+  t.nr.isError = true
+  const res = new ConverseResponse(t.nr)
+  assert.deepStrictEqual(res.completions, [])
+  assert.equal(res.finishReason, undefined)
+  assert.deepStrictEqual(res.headers, t.nr.response.$response.headers)
+  assert.equal(res.requestId, 'aws-request-1')
+  assert.equal(res.statusCode, 200)
+})
+
+test('inputTokenCount', (t) => {
+  const res = new ConverseResponse(t.nr)
+  assert.equal(res.inputTokenCount, 42)
+})
+
+test('outputTokenCount', (t) => {
+  const res = new ConverseResponse(t.nr)
+  assert.equal(res.outputTokenCount, 58)
+})
+
+test('totalTokenCount', (t) => {
+  const res = new ConverseResponse(t.nr)
+  assert.equal(res.totalTokenCount, 100)
+})

--- a/test/unit/llm-events/aws-bedrock/invoke-model-command.test.js
+++ b/test/unit/llm-events/aws-bedrock/invoke-model-command.test.js
@@ -8,7 +8,7 @@
 const test = require('node:test')
 const assert = require('node:assert')
 const structuredClone = require('./clone')
-const BedrockCommand = require('../../../../lib/llm-events/aws-bedrock/bedrock-command')
+const InvokeModelCommand = require('../../../../lib/llm-events/aws-bedrock/invoke-model-command')
 
 const claude = {
   modelId: 'anthropic.claude-v1',
@@ -108,7 +108,7 @@ test.beforeEach((ctx) => {
 })
 
 test('non-conforming command is handled gracefully', async (t) => {
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   for (const model of [
     'Claude',
     'Claude3',
@@ -127,9 +127,16 @@ test('non-conforming command is handled gracefully', async (t) => {
   assert.equal(cmd.temperature, undefined)
 })
 
+test('claude modelId with malformed body missing `prompt` produces an empty prompt', async (t) => {
+  t.nr.updatePayload({ modelId: claude.modelId, body: {} })
+  const cmd = new InvokeModelCommand(t.nr.input)
+  assert.equal(cmd.isClaude(), true)
+  assert.deepEqual(cmd.prompt, [])
+})
+
 test('claude minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(claude))
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, claude.modelId)
@@ -140,7 +147,7 @@ test('claude minimal command works', async (t) => {
 
 test('region specific claude minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(regionClaude))
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, regionClaude.modelId)
@@ -154,7 +161,7 @@ test('claude complete command works', async (t) => {
   payload.body.max_tokens_to_sample = 25
   payload.body.temperature = 0.5
   t.nr.updatePayload(payload)
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude(), true)
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
@@ -168,7 +175,7 @@ test('region specific claude complete command works', async (t) => {
   payload.body.max_tokens_to_sample = 25
   payload.body.temperature = 0.5
   t.nr.updatePayload(payload)
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude(), true)
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
@@ -179,7 +186,7 @@ test('region specific claude complete command works', async (t) => {
 
 test('claude3 minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(claude3))
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude3(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, claude3.modelId)
@@ -190,7 +197,7 @@ test('claude3 minimal command works', async (t) => {
 
 test('region specific claude3 minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(regionClaude3))
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude3(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, regionClaude3.modelId)
@@ -204,7 +211,7 @@ test('claude3 complete command works', async (t) => {
   payload.body.max_tokens = 25
   payload.body.temperature = 0.5
   t.nr.updatePayload(payload)
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude3(), true)
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
@@ -218,7 +225,7 @@ test('region specific claude3 complete command works', async (t) => {
   payload.body.max_tokens = 25
   payload.body.temperature = 0.5
   t.nr.updatePayload(payload)
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude3(), true)
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
@@ -229,7 +236,7 @@ test('region specific claude3 complete command works', async (t) => {
 
 test('claude35 minimal command works with claude 3 api', async (t) => {
   t.nr.updatePayload(structuredClone(claude3))
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude3(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, claude3.modelId)
@@ -242,7 +249,7 @@ test('claude35 malformed payload produces reasonable values', async (t) => {
   const malformedPayload = structuredClone(claude35)
   malformedPayload.body = {}
   t.nr.updatePayload(malformedPayload)
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude3(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, claude35.modelId)
@@ -255,7 +262,7 @@ test('region specific claude35 malformed payload produces reasonable values', as
   const malformedPayload = structuredClone(regionClaude35)
   malformedPayload.body = {}
   t.nr.updatePayload(malformedPayload)
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude3(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, regionClaude35.modelId)
@@ -268,7 +275,7 @@ test('claude35 skips a message that is null in `body.messages`', async (t) => {
   const malformedPayload = structuredClone(claude35)
   malformedPayload.body.messages = [{ role: 'user', content: 'who are you' }, null]
   t.nr.updatePayload(malformedPayload)
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude3(), true)
   assert.deepEqual(cmd.prompt, [{ role: 'user', content: 'who are you' }])
 })
@@ -277,7 +284,7 @@ test('region specific claude35 skips a message that is null in `body.messages`',
   const malformedPayload = structuredClone(regionClaude35)
   malformedPayload.body.messages = [{ role: 'user', content: 'who are you' }, null]
   t.nr.updatePayload(malformedPayload)
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude3(), true)
   assert.deepEqual(cmd.prompt, [{ role: 'user', content: 'who are you' }])
 })
@@ -286,7 +293,7 @@ test('claude35 handles defaulting prompt to empty array when `body.messages` is 
   const malformedPayload = structuredClone(claude35)
   malformedPayload.body.messages = null
   t.nr.updatePayload(malformedPayload)
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude3(), true)
   assert.deepEqual(cmd.prompt, [])
 })
@@ -295,14 +302,14 @@ test('region specific claude35 handles defaulting prompt to empty array when `bo
   const malformedPayload = structuredClone(regionClaude35)
   malformedPayload.body.messages = null
   t.nr.updatePayload(malformedPayload)
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude3(), true)
   assert.deepEqual(cmd.prompt, [])
 })
 
 test('claude35 minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(claude35))
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude3(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, claude35.modelId)
@@ -313,7 +320,7 @@ test('claude35 minimal command works', async (t) => {
 
 test('region specific claude35 minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(regionClaude35))
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude3(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, regionClaude35.modelId)
@@ -327,7 +334,7 @@ test('claude35 complete command works', async (t) => {
   payload.body.max_tokens = 25
   payload.body.temperature = 0.5
   t.nr.updatePayload(payload)
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude3(), true)
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
@@ -341,7 +348,7 @@ test('region specific claude35 complete command works', async (t) => {
   payload.body.max_tokens = 25
   payload.body.temperature = 0.5
   t.nr.updatePayload(payload)
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaude3(), true)
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
@@ -352,7 +359,7 @@ test('region specific claude35 complete command works', async (t) => {
 
 test('cohere minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(cohere))
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isCohere(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, cohere.modelId)
@@ -366,7 +373,7 @@ test('cohere complete command works', async (t) => {
   payload.body.max_tokens = 25
   payload.body.temperature = 0.5
   t.nr.updatePayload(payload)
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isCohere(), true)
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
@@ -377,7 +384,7 @@ test('cohere complete command works', async (t) => {
 
 test('cohere embed minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(cohereEmbed))
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isCohereEmbed(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, cohereEmbed.modelId)
@@ -388,7 +395,7 @@ test('cohere embed minimal command works', async (t) => {
 
 test('llama3 minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(llama3))
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isLlama(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, llama3.modelId)
@@ -402,7 +409,7 @@ test('llama3 complete command works', async (t) => {
   payload.body.max_gen_length = 25
   payload.body.temperature = 0.5
   t.nr.updatePayload(payload)
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isLlama(), true)
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
@@ -413,7 +420,7 @@ test('llama3 complete command works', async (t) => {
 
 test('titan minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(titan))
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isTitan(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, titan.modelId)
@@ -429,7 +436,7 @@ test('titan complete command works', async (t) => {
     temperature: 0.5
   }
   t.nr.updatePayload(payload)
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isTitan(), true)
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
@@ -440,7 +447,7 @@ test('titan complete command works', async (t) => {
 
 test('titan embed minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(titanEmbed))
-  const cmd = new BedrockCommand(t.nr.input)
+  const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isTitanEmbed(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, titanEmbed.modelId)

--- a/test/unit/llm-events/aws-bedrock/invoke-model-response.test.js
+++ b/test/unit/llm-events/aws-bedrock/invoke-model-response.test.js
@@ -8,7 +8,7 @@
 const test = require('node:test')
 const assert = require('node:assert')
 const structuredClone = require('./clone')
-const BedrockResponse = require('../../../../lib/llm-events/aws-bedrock/bedrock-response')
+const InvokeModelResponse = require('../../../../lib/llm-events/aws-bedrock/invoke-model-response')
 
 const claude = {
   completion: 'claude-response',
@@ -60,15 +60,7 @@ test.beforeEach((ctx) => {
       }
     },
     output: {
-      body: new TextEncoder().encode('{"foo":"foo"}'),
-      output: {
-        message: { content: [{ text: 'Hello world' }] },
-      },
-      usage: {
-        inputTokens: 42,
-        outputTokens: 58,
-        totalTokens: 100
-      }
+      body: new TextEncoder().encode('{"foo":"foo"}')
     }
   }
 
@@ -87,8 +79,7 @@ test.beforeEach((ctx) => {
     },
     isTitan() {
       return false
-    },
-    isConverse: false
+    }
   }
 
   ctx.nr.updatePayload = (payload) => {
@@ -98,7 +89,7 @@ test.beforeEach((ctx) => {
 
 test('non-conforming response is handled gracefully', async (t) => {
   delete t.nr.response.response.headers
-  const res = new BedrockResponse(t.nr)
+  const res = new InvokeModelResponse(t.nr)
   assert.deepStrictEqual(res.completions, [])
   assert.equal(res.finishReason, undefined)
   assert.deepStrictEqual(res.headers, undefined)
@@ -109,7 +100,7 @@ test('non-conforming response is handled gracefully', async (t) => {
 
 test('claude malformed responses work', async (t) => {
   t.nr.bedrockCommand.isClaude = () => true
-  const res = new BedrockResponse(t.nr)
+  const res = new InvokeModelResponse(t.nr)
   assert.deepStrictEqual(res.completions, [])
   assert.equal(res.finishReason, undefined)
   assert.deepStrictEqual(res.headers, t.nr.response.response.headers)
@@ -121,7 +112,7 @@ test('claude malformed responses work', async (t) => {
 test('claude complete responses work', async (t) => {
   t.nr.bedrockCommand.isClaude = () => true
   t.nr.updatePayload(structuredClone(claude))
-  const res = new BedrockResponse(t.nr)
+  const res = new InvokeModelResponse(t.nr)
   assert.deepStrictEqual(res.completions, ['claude-response'])
   assert.equal(res.finishReason, 'done')
   assert.deepStrictEqual(res.headers, t.nr.response.response.headers)
@@ -133,7 +124,7 @@ test('claude complete responses work', async (t) => {
 test('claude 3.5 complete responses work', async (t) => {
   t.nr.bedrockCommand.isClaude3 = () => true
   t.nr.updatePayload(structuredClone(claude35))
-  const res = new BedrockResponse(t.nr)
+  const res = new InvokeModelResponse(t.nr)
   assert.deepStrictEqual(res.completions, ['Hello\n\nworld'])
   assert.equal(res.finishReason, 'done')
   assert.deepStrictEqual(res.headers, t.nr.response.response.headers)
@@ -144,7 +135,7 @@ test('claude 3.5 complete responses work', async (t) => {
 
 test('cohere malformed responses work', async (t) => {
   t.nr.bedrockCommand.isCohere = () => true
-  const res = new BedrockResponse(t.nr)
+  const res = new InvokeModelResponse(t.nr)
   assert.deepStrictEqual(res.completions, [])
   assert.equal(res.finishReason, undefined)
   assert.deepStrictEqual(res.headers, t.nr.response.response.headers)
@@ -156,7 +147,7 @@ test('cohere malformed responses work', async (t) => {
 test('cohere complete responses work', async (t) => {
   t.nr.bedrockCommand.isCohere = () => true
   t.nr.updatePayload(structuredClone(cohere))
-  const res = new BedrockResponse(t.nr)
+  const res = new InvokeModelResponse(t.nr)
   assert.deepStrictEqual(res.completions, ['cohere-response'])
   assert.equal(res.finishReason, 'done')
   assert.deepStrictEqual(res.headers, t.nr.response.response.headers)
@@ -167,7 +158,7 @@ test('cohere complete responses work', async (t) => {
 
 test('llama malformed responses work', async (t) => {
   t.nr.bedrockCommand.isLlama = () => true
-  const res = new BedrockResponse(t.nr)
+  const res = new InvokeModelResponse(t.nr)
   assert.deepStrictEqual(res.completions, [])
   assert.equal(res.finishReason, undefined)
   assert.deepStrictEqual(res.headers, t.nr.response.response.headers)
@@ -179,7 +170,7 @@ test('llama malformed responses work', async (t) => {
 test('llama complete responses work', async (t) => {
   t.nr.bedrockCommand.isLlama = () => true
   t.nr.updatePayload(structuredClone(llama))
-  const res = new BedrockResponse(t.nr)
+  const res = new InvokeModelResponse(t.nr)
   assert.deepStrictEqual(res.completions, ['llama-response'])
   assert.equal(res.finishReason, 'done')
   assert.deepStrictEqual(res.headers, t.nr.response.response.headers)
@@ -190,7 +181,7 @@ test('llama complete responses work', async (t) => {
 
 test('titan malformed responses work', async (t) => {
   t.nr.bedrockCommand.isTitan = () => true
-  const res = new BedrockResponse(t.nr)
+  const res = new InvokeModelResponse(t.nr)
   assert.deepStrictEqual(res.completions, [])
   assert.equal(res.finishReason, undefined)
   assert.deepStrictEqual(res.headers, t.nr.response.response.headers)
@@ -202,7 +193,7 @@ test('titan malformed responses work', async (t) => {
 test('titan complete responses work', async (t) => {
   t.nr.bedrockCommand.isTitan = () => true
   t.nr.updatePayload(structuredClone(titan))
-  const res = new BedrockResponse(t.nr)
+  const res = new InvokeModelResponse(t.nr)
   assert.deepStrictEqual(res.completions, ['titan-response'])
   assert.equal(res.finishReason, 'done')
   assert.deepStrictEqual(res.headers, t.nr.response.response.headers)
@@ -216,7 +207,7 @@ test('should only set data from raw response on error', (t) => {
   delete t.nr.response.response
   delete t.nr.response.output
   t.nr.isError = true
-  const res = new BedrockResponse(t.nr)
+  const res = new InvokeModelResponse(t.nr)
   assert.deepStrictEqual(res.completions, [])
   assert.equal(res.id, undefined)
   assert.equal(res.finishReason, undefined)
@@ -226,28 +217,16 @@ test('should only set data from raw response on error', (t) => {
 })
 
 test('inputTokenCount', (t) => {
-  t.nr.bedrockCommand.isConverse = true
-  const res = new BedrockResponse(t.nr)
-  assert.equal(res.inputTokenCount, 42)
-  t.nr.bedrockCommand.isConverse = false
-  const res2 = new BedrockResponse(t.nr)
-  assert.equal(res2.inputTokenCount, 56)
+  const res = new InvokeModelResponse(t.nr)
+  assert.equal(res.inputTokenCount, 56)
 })
 
 test('outputTokenCount', (t) => {
-  t.nr.bedrockCommand.isConverse = true
-  const res = new BedrockResponse(t.nr)
-  assert.equal(res.outputTokenCount, 58)
-  t.nr.bedrockCommand.isConverse = false
-  const res2 = new BedrockResponse(t.nr)
-  assert.equal(res2.outputTokenCount, 46)
+  const res = new InvokeModelResponse(t.nr)
+  assert.equal(res.outputTokenCount, 46)
 })
 
 test('totalTokenCount', (t) => {
-  t.nr.bedrockCommand.isConverse = true
-  const res = new BedrockResponse(t.nr)
-  assert.equal(res.totalTokenCount, 100)
-  t.nr.bedrockCommand.isConverse = false
-  const res2 = new BedrockResponse(t.nr)
-  assert.equal(res2.totalTokenCount, 102)
+  const res = new InvokeModelResponse(t.nr)
+  assert.equal(res.totalTokenCount, 102)
 })

--- a/test/unit/subscribers/aws-sdk/stream-handler.test.js
+++ b/test/unit/subscribers/aws-sdk/stream-handler.test.js
@@ -8,8 +8,8 @@
 const test = require('node:test')
 const assert = require('node:assert')
 const {
-  BedrockCommand,
-  BedrockResponse,
+  InvokeModelCommand,
+  InvokeModelResponse,
 } = require('#agentlib/llm-events/aws-bedrock/index.js')
 const StreamHandler = require('#agentlib/subscribers/aws-sdk/middleware/bedrock/stream-handler.js')
 
@@ -110,14 +110,14 @@ test('handles claude streams', async (t) => {
     }
   })
 
-  const bc = new BedrockCommand({
+  const bc = new InvokeModelCommand({
     modelId: 'anthropic.claude-v1',
     body: JSON.stringify({
       prompt: 'prompt',
       maxTokens: 5
     })
   })
-  const br = new BedrockResponse({ bedrockCommand: bc, response: handler.response })
+  const br = new InvokeModelResponse({ bedrockCommand: bc, response: handler.response })
   assert.equal(br.completions.length, 1)
   assert.equal(br.finishReason, 'done')
   assert.equal(br.requestId, 'aws-req-1')
@@ -150,14 +150,14 @@ test('handles region specific claude streams', async (t) => {
     }
   })
 
-  const bc = new BedrockCommand({
+  const bc = new InvokeModelCommand({
     modelId: 'us.anthropic.claude-v1',
     body: JSON.stringify({
       prompt: 'prompt',
       maxTokens: 5
     })
   })
-  const br = new BedrockResponse({ bedrockCommand: bc, response: handler.response })
+  const br = new InvokeModelResponse({ bedrockCommand: bc, response: handler.response })
   assert.equal(br.completions.length, 1)
   assert.equal(br.finishReason, 'done')
   assert.equal(br.requestId, 'aws-req-1')
@@ -184,14 +184,14 @@ test('handles claude3streams', async (t) => {
     type: 'message_stop'
   })
 
-  const bc = new BedrockCommand({
+  const bc = new InvokeModelCommand({
     modelId: 'anthropic.claude-3-haiku-20240307-v1:0',
     body: JSON.stringify({
       messages: [{ content: 'prompt' }],
       maxTokens: 5
     })
   })
-  const br = new BedrockResponse({ bedrockCommand: bc, response: handler.response })
+  const br = new InvokeModelResponse({ bedrockCommand: bc, response: handler.response })
   assert.equal(br.completions.length, 1)
   assert.equal(br.finishReason, 'done')
   assert.equal(br.requestId, 'aws-req-1')
@@ -218,14 +218,14 @@ test('handles region specific claude3streams', async (t) => {
     type: 'message_stop'
   })
 
-  const bc = new BedrockCommand({
+  const bc = new InvokeModelCommand({
     modelId: 'us.anthropic.claude-3-haiku-20240307-v1:0',
     body: JSON.stringify({
       messages: [{ content: 'prompt' }],
       maxTokens: 5
     })
   })
-  const br = new BedrockResponse({ bedrockCommand: bc, response: handler.response })
+  const br = new InvokeModelResponse({ bedrockCommand: bc, response: handler.response })
   assert.equal(br.completions.length, 1)
   assert.equal(br.finishReason, 'done')
   assert.equal(br.requestId, 'aws-req-1')
@@ -265,14 +265,14 @@ test('handles cohere streams', async (t) => {
     }
   })
 
-  const bc = new BedrockCommand({
+  const bc = new InvokeModelCommand({
     modelId: 'cohere.',
     body: JSON.stringify({
       texts: ['prompt'],
       max_tokens: 5
     })
   })
-  const br = new BedrockResponse({ bedrockCommand: bc, response: handler.response })
+  const br = new InvokeModelResponse({ bedrockCommand: bc, response: handler.response })
   assert.equal(br.completions.length, 2)
   assert.equal(br.finishReason, 'done')
   assert.equal(br.requestId, 'aws-req-1')
@@ -317,14 +317,14 @@ test('handles cohere embedding streams', async (t) => {
     }
   })
 
-  const bc = new BedrockCommand({
+  const bc = new InvokeModelCommand({
     modelId: 'cohere.',
     body: JSON.stringify({
       texts: ['prompt'],
       max_tokens: 5
     })
   })
-  const br = new BedrockResponse({ bedrockCommand: bc, response: handler.response })
+  const br = new InvokeModelResponse({ bedrockCommand: bc, response: handler.response })
   assert.equal(br.completions.length, 0)
   assert.equal(br.finishReason, undefined)
   assert.equal(br.requestId, 'aws-req-1')
@@ -357,14 +357,14 @@ test('handles llama streams', async (t) => {
     }
   })
 
-  const bc = new BedrockCommand({
+  const bc = new InvokeModelCommand({
     modelId: 'meta.llama',
     body: JSON.stringify({
       prompt: 'prompt',
       max_gen_length: 5
     })
   })
-  const br = new BedrockResponse({ bedrockCommand: bc, response: handler.response })
+  const br = new InvokeModelResponse({ bedrockCommand: bc, response: handler.response })
   assert.equal(br.completions.length, 1)
   assert.equal(br.finishReason, 'done')
   assert.equal(br.requestId, 'aws-req-1')
@@ -403,7 +403,7 @@ test('handles titan streams', async (t) => {
     }
   })
 
-  const bc = new BedrockCommand({
+  const bc = new InvokeModelCommand({
     modelId: 'amazon.titan',
     body: JSON.stringify({
       inputText: 'prompt',
@@ -413,7 +413,7 @@ test('handles titan streams', async (t) => {
       }
     })
   })
-  const br = new BedrockResponse({ bedrockCommand: bc, response: handler.response })
+  const br = new InvokeModelResponse({ bedrockCommand: bc, response: handler.response })
   assert.equal(br.completions.length, 1)
   assert.equal(br.finishReason, 'done')
   assert.equal(br.requestId, 'aws-req-1')


### PR DESCRIPTION
## Description

While I was triaging a customer's reported bug with AWS Bedrock, I noticed that the `BedrockResponse` and `BedrockCommand` classes have gotten a bit complex and hard to reason about. So I split `BedrockResponse` into `InvokeModelResponse` and `ConverseResponse` and likewise with `BedrockCommand`. We can deduce which API it is (`InvokeModel` vs. `Converse`) when we wrap the Bedrock middleware because we have access to the initial command name there.

## How to Test

```
node --test test/unit/llm-events/aws-bedrock/*.test.js test/unit/subscribers/aws-sdk/*.test.js
npm run versioned aws-sdk-v3
```

## Related Issues

Discovered while researching https://github.com/newrelic/node-newrelic/issues/4230