### PR TITLE
fix: Prevented duplicate external segments when undici negotiates HTTP/2

### DIFF
--- a/lib/instrumentation/core/http2.js
+++ b/lib/instrumentation/core/http2.js
@@ -13,7 +13,7 @@ const logger = require('../../logger').child({ component: 'http2' })
 const synthetics = require('../../synthetics')
 const urltils = require('../../util/urltils.js')
 const http2ConnectUrl = Symbol('http2ConnectUrl')
-const undiciConnection = Symbol.for('newrelic.undici.connection')
+const { undiciConnection } = require('../../symbols')
 
 function initialize(agent, http2, moduleName, shim) {
   shim.wrap(http2, 'connect', wrapConnect)
@@ -31,7 +31,7 @@ function initialize(agent, http2, moduleName, shim) {
     return function wrappedConnect(...args) {
       const session = fn.apply(this, args)
       if (session.socket?.[undiciConnection]) {
-        logger.trace('Not instrumenting http2 session.request; connection owned by undici')
+        logger.trace('Not instrumenting http2 session.request; connection already instrumented by undici instrumentation')
         return session
       }
       session[http2ConnectUrl] = args[0]

--- a/lib/instrumentation/core/http2.js
+++ b/lib/instrumentation/core/http2.js
@@ -5,13 +5,15 @@
 
 'use strict'
 
+module.exports = initialize
+
 const NAMES = require('../../metrics/names')
 const recordExternal = require('../../metrics/recorders/http_external')
 const logger = require('../../logger').child({ component: 'http2' })
 const synthetics = require('../../synthetics')
 const urltils = require('../../util/urltils.js')
 const http2ConnectUrl = Symbol('http2ConnectUrl')
-module.exports = initialize
+const undiciConnection = Symbol.for('newrelic.undici.connection')
 
 function initialize(agent, http2, moduleName, shim) {
   shim.wrap(http2, 'connect', wrapConnect)
@@ -28,6 +30,10 @@ function initialize(agent, http2, moduleName, shim) {
   function wrapConnect(shim, fn) {
     return function wrappedConnect(...args) {
       const session = fn.apply(this, args)
+      if (session.socket?.[undiciConnection]) {
+        logger.trace('Not instrumenting http2 session.request; connection owned by undici')
+        return session
+      }
       session[http2ConnectUrl] = args[0]
       return shim.wrap(session, ['request'], wrapRequest)
     }

--- a/lib/subscribers/undici/build-connector.js
+++ b/lib/subscribers/undici/build-connector.js
@@ -6,16 +6,15 @@
 'use strict'
 
 const Subscriber = require('../base.js')
-
-const undiciConnection = Symbol.for('newrelic.undici.connection')
+const { undiciConnection } = require('#agentlib/symbols.js')
 
 /**
  * undici builds its socket connector via `buildConnector`, and hands the socket
  * that connector produces to `http2.connect` (via `createConnection`) when it
  * negotiates HTTP/2. The undici subscriber already records an external segment
  * for the request, so the core http2 instrumentation must not create a second
- * one. We stamp every socket undici's connector returns with the well-known
- * symbol; the http2 instrumentation checks for it and skips.
+ * one. We stamp every socket undici's connector returns a symbol;
+ * the http2 instrumentation checks for it and skips.
  *
  * `buildConnector` is a factory: it returns the connector function that, when
  * called, synchronously returns the socket. We wrap that returned connector so
@@ -36,13 +35,11 @@ class BuildConnectorSubscriber extends Subscriber {
    *
    * @param {object} data event data from Orchestrion; `data.result` is the
    * connector function returned by `buildConnector`.
-   * @param {object} ctx current context.
-   * @returns {object} the unchanged context.
    */
-  end(data, ctx) {
+  end(data) {
     const connector = data.result
     if (typeof connector !== 'function') {
-      return ctx
+      return
     }
 
     data.result = function nrWrappedConnector(...args) {
@@ -52,8 +49,6 @@ class BuildConnectorSubscriber extends Subscriber {
       }
       return socket
     }
-
-    return ctx
   }
 }
 

--- a/lib/subscribers/undici/build-connector.js
+++ b/lib/subscribers/undici/build-connector.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const Subscriber = require('../base.js')
+
+const undiciConnection = Symbol.for('newrelic.undici.connection')
+
+/**
+ * undici builds its socket connector via `buildConnector`, and hands the socket
+ * that connector produces to `http2.connect` (via `createConnection`) when it
+ * negotiates HTTP/2. The undici subscriber already records an external segment
+ * for the request, so the core http2 instrumentation must not create a second
+ * one. We stamp every socket undici's connector returns with the well-known
+ * symbol; the http2 instrumentation checks for it and skips.
+ *
+ * `buildConnector` is a factory: it returns the connector function that, when
+ * called, synchronously returns the socket. We wrap that returned connector so
+ * the socket is stamped before undici passes it to `http2.connect`.
+ *
+ * @see https://github.com/newrelic/node-newrelic/issues/4250
+ */
+class BuildConnectorSubscriber extends Subscriber {
+  constructor({ agent, logger }) {
+    super({ agent, logger, packageName: 'undici', channelName: 'nr_buildConnector' })
+    this.requireActiveTx = false
+    this.events = ['end']
+  }
+
+  /**
+   * Picks up the connector function returned by `buildConnector` and replaces
+   * it with a wrapper that stamps the socket it produces.
+   *
+   * @param {object} data event data from Orchestrion; `data.result` is the
+   * connector function returned by `buildConnector`.
+   * @param {object} ctx current context.
+   * @returns {object} the unchanged context.
+   */
+  end(data, ctx) {
+    const connector = data.result
+    if (typeof connector !== 'function') {
+      return ctx
+    }
+
+    data.result = function nrWrappedConnector(...args) {
+      const socket = connector.apply(this, args)
+      if (socket) {
+        socket[undiciConnection] = true
+      }
+      return socket
+    }
+
+    return ctx
+  }
+}
+
+module.exports = BuildConnectorSubscriber

--- a/lib/subscribers/undici/config.js
+++ b/lib/subscribers/undici/config.js
@@ -4,8 +4,23 @@
  */
 
 module.exports = {
-  undici: [{
-    path: './undici',
-    instrumentations: []
-  }]
+  undici: [
+    {
+      path: './undici',
+      instrumentations: []
+    },
+    {
+      path: './undici/build-connector',
+      instrumentations: [
+        {
+          channelName: 'nr_buildConnector',
+          module: { name: 'undici', versionRange: '>=5.0.0', filePath: 'lib/core/connect.js' },
+          functionQuery: {
+            functionName: 'buildConnector',
+            kind: 'Sync'
+          }
+        }
+      ]
+    }
+  ]
 }

--- a/lib/subscribers/undici/config.js
+++ b/lib/subscribers/undici/config.js
@@ -14,7 +14,7 @@ module.exports = {
       instrumentations: [
         {
           channelName: 'nr_buildConnector',
-          module: { name: 'undici', versionRange: '>=5.0.0', filePath: 'lib/core/connect.js' },
+          module: { name: 'undici', versionRange: '>=5.25.0', filePath: 'lib/core/connect.js' },
           functionQuery: {
             functionName: 'buildConnector',
             kind: 'Sync'

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -38,6 +38,7 @@ module.exports = {
   unwrapPool: Symbol('unwrapPool'),
   undiciParent: Symbol('undiciParent'),
   undiciSegment: Symbol('undiciSegment'),
+  undiciConnection: Symbol('undiciConnection'),
   clusterOf: Symbol('clusterOf'),
   createPoolCluster: Symbol('createPoolCluster'),
   wrappedPoolConnection: Symbol('wrappedPoolConnection'),

--- a/test/unit/instrumentation/http2/http2.test.js
+++ b/test/unit/instrumentation/http2/http2.test.js
@@ -12,6 +12,7 @@ const helper = require('../../../lib/agent_helper')
 const createHttp2ResponseServer = require('./fixtures/http2')
 const events = require('node:events')
 const nodeVersion = Number(/^v?(\d+)/.exec(process.version)[1])
+const { undiciConnection } = require('#agentlib/symbols.js')
 
 const beforeEach = async (ctx) => {
   const { server, baseUrl, responses, host, port } = await createHttp2ResponseServer()
@@ -815,8 +816,6 @@ test('http2 error handling', async (t) => {
 
 test('http2 caller-managed connection (e.g. undici)', async (t) => {
   const net = require('node:net')
-  const undiciConnection = Symbol.for('newrelic.undici.connection')
-
   t.beforeEach(beforeEach)
   t.afterEach(afterEach)
 

--- a/test/unit/instrumentation/http2/http2.test.js
+++ b/test/unit/instrumentation/http2/http2.test.js
@@ -813,6 +813,76 @@ test('http2 error handling', async (t) => {
   })
 })
 
+test('http2 caller-managed connection (e.g. undici)', async (t) => {
+  const net = require('node:net')
+  const undiciConnection = Symbol.for('newrelic.undici.connection')
+
+  t.beforeEach(beforeEach)
+  t.afterEach(afterEach)
+
+  /**
+   * Supplies the connection socket via `createConnection` (as undici does),
+   * optionally stamping it with the undici symbol before http2 assigns it to
+   * `session.socket`, drives a request, and returns the external child segments.
+   *
+   * @param {object} t node:test context
+   * @param {Function} finish invoked with the collected results
+   * @param {object} opts options
+   * @param {boolean} opts.stamp whether to stamp the socket with the undici symbol
+   */
+  const runRequest = (t, finish, { stamp }) => {
+    const { agent, http2, host, port } = t.nr
+    helper.runInTransaction(agent, function () {
+      const transaction = agent.getTransaction()
+      const session = http2.connect(`http://${host}:${port}`, {
+        createConnection() {
+          const socket = net.connect(port, host)
+          if (stamp === true) {
+            socket[undiciConnection] = true
+          }
+          return socket
+        }
+      })
+
+      const req = session.request({ ':path': '/', ':method': 'GET' })
+      req.setEncoding('utf8')
+      req.on('response', () => {
+        req.on('data', () => {})
+        req.on('end', () => {
+          session.close()
+          transaction.end()
+          const externals = transaction.trace
+            .getChildren(transaction.trace.root.id)
+            .flatMap(function collect(seg) {
+              const kids = transaction.trace.getChildren(seg.id).flatMap(collect)
+              return seg.name.startsWith(NAMES.EXTERNAL.PREFIX) ? [seg, ...kids] : kids
+            })
+          finish({ agent, externals, host, port })
+        })
+      })
+      req.end()
+    })
+  }
+
+  await t.test('should NOT create an http2 external when the socket is undici-owned', (t, end) => {
+    runRequest(t, ({ agent, externals, host, port }) => {
+      assert.equal(externals.length, 0, 'should not create any http2 external segment')
+      const metric = agent.metrics.getMetric(`External/${host}:${port}/http2`)
+      assert.equal(metric, undefined, 'should not record an http2 external metric')
+      end()
+    }, { stamp: true })
+  })
+
+  await t.test('should create an http2 external when the socket is not undici-owned', (t, end) => {
+    runRequest(t, ({ agent, externals, host, port }) => {
+      assert.equal(externals.length, 1, 'should create exactly one http2 external segment')
+      const metric = agent.metrics.getOrCreateMetric(`External/${host}:${port}/http2`)
+      assert.equal(metric.callCount, 1, 'should record the http2 external metric')
+      end()
+    }, { stamp: false })
+  })
+})
+
 // Unlike http, http2 requests take place after an explicit connect is invoked
 async function makeRequest(http2, params, cb) {
   const { protocol, host, port, path, method, headers: requestHeaders, body = '', testing = {} } = params

--- a/test/unit/lib/subscribers/undici-build-connector.test.js
+++ b/test/unit/lib/subscribers/undici-build-connector.test.js
@@ -9,9 +9,9 @@ const assert = require('node:assert')
 const test = require('node:test')
 const sinon = require('sinon')
 const helper = require('#testlib/agent_helper.js')
+const { undiciConnection } = require('#agentlib/symbols.js')
 
 const BuildConnectorSubscriber = require('#agentlib/subscribers/undici/build-connector.js')
-const undiciConnection = Symbol.for('newrelic.undici.connection')
 
 test('undici build-connector instrumentation', async function (t) {
   t.beforeEach(function (ctx) {
@@ -33,7 +33,7 @@ test('undici build-connector instrumentation', async function (t) {
     const connector = () => socket
     const data = { result: connector }
 
-    const ctx = subscriber.end(data, 'ctx')
+    subscriber.end(data)
 
     // the connector is replaced with a wrapper
     assert.notEqual(data.result, connector)
@@ -43,9 +43,6 @@ test('undici build-connector instrumentation', async function (t) {
     const returned = data.result()
     assert.equal(returned, socket)
     assert.equal(socket[undiciConnection], true)
-
-    // context is passed through unchanged
-    assert.equal(ctx, 'ctx')
   })
 
   await t.test('should forward connector arguments and `this`', function (t) {
@@ -55,7 +52,7 @@ test('undici build-connector instrumentation', async function (t) {
     const connector = sinon.stub().returns(socket)
     const data = { result: connector }
 
-    subscriber.end(data, 'ctx')
+    subscriber.end(data)
     data.result.call(thisArg, 'a', 'b')
 
     assert.equal(connector.thisValues[0], thisArg)
@@ -67,7 +64,7 @@ test('undici build-connector instrumentation', async function (t) {
     const connector = () => undefined
     const data = { result: connector }
 
-    subscriber.end(data, 'ctx')
+    subscriber.end(data)
     assert.doesNotThrow(() => data.result())
   })
 
@@ -75,8 +72,7 @@ test('undici build-connector instrumentation', async function (t) {
     const { subscriber } = t.nr
     const data = { result: 'not-a-function' }
 
-    const ctx = subscriber.end(data, 'ctx')
+    subscriber.end(data)
     assert.equal(data.result, 'not-a-function')
-    assert.equal(ctx, 'ctx')
   })
 })

--- a/test/unit/lib/subscribers/undici-build-connector.test.js
+++ b/test/unit/lib/subscribers/undici-build-connector.test.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const assert = require('node:assert')
+const test = require('node:test')
+const sinon = require('sinon')
+const helper = require('#testlib/agent_helper.js')
+
+const BuildConnectorSubscriber = require('#agentlib/subscribers/undici/build-connector.js')
+const undiciConnection = Symbol.for('newrelic.undici.connection')
+
+test('undici build-connector instrumentation', async function (t) {
+  t.beforeEach(function (ctx) {
+    const sandbox = sinon.createSandbox()
+    const loggerMock = require('../../mocks/logger')(sandbox)
+    const agent = helper.loadMockedAgent()
+    const subscriber = new BuildConnectorSubscriber({ agent, logger: loggerMock })
+    ctx.nr = { agent, sandbox, subscriber }
+  })
+
+  t.afterEach(function (ctx) {
+    ctx.nr.sandbox.restore()
+    helper.unloadAgent(ctx.nr.agent)
+  })
+
+  await t.test('should stamp the socket returned by the connector', function (t) {
+    const { subscriber } = t.nr
+    const socket = {}
+    const connector = () => socket
+    const data = { result: connector }
+
+    const ctx = subscriber.end(data, 'ctx')
+
+    // the connector is replaced with a wrapper
+    assert.notEqual(data.result, connector)
+    assert.equal(typeof data.result, 'function')
+
+    // calling the wrapper returns the same socket, now stamped
+    const returned = data.result()
+    assert.equal(returned, socket)
+    assert.equal(socket[undiciConnection], true)
+
+    // context is passed through unchanged
+    assert.equal(ctx, 'ctx')
+  })
+
+  await t.test('should forward connector arguments and `this`', function (t) {
+    const { subscriber } = t.nr
+    const socket = {}
+    const thisArg = {}
+    const connector = sinon.stub().returns(socket)
+    const data = { result: connector }
+
+    subscriber.end(data, 'ctx')
+    data.result.call(thisArg, 'a', 'b')
+
+    assert.equal(connector.thisValues[0], thisArg)
+    assert.deepEqual(connector.args[0], ['a', 'b'])
+  })
+
+  await t.test('should not stamp when the connector returns no socket', function (t) {
+    const { subscriber } = t.nr
+    const connector = () => undefined
+    const data = { result: connector }
+
+    subscriber.end(data, 'ctx')
+    assert.doesNotThrow(() => data.result())
+  })
+
+  await t.test('should leave a non-function result untouched', function (t) {
+    const { subscriber } = t.nr
+    const data = { result: 'not-a-function' }
+
+    const ctx = subscriber.end(data, 'ctx')
+    assert.equal(data.result, 'not-a-function')
+    assert.equal(ctx, 'ctx')
+  })
+})

--- a/test/versioned/undici/issue-4250.js
+++ b/test/versioned/undici/issue-4250.js
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+// Reproduction for https://github.com/newrelic/node-newrelic/issues/4250
+//
+// When undici negotiates HTTP/2 via ALPN, a single request produces
+// two sibling external segments for the same URL: one attributed to `undici`
+// (created by the undici diagnostics-channel subscriber) and one attributed to
+// `http2` (created by the core http2 instrumentation, because undici internally
+// drives http2.connect()/session.request()). Only one request is sent, so this
+// inflates external call counts and aggregate external duration.
+
+const test = require('node:test')
+const assert = require('node:assert')
+const http2 = require('node:http2')
+const helper = require('../../lib/agent_helper')
+const fakeCert = require('../../lib/fake-cert')
+
+const cert = fakeCert({ commonName: 'localhost' })
+
+/**
+ * Creates a secure HTTP/2 server that negotiates `h2` via ALPN.
+ *
+ * @returns {Promise<object>} the listening server and its origin
+ */
+function createHttp2Server() {
+  const server = http2.createSecureServer({
+    key: cert.privateKey,
+    cert: cert.certificate,
+    allowHTTP1: true
+  })
+
+  server.on('stream', (stream) => {
+    stream.respond({ ':status': 200, 'content-type': 'text/plain' })
+    stream.end('hello over ' + stream.session.alpnProtocol)
+  })
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address()
+      resolve({ server, origin: `https://127.0.0.1:${port}`, port })
+    })
+  })
+}
+
+/**
+ * Recursively collects all external segments from a trace.
+ *
+ * @param {Transaction} tx active transaction
+ * @param {TraceSegment} segment segment to start from
+ * @param {Array} out accumulator
+ * @returns {Array} external segments
+ */
+function collectExternals(tx, segment, out = []) {
+  if (segment.name?.startsWith('External/')) {
+    out.push(segment)
+  }
+  for (const child of tx.trace.getChildren(segment.id)) {
+    collectExternals(tx, child, out)
+  }
+  return out
+}
+
+test.beforeEach(async (ctx) => {
+  const agent = helper.instrumentMockedAgent({
+    distributed_tracing: { enabled: true }
+  })
+  const undici = require('undici')
+  const { server, origin, port } = await createHttp2Server()
+  ctx.nr = { agent, undici, server, origin, port }
+})
+
+test.afterEach((ctx) => {
+  helper.unloadAgent(ctx.nr.agent)
+  ctx.nr.server.close()
+})
+
+// The double-instrumentation bug is triggered by HTTP/2 negotiation, not by any
+// particular undici major version. `allowH2` is explicitly enabled here so that
+// h2 is negotiated on every supported undici major (>= 5), which keeps this test
+// deterministic across the versioned matrix. undici 8 flipped the `allowH2`
+// default to true, which is what surfaced this bug for users on an upgrade.
+test('undici HTTP/2 request should create exactly one external segment', async (t) => {
+  const { agent, undici, origin, port } = t.nr
+  const dispatcher = new undici.Agent({
+    connect: { rejectUnauthorized: false },
+    allowH2: true
+  })
+
+  await helper.runInTransaction(agent, async (tx) => {
+    const res = await undici.request(origin + '/foo', { dispatcher })
+    const body = await res.body.text()
+    // sanity check that HTTP/2 was actually negotiated
+    assert.equal(body, 'hello over h2', 'server should have negotiated h2 via ALPN')
+    tx.end()
+
+    const externals = collectExternals(tx, tx.trace.root)
+    assert.equal(
+      externals.length,
+      1,
+      `expected exactly one external segment, got ${externals.length}: ` +
+        externals.map((e) => e.name).join(', ')
+    )
+
+    // the single external should be attributed to undici, not http2
+    const unscoped = agent.metrics._metrics.unscoped
+    assert.ok(
+      unscoped[`External/127.0.0.1:${port}/undici`],
+      'external metric should be attributed to undici'
+    )
+    assert.ok(
+      !unscoped[`External/127.0.0.1:${port}/http2`],
+      'external metric should NOT be attributed to http2'
+    )
+    assert.equal(
+      unscoped[`External/127.0.0.1:${port}/all`].callCount,
+      1,
+      'External/<host>/all should count a single call'
+    )
+    assert.equal(unscoped['External/all'].callCount, 1, 'External/all should count a single call')
+  })
+
+  await dispatcher.close()
+})

--- a/test/versioned/undici/issue-4250.js
+++ b/test/versioned/undici/issue-4250.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 New Relic Corporation. All rights reserved.
+ * Copyright 2026 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/versioned/undici/issue-4250.test.js
+++ b/test/versioned/undici/issue-4250.test.js
@@ -19,6 +19,8 @@ const assert = require('node:assert')
 const http2 = require('node:http2')
 const helper = require('../../lib/agent_helper')
 const fakeCert = require('../../lib/fake-cert')
+const { version: pkgVersion } = require('undici/package.json')
+const semver = require('semver')
 
 const cert = fakeCert({ commonName: 'localhost' })
 
@@ -84,7 +86,7 @@ test.afterEach((ctx) => {
 // h2 is negotiated on every supported undici major (>= 5), which keeps this test
 // deterministic across the versioned matrix. undici 8 flipped the `allowH2`
 // default to true, which is what surfaced this bug for users on an upgrade.
-test('undici HTTP/2 request should create exactly one external segment', async (t) => {
+test('undici HTTP/2 request should create exactly one external segment', { skip: semver.lt(pkgVersion, '5.25.0') }, async (t) => {
   const { agent, undici, origin, port } = t.nr
   const dispatcher = new undici.Agent({
     connect: { rejectUnauthorized: false },

--- a/test/versioned/undici/package.json
+++ b/test/versioned/undici/package.json
@@ -12,6 +12,7 @@
         "undici": ">=5.0.0"
       },
       "files": [
+        "issue-4250.js",
         "requests.test.js"
       ]
     }

--- a/test/versioned/undici/package.json
+++ b/test/versioned/undici/package.json
@@ -9,10 +9,10 @@
         "node": ">=22"
       },
       "dependencies": {
-        "undici": ">=5.0.0"
+        "undici": ">=5.0.0 <5.2.0 || >=5.3.0 <6.11.0 || >=6.11.1"
       },
       "files": [
-        "issue-4250.js",
+        "issue-4250.test.js",
         "requests.test.js"
       ]
     }


### PR DESCRIPTION
## Description

When undici negotiates HTTP/2 via ALPN, a single physical request was represented by **two** sibling external segments for the same URL — one attributed to `undici` and one to `http2`. This is because undici internally calls `http2.connect()` / `session.request()`, which the core HTTP/2 instrumentation also traces. The result inflated external call counts and aggregate external duration even though only one request is sent.

This is triggered by HTTP/2 negotiation, not a specific undici version: it reproduces on undici 5, 6, 7, and 8 whenever `allowH2` is enabled. undici 8 flipped the `allowH2` default to `true`, which is why users hit it after upgrading.

## How it works

undici owns the socket it uses for HTTP/2: it builds the socket through its internal connector factory `buildConnector` (`lib/core/connect.js`) and hands that socket to `http2.connect` via `createConnection`.

- A new orchestrion-based subscriber (`lib/subscribers/undici/build-connector.js`) instruments `buildConnector` and wraps the connector it returns so every socket undici produces is stamped with the well-known registry symbol `Symbol.for('newrelic.undici.connection')`.
- The core http2 instrumentation (`lib/instrumentation/core/http2.js`) reads that symbol off `session.socket` in `wrapConnect`; when present, it skips creating its own external segment.

The two instrumentations coordinate purely through the registered symbol (resolved by key on both sides), so neither imports the other. Direct `http2.connect()` usage (e.g. grpc-js, which uses http2 under the hood) is unaffected.

## Testing

- New versioned test `test/versioned/undici/issue-4250.js` asserts exactly one external segment (attributed to `undici`, not `http2`) for an HTTP/2 undici request. Deterministic across undici 5–8 (forces `allowH2: true`).
- New unit test `test/unit/lib/subscribers/undici-build-connector.test.js` covers the stamping subscriber.
- New http2 unit cases assert the segment is skipped when the socket is undici-owned and still created otherwise.
- `npm run versioned:major undici` and `npm run versioned:major grpc` both pass; `npm run lint` clean.

Fixes #4250
