### PR TITLE
chore: Deprecated `utilization.gcp_use_instance_as_host` in favor of `utilization.gcp_cloud_run.use_instance_as_host`

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -559,6 +559,9 @@ defaultConfig.definition = () => {
       },
 
       /**
+       * Deprecated and will be removed in v15 of the agent.
+       * Please use `utilization.gcp_cloud_run.use_instance_as_host` instead.
+       *
        * When enabled, it will use GCP metadata id
        * to set the hostname of the running application.
        */
@@ -577,7 +580,15 @@ defaultConfig.definition = () => {
         include_revision_in_host: {
           default: false,
           formatter: boolean
-        }
+        },
+        /**
+         * When enabled, it will use GCP metadata id
+         * to set the hostname of the running application.
+         */
+        use_instance_as_host: {
+          default: true,
+          formatter: boolean
+        },
       }
     },
     transaction_tracer: {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1048,7 +1048,12 @@ function getHostnameSafe(gcpId = null) {
     if (config.heroku.use_dyno_names && process.env.DYNO) {
       _hostname = process.env.DYNO || os.hostname()
       logger.info('Using Heroku dyno name for host name: %s', _hostname)
-    } else if (config.utilization.gcp_use_instance_as_host && process.env.K_SERVICE && gcpId) {
+    } else if (
+      // TODO: `gcp_use_instance_as_host` is deprecated (will be removed
+      // in v15 of the agent) in favor of `gcp_cloud_run.use_instance_as_host`.
+      (config.utilization.gcp_cloud_run.use_instance_as_host ||
+      config.utilization.gcp_use_instance_as_host) &&
+      process.env.K_SERVICE && gcpId) {
       _hostname = getGcpHostname(config, gcpId)
     } else {
       _hostname = os.hostname()

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1017,6 +1017,22 @@ function getGcpHostname(config, gcpId) {
 }
 
 /**
+ * Identifies if `use_instance_as_host` is enabled and if the process
+ * is in a Google Cloud Run environment.
+ * @param {object} config agent config
+ * @param {string} gcpId GCP metadata ID
+ * @returns {boolean} True if `use_instance_as_host` is set to true and
+ * if GCP-identifying environment variable and metadata ID are present.
+ */
+function isGcpCloudRun(config, gcpId) {
+  // TODO: `gcp_use_instance_as_host` is deprecated (will be removed
+  // in v15 of the agent) in favor of `gcp_cloud_run.use_instance_as_host`.
+  const useInstanceAsHost = config.utilization.gcp_cloud_run.use_instance_as_host ||
+      config.utilization.gcp_use_instance_as_host
+  return useInstanceAsHost && process.env.K_SERVICE && gcpId
+}
+
+/**
  * Gets the system's host name. If that fails, it just returns ipv4/6
  * based on the user's process_host.ipv_preference setting.
  * @param {string} gcpId GCP metadata ID
@@ -1048,12 +1064,7 @@ function getHostnameSafe(gcpId = null) {
     if (config.heroku.use_dyno_names && process.env.DYNO) {
       _hostname = process.env.DYNO || os.hostname()
       logger.info('Using Heroku dyno name for host name: %s', _hostname)
-    } else if (
-      // TODO: `gcp_use_instance_as_host` is deprecated (will be removed
-      // in v15 of the agent) in favor of `gcp_cloud_run.use_instance_as_host`.
-      (config.utilization.gcp_cloud_run.use_instance_as_host ||
-      config.utilization.gcp_use_instance_as_host) &&
-      process.env.K_SERVICE && gcpId) {
+    } else if (isGcpCloudRun(config, gcpId)) {
       _hostname = getGcpHostname(config, gcpId)
     } else {
       _hostname = os.hostname()

--- a/test/unit/collector/facts.test.js
+++ b/test/unit/collector/facts.test.js
@@ -639,7 +639,9 @@ test('display_host facts', async (t) => {
     }
 
     ctx.nr.agent = helper.loadMockedAgent(structuredClone(DISABLE_ALL_DETECTIONS))
-    ctx.nr.agent.config.utilization = {}
+    ctx.nr.agent.config.utilization = {
+      gcp_cloud_run: {}
+    }
 
     ctx.nr.osNetworkInterfaces = os.networkInterfaces
     ctx.nr.osHostname = os.hostname
@@ -840,7 +842,9 @@ test('host facts', async (t) => {
     }
 
     ctx.nr.agent = helper.loadMockedAgent(structuredClone(DISABLE_ALL_DETECTIONS))
-    ctx.nr.agent.config.utilization = null
+    ctx.nr.agent.config.utilization = {
+      gcp_cloud_run: {}
+    }
   })
 
   t.afterEach((ctx) => {
@@ -870,7 +874,13 @@ test('host facts', async (t) => {
   await t.test('should be GCP id when K_SERVICE is set', (t, end) => {
     const { agent, facts } = t.nr
 
-    agent.config.utilization = { gcp_use_instance_as_host: true }
+    agent.config.utilization = {
+      gcp_use_instance_as_host: true, // will be removed in v15
+      gcp_cloud_run: {
+        use_instance_as_host: true,
+        include_revision_in_host: false
+      }
+    }
     process.env.K_SERVICE = 'mock-service'
 
     facts(agent, (result) => {
@@ -883,7 +893,13 @@ test('host facts', async (t) => {
     const { agent, facts } = t.nr
     agent.config.getDisplayHost()
 
-    agent.config.utilization = { gcp_use_instance_as_host: true }
+    agent.config.utilization = {
+      gcp_use_instance_as_host: true, // will be removed in v15
+      gcp_cloud_run: {
+        use_instance_as_host: true,
+        include_revision_in_host: false
+      }
+    }
     process.env.K_SERVICE = 'mock-service'
 
     facts(agent, (result) => {
@@ -895,7 +911,13 @@ test('host facts', async (t) => {
   await t.test('should not be GCP id when K_SERVICE is not present', (t, end) => {
     const { agent, facts } = t.nr
 
-    agent.config.utilization = { gcp_use_instance_as_host: true }
+    agent.config.utilization = {
+      gcp_use_instance_as_host: true, // will be removed in v15
+      gcp_cloud_run: {
+        use_instance_as_host: true,
+        include_revision_in_host: false
+      }
+    }
 
     facts(agent, (result) => {
       assert.equal(result.host, os.hostname(), 'Hostname should not be set to GCP instance ID')
@@ -903,10 +925,16 @@ test('host facts', async (t) => {
     })
   })
 
-  await t.test('should not be GCP id when K_SERVICE is set but utilization.gcp_use_instance_as_host is false', (t, end) => {
+  await t.test('should not be GCP id when K_SERVICE is set but gcp_cloud_run.use_instance_as_host is false', (t, end) => {
     const { agent, facts } = t.nr
 
-    agent.config.utilization = { gcp_use_instance_as_host: false }
+    agent.config.utilization = {
+      gcp_use_instance_as_host: false, // will be removed in v15
+      gcp_cloud_run: {
+        use_instance_as_host: false,
+        include_revision_in_host: false
+      }
+    }
     process.env.K_SERVICE = 'mock-service'
 
     facts(agent, (result) => {
@@ -919,8 +947,11 @@ test('host facts', async (t) => {
     const { agent, facts } = t.nr
 
     agent.config.utilization = {
-      gcp_use_instance_as_host: true,
-      gcp_cloud_run: { include_revision_in_host: true }
+      gcp_use_instance_as_host: true, // will be removed in v15
+      gcp_cloud_run: {
+        use_instance_as_host: true,
+        include_revision_in_host: true
+      }
     }
     process.env.K_SERVICE = 'mock-service'
     process.env.K_REVISION = 'mock-revision'
@@ -939,8 +970,11 @@ test('host facts', async (t) => {
     const { agent, facts } = t.nr
 
     agent.config.utilization = {
-      gcp_use_instance_as_host: true,
-      gcp_cloud_run: { include_revision_in_host: true }
+      gcp_use_instance_as_host: true, // will be removed in v15
+      gcp_cloud_run: {
+        use_instance_as_host: true,
+        include_revision_in_host: true
+      }
     }
     process.env.K_SERVICE = 'mock-service'
 
@@ -958,8 +992,11 @@ test('host facts', async (t) => {
     const { agent, facts } = t.nr
 
     agent.config.utilization = {
-      gcp_use_instance_as_host: true,
-      gcp_cloud_run: { include_revision_in_host: false }
+      gcp_use_instance_as_host: true, // will be removed in v15
+      gcp_cloud_run: {
+        use_instance_as_host: true,
+        include_revision_in_host: false
+      }
     }
     process.env.K_SERVICE = 'mock-service'
     process.env.K_REVISION = 'mock-revision'


### PR DESCRIPTION
## Description

Adhering to Spec 832, the config option `utilization.gcp_use_instance_as_host` needs to be renamed to `utilization.gcp_cloud_run.use_instance_as_host` to match its intended sibling `utilization.gcp_cloud_run.include_revision_in_host`. This PR **deprecates** `gcp_use_instance_as_host` and adds `gcp_cloud_run.use_instance_as_host`; they are intentional duplicates. In the next major version of the agent (v15), we will completely remove `gcp_use_instance_as_host`.

## How to Test

```
node --test test/unit/collector/facts.test.js
```

## Related Issues

N/A, precursor to issue #4254. 