### PR TITLE
refactor: Update Claude detection logic in `InvokeModelCommand`

### DIFF
--- a/ai-support.json
+++ b/ai-support.json
@@ -98,7 +98,7 @@
     "footnote": "Note: if a model supports streaming, we also instrument the streaming variant.",
     "models": [
       {
-        "name": "Anthropic Claude",
+        "name": "Anthropic Claude (model versions 1-5)",
         "features": [
           {
             "title": "Text",
@@ -128,7 +128,7 @@
         ]
       },
       {
-        "name": "Meta Llama3",
+        "name": "Meta Llama (all versions)",
         "features": [
           {
             "title": "Text",

--- a/ai-support.json
+++ b/ai-support.json
@@ -98,7 +98,7 @@
     "footnote": "Note: if a model supports streaming, we also instrument the streaming variant.",
     "models": [
       {
-        "name": "Anthropic Claude (model versions 1-5)",
+        "name": "Anthropic Claude",
         "features": [
           {
             "title": "Text",
@@ -128,7 +128,7 @@
         ]
       },
       {
-        "name": "Meta Llama (all versions)",
+        "name": "Meta Llama3",
         "features": [
           {
             "title": "Text",

--- a/lib/llm-events/aws-bedrock/invoke-model-command.js
+++ b/lib/llm-events/aws-bedrock/invoke-model-command.js
@@ -61,14 +61,14 @@ class InvokeModelCommand extends ModelCommand {
     }
 
     if (
-      this.isClaudePromptApi(this.#body) ||
+      this.isClaudePromptApi() ||
       this.isCohere() ||
       this.isLlama()
     ) {
       return [{ role: 'user', content: this.#body.prompt }]
     }
 
-    if (this.isClaudeMessagesApi(this.#body)) {
+    if (this.isClaudeMessagesApi()) {
       return normalizeClaudeMessages(this.#body?.messages)
     }
 

--- a/lib/llm-events/aws-bedrock/invoke-model-command.js
+++ b/lib/llm-events/aws-bedrock/invoke-model-command.js
@@ -32,10 +32,10 @@ class InvokeModelCommand extends ModelCommand {
    * @returns {number|undefined}
    */
   get maxTokens() {
-    if (this.isClaude() === true) {
+    if (this.isClaudePromptApi() === true) {
       return this.#body.max_tokens_to_sample
     }
-    if (this.isClaude3() === true || this.isCohere() === true) {
+    if (this.isClaudeMessagesApi() === true || this.isCohere() === true) {
       return this.#body.max_tokens
     }
     if (this.isLlama() === true) {
@@ -61,7 +61,7 @@ class InvokeModelCommand extends ModelCommand {
     }
 
     if (
-      this.isClaudeTextCompletionApi(this.#body) ||
+      this.isClaudePromptApi(this.#body) ||
       this.isCohere() ||
       this.isLlama()
     ) {
@@ -69,7 +69,7 @@ class InvokeModelCommand extends ModelCommand {
     }
 
     if (this.isClaudeMessagesApi(this.#body)) {
-      return normalizeClaude3Messages(this.#body?.messages)
+      return normalizeClaudeMessages(this.#body?.messages)
     }
 
     return []
@@ -83,8 +83,8 @@ class InvokeModelCommand extends ModelCommand {
       return this.#body.textGenerationConfig?.temperature
     }
     if (
-      this.isClaude() === true ||
-        this.isClaude3() === true ||
+      this.isClaudePromptApi() === true ||
+        this.isClaudeMessagesApi() === true ||
         this.isCohere() === true ||
         this.isLlama() === true
     ) {
@@ -93,12 +93,25 @@ class InvokeModelCommand extends ModelCommand {
   }
 
   // Helper methods to determine which LLM vendor was used based on modelId
-  isClaude() {
-    return this.modelId.split('.').slice(-2).join('.').startsWith('anthropic.claude-v')
+  /**
+   * The Claude Text Completions API (v1/v2) body has `prompt`.
+   * @returns {boolean} True if the command used a Claude model and the Claude Prompt API.
+   */
+  isClaudePromptApi() {
+    const matchesModelId = this.modelId.split('.').slice(-2).join('.').startsWith('anthropic.claude-v')
+    const matchesBodyShape = !!this.#body.anthropic_version && 'prompt' in this.#body
+    return matchesModelId || matchesBodyShape
   }
 
-  isClaude3() {
-    return this.modelId.split('.').slice(-2).join('.').startsWith('anthropic.claude-3')
+  /**
+   * The Claude Messages API (v3+) body has `messages`.
+   * @returns {boolean} True if the command used a Claude model and the Claude Messages API.
+   */
+  isClaudeMessagesApi() {
+    const strippedModelId = this.modelId.split('.').slice(-2).join('.')
+    const matchesModelId = strippedModelId.startsWith('anthropic.claude-') && !strippedModelId.startsWith('anthropic.claude-v')
+    const matchesBodyShape = !!this.#body.anthropic_version && 'messages' in this.#body
+    return matchesModelId || matchesBodyShape
   }
 
   isCohere() {
@@ -120,25 +133,16 @@ class InvokeModelCommand extends ModelCommand {
   isTitanEmbed() {
     return this.modelId.startsWith('amazon.titan-embed')
   }
-
-  isClaudeMessagesApi(body) {
-    return (this.isClaude3() === true || this.isClaude() === true) && 'messages' in body
-  }
-
-  isClaudeTextCompletionApi(body) {
-    return this.isClaude() === true && 'prompt' in body
-  }
 }
 
 /**
- * Claude v3 requests in Bedrock can have two different "chat" flavors.
- * This function normalizes them into a consistent
- * format per the AIM agent spec
+ * Claude Messages API requests in Bedrock can have two different "chat" flavors.
+ * This function normalizes them into a consistent format per the AIM agent spec.
  *
  * @param {Array<object>} messages - The raw array of messages passed to the invoke API
  * @returns {Array<object>} - The normalized messages
  */
-function normalizeClaude3Messages(messages) {
+function normalizeClaudeMessages(messages) {
   const result = []
   for (const message of messages ?? []) {
     if (message == null) {

--- a/lib/llm-events/aws-bedrock/invoke-model-command.js
+++ b/lib/llm-events/aws-bedrock/invoke-model-command.js
@@ -94,8 +94,9 @@ class InvokeModelCommand extends ModelCommand {
 
   // Helper methods to determine which LLM vendor was used based on modelId
   /**
-   * The Claude Text Completions API (v1/v2) body has `prompt`.
-   * @returns {boolean} True if the command used a Claude model and the Claude Prompt API.
+   * Detects if the command used the Claude Text Completions API (v1/v2)
+   * via the presence of the `prompt` field on the body.
+   * @returns {boolean} True if the command used a Claude model and the Claude Text Completions API.
    */
   isClaudePromptApi() {
     const matchesModelId = this.modelId.split('.').slice(-2).join('.').startsWith('anthropic.claude-v')
@@ -104,7 +105,8 @@ class InvokeModelCommand extends ModelCommand {
   }
 
   /**
-   * The Claude Messages API (v3+) body has `messages`.
+   * Detects if the command used the Claude Messages API (v3+)
+   * via the presence of the `messages` field on the body.
    * @returns {boolean} True if the command used a Claude model and the Claude Messages API.
    */
   isClaudeMessagesApi() {

--- a/lib/llm-events/aws-bedrock/invoke-model-command.js
+++ b/lib/llm-events/aws-bedrock/invoke-model-command.js
@@ -94,25 +94,25 @@ class InvokeModelCommand extends ModelCommand {
 
   // Helper methods to determine which LLM vendor was used based on modelId
   /**
-   * Detects if the command used the Claude Text Completions API (v1/v2)
-   * via the presence of the `prompt` field on the body.
+   * Detects if the command used the Claude Text Completions API (v1/v2),
+   * either via the modelId or via the presence of the `prompt` field on the body.
    * @returns {boolean} True if the command used a Claude model and the Claude Text Completions API.
    */
   isClaudePromptApi() {
     const matchesModelId = this.modelId.split('.').slice(-2).join('.').startsWith('anthropic.claude-v')
-    const matchesBodyShape = !!this.#body.anthropic_version && 'prompt' in this.#body
+    const matchesBodyShape = this.#body.anthropic_version != null && Object.hasOwn(this.#body, 'prompt')
     return matchesModelId || matchesBodyShape
   }
 
   /**
-   * Detects if the command used the Claude Messages API (v3+)
-   * via the presence of the `messages` field on the body.
+   * Detects if the command used the Claude Messages API (v3+), either via the
+   * modelId or via the presence of the `messages` field on the body.
    * @returns {boolean} True if the command used a Claude model and the Claude Messages API.
    */
   isClaudeMessagesApi() {
     const strippedModelId = this.modelId.split('.').slice(-2).join('.')
     const matchesModelId = strippedModelId.startsWith('anthropic.claude-') && !strippedModelId.startsWith('anthropic.claude-v')
-    const matchesBodyShape = !!this.#body.anthropic_version && 'messages' in this.#body
+    const matchesBodyShape = this.#body.anthropic_version != null && Object.hasOwn(this.#body, 'messages')
     return matchesModelId || matchesBodyShape
   }
 

--- a/lib/llm-events/aws-bedrock/invoke-model-response.js
+++ b/lib/llm-events/aws-bedrock/invoke-model-response.js
@@ -97,7 +97,7 @@ class InvokeModelResponse extends ModelResponse {
       return undefined
     }
     const cmd = this.#command
-    if (cmd.isClaude() === true || cmd.isClaude3() === true) {
+    if (cmd.isClaudePromptApi() === true || cmd.isClaudeMessagesApi() === true) {
       return this.#parsedBody.stop_reason
     }
     if (cmd.isCohere() === true) {
@@ -127,9 +127,9 @@ class InvokeModelResponse extends ModelResponse {
    * @param {*} body InvokeModel response body
    */
   #extractCompletionsAndId(cmd, body) {
-    if (cmd.isClaude() === true) {
+    if (cmd.isClaudePromptApi() === true) {
       body.completion && this.#completions.push(body.completion)
-    } else if (cmd.isClaude3() === true) {
+    } else if (cmd.isClaudeMessagesApi() === true) {
       if (body?.type === 'message_stop') {
         // Streamed response
         this.#completions.push(body.completions)

--- a/lib/subscribers/aws-sdk/middleware/bedrock/stream-handler.js
+++ b/lib/subscribers/aws-sdk/middleware/bedrock/stream-handler.js
@@ -109,12 +109,12 @@ class StreamHandler {
     // a `catch` block. As of 2024-01-17, we are not able to determine a viable
     // means of inducing an error in the stream such that a `catch` block in
     // our wrapping handler would be hit.
-    if (bedrockCommand.isClaude() === true) {
+    if (bedrockCommand.isClaudePromptApi() === true) {
       this.stopReasonKey = 'stop_reason'
-      this.generator = handleClaude
-    } else if (bedrockCommand.isClaude3() === true) {
+      this.generator = handleClaudePromptApi
+    } else if (bedrockCommand.isClaudeMessagesApi() === true) {
       this.stopReasonKey = 'stop_reason'
-      this.generator = handleClaude3
+      this.generator = handleClaudeMessagesApi
     } else if (bedrockCommand.isCohere() === true) {
       this.stopReasonKey = 'generations.0.finish_reason'
       this.generator = handleCohere
@@ -205,7 +205,7 @@ class StreamHandler {
   }
 }
 
-async function * handleClaude() {
+async function * handleClaudePromptApi() {
   let currentBody = {}
   let completion = ''
 
@@ -225,7 +225,7 @@ async function * handleClaude() {
   }
 }
 
-async function * handleClaude3() {
+async function * handleClaudeMessagesApi() {
   let currentBody = {}
   let stopReason
   let response = ''

--- a/test/unit/llm-events/aws-bedrock/invoke-model-command.test.js
+++ b/test/unit/llm-events/aws-bedrock/invoke-model-command.test.js
@@ -52,15 +52,10 @@ const claudeMsgsApi = {
   }
 }
 
-const claudeOpus4 = {
-  modelId: 'anthropic.claude-opus-4-1-20250805-v1:0',
-  body: {
-    messages: [{ role: 'user', content: 'who are you' }]
-  }
-}
-
-const claudeSonnet45 = {
-  modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+// Claude 4 and Claude 5 model IDs on Bedrock share the same shape,
+// e.g. `anthropic.claude-opus-4-1-20250805-v1:0`, so a v5 fixture covers both.
+const claudeOpus5 = {
+  modelId: 'anthropic.claude-opus-5-20260601-v1:0',
   body: {
     messages: [{ role: 'user', content: 'who are you' }]
   }
@@ -241,16 +236,8 @@ test('region specific claudeMsgsApi complete command works', async (t) => {
   assert.equal(cmd.temperature, payload.body.temperature)
 })
 
-test('claude opus 4 command is detected via modelId', async (t) => {
-  const payload = structuredClone(claudeOpus4)
-  payload.body = {}
-  t.nr.updatePayload(payload)
-  const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaudeMessagesApi(), true)
-})
-
-test('claude sonnet 4.5 command is detected via modelId', async (t) => {
-  const payload = structuredClone(claudeSonnet45)
+test('claude opus 5 command is detected via modelId', async (t) => {
+  const payload = structuredClone(claudeOpus5)
   payload.body = {}
   t.nr.updatePayload(payload)
   const cmd = new InvokeModelCommand(t.nr.input)

--- a/test/unit/llm-events/aws-bedrock/invoke-model-command.test.js
+++ b/test/unit/llm-events/aws-bedrock/invoke-model-command.test.js
@@ -10,63 +10,28 @@ const assert = require('node:assert')
 const structuredClone = require('./clone')
 const InvokeModelCommand = require('../../../../lib/llm-events/aws-bedrock/invoke-model-command')
 
-const claude = {
+const claudePromptApi = {
+  // The body.prompt field only existed for v1 and v2 Claude models.
   modelId: 'anthropic.claude-v1',
   body: {
     prompt: '\n\nHuman: yes\n\nAssistant:'
   }
 }
+const regionClaudePromptApi = { ...claudePromptApi, modelId: `us.${claudePromptApi.modelId}` }
 
-const regionClaude = {
-  modelId: 'us.anthropic.claude-v1',
-  body: {
-    prompt: '\n\nHuman: yes\n\nAssistant:'
-  }
-}
-
-const claude35 = {
-  modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
-  body: {
-    messages: [
-      { role: 'user', content: [{ type: 'text', text: 'who are' }] },
-      { role: 'assistant', content: [{ type: 'text', text: 'researching' }] },
-      { role: 'user', content: [{ type: 'text', text: 'you' }] }
-    ]
-  }
-}
-
-const regionClaude35 = {
-  modelId: 'us.anthropic.claude-3-5-sonnet-20240620-v1:0',
-  body: {
-    messages: [
-      { role: 'user', content: [{ type: 'text', text: 'who are' }] },
-      { role: 'assistant', content: [{ type: 'text', text: 'researching' }] },
-      { role: 'user', content: [{ type: 'text', text: 'you' }] }
-    ]
-  }
-}
 const claudeMsgsApi = {
-  modelId: 'anthropic.claude-3-haiku-20240307-v1:0',
-  body: {
-    messages: [{ role: 'user', content: 'who are you' }]
-  }
-}
-
-// Claude 4 and Claude 5 model IDs on Bedrock share the same shape,
-// e.g. `anthropic.claude-opus-4-1-20250805-v1:0`, so a v5 fixture covers both.
-const claudeOpus5 = {
+  // The specific modelId (v3, v4, or v5) doesn't matter here as long as
+  // it is prefixed with 'anthropic.claude' and the body.messages field exists.
   modelId: 'anthropic.claude-opus-5-20260601-v1:0',
   body: {
-    messages: [{ role: 'user', content: 'who are you' }]
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: 'who are' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'researching' }] },
+      { role: 'user', content: [{ type: 'text', text: 'you' }] }
+    ]
   }
 }
-
-const regionClaudeMsgsApi = {
-  modelId: 'us.anthropic.claude-3-haiku-20240307-v1:0',
-  body: {
-    messages: [{ role: 'user', content: 'who are you' }]
-  }
-}
+const regionClaudeMsgsApi = { ...claudeMsgsApi, modelId: `us.${claudeMsgsApi.modelId}` }
 
 const cohere = {
   modelId: 'cohere.command-text-v14',
@@ -137,29 +102,29 @@ test('non-conforming command is handled gracefully', async (t) => {
 })
 
 test('claude minimal command works', async (t) => {
-  t.nr.updatePayload(structuredClone(claude))
+  t.nr.updatePayload(structuredClone(claudePromptApi))
   const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaudePromptApi(), true)
   assert.equal(cmd.maxTokens, undefined)
-  assert.equal(cmd.modelId, claude.modelId)
+  assert.equal(cmd.modelId, claudePromptApi.modelId)
   assert.equal(cmd.modelType, 'completion')
-  assert.deepEqual(cmd.prompt, [{ role: 'user', content: claude.body.prompt }])
+  assert.deepEqual(cmd.prompt, [{ role: 'user', content: claudePromptApi.body.prompt }])
   assert.equal(cmd.temperature, undefined)
 })
 
 test('region specific claude minimal command works', async (t) => {
-  t.nr.updatePayload(structuredClone(regionClaude))
+  t.nr.updatePayload(structuredClone(regionClaudePromptApi))
   const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaudePromptApi(), true)
   assert.equal(cmd.maxTokens, undefined)
-  assert.equal(cmd.modelId, regionClaude.modelId)
+  assert.equal(cmd.modelId, regionClaudePromptApi.modelId)
   assert.equal(cmd.modelType, 'completion')
-  assert.deepEqual(cmd.prompt, [{ role: 'user', content: claude.body.prompt }])
+  assert.deepEqual(cmd.prompt, [{ role: 'user', content: claudePromptApi.body.prompt }])
   assert.equal(cmd.temperature, undefined)
 })
 
 test('claude complete command works', async (t) => {
-  const payload = structuredClone(claude)
+  const payload = structuredClone(claudePromptApi)
   payload.body.max_tokens_to_sample = 25
   payload.body.temperature = 0.5
   t.nr.updatePayload(payload)
@@ -173,7 +138,7 @@ test('claude complete command works', async (t) => {
 })
 
 test('region specific claude complete command works', async (t) => {
-  const payload = structuredClone(regionClaude)
+  const payload = structuredClone(regionClaudePromptApi)
   payload.body.max_tokens_to_sample = 25
   payload.body.temperature = 0.5
   t.nr.updatePayload(payload)
@@ -186,14 +151,103 @@ test('region specific claude complete command works', async (t) => {
   assert.equal(cmd.temperature, payload.body.temperature)
 })
 
-test('claudeMsgsApi minimal command works', async (t) => {
+test('claude opus 5 command is detected via modelId', async (t) => {
+  t.nr.updatePayload({ modelId: 'anthropic.claude-opus-5-20260601-v1:0', body: {} })
+  const cmd = new InvokeModelCommand(t.nr.input)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
+})
+
+test('claude prompt api modelId is not mistaken for the messages api', async (t) => {
+  const payload = structuredClone(claudePromptApi)
+  payload.body = {}
+  t.nr.updatePayload(payload)
+  const cmd = new InvokeModelCommand(t.nr.input)
+  assert.equal(cmd.isClaudeMessagesApi(), false)
+})
+
+test('claudeMsgsApi malformed payload produces reasonable values', async (t) => {
+  const malformedPayload = structuredClone(claudeMsgsApi)
+  malformedPayload.body = {}
+  t.nr.updatePayload(malformedPayload)
+  const cmd = new InvokeModelCommand(t.nr.input)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
+  assert.equal(cmd.maxTokens, undefined)
+  assert.equal(cmd.modelId, claudeMsgsApi.modelId)
+  assert.equal(cmd.modelType, 'completion')
+  assert.deepEqual(cmd.prompt, [])
+  assert.equal(cmd.temperature, undefined)
+})
+
+test('region specific claudeMsgsApi malformed payload produces reasonable values', async (t) => {
+  const malformedPayload = structuredClone(regionClaudeMsgsApi)
+  malformedPayload.body = {}
+  t.nr.updatePayload(malformedPayload)
+  const cmd = new InvokeModelCommand(t.nr.input)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
+  assert.equal(cmd.maxTokens, undefined)
+  assert.equal(cmd.modelId, regionClaudeMsgsApi.modelId)
+  assert.equal(cmd.modelType, 'completion')
+  assert.deepEqual(cmd.prompt, [])
+  assert.equal(cmd.temperature, undefined)
+})
+
+test('claudeMsgsApi skips a message that is null in `body.messages`', async (t) => {
+  const malformedPayload = structuredClone(claudeMsgsApi)
+  malformedPayload.body.messages = [{ role: 'user', content: 'who are you' }, null]
+  t.nr.updatePayload(malformedPayload)
+  const cmd = new InvokeModelCommand(t.nr.input)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
+  assert.deepEqual(cmd.prompt, [{ role: 'user', content: 'who are you' }])
+})
+
+test('region specific claudeMsgsApi skips a message that is null in `body.messages`', async (t) => {
+  const malformedPayload = structuredClone(regionClaudeMsgsApi)
+  malformedPayload.body.messages = [{ role: 'user', content: 'who are you' }, null]
+  t.nr.updatePayload(malformedPayload)
+  const cmd = new InvokeModelCommand(t.nr.input)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
+  assert.deepEqual(cmd.prompt, [{ role: 'user', content: 'who are you' }])
+})
+
+test('claudeMsgsApi handles defaulting prompt to empty array when `body.messages` is null', async (t) => {
+  const malformedPayload = structuredClone(claudeMsgsApi)
+  malformedPayload.body.messages = null
+  t.nr.updatePayload(malformedPayload)
+  const cmd = new InvokeModelCommand(t.nr.input)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
+  assert.deepEqual(cmd.prompt, [])
+})
+
+test('region specific claudeMsgsApi handles defaulting prompt to empty array when `body.messages` is null', async (t) => {
+  const malformedPayload = structuredClone(regionClaudeMsgsApi)
+  malformedPayload.body.messages = null
+  t.nr.updatePayload(malformedPayload)
+  const cmd = new InvokeModelCommand(t.nr.input)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
+  assert.deepEqual(cmd.prompt, [])
+})
+
+test('claudeMsgsApi minimal command works with string content', async (t) => {
+  const payload = structuredClone(claudeMsgsApi)
+  payload.body.messages = [{ role: 'user', content: 'who are you' }]
+  t.nr.updatePayload(payload)
+  const cmd = new InvokeModelCommand(t.nr.input)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
+  assert.equal(cmd.maxTokens, undefined)
+  assert.equal(cmd.modelId, claudeMsgsApi.modelId)
+  assert.equal(cmd.modelType, 'completion')
+  assert.deepEqual(cmd.prompt, payload.body.messages)
+  assert.equal(cmd.temperature, undefined)
+})
+
+test('claudeMsgsApi minimal command works with chunked content', async (t) => {
   t.nr.updatePayload(structuredClone(claudeMsgsApi))
   const cmd = new InvokeModelCommand(t.nr.input)
   assert.equal(cmd.isClaudeMessagesApi(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, claudeMsgsApi.modelId)
   assert.equal(cmd.modelType, 'completion')
-  assert.deepEqual(cmd.prompt, claudeMsgsApi.body.messages)
+  assert.deepEqual(cmd.prompt, [{ role: 'user', content: 'who are' }, { role: 'assistant', content: 'researching' }, { role: 'user', content: 'you' }])
   assert.equal(cmd.temperature, undefined)
 })
 
@@ -204,7 +258,7 @@ test('region specific claudeMsgsApi minimal command works', async (t) => {
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, regionClaudeMsgsApi.modelId)
   assert.equal(cmd.modelType, 'completion')
-  assert.deepEqual(cmd.prompt, claudeMsgsApi.body.messages)
+  assert.deepEqual(cmd.prompt, [{ role: 'user', content: 'who are' }, { role: 'assistant', content: 'researching' }, { role: 'user', content: 'you' }])
   assert.equal(cmd.temperature, undefined)
 })
 
@@ -218,151 +272,12 @@ test('claudeMsgsApi complete command works', async (t) => {
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
   assert.equal(cmd.modelType, 'completion')
-  assert.deepEqual(cmd.prompt, payload.body.messages)
+  assert.deepEqual(cmd.prompt, [{ role: 'user', content: 'who are' }, { role: 'assistant', content: 'researching' }, { role: 'user', content: 'you' }])
   assert.equal(cmd.temperature, payload.body.temperature)
 })
 
 test('region specific claudeMsgsApi complete command works', async (t) => {
   const payload = structuredClone(regionClaudeMsgsApi)
-  payload.body.max_tokens = 25
-  payload.body.temperature = 0.5
-  t.nr.updatePayload(payload)
-  const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaudeMessagesApi(), true)
-  assert.equal(cmd.maxTokens, 25)
-  assert.equal(cmd.modelId, payload.modelId)
-  assert.equal(cmd.modelType, 'completion')
-  assert.deepEqual(cmd.prompt, payload.body.messages)
-  assert.equal(cmd.temperature, payload.body.temperature)
-})
-
-test('claude opus 5 command is detected via modelId', async (t) => {
-  const payload = structuredClone(claudeOpus5)
-  payload.body = {}
-  t.nr.updatePayload(payload)
-  const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaudeMessagesApi(), true)
-})
-
-test('claude prompt api modelId is not mistaken for the messages api', async (t) => {
-  const payload = structuredClone(claude)
-  payload.body = {}
-  t.nr.updatePayload(payload)
-  const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaudeMessagesApi(), false)
-})
-
-test('claude35 minimal command works with claude 3 api', async (t) => {
-  t.nr.updatePayload(structuredClone(claudeMsgsApi))
-  const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaudeMessagesApi(), true)
-  assert.equal(cmd.maxTokens, undefined)
-  assert.equal(cmd.modelId, claudeMsgsApi.modelId)
-  assert.equal(cmd.modelType, 'completion')
-  assert.deepEqual(cmd.prompt, claudeMsgsApi.body.messages)
-  assert.equal(cmd.temperature, undefined)
-})
-
-test('claude35 malformed payload produces reasonable values', async (t) => {
-  const malformedPayload = structuredClone(claude35)
-  malformedPayload.body = {}
-  t.nr.updatePayload(malformedPayload)
-  const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaudeMessagesApi(), true)
-  assert.equal(cmd.maxTokens, undefined)
-  assert.equal(cmd.modelId, claude35.modelId)
-  assert.equal(cmd.modelType, 'completion')
-  assert.deepEqual(cmd.prompt, [])
-  assert.equal(cmd.temperature, undefined)
-})
-
-test('region specific claude35 malformed payload produces reasonable values', async (t) => {
-  const malformedPayload = structuredClone(regionClaude35)
-  malformedPayload.body = {}
-  t.nr.updatePayload(malformedPayload)
-  const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaudeMessagesApi(), true)
-  assert.equal(cmd.maxTokens, undefined)
-  assert.equal(cmd.modelId, regionClaude35.modelId)
-  assert.equal(cmd.modelType, 'completion')
-  assert.deepEqual(cmd.prompt, [])
-  assert.equal(cmd.temperature, undefined)
-})
-
-test('claude35 skips a message that is null in `body.messages`', async (t) => {
-  const malformedPayload = structuredClone(claude35)
-  malformedPayload.body.messages = [{ role: 'user', content: 'who are you' }, null]
-  t.nr.updatePayload(malformedPayload)
-  const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaudeMessagesApi(), true)
-  assert.deepEqual(cmd.prompt, [{ role: 'user', content: 'who are you' }])
-})
-
-test('region specific claude35 skips a message that is null in `body.messages`', async (t) => {
-  const malformedPayload = structuredClone(regionClaude35)
-  malformedPayload.body.messages = [{ role: 'user', content: 'who are you' }, null]
-  t.nr.updatePayload(malformedPayload)
-  const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaudeMessagesApi(), true)
-  assert.deepEqual(cmd.prompt, [{ role: 'user', content: 'who are you' }])
-})
-
-test('claude35 handles defaulting prompt to empty array when `body.messages` is null', async (t) => {
-  const malformedPayload = structuredClone(claude35)
-  malformedPayload.body.messages = null
-  t.nr.updatePayload(malformedPayload)
-  const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaudeMessagesApi(), true)
-  assert.deepEqual(cmd.prompt, [])
-})
-
-test('region specific claude35 handles defaulting prompt to empty array when `body.messages` is null', async (t) => {
-  const malformedPayload = structuredClone(regionClaude35)
-  malformedPayload.body.messages = null
-  t.nr.updatePayload(malformedPayload)
-  const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaudeMessagesApi(), true)
-  assert.deepEqual(cmd.prompt, [])
-})
-
-test('claude35 minimal command works', async (t) => {
-  t.nr.updatePayload(structuredClone(claude35))
-  const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaudeMessagesApi(), true)
-  assert.equal(cmd.maxTokens, undefined)
-  assert.equal(cmd.modelId, claude35.modelId)
-  assert.equal(cmd.modelType, 'completion')
-  assert.deepEqual(cmd.prompt, [{ role: 'user', content: 'who are' }, { role: 'assistant', content: 'researching' }, { role: 'user', content: 'you' }])
-  assert.equal(cmd.temperature, undefined)
-})
-
-test('region specific claude35 minimal command works', async (t) => {
-  t.nr.updatePayload(structuredClone(regionClaude35))
-  const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaudeMessagesApi(), true)
-  assert.equal(cmd.maxTokens, undefined)
-  assert.equal(cmd.modelId, regionClaude35.modelId)
-  assert.equal(cmd.modelType, 'completion')
-  assert.deepEqual(cmd.prompt, [{ role: 'user', content: 'who are' }, { role: 'assistant', content: 'researching' }, { role: 'user', content: 'you' }])
-  assert.equal(cmd.temperature, undefined)
-})
-
-test('claude35 complete command works', async (t) => {
-  const payload = structuredClone(claude35)
-  payload.body.max_tokens = 25
-  payload.body.temperature = 0.5
-  t.nr.updatePayload(payload)
-  const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaudeMessagesApi(), true)
-  assert.equal(cmd.maxTokens, 25)
-  assert.equal(cmd.modelId, payload.modelId)
-  assert.equal(cmd.modelType, 'completion')
-  assert.deepEqual(cmd.prompt, [{ role: 'user', content: 'who are' }, { role: 'assistant', content: 'researching' }, { role: 'user', content: 'you' }])
-  assert.equal(cmd.temperature, payload.body.temperature)
-})
-
-test('region specific claude35 complete command works', async (t) => {
-  const payload = structuredClone(regionClaude35)
   payload.body.max_tokens = 25
   payload.body.temperature = 0.5
   t.nr.updatePayload(payload)

--- a/test/unit/llm-events/aws-bedrock/invoke-model-command.test.js
+++ b/test/unit/llm-events/aws-bedrock/invoke-model-command.test.js
@@ -45,14 +45,28 @@ const regionClaude35 = {
     ]
   }
 }
-const claude3 = {
+const claudeMsgsApi = {
   modelId: 'anthropic.claude-3-haiku-20240307-v1:0',
   body: {
     messages: [{ role: 'user', content: 'who are you' }]
   }
 }
 
-const regionClaude3 = {
+const claudeOpus4 = {
+  modelId: 'anthropic.claude-opus-4-1-20250805-v1:0',
+  body: {
+    messages: [{ role: 'user', content: 'who are you' }]
+  }
+}
+
+const claudeSonnet45 = {
+  modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+  body: {
+    messages: [{ role: 'user', content: 'who are you' }]
+  }
+}
+
+const regionClaudeMsgsApi = {
   modelId: 'us.anthropic.claude-3-haiku-20240307-v1:0',
   body: {
     messages: [{ role: 'user', content: 'who are you' }]
@@ -110,8 +124,8 @@ test.beforeEach((ctx) => {
 test('non-conforming command is handled gracefully', async (t) => {
   const cmd = new InvokeModelCommand(t.nr.input)
   for (const model of [
-    'Claude',
-    'Claude3',
+    'ClaudePromptApi',
+    'ClaudeMessagesApi',
     'Cohere',
     'CohereEmbed',
     'Llama',
@@ -127,17 +141,10 @@ test('non-conforming command is handled gracefully', async (t) => {
   assert.equal(cmd.temperature, undefined)
 })
 
-test('claude modelId with malformed body missing `prompt` produces an empty prompt', async (t) => {
-  t.nr.updatePayload({ modelId: claude.modelId, body: {} })
-  const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude(), true)
-  assert.deepEqual(cmd.prompt, [])
-})
-
 test('claude minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(claude))
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude(), true)
+  assert.equal(cmd.isClaudePromptApi(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, claude.modelId)
   assert.equal(cmd.modelType, 'completion')
@@ -148,7 +155,7 @@ test('claude minimal command works', async (t) => {
 test('region specific claude minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(regionClaude))
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude(), true)
+  assert.equal(cmd.isClaudePromptApi(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, regionClaude.modelId)
   assert.equal(cmd.modelType, 'completion')
@@ -162,7 +169,7 @@ test('claude complete command works', async (t) => {
   payload.body.temperature = 0.5
   t.nr.updatePayload(payload)
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude(), true)
+  assert.equal(cmd.isClaudePromptApi(), true)
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
   assert.equal(cmd.modelType, 'completion')
@@ -176,7 +183,7 @@ test('region specific claude complete command works', async (t) => {
   payload.body.temperature = 0.5
   t.nr.updatePayload(payload)
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude(), true)
+  assert.equal(cmd.isClaudePromptApi(), true)
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
   assert.equal(cmd.modelType, 'completion')
@@ -184,35 +191,35 @@ test('region specific claude complete command works', async (t) => {
   assert.equal(cmd.temperature, payload.body.temperature)
 })
 
-test('claude3 minimal command works', async (t) => {
-  t.nr.updatePayload(structuredClone(claude3))
+test('claudeMsgsApi minimal command works', async (t) => {
+  t.nr.updatePayload(structuredClone(claudeMsgsApi))
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
   assert.equal(cmd.maxTokens, undefined)
-  assert.equal(cmd.modelId, claude3.modelId)
+  assert.equal(cmd.modelId, claudeMsgsApi.modelId)
   assert.equal(cmd.modelType, 'completion')
-  assert.deepEqual(cmd.prompt, claude3.body.messages)
+  assert.deepEqual(cmd.prompt, claudeMsgsApi.body.messages)
   assert.equal(cmd.temperature, undefined)
 })
 
-test('region specific claude3 minimal command works', async (t) => {
-  t.nr.updatePayload(structuredClone(regionClaude3))
+test('region specific claudeMsgsApi minimal command works', async (t) => {
+  t.nr.updatePayload(structuredClone(regionClaudeMsgsApi))
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
   assert.equal(cmd.maxTokens, undefined)
-  assert.equal(cmd.modelId, regionClaude3.modelId)
+  assert.equal(cmd.modelId, regionClaudeMsgsApi.modelId)
   assert.equal(cmd.modelType, 'completion')
-  assert.deepEqual(cmd.prompt, claude3.body.messages)
+  assert.deepEqual(cmd.prompt, claudeMsgsApi.body.messages)
   assert.equal(cmd.temperature, undefined)
 })
 
-test('claude3 complete command works', async (t) => {
-  const payload = structuredClone(claude3)
+test('claudeMsgsApi complete command works', async (t) => {
+  const payload = structuredClone(claudeMsgsApi)
   payload.body.max_tokens = 25
   payload.body.temperature = 0.5
   t.nr.updatePayload(payload)
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
   assert.equal(cmd.modelType, 'completion')
@@ -220,28 +227,52 @@ test('claude3 complete command works', async (t) => {
   assert.equal(cmd.temperature, payload.body.temperature)
 })
 
-test('region specific claude3 complete command works', async (t) => {
-  const payload = structuredClone(regionClaude3)
+test('region specific claudeMsgsApi complete command works', async (t) => {
+  const payload = structuredClone(regionClaudeMsgsApi)
   payload.body.max_tokens = 25
   payload.body.temperature = 0.5
   t.nr.updatePayload(payload)
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
   assert.equal(cmd.modelType, 'completion')
   assert.deepEqual(cmd.prompt, payload.body.messages)
   assert.equal(cmd.temperature, payload.body.temperature)
+})
+
+test('claude opus 4 command is detected via modelId', async (t) => {
+  const payload = structuredClone(claudeOpus4)
+  payload.body = {}
+  t.nr.updatePayload(payload)
+  const cmd = new InvokeModelCommand(t.nr.input)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
+})
+
+test('claude sonnet 4.5 command is detected via modelId', async (t) => {
+  const payload = structuredClone(claudeSonnet45)
+  payload.body = {}
+  t.nr.updatePayload(payload)
+  const cmd = new InvokeModelCommand(t.nr.input)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
+})
+
+test('claude prompt api modelId is not mistaken for the messages api', async (t) => {
+  const payload = structuredClone(claude)
+  payload.body = {}
+  t.nr.updatePayload(payload)
+  const cmd = new InvokeModelCommand(t.nr.input)
+  assert.equal(cmd.isClaudeMessagesApi(), false)
 })
 
 test('claude35 minimal command works with claude 3 api', async (t) => {
-  t.nr.updatePayload(structuredClone(claude3))
+  t.nr.updatePayload(structuredClone(claudeMsgsApi))
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
   assert.equal(cmd.maxTokens, undefined)
-  assert.equal(cmd.modelId, claude3.modelId)
+  assert.equal(cmd.modelId, claudeMsgsApi.modelId)
   assert.equal(cmd.modelType, 'completion')
-  assert.deepEqual(cmd.prompt, claude3.body.messages)
+  assert.deepEqual(cmd.prompt, claudeMsgsApi.body.messages)
   assert.equal(cmd.temperature, undefined)
 })
 
@@ -250,7 +281,7 @@ test('claude35 malformed payload produces reasonable values', async (t) => {
   malformedPayload.body = {}
   t.nr.updatePayload(malformedPayload)
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, claude35.modelId)
   assert.equal(cmd.modelType, 'completion')
@@ -263,7 +294,7 @@ test('region specific claude35 malformed payload produces reasonable values', as
   malformedPayload.body = {}
   t.nr.updatePayload(malformedPayload)
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, regionClaude35.modelId)
   assert.equal(cmd.modelType, 'completion')
@@ -276,7 +307,7 @@ test('claude35 skips a message that is null in `body.messages`', async (t) => {
   malformedPayload.body.messages = [{ role: 'user', content: 'who are you' }, null]
   t.nr.updatePayload(malformedPayload)
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
   assert.deepEqual(cmd.prompt, [{ role: 'user', content: 'who are you' }])
 })
 
@@ -285,7 +316,7 @@ test('region specific claude35 skips a message that is null in `body.messages`',
   malformedPayload.body.messages = [{ role: 'user', content: 'who are you' }, null]
   t.nr.updatePayload(malformedPayload)
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
   assert.deepEqual(cmd.prompt, [{ role: 'user', content: 'who are you' }])
 })
 
@@ -294,7 +325,7 @@ test('claude35 handles defaulting prompt to empty array when `body.messages` is 
   malformedPayload.body.messages = null
   t.nr.updatePayload(malformedPayload)
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
   assert.deepEqual(cmd.prompt, [])
 })
 
@@ -303,14 +334,14 @@ test('region specific claude35 handles defaulting prompt to empty array when `bo
   malformedPayload.body.messages = null
   t.nr.updatePayload(malformedPayload)
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
   assert.deepEqual(cmd.prompt, [])
 })
 
 test('claude35 minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(claude35))
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, claude35.modelId)
   assert.equal(cmd.modelType, 'completion')
@@ -321,7 +352,7 @@ test('claude35 minimal command works', async (t) => {
 test('region specific claude35 minimal command works', async (t) => {
   t.nr.updatePayload(structuredClone(regionClaude35))
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
   assert.equal(cmd.maxTokens, undefined)
   assert.equal(cmd.modelId, regionClaude35.modelId)
   assert.equal(cmd.modelType, 'completion')
@@ -335,7 +366,7 @@ test('claude35 complete command works', async (t) => {
   payload.body.temperature = 0.5
   t.nr.updatePayload(payload)
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
   assert.equal(cmd.modelType, 'completion')
@@ -349,7 +380,7 @@ test('region specific claude35 complete command works', async (t) => {
   payload.body.temperature = 0.5
   t.nr.updatePayload(payload)
   const cmd = new InvokeModelCommand(t.nr.input)
-  assert.equal(cmd.isClaude3(), true)
+  assert.equal(cmd.isClaudeMessagesApi(), true)
   assert.equal(cmd.maxTokens, 25)
   assert.equal(cmd.modelId, payload.modelId)
   assert.equal(cmd.modelType, 'completion')

--- a/test/unit/llm-events/aws-bedrock/invoke-model-response.test.js
+++ b/test/unit/llm-events/aws-bedrock/invoke-model-response.test.js
@@ -10,12 +10,12 @@ const assert = require('node:assert')
 const structuredClone = require('./clone')
 const InvokeModelResponse = require('../../../../lib/llm-events/aws-bedrock/invoke-model-response')
 
-const claude = {
-  completion: 'claude-response',
+const claudePromptApi = {
+  completion: 'claudePromptApi-response',
   stop_reason: 'done'
 }
 
-const claude35 = {
+const claudeMsgsApi = {
   content: [
     { type: 'text', text: 'Hello' },
     { type: 'text', text: 'world' }
@@ -65,10 +65,10 @@ test.beforeEach((ctx) => {
   }
 
   ctx.nr.bedrockCommand = {
-    isClaude() {
+    isClaudePromptApi() {
       return false
     },
-    isClaude3() {
+    isClaudeMessagesApi() {
       return false
     },
     isCohere() {
@@ -98,8 +98,8 @@ test('non-conforming response is handled gracefully', async (t) => {
   assert.equal(res.statusCode, 200)
 })
 
-test('claude malformed responses work', async (t) => {
-  t.nr.bedrockCommand.isClaude = () => true
+test('claudePromptApi malformed responses work', async (t) => {
+  t.nr.bedrockCommand.isClaudePromptApi = () => true
   const res = new InvokeModelResponse(t.nr)
   assert.deepStrictEqual(res.completions, [])
   assert.equal(res.finishReason, undefined)
@@ -109,11 +109,11 @@ test('claude malformed responses work', async (t) => {
   assert.equal(res.statusCode, 200)
 })
 
-test('claude complete responses work', async (t) => {
-  t.nr.bedrockCommand.isClaude = () => true
-  t.nr.updatePayload(structuredClone(claude))
+test('claudePromptApi complete responses work', async (t) => {
+  t.nr.bedrockCommand.isClaudePromptApi = () => true
+  t.nr.updatePayload(structuredClone(claudePromptApi))
   const res = new InvokeModelResponse(t.nr)
-  assert.deepStrictEqual(res.completions, ['claude-response'])
+  assert.deepStrictEqual(res.completions, ['claudePromptApi-response'])
   assert.equal(res.finishReason, 'done')
   assert.deepStrictEqual(res.headers, t.nr.response.response.headers)
   assert.equal(res.id, undefined)
@@ -121,9 +121,9 @@ test('claude complete responses work', async (t) => {
   assert.equal(res.statusCode, 200)
 })
 
-test('claude 3.5 complete responses work', async (t) => {
-  t.nr.bedrockCommand.isClaude3 = () => true
-  t.nr.updatePayload(structuredClone(claude35))
+test('claudeMsgsApi complete responses work', async (t) => {
+  t.nr.bedrockCommand.isClaudeMessagesApi = () => true
+  t.nr.updatePayload(structuredClone(claudeMsgsApi))
   const res = new InvokeModelResponse(t.nr)
   assert.deepStrictEqual(res.completions, ['Hello\n\nworld'])
   assert.equal(res.finishReason, 'done')

--- a/test/unit/subscribers/aws-sdk/stream-handler.test.js
+++ b/test/unit/subscribers/aws-sdk/stream-handler.test.js
@@ -40,10 +40,10 @@ test.beforeEach((ctx) => {
       isCohereEmbed() {
         return false
       },
-      isClaude() {
+      isClaudePromptApi() {
         return false
       },
-      isClaude3() {
+      isClaudeMessagesApi() {
         return false
       },
       isLlama() {
@@ -85,14 +85,14 @@ test('unrecognized or unhandled model uses original stream', async (t) => {
 })
 
 test('handles claude streams', async (t) => {
-  t.nr.passThroughParams.bedrockCommand.isClaude = () => true
+  t.nr.passThroughParams.bedrockCommand.isClaudePromptApi = () => true
   t.nr.chunks = [
     { completion: '1', stop_reason: null },
     { completion: '2', stop_reason: 'done', ...t.nr.metrics }
   ]
   const handler = new StreamHandler(t.nr)
 
-  assert.equal(handler.generator.name, 'handleClaude')
+  assert.equal(handler.generator.name, 'handleClaudePromptApi')
   for await (const event of handler.generator()) {
     assert.equal(event.chunk.bytes.constructor, Uint8Array)
   }
@@ -125,14 +125,14 @@ test('handles claude streams', async (t) => {
 })
 
 test('handles region specific claude streams', async (t) => {
-  t.nr.passThroughParams.bedrockCommand.isClaude = () => true
+  t.nr.passThroughParams.bedrockCommand.isClaudePromptApi = () => true
   t.nr.chunks = [
     { completion: '1', stop_reason: null },
     { completion: '2', stop_reason: 'done', ...t.nr.metrics }
   ]
   const handler = new StreamHandler(t.nr)
 
-  assert.equal(handler.generator.name, 'handleClaude')
+  assert.equal(handler.generator.name, 'handleClaudePromptApi')
   for await (const event of handler.generator()) {
     assert.equal(event.chunk.bytes.constructor, Uint8Array)
   }
@@ -165,7 +165,7 @@ test('handles region specific claude streams', async (t) => {
 })
 
 test('handles claude3streams', async (t) => {
-  t.nr.passThroughParams.bedrockCommand.isClaude3 = () => true
+  t.nr.passThroughParams.bedrockCommand.isClaudeMessagesApi = () => true
   t.nr.chunks = [
     { type: 'content_block_delta', delta: { type: 'text_delta', text: '42' } },
     { type: 'message_delta', delta: { stop_reason: 'done' } },
@@ -173,7 +173,7 @@ test('handles claude3streams', async (t) => {
   ]
   const handler = new StreamHandler(t.nr)
 
-  assert.equal(handler.generator.name, 'handleClaude3')
+  assert.equal(handler.generator.name, 'handleClaudeMessagesApi')
   for await (const event of handler.generator()) {
     assert.equal(event.chunk.bytes.constructor, Uint8Array)
   }
@@ -199,7 +199,7 @@ test('handles claude3streams', async (t) => {
 })
 
 test('handles region specific claude3streams', async (t) => {
-  t.nr.passThroughParams.bedrockCommand.isClaude3 = () => true
+  t.nr.passThroughParams.bedrockCommand.isClaudeMessagesApi = () => true
   t.nr.chunks = [
     { type: 'content_block_delta', delta: { type: 'text_delta', text: '42' } },
     { type: 'message_delta', delta: { stop_reason: 'done' } },
@@ -207,7 +207,7 @@ test('handles region specific claude3streams', async (t) => {
   ]
   const handler = new StreamHandler(t.nr)
 
-  assert.equal(handler.generator.name, 'handleClaude3')
+  assert.equal(handler.generator.name, 'handleClaudeMessagesApi')
   for await (const event of handler.generator()) {
     assert.equal(event.chunk.bytes.constructor, Uint8Array)
   }

--- a/test/unit/subscribers/aws-sdk/stream-handler.test.js
+++ b/test/unit/subscribers/aws-sdk/stream-handler.test.js
@@ -164,7 +164,7 @@ test('handles region specific claude streams', async (t) => {
   assert.equal(br.statusCode, 200)
 })
 
-test('handles claude3streams', async (t) => {
+test('handles claudeMsgsApi streams', async (t) => {
   t.nr.passThroughParams.bedrockCommand.isClaudeMessagesApi = () => true
   t.nr.chunks = [
     { type: 'content_block_delta', delta: { type: 'text_delta', text: '42' } },
@@ -198,7 +198,7 @@ test('handles claude3streams', async (t) => {
   assert.equal(br.statusCode, 200)
 })
 
-test('handles region specific claude3streams', async (t) => {
+test('handles region specific claudeMsgsApi streams', async (t) => {
   t.nr.passThroughParams.bedrockCommand.isClaudeMessagesApi = () => true
   t.nr.chunks = [
     { type: 'content_block_delta', delta: { type: 'text_delta', text: '42' } },


### PR DESCRIPTION
## Description

Follow up to PR #4235. Our current Claude detection logic in `InvokeModelCommand` lives across 4 separate booleans and there are no test cases for v4 or v5 Claude models. This PR simplifies the Claude detection logic to be just two booleans; they detect the Claude API called rather than relying on the model version in the model ID. This PR also adds tests for the Claude v4/v5 models via making the tests not relying on the model ID version number, but instead on the API response shape.

* `isClaude` and `isClaudeTextCompletionApi` -> `isClaudePromptApi` (matches v1/v2)
* `isClaude3` and `isClaudeMessagesApi` -> `isClaudeMessagesApi` (matches v3+)

## How to Test

```
node --test test/unit/llm-events/aws-bedrock/invoke-model-command.test.js
node --test test/unit/llm-events/aws-bedrock/invoke-model-response.test.js
node --test test/unit/subscribers/aws-sdk/stream-handler.test.js

npm run versioned aws-sdk-v3
```

## Related Issues

Discovered while researching #4230 