### PR TITLE
chore: Regenerated agent config json schema

### DIFF
--- a/.fleetControl/schemas/config.json
+++ b/.fleetControl/schemas/config.json
@@ -41,6 +41,11 @@
       "default": 443,
       "description": "The port on which the collector proxy will be listening. You shouldn't need to change this."
     },
+    "fake_config": {
+      "type": "boolean",
+      "default": true,
+      "description": "Test json schema update"
+    },
     "proxy": {
       "type": "string",
       "default": "",


### PR DESCRIPTION
Auto-generated after 5381e270da8b253bdb8c5dec2a1f14e052421447 changed the config
definition on `main`.

Regenerated by running `generate-schema.js` against the
merged config. Review the schema diff before merging.