### PR TITLE
chore: Regenerated agent config json schema

### DIFF
--- a/.fleetControl/schemas/config.json
+++ b/.fleetControl/schemas/config.json
@@ -2240,6 +2240,36 @@
       },
       "additionalProperties": true,
       "description": "Stanza for customizing behavior for apollo server instrumentation"
+    },
+    "kafka": {
+      "type": "object",
+      "properties": {
+        "metrics": {
+          "type": "object",
+          "properties": {
+            "cluster": {
+              "type": "object",
+              "properties": {
+                "metrics": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Enables capture of the `MessageBroker/Kafka/Cluster/{cluster_id}/{Produce|Consume}/{topic_name}` metrics. Disabled by default."
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true,
+      "description": "Stanza for customizing behavior for Kafka instrumentation"
     }
   },
   "required": [


### PR DESCRIPTION
Auto-generated after 3be98f12810535e0abf274a99f6cafad9e19284a changed the config
definition on `main`.

Regenerated by running `generate-schema.js` against the
merged config. Review the schema diff before merging.