### PR TITLE
feat: Added `browser_monitoring.version` configuration option

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -770,7 +770,26 @@ Agent.prototype._enabledChange = function _enabledChange() {
  * always occurs after handling a response from a connect call.
  */
 Agent.prototype._configChange = function _configChange() {
+  this._checkBrowserMonitoringVersion()
   this.collector.reportSettings()
+}
+
+/**
+ * Logs a local warning if a customer-requested browser agent loader version
+ * was not resolved by the collector. A missing loader does not necessarily
+ * mean the requested version was bad, since the loader is also omitted when
+ * `browser_monitoring.loader` is `'none'` or browser monitoring is disabled,
+ * so those cases are excluded.
+ */
+Agent.prototype._checkBrowserMonitoringVersion = function _checkBrowserMonitoringVersion() {
+  const bm = this.config.browser_monitoring
+  if (bm.version && bm.enable && bm.loader !== 'none' && !bm.js_agent_loader) {
+    logger.warn(
+      'browser_monitoring.version was set to "%s" but no js_agent_loader was returned by ' +
+        'the collector; the requested version may not have been resolved.',
+      bm.version
+    )
+  }
 }
 
 Agent.prototype._addIntrinsicAttrsFromTransaction = _addIntrinsicAttrsFromTransaction

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -715,6 +715,7 @@ Agent.prototype.reconfigure = function reconfigure(configuration) {
   }
 
   this.config.onConnect(configuration)
+  this._checkBrowserMonitoringVersion()
 }
 
 /**
@@ -770,7 +771,6 @@ Agent.prototype._enabledChange = function _enabledChange() {
  * always occurs after handling a response from a connect call.
  */
 Agent.prototype._configChange = function _configChange() {
-  this._checkBrowserMonitoringVersion()
   this.collector.reportSettings()
 }
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -715,7 +715,6 @@ Agent.prototype.reconfigure = function reconfigure(configuration) {
   }
 
   this.config.onConnect(configuration)
