### PR TITLE
feat: Updated GCP hostname to support more Cloud Run instance types

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -562,8 +562,8 @@ defaultConfig.definition = () => {
        * Deprecated and will be removed in v15 of the agent.
        * Please use `utilization.gcp_cloud_run.use_instance_as_host` instead.
        *
-       * When enabled, it will use GCP metadata id
-       * to set the hostname of the running application.
+       * When enabled, it will use the GCP metadata id to set the hostname
+       * of the running application (Services, Worker Pools, and Jobs).
        */
       gcp_use_instance_as_host: {
         default: true,
@@ -572,18 +572,20 @@ defaultConfig.definition = () => {
 
       gcp_cloud_run: {
         /**
-         * When enabled, and `gcp_use_instance_as_host` is also enabled, the
-         * GCP Cloud Run revision (`K_REVISION`) will be prepended to the
-         * instance id when setting the hostname of the running application,
-         * resulting in a hostname of `${K_REVISION}-${instance_id}`.
+         * If `true`, the agent prepends the Cloud Run revision name to the
+         * GCP instance id to form the hostname (`{revision}-{instance id}`)
+         * on Google Cloud Run. The revision name comes from `K_REVISION` on
+         * a Cloud Run Service, `CLOUD_RUN_REVISION` on a Cloud Run Worker Pool,
+         * and `CLOUD_RUN_EXECUTION` on a Cloud Run Job. Has no effect unless
+         * `utilization.gcp_use_instance_as_host` is also `true`.
          */
         include_revision_in_host: {
           default: false,
           formatter: boolean
         },
         /**
-         * When enabled, it will use GCP metadata id
-         * to set the hostname of the running application.
+         * When enabled, it will use the GCP metadata id to set the hostname
+         * of the running application (Services, Worker Pools, and Jobs).
          */
         use_instance_as_host: {
           default: true,

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1032,7 +1032,7 @@ function isGcpCloudRun(config, gcpId) {
   // in v15 of the agent) in favor of `gcp_cloud_run.use_instance_as_host`.
   const useInstanceAsHost = config.utilization.gcp_cloud_run.use_instance_as_host ||
       config.utilization.gcp_use_instance_as_host
-  return useInstanceAsHost && process.env.K_SERVICE && gcpId
+  return useInstanceAsHost && gcpId
 }
 
 /**

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -997,18 +997,21 @@ Config.prototype.getIPAddresses = function getIPAddresses() {
 
 /**
  * Determines the GCP Cloud Run host name from the instance id. When
- * `utilization.gcp_cloud_run.include_revision_in_host` is enabled and the
- * `K_REVISION` env var is present, the revision is prepended to the instance
- * id, resulting in a host name of `${K_REVISION}-${gcpId}`.
+ * `utilization.gcp_cloud_run.include_revision_in_host` is enabled and
+ * an instance-identifying env var (`K_REVISION`, `CLOUD_RUN_REVISION`, or
+ * `CLOUD_RUN_EXECUTION`) is present, the revision is prepended to the instance
+ * id, resulting in a host name of `${revision}-${gcpId}`.
  *
  * @param {object} config agent config
  * @param {string} gcpId GCP metadata ID
  * @returns {string} host name
  */
 function getGcpHostname(config, gcpId) {
-  if (config.utilization.gcp_cloud_run?.include_revision_in_host && process.env.K_REVISION) {
-    const hostname = `${process.env.K_REVISION}-${gcpId}`
-    logger.info('Using GCP revision and instance ID for host name: %s', hostname)
+  // Used to determine what environment the app is running in: services, worker pools, or jobs, respectively
+  const gcpEnvVar = process.env.K_REVISION ?? process.env.CLOUD_RUN_REVISION ?? process.env.CLOUD_RUN_EXECUTION
+  if (gcpEnvVar && config.utilization.gcp_cloud_run.include_revision_in_host) {
+    const hostname = `${gcpEnvVar}-${gcpId}`
+    logger.info('Using identifying GCP env var and instance ID for host name: %s', hostname)
     return hostname
   }
 

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -996,7 +996,7 @@ Config.prototype.getIPAddresses = function getIPAddresses() {
 }
 
 /**
- * Determines the GCP Cloud Run host name from the instance id. When
+ * Determines the Google Cloud Run host name from the instance id. When
  * `utilization.gcp_cloud_run.include_revision_in_host` is enabled and
  * an instance-identifying env var (`K_REVISION`, `CLOUD_RUN_REVISION`, or
  * `CLOUD_RUN_EXECUTION`) is present, the revision is prepended to the instance
@@ -1006,12 +1006,12 @@ Config.prototype.getIPAddresses = function getIPAddresses() {
  * @param {string} gcpId GCP metadata ID
  * @returns {string} host name
  */
-function getGcpHostname(config, gcpId) {
+function getGcrHostname(config, gcpId) {
   // Used to determine what environment the app is running in: services, worker pools, or jobs, respectively
-  const gcpEnvVar = process.env.K_REVISION ?? process.env.CLOUD_RUN_REVISION ?? process.env.CLOUD_RUN_EXECUTION
-  if (gcpEnvVar && config.utilization.gcp_cloud_run.include_revision_in_host) {
-    const hostname = `${gcpEnvVar}-${gcpId}`
-    logger.info('Using identifying GCP env var and instance ID for host name: %s', hostname)
+  const gcrEnvVar = process.env.K_REVISION ?? process.env.CLOUD_RUN_REVISION ?? process.env.CLOUD_RUN_EXECUTION
+  if (gcrEnvVar && config.utilization.gcp_cloud_run.include_revision_in_host) {
+    const hostname = `${gcrEnvVar}-${gcpId}`
+    logger.info('Using identifying Google Cloud Run env var and GCP instance ID for host name: %s', hostname)
     return hostname
   }
 
@@ -1021,18 +1021,19 @@ function getGcpHostname(config, gcpId) {
 
 /**
  * Identifies if `use_instance_as_host` is enabled and if the process
- * is in a Google Cloud Run environment.
+ * is in a Google Cloud Run (GCR) environment.
  * @param {object} config agent config
  * @param {string} gcpId GCP metadata ID
  * @returns {boolean} True if `use_instance_as_host` is set to true and
- * if GCP-identifying environment variable and metadata ID are present.
+ * if a GCR-identifying environment variable and metadata ID are present.
  */
-function isGcpCloudRun(config, gcpId) {
+function shouldUseGcrHostname(config, gcpId) {
   // TODO: `gcp_use_instance_as_host` is deprecated (will be removed
   // in v15 of the agent) in favor of `gcp_cloud_run.use_instance_as_host`.
   const useInstanceAsHost = config.utilization.gcp_cloud_run.use_instance_as_host ||
       config.utilization.gcp_use_instance_as_host
-  return useInstanceAsHost && gcpId
+  const isCloudRun = process.env.K_SERVICE || process.env.CLOUD_RUN_JOB || process.env.CLOUD_RUN_WORKER_POOL
+  return useInstanceAsHost && isCloudRun && gcpId
 }
 
 /**
@@ -1067,8 +1068,8 @@ function getHostnameSafe(gcpId = null) {
     if (config.heroku.use_dyno_names && process.env.DYNO) {
       _hostname = process.env.DYNO || os.hostname()
       logger.info('Using Heroku dyno name for host name: %s', _hostname)
-    } else if (isGcpCloudRun(config, gcpId)) {
-      _hostname = getGcpHostname(config, gcpId)
+    } else if (shouldUseGcrHostname(config, gcpId)) {
+      _hostname = getGcrHostname(config, gcpId)
     } else {
       _hostname = os.hostname()
       logger.info('Using OS hostname for host name: %s', _hostname)

--- a/lib/utilization/gcp-info.js
+++ b/lib/utilization/gcp-info.js
@@ -52,8 +52,10 @@ function fetchGCPInfo(agent, callback) {
 
       // Most GCP services have id, zone, machineType, and name,
       // but GCP Cloud Run only has id and zone.
-      // If K_SERVICE is set, we are in GCP Cloud Run.
-      const needAllKeys = !process.env.K_SERVICE
+      // If K_SERVICE is set, we are in a Cloud Run service;
+      // if CLOUD_RUN_JOB is set, we are in a Cloud Run job;
+      // if CLOUD_RUN_WORKER_POOL, we are in a Cloud Run worker pool.
+      const needAllKeys = !(process.env.K_SERVICE || process.env.CLOUD_RUN_JOB || process.env.CLOUD_RUN_WORKER_POOL)
       const results = common.getKeys(data, ['id', 'zone', 'machineType', 'name'], needAllKeys)
       if (!results?.id || !results?.zone) {
         // id and zone are required

--- a/test/unit/collector/facts.test.js
+++ b/test/unit/collector/facts.test.js
@@ -853,6 +853,8 @@ test('host facts', async (t) => {
     delete process.env.K_REVISION
     delete process.env.CLOUD_RUN_REVISION
     delete process.env.CLOUD_RUN_EXECUTION
+    delete process.env.CLOUD_RUN_JOB
+    delete process.env.CLOUD_RUN_WORKER_POOL
 
     // Restore system-info cache
     if (ctx.systemInfoPath) {
@@ -997,15 +999,15 @@ test('host facts', async (t) => {
   })
 
   await t.test(
-    'should be CLOUD_RUN_REVISION-GCPid when gcp_cloud_run.include_revision_in_host is true and K_REVISION is not set',
+    'should be CLOUD_RUN_REVISION-GCPid on a Cloud Run worker pool when gcp_cloud_run.include_revision_in_host is true',
     (t, end) => {
       const { agent, facts } = t.nr
 
       agent.config.utilization = {
         gcp_use_instance_as_host: true,
-        gcp_cloud_run: { include_revision_in_host: true }
+        gcp_cloud_run: { use_instance_as_host: true, include_revision_in_host: true }
       }
-      process.env.K_SERVICE = 'mock-service'
+      process.env.CLOUD_RUN_WORKER_POOL = 'mock-worker-pool'
       process.env.CLOUD_RUN_REVISION = 'mock-cloud-run-revision'
 
       facts(agent, (result) => {
@@ -1020,15 +1022,15 @@ test('host facts', async (t) => {
   )
 
   await t.test(
-    'should be CLOUD_RUN_EXECUTION-GCPid when gcp_cloud_run.include_revision_in_host is true and neither K_REVISION nor CLOUD_RUN_REVISION is set',
+    'should be CLOUD_RUN_EXECUTION-GCPid on a Cloud Run job when gcp_cloud_run.include_revision_in_host is true',
     (t, end) => {
       const { agent, facts } = t.nr
 
       agent.config.utilization = {
         gcp_use_instance_as_host: true,
-        gcp_cloud_run: { include_revision_in_host: true }
+        gcp_cloud_run: { use_instance_as_host: true, include_revision_in_host: true }
       }
-      process.env.K_SERVICE = 'mock-service'
+      process.env.CLOUD_RUN_JOB = 'mock-job'
       process.env.CLOUD_RUN_EXECUTION = 'mock-cloud-run-execution'
 
       facts(agent, (result) => {
@@ -1049,7 +1051,7 @@ test('host facts', async (t) => {
 
       agent.config.utilization = {
         gcp_use_instance_as_host: true,
-        gcp_cloud_run: { include_revision_in_host: true }
+        gcp_cloud_run: { use_instance_as_host: true, include_revision_in_host: true }
       }
       process.env.K_SERVICE = 'mock-service'
       process.env.K_REVISION = 'mock-revision'
@@ -1074,9 +1076,9 @@ test('host facts', async (t) => {
 
       agent.config.utilization = {
         gcp_use_instance_as_host: true,
-        gcp_cloud_run: { include_revision_in_host: true }
+        gcp_cloud_run: { use_instance_as_host: true, include_revision_in_host: true }
       }
-      process.env.K_SERVICE = 'mock-service'
+      process.env.CLOUD_RUN_WORKER_POOL = 'mock-worker-pool'
       process.env.CLOUD_RUN_REVISION = 'mock-cloud-run-revision'
       process.env.CLOUD_RUN_EXECUTION = 'mock-cloud-run-execution'
 
@@ -1090,6 +1092,24 @@ test('host facts', async (t) => {
       })
     }
   )
+
+  await t.test('should not be GCP id when none of the Cloud Run identifying env vars are set', (t, end) => {
+    const { agent, facts } = t.nr
+
+    agent.config.utilization = {
+      gcp_use_instance_as_host: true,
+      gcp_cloud_run: { use_instance_as_host: true, include_revision_in_host: true }
+    }
+
+    facts(agent, (result) => {
+      assert.equal(
+        result.host,
+        os.hostname(),
+        'Hostname should not be set to GCP instance ID outside of a Cloud Run environment'
+      )
+      end()
+    })
+  })
 })
 
 function mockIpAddresses(values) {

--- a/test/unit/collector/facts.test.js
+++ b/test/unit/collector/facts.test.js
@@ -851,6 +851,8 @@ test('host facts', async (t) => {
     helper.unloadAgent(ctx.nr.agent)
     delete process.env.K_SERVICE
     delete process.env.K_REVISION
+    delete process.env.CLOUD_RUN_REVISION
+    delete process.env.CLOUD_RUN_EXECUTION
 
     // Restore system-info cache
     if (ctx.systemInfoPath) {
@@ -1010,6 +1012,101 @@ test('host facts', async (t) => {
       end()
     })
   })
+
+  await t.test(
+    'should be CLOUD_RUN_REVISION-GCPid when gcp_cloud_run.include_revision_in_host is true and K_REVISION is not set',
+    (t, end) => {
+      const { agent, facts } = t.nr
+
+      agent.config.utilization = {
+        gcp_use_instance_as_host: true,
+        gcp_cloud_run: { include_revision_in_host: true }
+      }
+      process.env.K_SERVICE = 'mock-service'
+      process.env.CLOUD_RUN_REVISION = 'mock-cloud-run-revision'
+
+      facts(agent, (result) => {
+        assert.equal(
+          result.host,
+          'mock-cloud-run-revision-mock-gcp-instance-id',
+          'Hostname should include the Cloud Run revision and instance ID'
+        )
+        end()
+      })
+    }
+  )
+
+  await t.test(
+    'should be CLOUD_RUN_EXECUTION-GCPid when gcp_cloud_run.include_revision_in_host is true and neither K_REVISION nor CLOUD_RUN_REVISION is set',
+    (t, end) => {
+      const { agent, facts } = t.nr
+
+      agent.config.utilization = {
+        gcp_use_instance_as_host: true,
+        gcp_cloud_run: { include_revision_in_host: true }
+      }
+      process.env.K_SERVICE = 'mock-service'
+      process.env.CLOUD_RUN_EXECUTION = 'mock-cloud-run-execution'
+
+      facts(agent, (result) => {
+        assert.equal(
+          result.host,
+          'mock-cloud-run-execution-mock-gcp-instance-id',
+          'Hostname should include the Cloud Run execution ID and instance ID'
+        )
+        end()
+      })
+    }
+  )
+
+  await t.test(
+    'should prefer K_REVISION over CLOUD_RUN_REVISION and CLOUD_RUN_EXECUTION when all are set',
+    (t, end) => {
+      const { agent, facts } = t.nr
+
+      agent.config.utilization = {
+        gcp_use_instance_as_host: true,
+        gcp_cloud_run: { include_revision_in_host: true }
+      }
+      process.env.K_SERVICE = 'mock-service'
+      process.env.K_REVISION = 'mock-revision'
+      process.env.CLOUD_RUN_REVISION = 'mock-cloud-run-revision'
+      process.env.CLOUD_RUN_EXECUTION = 'mock-cloud-run-execution'
+
+      facts(agent, (result) => {
+        assert.equal(
+          result.host,
+          'mock-revision-mock-gcp-instance-id',
+          'Hostname should prefer K_REVISION over the other identifying env vars'
+        )
+        end()
+      })
+    }
+  )
+
+  await t.test(
+    'should prefer CLOUD_RUN_REVISION over CLOUD_RUN_EXECUTION when K_REVISION is not set',
+    (t, end) => {
+      const { agent, facts } = t.nr
+
+      agent.config.utilization = {
+        gcp_use_instance_as_host: true,
+        gcp_cloud_run: { include_revision_in_host: true }
+      }
+      process.env.K_SERVICE = 'mock-service'
+      process.env.CLOUD_RUN_REVISION = 'mock-cloud-run-revision'
+      process.env.CLOUD_RUN_EXECUTION = 'mock-cloud-run-execution'
+
+      facts(agent, (result) => {
+        assert.equal(
+          result.host,
+          'mock-cloud-run-revision-mock-gcp-instance-id',
+          'Hostname should prefer CLOUD_RUN_REVISION over CLOUD_RUN_EXECUTION'
+        )
+        end()
+      })
+    }
+  )
 })
 
 function mockIpAddresses(values) {

--- a/test/unit/collector/facts.test.js
+++ b/test/unit/collector/facts.test.js
@@ -910,24 +910,7 @@ test('host facts', async (t) => {
     })
   })
 
-  await t.test('should not be GCP id when K_SERVICE is not present', (t, end) => {
-    const { agent, facts } = t.nr
-
-    agent.config.utilization = {
-      gcp_use_instance_as_host: true, // will be removed in v15
-      gcp_cloud_run: {
-        use_instance_as_host: true,
-        include_revision_in_host: false
-      }
-    }
-
-    facts(agent, (result) => {
-      assert.equal(result.host, os.hostname(), 'Hostname should not be set to GCP instance ID')
-      end()
-    })
-  })
-
-  await t.test('should not be GCP id when K_SERVICE is set but gcp_cloud_run.use_instance_as_host is false', (t, end) => {
+  await t.test('should not be GCP id when K_SERVICE is set but utilization.gcp_use_instance_as_host is false', (t, end) => {
     const { agent, facts } = t.nr
 
     agent.config.utilization = {


### PR DESCRIPTION
## Description

Spec 832 requires us to look at other Google Cloud Run environment variables to craft our special GCP hostname override if the coordinating config options are set to `true` (`gcp_use_instance_as_host` and `gcp_cloud_run.include_revision_in_host`). Currently, we only use `K_REVISION` if `include_revision_in_host` is `true`, but that env var only applies to services. **This PR adds support for worker pools** (via `CLOUD_RUN_REVISION`) **and jobs** (via `CLOUD_RUN_EXECUTION`). The order to check these env vars is `K_REVISION`, then `CLOUD_RUN_REVISION`, and then finally `CLOUD_RUN_EXECUTION`.

Also, we were using `K_SERVICE` before we constructed the hostname with the revision to detect if the app is in a GCP environment. However, jobs and workers pools will not have `K_SERVICE` set, they will have `CLOUD_RUN_JOB` and `CLOUD_RUN_WORKER_POOL` set instead, [according to Google's docs](https://docs.cloud.google.com/run/docs/container-contract#env-vars). We cannot get rid of this detection because then this Cloud-Run-specific logic would apply to other GCP services.

Also, in `gcp-info.js`, we needed to modify the boolean to determine if we were in Cloud Run vs another GCP service to include jobs and worker pools.

Follow up:
- [X] ~~Our `utilization.gcp_use_instance_as_host` config option differs from the spec's `utilization.gcp_cloud_run.use_instance_as_host`. What would be the impact on customers if we renamed the config option to be spec-compliant?~~ Solved in PR https://github.com/newrelic/node-newrelic/pull/4258

## How to Test

```
node --test test/unit/collector/facts.test.js
```

## Related Issues

Closes #4254