### PR TITLE
fix: Fixed duplicated router mount path in transaction names for async middleware

### DIFF
--- a/lib/subscribers/middleware-wrapper.js
+++ b/lib/subscribers/middleware-wrapper.js
@@ -189,11 +189,11 @@ class MiddlewareWrapper {
   /**
    * Wraps the done/next handler so that it pops the middleware's route from the
    * transaction name state and handles any error passed to it. When the handler
-   * is synchronous the wrapped done also restores and re-enters the previous
+   * is synchronous the wrapped `done` also restores and re-enters the previous
    * context; async handlers propagate context via their returned promise so
-   * only the path pop / error handling is needed.
+   * only the `path pop` / `error` handling is needed.
    *
-   * The path pop must happen for async handlers too. Otherwise a route/mount
+   * The path pop must happen for async handlers too. Otherwise, a route/mount
    * path appended by an async middleware is never removed, and a subsequent
    * middleware or router registered at the same path duplicates the prefix in
    * the transaction name (e.g. //foo/:bar/foo/:bar/...).
@@ -234,7 +234,13 @@ class MiddlewareWrapper {
       // executed. Async handlers restore context via their awaited promise, so
       // just invoke the original done handler.
       if (isSync) {
-        return self.agent.tracer.runInContext({ handler: doneFn, context: ctx, thisArg: this, args: doneArgs, full: false })
+        return self.agent.tracer.runInContext({
+          handler: doneFn,
+          context: ctx,
+          thisArg: this,
+          args: doneArgs,
+          full: false
+        })
       }
       return doneFn.apply(this, doneArgs)
     }

--- a/lib/subscribers/middleware-wrapper.js
+++ b/lib/subscribers/middleware-wrapper.js
@@ -187,12 +187,16 @@ class MiddlewareWrapper {
   }
 
   /**
-   * Wraps the done/next handler if it is a sync middleware handler
-   * and propagates that segment context accordingly. It also, handles
-   * the error if one is passed to handler.
+   * Wraps the done/next handler so that it pops the middleware's route from the
+   * transaction name state and handles any error passed to it. When the handler
+   * is synchronous the wrapped done also restores and re-enters the previous
+   * context; async handlers propagate context via their returned promise so
+   * only the path pop / error handling is needed.
    *
-   * In most web frameworks the `done` function is synchronous aside from the
-   * handler `done` function that is async.
+   * The path pop must happen for async handlers too. Otherwise a route/mount
+   * path appended by an async middleware is never removed, and a subsequent
+   * middleware or router registered at the same path duplicates the prefix in
+   * the transaction name (e.g. //foo/:bar/foo/:bar/...).
    *
    * @param {object} params to function
    * @param {Array} params.args arguments to middleware function
@@ -207,36 +211,43 @@ class MiddlewareWrapper {
   wrapDoneHandler({ args, segment, ctx, handler, txInfo, route, nextIdx }) {
     const self = this
     const doneFn = args.at(nextIdx)
-    const isSync = typeof doneFn === 'function' &&
-      handler.constructor.name !== 'AsyncFunction'
 
-    if (isSync) {
-      function wrappedDone(...doneArgs) {
-        const [err] = doneArgs
-        if (self.isError(err)) {
-          self.maybeHandleError(txInfo, err)
-        // route has been completed, pop from path
-        // to allow other handlers to name it more accurately
-        } else if (route) {
-          route = Array.isArray(route) ? route.join(',') : route
-          ctx?.transaction?.nameState?.popPath(route)
-        }
+    if (typeof doneFn !== 'function') {
+      return
+    }
 
-        segment.touch()
-        // binding previous ctx as it should restore once this cb is executed
+    const isSync = handler.constructor.name !== 'AsyncFunction'
+
+    function wrappedDone(...doneArgs) {
+      const [err] = doneArgs
+      if (self.isError(err)) {
+        self.maybeHandleError(txInfo, err)
+      // route has been completed, pop from path
+      // to allow other handlers to name it more accurately
+      } else if (route) {
+        route = Array.isArray(route) ? route.join(',') : route
+        ctx?.transaction?.nameState?.popPath(route)
+      }
+
+      segment.touch()
+      // For sync handlers the previous context must be restored once this cb is
+      // executed. Async handlers restore context via their awaited promise, so
+      // just invoke the original done handler.
+      if (isSync) {
         return self.agent.tracer.runInContext({ handler: doneFn, context: ctx, thisArg: this, args: doneArgs, full: false })
       }
+      return doneFn.apply(this, doneArgs)
+    }
 
-      Object.defineProperties(wrappedDone, {
-        name: { value: doneFn.name },
-        length: { value: doneFn.length }
-      })
+    Object.defineProperties(wrappedDone, {
+      name: { value: doneFn.name },
+      length: { value: doneFn.length }
+    })
 
-      if (nextIdx === -1) {
-        args[args.length - 1] = wrappedDone
-      } else {
-        args[nextIdx] = wrappedDone
-      }
+    if (nextIdx === -1) {
+      args[args.length - 1] = wrappedDone
+    } else {
+      args[nextIdx] = wrappedDone
     }
   }
 

--- a/lib/subscribers/middleware-wrapper.js
+++ b/lib/subscribers/middleware-wrapper.js
@@ -222,9 +222,9 @@ class MiddlewareWrapper {
       const [err] = doneArgs
       if (self.isError(err)) {
         self.maybeHandleError(txInfo, err)
-      // route has been completed, pop from path
-      // to allow other handlers to name it more accurately
       } else if (route) {
+        // route has been completed, pop from path
+        // to allow other handlers to name it more accurately
         route = Array.isArray(route) ? route.join(',') : route
         ctx?.transaction?.nameState?.popPath(route)
       }

--- a/test/versioned/express/async-middleware-naming.test.js
+++ b/test/versioned/express/async-middleware-naming.test.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+process.env.NODE_ENV = 'test'
+
+const assert = require('node:assert')
+const test = require('node:test')
+const { makeRequest, setup, teardown } = require('./utils')
+
+test.beforeEach(async (ctx) => {
+  await setup(ctx)
+})
+
+test.afterEach(teardown)
+
+test('async middleware at same mount path as router does not duplicate name', async (t) => {
+  const { agent, app, express, port } = t.nr
+
+  app.use('/resources/:resourceId', async function (req, res, next) {
+    next()
+  })
+
+  const router = new express.Router({ mergeParams: true })
+  router.get('/:itemId/details', function (req, res) {
+    res.end()
+  })
+  app.use('/resources/:resourceId', router)
+
+  const { promise, resolve } = Promise.withResolvers()
+  agent.on('transactionFinished', (tx) => resolve(tx.name))
+  makeRequest(port, '/resources/abc/123/details')
+
+  const name = await promise
+  assert.equal(name, 'WebTransaction/Expressjs/GET//resources/:resourceId/:itemId/details')
+})

--- a/test/versioned/express/package.json
+++ b/test/versioned/express/package.json
@@ -25,6 +25,7 @@
         "app-use.test.js",
         "async-error.test.js",
         "async-handlers.test.js",
+        "async-middleware-naming.test.js",
         "bare-router.test.js",
         "captures-params.test.js",
         "client-disconnect.test.js",


### PR DESCRIPTION
## Problem

After upgrading from `13.5.0` → `14.3.x`, transaction names duplicate a router's mount path when an `async` middleware is registered at the same path as a router. For example:

- Expected: `WebTransaction/Expressjs/GET//resources/:resourceId/:itemId/details`
- Broken: `WebTransaction/Expressjs/GET//resources/:resourceId/resources/:resourceId/:itemId/details`

The mount path `/resources/:resourceId` appears twice.

## Root cause

The express instrumentation was rewritten as `diagnostics_channel` subscribers in `13.6.0` (#3424). In the shared `lib/subscribers/middleware-wrapper.js`, `wrapDoneHandler` only wrapped the `next`/`done` callback for **synchronous** middleware. The route/mount path appended by an `async` middleware was therefore never popped from the transaction name state, so a subsequent middleware or router registered at the same path appended the identical prefix a second time.

## Fix

The `next`/`done` callback is now wrapped for async handlers as well, so the path is popped (and errors handled) regardless of whether the handler is sync or async. Context re-entry via `runInContext` remains sync-only, since async handlers already propagate context through their awaited promise.

## Testing

Added a versioned regression test (`test/versioned/express/async-middleware-naming.test.js`) that registers an async middleware and a router at the same param mount path and asserts the transaction name is not duplicated.

With the **broken** code, the test's request to `/resources/abc/123/details` produced:

```
WebTransaction/Expressjs/GET//resources/:resourceId/resources/:resourceId/:itemId/details
```

instead of the expected:

```
WebTransaction/Expressjs/GET//resources/:resourceId/:itemId/details
```

Verified passing after the fix across the shared middleware wrapper's consumers: express (4.22.2, 5.2.1), connect (3.7.0), fastify (3/4/5), koa (2/3), hapi (20/21), and the `middleware-wrapper` unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