-  this._checkBrowserMonitoringVersion()
 }
 
 /**
@@ -771,6 +770,7 @@ Agent.prototype._enabledChange = function _enabledChange() {
  * always occurs after handling a response from a connect call.
  */
 Agent.prototype._configChange = function _configChange() {
+  this._checkBrowserMonitoringVersion()
   this.collector.reportSettings()
 }
 

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -823,8 +823,7 @@ defaultConfig.definition = () => {
        * for which versions are currently available and supported.
        */
       version: {
-        default: '',
-        env: 'NEW_RELIC_BROWSER_MONITOR_VERSION'
+        default: ''
       }
     },
     /**

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -816,6 +816,15 @@ defaultConfig.definition = () => {
         formatter: boolean,
         default: false,
         env: 'NEW_RELIC_BROWSER_MONITOR_DEBUG'
+      },
+      /**
+       * The browser agent loader version to request, e.g. `"1.317.0"`. See the
+       * [browser agent EOL policy](https://docs.newrelic.com/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy/)
+       * for which versions are currently available and supported.
+       */
+      version: {
+        default: '',
+        env: 'NEW_RELIC_BROWSER_MONITOR_VERSION'
       }
     },
     /**

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -276,29 +276,7 @@ Config.prototype.onConnect = function onConnect(json, recursion) {
     this._fromServer(json, key)
   }
 
-  if (!recursion) {
-    this._checkBrowserMonitoringVersion()
-  }
-
   this.emit('change', this)
-}
-
-/**
- * Logs a local warning if a customer-requested browser agent loader version
- * was not resolved by the collector. A missing loader does not necessarily
- * mean the requested version was bad, since the loader is also omitted when
- * `browser_monitoring.loader` is `'none'` or browser monitoring is disabled,
- * so those cases are excluded.
- */
-Config.prototype._checkBrowserMonitoringVersion = function _checkBrowserMonitoringVersion() {
-  const bm = this.browser_monitoring
-  if (bm.version && bm.enable && bm.loader !== 'none' && !bm.js_agent_loader) {
-    logger.warn(
-      'browser_monitoring.version was set to "%s" but no js_agent_loader was returned by ' +
-        'the collector; the requested version may not have been resolved.',
-      bm.version
-    )
-  }
 }
 
 /**

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -276,7 +276,29 @@ Config.prototype.onConnect = function onConnect(json, recursion) {
     this._fromServer(json, key)
   }
 
+  if (!recursion) {
+    this._checkBrowserMonitoringVersion()
+  }
+
   this.emit('change', this)
+}
+
+/**
+ * Logs a local warning if a customer-requested browser agent loader version
+ * was not resolved by the collector. A missing loader does not necessarily
+ * mean the requested version was bad, since the loader is also omitted when
+ * `browser_monitoring.loader` is `'none'` or browser monitoring is disabled,
+ * so those cases are excluded.
+ */
+Config.prototype._checkBrowserMonitoringVersion = function _checkBrowserMonitoringVersion() {
+  const bm = this.browser_monitoring
+  if (bm.version && bm.enable && bm.loader !== 'none' && !bm.js_agent_loader) {
+    logger.warn(
+      'browser_monitoring.version was set to "%s" but no js_agent_loader was returned by ' +
+        'the collector; the requested version may not have been resolved.',
+      bm.version
+    )
+  }
 }
 
 /**

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -592,7 +592,6 @@ Config.prototype._fromServer = function _fromServer(params, key) {
     case 'collect_ai':
       if (!params?.agent_config?.['ai_monitoring.enabled']) {
         this._disableOption(params.collect_ai, 'ai_monitoring')
-        this.emit('change', this)
       }
       break
     case 'ai_monitoring.enabled':

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -455,6 +455,10 @@ Config.prototype._fromServer = function _fromServer(params, key) {
       this._updateNestedIfChangedRaw(params, this.browser_monitoring, key, 'loader')
       break
 
+    case 'browser_monitoring.loader_version':
+      this._updateNestedIfChangedRaw(params, this.browser_monitoring, key, 'loader_version')
+      break
+
     // these are used by browser_monitoring
     // and the api.getRUMHeader() method
     case 'js_agent_file':

--- a/test/unit/agent/agent.test.js
+++ b/test/unit/agent/agent.test.js
@@ -17,6 +17,7 @@ const configurator = require('../../../lib/config')
 const Agent = require('../../../lib/agent')
 const Transaction = require('../../../lib/transaction')
 const CollectorResponse = require('../../../lib/collector/response')
+const logger = require('../../../lib/logger')
 
 const fs = require('node:fs')
 const os = require('node:os')
@@ -1566,6 +1567,63 @@ test('_reset*', async (t) => {
     const { agent } = t.nr
     agent._resetCustomEvents()
     assert.equal(agent.customEventAggregator.clear.callCount, 1)
+  })
+})
+
+test('_checkBrowserMonitoringVersion', async (t) => {
+  t.beforeEach((ctx) => {
+    const agent = helper.loadMockedAgent()
+
+    const sandbox = sinon.createSandbox()
+    sandbox.stub(agent.collector, 'reportSettings')
+    sandbox.stub(logger, 'warn')
+    ctx.nr = { agent, sandbox }
+  })
+
+  t.afterEach((ctx) => {
+    helper.unloadAgent(ctx.nr.agent)
+    ctx.nr.sandbox.restore()
+  })
+
+  await t.test('should warn when version is set but no js_agent_loader is returned', (t) => {
+    const { agent } = t.nr
+    agent.config.browser_monitoring.version = '1.317.0'
+    agent.config.browser_monitoring.enable = true
+    agent._configChange()
+    assert.equal(logger.warn.callCount, 1)
+  })
+
+  await t.test('should not warn when browser_monitoring.version is unset', (t) => {
+    const { agent } = t.nr
+    agent.config.browser_monitoring.enable = true
+    agent._configChange()
+    assert.equal(logger.warn.callCount, 0)
+  })
+
+  await t.test('should not warn when browser_monitoring.loader is "none"', (t) => {
+    const { agent } = t.nr
+    agent.config.browser_monitoring.version = '1.317.0'
+    agent.config.browser_monitoring.enable = true
+    agent.config.browser_monitoring.loader = 'none'
+    agent._configChange()
+    assert.equal(logger.warn.callCount, 0)
+  })
+
+  await t.test('should not warn when browser_monitoring.enable is false', (t) => {
+    const { agent } = t.nr
+    agent.config.browser_monitoring.version = '1.317.0'
+    agent.config.browser_monitoring.enable = false
+    agent._configChange()
+    assert.equal(logger.warn.callCount, 0)
+  })
+
+  await t.test('should not warn when js_agent_loader is returned', (t) => {
+    const { agent } = t.nr
+    agent.config.browser_monitoring.version = '1.317.0'
+    agent.config.browser_monitoring.enable = true
+    agent.config.browser_monitoring.js_agent_loader = 'function(){}'
+    agent._configChange()
+    assert.equal(logger.warn.callCount, 0)
   })
 })
 

--- a/test/unit/agent/agent.test.js
+++ b/test/unit/agent/agent.test.js
@@ -1589,14 +1589,14 @@ test('_checkBrowserMonitoringVersion', async (t) => {
     const { agent } = t.nr
     agent.config.browser_monitoring.version = '1.317.0'
     agent.config.browser_monitoring.enable = true
-    agent._configChange()
+    agent._checkBrowserMonitoringVersion()
     assert.equal(logger.warn.callCount, 1)
   })
 
   await t.test('should not warn when browser_monitoring.version is unset', (t) => {
     const { agent } = t.nr
     agent.config.browser_monitoring.enable = true
-    agent._configChange()
+    agent._checkBrowserMonitoringVersion()
     assert.equal(logger.warn.callCount, 0)
   })
 
@@ -1605,7 +1605,7 @@ test('_checkBrowserMonitoringVersion', async (t) => {
     agent.config.browser_monitoring.version = '1.317.0'
     agent.config.browser_monitoring.enable = true
     agent.config.browser_monitoring.loader = 'none'
-    agent._configChange()
+    agent._checkBrowserMonitoringVersion()
     assert.equal(logger.warn.callCount, 0)
   })
 
@@ -1613,7 +1613,7 @@ test('_checkBrowserMonitoringVersion', async (t) => {
     const { agent } = t.nr
     agent.config.browser_monitoring.version = '1.317.0'
     agent.config.browser_monitoring.enable = false
-    agent._configChange()
+    agent._checkBrowserMonitoringVersion()
     assert.equal(logger.warn.callCount, 0)
   })
 
@@ -1622,8 +1622,23 @@ test('_checkBrowserMonitoringVersion', async (t) => {
     agent.config.browser_monitoring.version = '1.317.0'
     agent.config.browser_monitoring.enable = true
     agent.config.browser_monitoring.js_agent_loader = 'function(){}'
-    agent._configChange()
+    agent._checkBrowserMonitoringVersion()
     assert.equal(logger.warn.callCount, 0)
+  })
+
+  await t.test('should run the check from reconfigure() after a connect response', (t) => {
+    const { agent } = t.nr
+    agent.config.browser_monitoring.version = '1.321.0'
+    agent.config.browser_monitoring.enable = true
+
+    agent.reconfigure({
+      'browser_monitoring.loader_version': '1.321.0',
+      js_agent_loader: 'function(){}'
+    })
+
+    assert.equal(logger.warn.callCount, 0)
+    assert.equal(agent.config.browser_monitoring.loader_version, '1.321.0')
+    assert.equal(agent.config.browser_monitoring.js_agent_loader, 'function(){}')
   })
 })
 

--- a/test/unit/config/config-env.test.js
+++ b/test/unit/config/config-env.test.js
@@ -904,6 +904,13 @@ test('when overriding configuration values via environment variables', async (t)
     })
   })
 
+  await t.test('should pick up browser_monitoring.version via the standard derived env var name', (t, end) => {
+    idempotentEnv({ NEW_RELIC_BROWSER_MONITORING_VERSION: '1.317.0' }, function (tc) {
+      assert.equal(tc.browser_monitoring.version, '1.317.0')
+      end()
+    })
+  })
+
   const ipvValues = ['4', '6', 'bogus']
   for (const val of ipvValues) {
     const expectedValue = val === 'bogus' ? '4' : val

--- a/test/unit/config/config-server-side.test.js
+++ b/test/unit/config/config-server-side.test.js
@@ -296,6 +296,12 @@ describe('when receiving server-side configuration', () => {
     })
   })
 
+  test('should set browser_monitoring.loader_version when received', (t) => {
+    const { config } = t.nr
+    config.onConnect({ 'browser_monitoring.loader_version': '1.317.0' })
+    assert.equal(config.browser_monitoring.loader_version, '1.317.0')
+  })
+
   test('should not blow up when beacon is received', (t) => {
     const { config } = t.nr
     assert.doesNotThrow(() => {

--- a/test/unit/config/config-server-side.test.js
+++ b/test/unit/config/config-server-side.test.js
@@ -8,6 +8,7 @@
 const { describe, test } = require('node:test')
 const assert = require('node:assert')
 const Config = require('../../../lib/config')
+const { idempotentEnv } = require('./helper')
 
 describe('when receiving server-side configuration', () => {
   // Unfortunately, the Config currently relies on initialize to
@@ -819,6 +820,47 @@ describe('when receiving server-side configuration', () => {
       config.otlp_resource_attributes = {}
       config.onConnect({ otlp_resource_attributes: undefined })
       assert.deepEqual(config.otlp_resource_attributes, {})
+    })
+  })
+
+  describe('browser_monitoring.version resolution warning', () => {
+    test('should warn when version is set but no js_agent_loader is returned', () => {
+      idempotentEnv({}, { browser_monitoring: { version: '1.317.0', enable: true } }, (config, loggerInstance) => {
+        config.onConnect({ agent_run_id: 1234 })
+        assert.equal(loggerInstance.logs.warn.length, 1)
+      })
+    })
+
+    test('should not warn when browser_monitoring.version is unset', () => {
+      idempotentEnv({}, { browser_monitoring: { enable: true } }, (config, loggerInstance) => {
+        config.onConnect({ agent_run_id: 1234 })
+        assert.equal(loggerInstance.logs.warn.length, 0)
+      })
+    })
+
+    test('should not warn when browser_monitoring.loader is "none"', () => {
+      idempotentEnv(
+        {},
+        { browser_monitoring: { version: '1.317.0', enable: true, loader: 'none' } },
+        (config, loggerInstance) => {
+          config.onConnect({ agent_run_id: 1234 })
+          assert.equal(loggerInstance.logs.warn.length, 0)
+        }
+      )
+    })
+
+    test('should not warn when browser_monitoring.enable is false', () => {
+      idempotentEnv({}, { browser_monitoring: { version: '1.317.0', enable: false } }, (config, loggerInstance) => {
+        config.onConnect({ agent_run_id: 1234 })
+        assert.equal(loggerInstance.logs.warn.length, 0)
+      })
+    })
+
+    test('should not warn when js_agent_loader is returned', () => {
+      idempotentEnv({}, { browser_monitoring: { version: '1.317.0', enable: true } }, (config, loggerInstance) => {
+        config.onConnect({ js_agent_loader: 'function(){}' })
+        assert.equal(loggerInstance.logs.warn.length, 0)
+      })
     })
   })
 })

--- a/test/unit/config/config-server-side.test.js
+++ b/test/unit/config/config-server-side.test.js
@@ -8,7 +8,6 @@
 const { describe, test } = require('node:test')
 const assert = require('node:assert')
 const Config = require('../../../lib/config')
-const { idempotentEnv } = require('./helper')
 
 describe('when receiving server-side configuration', () => {
   // Unfortunately, the Config currently relies on initialize to
@@ -826,47 +825,6 @@ describe('when receiving server-side configuration', () => {
       config.otlp_resource_attributes = {}
       config.onConnect({ otlp_resource_attributes: undefined })
       assert.deepEqual(config.otlp_resource_attributes, {})
-    })
-  })
-
-  describe('browser_monitoring.version resolution warning', () => {
-    test('should warn when version is set but no js_agent_loader is returned', () => {
-      idempotentEnv({}, { browser_monitoring: { version: '1.317.0', enable: true } }, (config, loggerInstance) => {
-        config.onConnect({ agent_run_id: 1234 })
-        assert.equal(loggerInstance.logs.warn.length, 1)
-      })
-    })
-
-    test('should not warn when browser_monitoring.version is unset', () => {
-      idempotentEnv({}, { browser_monitoring: { enable: true } }, (config, loggerInstance) => {
-        config.onConnect({ agent_run_id: 1234 })
-        assert.equal(loggerInstance.logs.warn.length, 0)
-      })
-    })
-
-    test('should not warn when browser_monitoring.loader is "none"', () => {
-      idempotentEnv(
-        {},
-        { browser_monitoring: { version: '1.317.0', enable: true, loader: 'none' } },
-        (config, loggerInstance) => {
-          config.onConnect({ agent_run_id: 1234 })
-          assert.equal(loggerInstance.logs.warn.length, 0)
-        }
-      )
-    })
-
-    test('should not warn when browser_monitoring.enable is false', () => {
-      idempotentEnv({}, { browser_monitoring: { version: '1.317.0', enable: false } }, (config, loggerInstance) => {
-        config.onConnect({ agent_run_id: 1234 })
-        assert.equal(loggerInstance.logs.warn.length, 0)
-      })
-    })
-
-    test('should not warn when js_agent_loader is returned', () => {
-      idempotentEnv({}, { browser_monitoring: { version: '1.317.0', enable: true } }, (config, loggerInstance) => {
-        config.onConnect({ js_agent_loader: 'function(){}' })
-        assert.equal(loggerInstance.logs.warn.length, 0)
-      })
     })
   })
 })

--- a/test/unit/config/helper.js
+++ b/test/unit/config/helper.js
@@ -9,7 +9,6 @@ const Config = require('../../../lib/config')
 
 class TestConfigLogger {
   #logs = {
-    debug: [],
     error: [],
     info: [],
     trace: [],
@@ -20,10 +19,6 @@ class TestConfigLogger {
 
   child() {
     return this
-  }
-
-  debug(...args) {
-    this.#logs.debug.push(args)
   }
 
   error(...args) {

--- a/test/unit/config/helper.js
+++ b/test/unit/config/helper.js
@@ -9,6 +9,7 @@ const Config = require('../../../lib/config')
 
 class TestConfigLogger {
   #logs = {
+    debug: [],
     error: [],
     info: [],
     trace: [],
@@ -19,6 +20,10 @@ class TestConfigLogger {
 
   child() {
     return this
+  }
+
+  debug(...args) {
+    this.#logs.debug.push(args)
   }
 
   error(...args) {


### PR DESCRIPTION

## Description

Added support for the `browser_monitoring.version` configuration option, which lets customers request a specific browser agent loader version (e.g. `"1.317.0"`) instead of always receiving the latest. Per the collector spec, this value is customer-supplied, defaults to `""` (unset), and must be included in the settings map sent up on connect — the collector is responsible for resolving it and returning a matching loader.

To support the collector's version resolution behavior, this PR also:
- Wires up `browser_monitoring.loader_version` so the resolved version reported back by the collector on connect is actually stored on the config, rather than being silently dropped as an unknown key.
- Adds a local warning, logged when `browser_monitoring.version` is set but the collector does not return a `js_agent_loader`, since that combination usually means the requested version could not be resolved. The warning correctly excludes the two other cases where a missing loader is expected and not an error: `browser_monitoring.loader` set to `"none"`, and browser monitoring disabled (`browser_monitoring.enable` is `false`).


## How to Test

```
node --test test/unit/config/*.test.js
node --test test/unit/agent/agent.test.js
```

## Related Issues
Closes #4262