### PR TITLE
chore: Regenerated agent config json schema

### DIFF
--- a/.fleetControl/schemas/config.json
+++ b/.fleetControl/schemas/config.json
@@ -379,7 +379,7 @@
         "gcp_use_instance_as_host": {
           "type": "boolean",
           "default": true,
-          "description": "Deprecated and will be removed in v15 of the agent. Please use `utilization.gcp_cloud_run.use_instance_as_host` instead. When enabled, it will use GCP metadata id to set the hostname of the running application."
+          "description": "Deprecated and will be removed in v15 of the agent. Please use `utilization.gcp_cloud_run.use_instance_as_host` instead. When enabled, it will use the GCP metadata id to set the hostname of the running application (Services, Worker Pools, and Jobs)."
         },
         "gcp_cloud_run": {
           "type": "object",
@@ -387,12 +387,12 @@
             "include_revision_in_host": {
               "type": "boolean",
               "default": false,
-              "description": "When enabled, and `gcp_use_instance_as_host` is also enabled, the GCP Cloud Run revision (`K_REVISION`) will be prepended to the instance id when setting the hostname of the running application, resulting in a hostname of `${K_REVISION}-${instance_id}`."
+              "description": "If `true`, the agent prepends the Cloud Run revision name to the GCP instance id to form the hostname (`{revision}-{instance id}`) on Google Cloud Run. The revision name comes from `K_REVISION` on a Cloud Run Service, `CLOUD_RUN_REVISION` on a Cloud Run Worker Pool, and `CLOUD_RUN_EXECUTION` on a Cloud Run Job. Has no effect unless `utilization.gcp_use_instance_as_host` is also `true`."
             },
             "use_instance_as_host": {
               "type": "boolean",
               "default": true,
-              "description": "When enabled, it will use GCP metadata id to set the hostname of the running application."
+              "description": "When enabled, it will use the GCP metadata id to set the hostname of the running application (Services, Worker Pools, and Jobs)."
             }
           },
           "additionalProperties": true


### PR DESCRIPTION
Auto-generated after 67bfd0dc79a189ddd984a13e217081d2e73167c0 changed the config
definition on `main`.

Regenerated by running `generate-schema.js` against the
merged config. Review the schema diff before merging.