### PR TITLE
fix: Fixed otlp payload format for metrics in AWS Lambda

### DIFF
--- a/lib/collector/serverless.js
+++ b/lib/collector/serverless.js
@@ -152,7 +152,7 @@ class ServerlessCollector {
       // based. So we have to finalize our export out-of-band when the metrics
       // API is available (i.e. OTEL + OTEL Metrics have been enabled).
       this._agent.otel.metrics.flushToString().then((serializedMetrics) => {
-        this.payload.otlp_payload = serializedMetrics
+        this.payload.otlp_payload = [serializedMetrics]
         this.#finalizeSync()
       })
     } else {

--- a/test/unit/collector/serverless.test.js
+++ b/test/unit/collector/serverless.test.js
@@ -180,7 +180,7 @@ test('ServerlessCollector API', async (t) => {
       await t.nr.written
 
       const decoded = JSON.parse(zlib.gunzipSync(Buffer.from(t.nr.outData[2], 'base64')))
-      assert.equal(decoded.data.otlp_payload, 'BASE64_OTLP')
+      assert.deepStrictEqual(decoded.data.otlp_payload, ['BASE64_OTLP'])
       assert.deepStrictEqual(decoded.data.metric_data, [1, 2, 3])
     })
 
@@ -193,7 +193,7 @@ test('ServerlessCollector API', async (t) => {
       api.flushPayloadSync()
 
       const decoded = JSON.parse(zlib.gunzipSync(Buffer.from(t.nr.outData[2], 'base64')))
-      assert.equal(decoded.data.otlp_payload, undefined)
+      assert.strictEqual(decoded.data.otlp_payload, undefined)
       assert.deepStrictEqual(decoded.data.metric_data, [1, 2, 3])
     })
   })


### PR DESCRIPTION
The spec (PR 833) requires the `otlp_payload` value to be an array with a single element. This PR updates our implementation to match.