### PR TITLE
fix: Fixed @google/adk instrumentation for v2.0.0

### DIFF
--- a/lib/subscribers/google-adk/config.js
+++ b/lib/subscribers/google-adk/config.js
@@ -8,7 +8,7 @@ const agentRunAsync = {
   instrumentations: [
     {
       channelName: 'nr_agentRunAsync',
-      module: { name: '@google/adk', versionRange: '>=1.1.0', filePath: 'dist/cjs/agents/base_agent.js' },
+      module: { name: '@google/adk', versionRange: '>=1.1.0 <2.0.0', filePath: 'dist/cjs/agents/base_agent.js' },
       functionQuery: {
         className: 'BaseAgent',
         methodName: 'runAsync',
@@ -17,10 +17,39 @@ const agentRunAsync = {
     },
     {
       channelName: 'nr_agentRunAsync',
-      module: { name: '@google/adk', versionRange: '>=1.1.0', filePath: 'dist/esm/agents/base_agent.js' },
+      module: { name: '@google/adk', versionRange: '>=2.0.0', filePath: 'dist/cjs/agents/base_agent.js' },
+      functionQuery: {
+        className: '_BaseAgent',
+        methodName: 'runAsync',
+        kind: 'Async'
+      }
+    },
+    {
+      channelName: 'nr_agentRunAsync',
+      module: { name: '@google/adk', versionRange: '>=1.1.0 <2.0.0', filePath: 'dist/esm/agents/base_agent.js' },
       functionQuery: {
         className: 'BaseAgent',
         methodName: 'runAsync',
+        kind: 'Async'
+      }
+    },
+    {
+      channelName: 'nr_agentRunAsync',
+      module: { name: '@google/adk', versionRange: '>=2.0.0', filePath: 'dist/esm/agents/base_agent.js' },
+      functionQuery: {
+        className: 'BaseAgent',
+        methodName: 'runAsync',
+        // v2.0.0 does the following:
+        //
+        // ```
+        // const _BaseAgent = class _BaseAgent {}
+        // const BaseAgent = _BaseAgent
+        // export { BaseAgent }
+        // ```
+        //
+        // This is equivalent to `export { _BaseAgent as BaseAgent }`, which
+        // is what `isExportAlias` is designed to support.
+        isExportAlias: true,
         kind: 'Async'
       }
     }
@@ -32,7 +61,7 @@ const toolRunAsync = {
   instrumentations: [
     {
       channelName: 'nr_toolRunAsync',
-      module: { name: '@google/adk', versionRange: '>=1.1.0', filePath: 'dist/cjs/tools/function_tool.js' },
+      module: { name: '@google/adk', versionRange: '>=1.1.0 <2.0.0', filePath: 'dist/cjs/tools/function_tool.js' },
       functionQuery: {
         className: 'FunctionTool',
         methodName: 'runAsync',
@@ -41,10 +70,29 @@ const toolRunAsync = {
     },
     {
       channelName: 'nr_toolRunAsync',
-      module: { name: '@google/adk', versionRange: '>=1.1.0', filePath: 'dist/esm/tools/function_tool.js' },
+      module: { name: '@google/adk', versionRange: '>=2.0.0', filePath: 'dist/cjs/tools/function_tool.js' },
+      functionQuery: {
+        className: '_FunctionTool',
+        methodName: 'runAsync',
+        kind: 'Async'
+      }
+    },
+    {
+      channelName: 'nr_toolRunAsync',
+      module: { name: '@google/adk', versionRange: '>=1.1.0 <2.0.0', filePath: 'dist/esm/tools/function_tool.js' },
       functionQuery: {
         className: 'FunctionTool',
         methodName: 'runAsync',
+        kind: 'Async'
+      }
+    },
+    {
+      channelName: 'nr_toolRunAsync',
+      module: { name: '@google/adk', versionRange: '>=2.0.0', filePath: 'dist/esm/tools/function_tool.js' },
+      functionQuery: {
+        className: 'FunctionTool',
+        methodName: 'runAsync',
+        isExportAlias: true,
         kind: 'Async'
       }
     }


### PR DESCRIPTION
## Summary

- `@google/adk` v2.0.0 changed its build output so classes are emitted as named class expressions with underscore-prefixed internal identifiers (e.g. `const _BaseAgent = class _BaseAgent {}`) instead of plain class declarations
- This broke the esquery selectors generated from `className: 'BaseAgent'` / `'FunctionTool'` since they match on `id.name`, which is now `_BaseAgent` / `_FunctionTool` in v2.0.0
- Split each instrumentation entry in `lib/subscribers/google-adk/config.js` into version-ranged pairs to handle both the old and new class shapes

## Test plan

- [ ] `npm run versioned:major google-adk` passes for both 1.6.0 and 2.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)